### PR TITLE
Fix agent profile capabilities card: consistent rendering and XSS hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
+## Unreleased
+
+### Fixed
+
+- **Agent profile capabilities card renders all capability fields consistently:** The Writes To section was displaying comma-separated paths as a single line of text while Reads From displayed each path as a separate line item. Both sections now split on commas and render each path individually. The "What [agent] does" label also now correctly escapes and trims the display name before rendering.
+
 ## 0.8.11: Rich Markdown Editor & Find (2026-05-28)
 
 ### Added

--- a/public/app.js
+++ b/public/app.js
@@ -1207,9 +1207,9 @@ function showProfile(agentId) {
   if(a.capabilities) {
     const c = a.capabilities;
     h+=`<div class="profile-card">`;
-    if(c.does) h+=`<div class="profile-card-section"><div class="profile-section-label">What ${a.displayName} does</div><div class="profile-card-text">${esc(c.does)}</div></div>`;
-    if(c.reads) h+=`<div class="profile-card-section"><div class="profile-section-label">Reads from</div>${c.reads.split(',').map(r=>`<div class="profile-card-item">${r.trim()}</div>`).join('')}</div>`;
-    if(c.writes) h+=`<div class="profile-card-section"><div class="profile-section-label">Writes to</div><div class="profile-card-text">${esc(c.writes)}</div></div>`;
+    if(c.does) h+=`<div class="profile-card-section"><div class="profile-section-label">What ${esc(a.displayName.trim())} does</div><div class="profile-card-text">${esc(c.does)}</div></div>`;
+    if(c.reads) h+=`<div class="profile-card-section"><div class="profile-section-label">Reads from</div>${c.reads.split(',').map(r=>`<div class="profile-card-text">${esc(r.trim())}</div>`).join('')}</div>`;
+    if(c.writes) h+=`<div class="profile-card-section"><div class="profile-section-label">Writes to</div>${c.writes.split(',').map(w=>`<div class="profile-card-text">${esc(w.trim())}</div>`).join('')}</div>`;
     h+=`</div>`;
   }
   // Skills card


### PR DESCRIPTION
### Description

Fix the agent profile capabilities card to render `reads` and `writes` fields consistently. Apply `esc()` and `.trim()` to the display name in the capabilities label.

### Why

The profile card rendered the **Reads From** and **Writes To** sections differently despite both fields using identical comma-separated string format in agent frontmatter. `reads` split on commas and displayed each path as a separate line. `writes` rendered the raw string as a single block of text. The inconsistency was visible on any agent with multiple paths in both fields.

Two secondary issues were fixed in the same block: `reads` was using `profile-card-item` while `writes` used `profile-card-text`, and the display name in the "What \[agent\] does" label was rendered without `esc()` or `.trim()`.

Fixes \#\[issue number\].

### Testing

1. Open a workspace with an agent that has multiple paths in both `reads:` and `writes:` under `capabilities:` in its frontmatter  
2. Open that agent's profile  
3. Confirm **Reads From** and **Writes To** both display each path on its own line

Example frontmatter used to reproduce:

```yaml

capabilities:
  does: Startup ideation, market analysis, business plan generation.
  reads: 12\-startup/ideas/, 12\-startup/triage/, 12\-startup/plans/
  writes: 12\-startup/ideas/\[idea\-name\].md, 12\-startup/plans/\[plan\-name\].md, 12\-startup/triage/processed/
```

### Checklist

- [x] Code changes are scoped to one logical concern  
- [x] CHANGELOG.md updated under `## Unreleased` if user-visible  
- [x] No accidental edits to `.env`, secrets, or build output
