### PR TITLE
copy: retire browser and knowledge-work framing in positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A visual interface for AI agent teams. Built by someone running their own business, for people running their own.
 
-You run content, ops, sales, admin, and research. When you started, there was nobody else, so the work fell to you. A single chatbot is a single assistant. An agent platform built for developers assumes you can write code. Rundock gives you a team you can actually manage: an org chart of named specialists, conversations through the browser, and delegation that happens in front of you. One beta user described it as having a virtual team of highly paid experts, running in parallel. That is the experience.
+You run content, ops, sales, admin, and research. When you started, there was nobody else, so the work fell to you. A single chatbot is a single assistant. An agent platform built for developers assumes you can write code. Rundock gives you a team you can actually manage: an org chart of named specialists, parallel conversations you can watch side by side, and delegation that happens in front of you. One beta user described it as having a virtual team of highly paid experts, running in parallel. That is the experience.
 
 Built by [Liam Darmody](https://www.linkedin.com/in/liamdarmody/).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rundock",
   "version": "0.8.11",
-  "description": "A browser-based OS for AI agent teams. Built for knowledge work, powered by Claude Code.",
+  "description": "A visual interface for AI agent teams. Built for people running their own businesses, powered by Claude Code.",
   "main": "electron/main.js",
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Why

Rundock's public positioning was updated. Two phrases are retired across user-facing surfaces:

- **"browser-based" / "through the browser"** as a product description. Rundock is a downloadable macOS desktop app, not a browser-based tool. (Genuine dev instructions about opening localhost in a browser stay.)
- **"knowledge work"** as the audience. The audience line is now "people running their own businesses."

Canonical positioning string (already set on the GitHub About field):

> A visual interface for AI agent teams. Built for people running their own businesses, powered by Claude Code.

## Changes

**package.json `description`**
- Before: `A browser-based OS for AI agent teams. Built for knowledge work, powered by Claude Code.`
- After: `A visual interface for AI agent teams. Built for people running their own businesses, powered by Claude Code.`

**README.md hero paragraph (line 8)**
- Before: `...an org chart of named specialists, conversations through the browser, and delegation that happens in front of you.`
- After: `...an org chart of named specialists, parallel conversations you can watch side by side, and delegation that happens in front of you.`

## Left intentionally untouched

- README from-source setup: `Open http://localhost:3000 in your browser` (accurate dev instruction).
- Historical CHANGELOG entries (dated release notes; rewriting them would be inaccurate).
- Runtime / permission-UI browser references in `server.js`, `scripts/permission-hook.js`, `docs/AGENTS.md` (technical, accurate).
- `server.js` "knowledge management platform" / "knowledge work" strings: these are capability/file-type constraints in system prompts, not the public audience line. Out of scope for this positioning change and changing them risks runtime behavior.

## House style

UK spelling. No em or en dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)