### PR TITLE
README: GitHub star ask + UTM-tagged rundock.ai link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 [![License: PolyForm Perimeter 1.0.0](https://img.shields.io/badge/license-PolyForm%20Perimeter%201.0.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/liamdarmody/rundock)](https://github.com/liamdarmody/rundock/releases)
+[![GitHub stars](https://img.shields.io/github/stars/liamdarmody/rundock?style=social)](https://github.com/liamdarmody/rundock/stargazers)
 
 A visual interface for AI agent teams. Built by someone running their own business, for people running their own.
 
 You run content, ops, sales, admin, and research. When you started, there was nobody else, so the work fell to you. A single chatbot is a single assistant. An agent platform built for developers assumes you can write code. Rundock gives you a team you can actually manage: an org chart of named specialists, parallel conversations you can watch side by side, and delegation that happens in front of you. One beta user described it as having a virtual team of highly paid experts, running in parallel. That is the experience.
 
-Built by [Liam Darmody](https://www.linkedin.com/in/liamdarmody/).
+Built by [Liam Darmody](https://www.linkedin.com/in/liamdarmody/). Learn more at [rundock.ai](https://rundock.ai/?utm_source=github&utm_medium=readme).
+
+> **Star this repo** if Rundock is useful to you. It is the simplest way to support the project and helps other people running their own businesses find it. [Add a star ->](https://github.com/liamdarmody/rundock)
 
 ![Rundock app: an AI agent team org chart with the orchestrator at the top, six specialists, and a routines panel showing scheduled automations](docs/rundock-app-hero.png)
 


### PR DESCRIPTION
## What this does

- Adds a tasteful **"Star this repo"** ask near the top, plus a GitHub stars badge in the badge row.
- Adds an outbound link to **rundock.ai** UTM-tagged `?utm_source=github&utm_medium=readme` so site analytics can attribute GitHub traffic.

### Notes
- The README had no existing apex `rundock.ai` link, so the UTM-tagged link was added with the star ask.
- `docs.rundock.ai/principles` (a separate docs subdomain) and `http://localhost:3000` (dev link) are left untouched, per the brief.

**Do not merge.** Left for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)