### PR TITLE
feat: Add Windows support

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -21,13 +24,33 @@ jobs:
       - name: Build Windows installer
         run: node scripts/build.js --win
 
+      - name: Verify build artifacts
+        shell: bash
+        run: |
+          shopt -s nullglob
+          artifacts=(dist-output/*.exe dist-output/*.blockmap dist-output/latest.yml)
+          if [ ${#artifacts[@]} -eq 0 ]; then
+            echo "::error::No build artifacts found in dist-output/"
+            ls -la dist-output/ || true
+            exit 1
+          fi
+          echo "Found ${#artifacts[@]} artifacts:"
+          printf '  %s\n' "${artifacts[@]}"
+
       - name: Upload artifacts to release
         shell: bash
         run: |
+          shopt -s nullglob
+          files=()
+          for f in dist-output/*.exe dist-output/*.blockmap dist-output/latest.yml; do
+            [ -f "$f" ] && files+=("$f")
+          done
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No files to upload"
+            exit 1
+          fi
           gh release upload "${{ github.event.release.tag_name }}" \
-            dist-output/*.exe \
-            dist-output/*.blockmap \
-            dist-output/latest.yml \
+            "${files[@]}" \
             --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,33 @@
+name: Release Windows
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Build Windows installer
+        run: node scripts/build.js --win
+
+      - name: Upload artifacts to release
+        shell: bash
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist-output/*.exe \
+            dist-output/*.blockmap \
+            dist-output/latest.yml \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules/
 *.swp
 *.swo
 dist/
+.claude/settings.local.json
+dist-output/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
+## 0.8.12: Windows Support (2026-06-07)
+
+### Added
+
+- **Windows installer distribution.** Rundock now ships as a Windows NSIS installer (`.exe`) for x64. The installer creates desktop and Start Menu shortcuts, and updates are delivered via the same electron-builder auto-update mechanism as macOS. Windows releases are built automatically via GitHub Actions when a release is published.
+
+- **Platform-aware build pipeline.** Build scripts now detect whether Apple signing credentials are present and default to the appropriate platform: Windows when credentials are absent, macOS when credentials are available. You can override this with explicit flags: `node scripts/build.js --win` or `--mac`.
+
+- **Platform-aware UI.** The title bar and app menu now adapt to the operating system. macOS retains the hiddenInset title bar style and the classic Rundock/Edit/View menu layout. Windows uses the default title bar style and a File/Edit/View/Help menu structure with About and Check for Updates under Help.
+
 ## 0.8.11: Rich Markdown Editor & Find (2026-05-28)
 
 ### Added

--- a/docs/plans/2026-06-07-windows-support-design.md
+++ b/docs/plans/2026-06-07-windows-support-design.md
@@ -1,0 +1,118 @@
+# Windows Support Design
+
+**Date:** 2026-06-07  
+**Branch:** emdash/windows-conversion-laa3i
+
+## Goal
+
+Add Windows distribution to Rundock without changing the existing Mac build pipeline. Windows builds default when Apple credentials are absent; Mac builds run when credentials are present (or via explicit flag).
+
+## Distribution format
+
+NSIS one-click installer (`.exe`), x64 only. No Authenticode code signing initially — users will see a SmartScreen warning on first run, acceptable for early distribution.
+
+## Release pipeline
+
+- **Mac**: unchanged — `node scripts/release.js <version>` runs locally on a Mac with `.env` credentials, builds DMG, notarizes, staples, publishes the GitHub Release.
+- **Windows**: GitHub Actions workflow triggered by `release: types: [published]`. Runs on `windows-latest`, builds the NSIS `.exe`, uploads artifacts to the existing release via `gh release upload`.
+
+---
+
+## Changes
+
+### 1. `package.json`
+
+Add `win` and `nsis` sections to the `build` config. Change `directories.output` from the Unix-only `/tmp/rundock-dist` to the relative path `dist-output` so it works on both platforms.
+
+```json
+"directories": { "output": "dist-output" },
+"win": {
+  "icon": "electron/build/icon.ico",
+  "target": [{ "target": "nsis", "arch": ["x64"] }]
+},
+"nsis": {
+  "oneClick": true,
+  "perMachine": false,
+  "createDesktopShortcut": true,
+  "createStartMenuShortcut": true
+}
+```
+
+### 2. `scripts/build.js`
+
+Add a `hasAppleCreds()` helper that loads `.env` and checks for `CSC_LINK` and `APPLE_API_KEY`. Default to `--win` when absent; `--mac` when present. Honor explicit `--mac` / `--win` CLI flags as overrides.
+
+```
+node scripts/build.js           # --win (no creds) or --mac (creds found)
+node scripts/build.js --mac     # force Mac
+node scripts/build.js --win     # force Windows
+```
+
+### 3. `scripts/release.js`
+
+Three targeted changes:
+
+1. **Platform detection** — add `hasAppleCreds()`. Mac path: existing notarize/staple/xcrun chain. Windows path: skip all Apple-specific steps.
+2. **`DIST_DIR`** — change from `/tmp/rundock-dist` to `path.join(ROOT, 'dist-output')` to match the updated `package.json`.
+3. **`publishRelease()`** — make artifact filenames conditional:
+   - Mac: `Rundock-{version}-arm64.dmg`, `.blockmap`, `-arm64-mac.zip`, `.blockmap`, `latest-mac.yml`
+   - Windows: `Rundock Setup {version}.exe`, `.blockmap`, `latest.yml`
+4. **`updateSiteDownloadUrls()`** — remains Mac-only (already conditional on site repo existing).
+5. **`APP_PATH`** — hardcoded to `/tmp/rundock-dist/mac-arm64/Rundock.app`; update to use `DIST_DIR` and make the `.app` subpath Mac-only.
+
+### 4. `electron/main.js`
+
+Two small platform conditionals:
+
+1. **Wizard `titleBarStyle`** — `'hiddenInset'` is macOS-only and renders incorrectly on Windows:
+   ```js
+   titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default'
+   ```
+
+2. **App menu** — The leading "Rundock" menu item (About, Check for Updates, Quit) is a macOS convention. On Windows, restructure to put About and Check for Updates in a "Help" menu, with Quit under "File":
+   - macOS: current layout unchanged
+   - Windows: File (Quit) / Edit / View / Help (About, Check for Updates)
+
+### 5. `.github/workflows/release-windows.yml` (new file)
+
+Triggered by `release: types: [published]`. Single job on `windows-latest`:
+
+```yaml
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: node scripts/build.js --win
+      - run: gh release upload ${{ github.event.release.tag_name }} dist-output/*.exe dist-output/*.blockmap dist-output/latest.yml --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `package.json` | Add `win`/`nsis` build config, fix `directories.output` |
+| `scripts/build.js` | Add `hasAppleCreds()`, default to `--win` |
+| `scripts/release.js` | Platform detection, fix `DIST_DIR`, conditional artifacts |
+| `electron/main.js` | `titleBarStyle` conditional, platform-aware app menu |
+| `.github/workflows/release-windows.yml` | New CI workflow |
+
+## Out of scope
+
+- Authenticode code signing (can be added later by setting `WIN_CSC_LINK` / `WIN_CSC_KEY_PASSWORD` in `.env`)
+- Retiring `scripts/install-windows-source.ps1` (can be done after the installer ships)
+- Changing how the Mac release pipeline runs

--- a/docs/plans/2026-06-07-windows-support.md
+++ b/docs/plans/2026-06-07-windows-support.md
@@ -1,0 +1,589 @@
+# Windows Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Windows (NSIS installer) support to Rundock, defaulting to Windows builds when Apple credentials are absent and preserving the existing Mac pipeline when they are present.
+
+**Architecture:** Five targeted changes — build config, two build scripts, one Electron runtime file, and a new CI workflow. No unit tests exist for build scripts; verification is done by running the scripts and inspecting output. Electron runtime changes are verified by launching `npm run electron` on Windows.
+
+**Tech Stack:** electron-builder (NSIS target), GitHub Actions (windows-latest runner), Node.js, Electron 35.
+
+---
+
+### Task 1: `package.json` — add win/nsis build config and fix output path
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.gitignore`
+
+**Step 1: Add `dist-output` to `.gitignore`**
+
+Append one line to `.gitignore`:
+
+```
+dist-output/
+```
+
+**Step 2: Update `package.json` build config**
+
+Make three changes to the `"build"` section:
+
+1. Change `directories.output` from `/tmp/rundock-dist` to `dist-output`
+2. Add `"win"` section after `"dmg"`
+3. Add `"nsis"` section after `"win"`
+
+The updated `"build"` block (only changed/added lines shown):
+
+```json
+"directories": {
+  "output": "dist-output"
+},
+```
+
+```json
+"win": {
+  "icon": "electron/build/icon.ico",
+  "target": [{ "target": "nsis", "arch": ["x64"] }]
+},
+"nsis": {
+  "oneClick": true,
+  "perMachine": false,
+  "artifactName": "Rundock-${version}-Setup.exe",
+  "createDesktopShortcut": true,
+  "createStartMenuShortcut": true
+},
+```
+
+The `artifactName` avoids a space in the filename (`Rundock Setup 0.8.11.exe` → `Rundock-0.8.11-Setup.exe`), which keeps glob patterns simple in CI.
+
+**Step 3: Verify JSON is valid**
+
+```powershell
+node -e "const p = require('./package.json'); console.log('win target:', p.build.win.target[0].target); console.log('output:', p.build.directories.output)"
+```
+
+Expected output:
+```
+win target: nsis
+output: dist-output
+```
+
+**Step 4: Commit**
+
+```bash
+git add package.json .gitignore
+git commit -m "build: add windows NSIS target and fix output path"
+```
+
+---
+
+### Task 2: `scripts/build.js` — add `hasAppleCreds()`, default to `--win`
+
+**Files:**
+- Modify: `scripts/build.js`
+
+**Step 1: Replace the current platform arg with credential-aware detection**
+
+Current code at the bottom of `scripts/build.js` (around line 29):
+
+```js
+// Forward all CLI args to electron-builder
+const args = ['--mac', ...process.argv.slice(2)];
+```
+
+Replace with:
+
+```js
+function hasAppleCreds() {
+  return !!(process.env.CSC_LINK && process.env.APPLE_API_KEY);
+}
+
+const explicitMac = process.argv.includes('--mac');
+const explicitWin = process.argv.includes('--win');
+const platform = explicitMac ? '--mac' : explicitWin ? '--win' : hasAppleCreds() ? '--mac' : '--win';
+const extraArgs = process.argv.slice(2).filter(a => a !== '--mac' && a !== '--win');
+const args = [platform, ...extraArgs];
+```
+
+Note: `.env` is already loaded earlier in the file via `require('dotenv').config()`, so `process.env.CSC_LINK` is populated before `hasAppleCreds()` is called.
+
+**Step 2: Update the log line to show the resolved platform**
+
+Current line:
+```js
+console.log(`[build] Running: electron-builder ${args.join(' ')}`);
+```
+
+This already uses `args`, so it will automatically reflect the resolved platform — no change needed.
+
+**Step 3: Verify credential detection logic**
+
+```powershell
+node -e "
+const path = require('path');
+const fs = require('fs');
+// Simulate no creds
+delete process.env.CSC_LINK;
+delete process.env.APPLE_API_KEY;
+function hasAppleCreds() { return !!(process.env.CSC_LINK && process.env.APPLE_API_KEY); }
+const platform = hasAppleCreds() ? '--mac' : '--win';
+console.log('No creds, platform:', platform);
+// Simulate creds present
+process.env.CSC_LINK = 'fake';
+process.env.APPLE_API_KEY = 'fake';
+console.log('With creds, platform:', hasAppleCreds() ? '--mac' : '--win');
+"
+```
+
+Expected output:
+```
+No creds, platform: --win
+With creds, platform: --mac
+```
+
+**Step 4: Commit**
+
+```bash
+git add scripts/build.js
+git commit -m "build: default to --win when Apple credentials absent"
+```
+
+---
+
+### Task 3: `scripts/release.js` — platform detection, fix DIST_DIR, conditional artifacts
+
+**Files:**
+- Modify: `scripts/release.js`
+
+This task has five sub-changes. Make them in order.
+
+**Step 1: Fix `DIST_DIR` and `APP_PATH` constants (lines 34-35)**
+
+Current:
+```js
+const APP_PATH = '/tmp/rundock-dist/mac-arm64/Rundock.app';
+const DIST_DIR = '/tmp/rundock-dist';
+```
+
+Replace with:
+```js
+const DIST_DIR = path.join(ROOT, 'dist-output');
+const APP_PATH = path.join(DIST_DIR, 'mac-arm64', 'Rundock.app');
+```
+
+**Step 2: Add `hasAppleCreds()` helper after the `fail()` helper function**
+
+Find the `fail()` function (around line 47):
+```js
+function fail(step, msg) {
+  console.error(`[release:${step}] ERROR: ${msg}`);
+  process.exit(1);
+}
+```
+
+Add immediately after it:
+```js
+function hasAppleCreds() {
+  return !!(process.env.CSC_LINK && process.env.APPLE_API_KEY);
+}
+```
+
+**Step 3: Update `loadEnv()` to not fail when `.env` is missing (Windows case)**
+
+Current `loadEnv()`:
+```js
+function loadEnv() {
+  const envPath = path.join(ROOT, '.env');
+  if (fs.existsSync(envPath)) {
+    require('dotenv').config({ path: envPath });
+    log('env', 'Loaded .env');
+  } else {
+    fail('env', 'No .env file found. Cannot sign or notarise without credentials.');
+  }
+
+  const required = [
+    'APPLE_API_KEY',
+    'APPLE_API_KEY_ID',
+    'APPLE_API_ISSUER',
+    'CSC_LINK',
+    'CSC_KEY_PASSWORD',
+    'APPLE_TEAM_ID',
+  ];
+  const missing = required.filter((k) => !process.env[k]);
+  if (missing.length) {
+    fail('env', `Missing required env vars: ${missing.join(', ')}`);
+  }
+}
+```
+
+Replace with:
+```js
+function loadEnv() {
+  const envPath = path.join(ROOT, '.env');
+  if (fs.existsSync(envPath)) {
+    require('dotenv').config({ path: envPath });
+    log('env', 'Loaded .env');
+  } else {
+    log('env', 'No .env file found, proceeding without signing credentials.');
+  }
+
+  if (hasAppleCreds()) {
+    const required = [
+      'APPLE_API_KEY',
+      'APPLE_API_KEY_ID',
+      'APPLE_API_ISSUER',
+      'CSC_LINK',
+      'CSC_KEY_PASSWORD',
+      'APPLE_TEAM_ID',
+    ];
+    const missing = required.filter((k) => !process.env[k]);
+    if (missing.length) {
+      fail('env', `Missing required env vars: ${missing.join(', ')}`);
+    }
+  }
+}
+```
+
+**Step 4: Update `build()` to be platform-aware**
+
+Current `build()`:
+```js
+function build() {
+  log('build', 'Running electron-builder --mac');
+  try {
+    execFileSync(
+      path.join(ROOT, 'node_modules', '.bin', 'electron-builder'),
+      ['--mac', '--publish', 'never'],
+      { stdio: 'inherit', cwd: ROOT }
+    );
+  } catch (err) {
+    fail('build', `electron-builder exited with code ${err.status || 1}`);
+  }
+
+  if (!fs.existsSync(APP_PATH)) {
+    fail('build', `Expected .app not found at ${APP_PATH}`);
+  }
+  log('build', `Built ${APP_PATH}`);
+}
+```
+
+Replace with:
+```js
+function build() {
+  const platform = hasAppleCreds() ? '--mac' : '--win';
+  log('build', `Running electron-builder ${platform}`);
+  try {
+    execFileSync(
+      path.join(ROOT, 'node_modules', '.bin', 'electron-builder'),
+      [platform, '--publish', 'never'],
+      { stdio: 'inherit', cwd: ROOT }
+    );
+  } catch (err) {
+    fail('build', `electron-builder exited with code ${err.status || 1}`);
+  }
+
+  if (hasAppleCreds()) {
+    if (!fs.existsSync(APP_PATH)) {
+      fail('build', `Expected .app not found at ${APP_PATH}`);
+    }
+    log('build', `Built ${APP_PATH}`);
+  } else {
+    log('build', `Built Windows artifacts in ${DIST_DIR}`);
+  }
+}
+```
+
+**Step 5: Update `publishRelease()` artifact filenames to be platform-conditional**
+
+Current artifact block at the top of `publishRelease()` (around lines 373-379):
+```js
+const dmg = path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`);
+const dmgBlockmap = `${dmg}.blockmap`;
+const zip = path.join(DIST_DIR, `Rundock-${version}-arm64-mac.zip`);
+const zipBlockmap = `${zip}.blockmap`;
+const feed = path.join(DIST_DIR, 'latest-mac.yml');
+const assets = [dmg, dmgBlockmap, zip, zipBlockmap, feed];
+```
+
+Replace with:
+```js
+let assets;
+if (hasAppleCreds()) {
+  const dmg = path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`);
+  const zip = path.join(DIST_DIR, `Rundock-${version}-arm64-mac.zip`);
+  const feed = path.join(DIST_DIR, 'latest-mac.yml');
+  assets = [dmg, `${dmg}.blockmap`, zip, `${zip}.blockmap`, feed];
+} else {
+  const setup = path.join(DIST_DIR, `Rundock-${version}-Setup.exe`);
+  const feed = path.join(DIST_DIR, 'latest.yml');
+  assets = [setup, `${setup}.blockmap`, feed];
+}
+```
+
+**Step 6: Wrap notarize/staple/site steps at the bottom of the file**
+
+Current bottom of file:
+```js
+setVersion();
+loadEnv();
+promoteUnreleasedChangelog(process.argv[2]);
+commitAndPush(process.argv[2]);
+build();
+const submissionId = submitNotarisation();
+pollNotarisation(submissionId);
+staple();
+
+const version = process.argv[2];
+publishRelease(version);
+updateSiteDownloadUrls(version);
+```
+
+Replace with:
+```js
+setVersion();
+loadEnv();
+promoteUnreleasedChangelog(process.argv[2]);
+commitAndPush(process.argv[2]);
+build();
+
+if (hasAppleCreds()) {
+  const submissionId = submitNotarisation();
+  pollNotarisation(submissionId);
+  staple();
+}
+
+const version = process.argv[2];
+publishRelease(version);
+
+if (hasAppleCreds()) {
+  updateSiteDownloadUrls(version);
+}
+```
+
+**Step 7: Verify the script parses without errors**
+
+```powershell
+node --check scripts/release.js
+```
+
+Expected: no output (syntax is valid).
+
+**Step 8: Commit**
+
+```bash
+git add scripts/release.js
+git commit -m "build: make release.js platform-aware, default to windows when no Apple creds"
+```
+
+---
+
+### Task 4: `electron/main.js` — Windows UI conditionals
+
+**Files:**
+- Modify: `electron/main.js`
+
+**Step 1: Fix `titleBarStyle` in the wizard window (line 109)**
+
+Current:
+```js
+titleBarStyle: 'hiddenInset',
+```
+
+Replace with:
+```js
+titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
+```
+
+**Step 2: Replace `setupMenu()` with a platform-aware version (lines 157-204)**
+
+Replace the entire `setupMenu()` function body with:
+
+```js
+function setupMenu() {
+  const checkForUpdatesItem = { label: 'Check for Updates', click: () => {
+    if (!autoUpdater) {
+      dialog.showMessageBox(mainWindow, {
+        type: 'info',
+        message: 'Auto-update is not available in this build.',
+        buttons: ['OK'],
+      });
+      return;
+    }
+    isCheckingManually = true;
+    autoUpdater.checkForUpdates().catch((err) => {
+      isCheckingManually = false;
+      dialog.showMessageBox(mainWindow, {
+        type: 'error',
+        message: 'Could not check for updates',
+        detail: err && err.message ? err.message : String(err),
+        buttons: ['OK'],
+      });
+    });
+  } };
+
+  const editMenu = {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' }, { role: 'redo' }, { type: 'separator' },
+      { role: 'cut' }, { role: 'copy' }, { role: 'paste' }, { role: 'selectAll' },
+    ],
+  };
+
+  const viewMenu = {
+    label: 'View',
+    submenu: [
+      { role: 'reload' }, { role: 'toggleDevTools' },
+      { type: 'separator' },
+      { role: 'zoomIn' }, { role: 'zoomOut' }, { role: 'resetZoom' },
+    ],
+  };
+
+  const template = process.platform === 'darwin'
+    ? [
+        {
+          label: 'Rundock',
+          submenu: [
+            { label: 'About Rundock', role: 'about' },
+            checkForUpdatesItem,
+            { type: 'separator' },
+            { label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: () => { app.quit(); } },
+          ],
+        },
+        editMenu,
+        viewMenu,
+      ]
+    : [
+        {
+          label: 'File',
+          submenu: [
+            { label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: () => { app.quit(); } },
+          ],
+        },
+        editMenu,
+        viewMenu,
+        {
+          label: 'Help',
+          submenu: [
+            { label: 'About Rundock', role: 'about' },
+            checkForUpdatesItem,
+          ],
+        },
+      ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+```
+
+**Step 3: Verify the app launches**
+
+```powershell
+npm run electron
+```
+
+Expected:
+- App window opens
+- Menu bar shows: File / Edit / View / Help (on Windows)
+- Help menu contains "About Rundock" and "Check for Updates"
+- Closing and reopening does not crash
+
+If Claude Code is not installed, the wizard will appear — verify it opens without a blank/broken title bar area.
+
+**Step 4: Commit**
+
+```bash
+git add electron/main.js
+git commit -m "feat(electron): platform-aware titleBarStyle and app menu for Windows"
+```
+
+---
+
+### Task 5: `.github/workflows/release-windows.yml` — CI workflow
+
+**Files:**
+- Create: `.github/workflows/release-windows.yml`
+
+**Step 1: Create the workflow file**
+
+```yaml
+name: Release Windows
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Build Windows installer
+        run: node scripts/build.js --win
+
+      - name: Upload artifacts to release
+        shell: bash
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            dist-output/*.exe \
+            dist-output/*.blockmap \
+            dist-output/latest.yml \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Note: `shell: bash` on the upload step is required because PowerShell does not expand glob patterns (`*.exe`) the way bash does. GitHub Actions Windows runners have Git Bash available.
+
+**Step 2: Verify the workflow file is valid YAML**
+
+```powershell
+node -e "
+const fs = require('fs');
+const content = fs.readFileSync('.github/workflows/release-windows.yml', 'utf8');
+console.log('File size:', content.length, 'bytes');
+console.log('Trigger:', content.includes('release:') ? 'OK' : 'MISSING');
+console.log('Windows runner:', content.includes('windows-latest') ? 'OK' : 'MISSING');
+console.log('GH_TOKEN:', content.includes('GITHUB_TOKEN') ? 'OK' : 'MISSING');
+"
+```
+
+Expected output:
+```
+File size: <number> bytes
+Trigger: OK
+Windows runner: OK
+GH_TOKEN: OK
+```
+
+**Step 3: Commit**
+
+```bash
+git add .github/workflows/release-windows.yml
+git commit -m "ci: add Windows release workflow triggered on release published"
+```
+
+---
+
+## How to release after these changes
+
+**Windows release (this fork — no Apple creds):**
+```powershell
+node scripts/release.js 0.8.12
+```
+This builds the NSIS `.exe` locally (since no `.env`/Apple creds), creates the GitHub Release, uploads the Windows artifacts. The CI workflow then fires and re-uploads (idempotent via `--clobber`).
+
+Wait — actually on this fork, `release.js` creates the GitHub Release with the Windows artifacts directly. The CI workflow then fires from the `release: published` event, rebuilds, and uploads again via `--clobber`. This is fine — the CI upload is idempotent.
+
+**Mac release (original repo, with Apple creds in `.env`):**
+```bash
+node scripts/release.js 0.8.12
+```
+Builds DMG, notarizes, staples, creates GitHub Release with Mac artifacts. The CI Windows workflow fires automatically after the release is published and adds the NSIS `.exe` to the same release.

--- a/docs/plans/2026-06-07-windows-support.md.tasks.json
+++ b/docs/plans/2026-06-07-windows-support.md.tasks.json
@@ -4,7 +4,7 @@
     {
       "id": 3,
       "subject": "Task 1: package.json — add win/nsis build config and fix output path",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": 4,
@@ -15,18 +15,18 @@
     {
       "id": 5,
       "subject": "Task 3: scripts/release.js — platform detection, fix DIST_DIR, conditional artifacts",
-      "status": "pending",
+      "status": "completed",
       "blockedBy": [3]
     },
     {
       "id": 6,
       "subject": "Task 4: electron/main.js — Windows UI conditionals",
-      "status": "pending"
+      "status": "completed"
     },
     {
       "id": 7,
       "subject": "Task 5: .github/workflows/release-windows.yml — CI workflow",
-      "status": "pending"
+      "status": "completed"
     }
   ],
   "lastUpdated": "2026-06-07T00:00:00Z"

--- a/docs/plans/2026-06-07-windows-support.md.tasks.json
+++ b/docs/plans/2026-06-07-windows-support.md.tasks.json
@@ -1,0 +1,33 @@
+{
+  "planPath": "docs/plans/2026-06-07-windows-support.md",
+  "tasks": [
+    {
+      "id": 3,
+      "subject": "Task 1: package.json — add win/nsis build config and fix output path",
+      "status": "pending"
+    },
+    {
+      "id": 4,
+      "subject": "Task 2: scripts/build.js — add hasAppleCreds(), default to --win",
+      "status": "pending",
+      "blockedBy": [3]
+    },
+    {
+      "id": 5,
+      "subject": "Task 3: scripts/release.js — platform detection, fix DIST_DIR, conditional artifacts",
+      "status": "pending",
+      "blockedBy": [3]
+    },
+    {
+      "id": 6,
+      "subject": "Task 4: electron/main.js — Windows UI conditionals",
+      "status": "pending"
+    },
+    {
+      "id": 7,
+      "subject": "Task 5: .github/workflows/release-windows.yml — CI workflow",
+      "status": "pending"
+    }
+  ],
+  "lastUpdated": "2026-06-07T00:00:00Z"
+}

--- a/electron/main.js
+++ b/electron/main.js
@@ -106,7 +106,7 @@ function showWizard() {
       resizable: false,
       minimizable: false,
       maximizable: false,
-      titleBarStyle: 'hiddenInset',
+      titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
       webPreferences: {
         preload: path.join(__dirname, 'preload.js'),
         nodeIntegration: false,
@@ -155,51 +155,76 @@ ipcMain.handle('get-app-version', () => app.getVersion());
 // ===== APP MENU =====
 
 function setupMenu() {
-  const template = [
-    {
-      label: 'Rundock',
-      submenu: [
-        { label: 'About Rundock', role: 'about' },
-        { label: 'Check for Updates', click: () => {
-          if (!autoUpdater) {
-            dialog.showMessageBox(mainWindow, {
-              type: 'info',
-              message: 'Auto-update is not available in this build.',
-              buttons: ['OK'],
-            });
-            return;
-          }
-          isCheckingManually = true;
-          autoUpdater.checkForUpdates().catch((err) => {
-            isCheckingManually = false;
-            dialog.showMessageBox(mainWindow, {
-              type: 'error',
-              message: 'Could not check for updates',
-              detail: err && err.message ? err.message : String(err),
-              buttons: ['OK'],
-            });
-          });
-        } },
-        { type: 'separator' },
-        { label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: () => { app.quit(); } },
-      ],
-    },
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo' }, { role: 'redo' }, { type: 'separator' },
-        { role: 'cut' }, { role: 'copy' }, { role: 'paste' }, { role: 'selectAll' },
-      ],
-    },
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' }, { role: 'toggleDevTools' },
-        { type: 'separator' },
-        { role: 'zoomIn' }, { role: 'zoomOut' }, { role: 'resetZoom' },
-      ],
-    },
-  ];
+  const checkForUpdatesItem = { label: 'Check for Updates', click: () => {
+    if (!autoUpdater) {
+      dialog.showMessageBox(mainWindow, {
+        type: 'info',
+        message: 'Auto-update is not available in this build.',
+        buttons: ['OK'],
+      });
+      return;
+    }
+    isCheckingManually = true;
+    autoUpdater.checkForUpdates().catch((err) => {
+      isCheckingManually = false;
+      dialog.showMessageBox(mainWindow, {
+        type: 'error',
+        message: 'Could not check for updates',
+        detail: err && err.message ? err.message : String(err),
+        buttons: ['OK'],
+      });
+    });
+  } };
+
+  const editMenu = {
+    label: 'Edit',
+    submenu: [
+      { role: 'undo' }, { role: 'redo' }, { type: 'separator' },
+      { role: 'cut' }, { role: 'copy' }, { role: 'paste' }, { role: 'selectAll' },
+    ],
+  };
+
+  const viewMenu = {
+    label: 'View',
+    submenu: [
+      { role: 'reload' }, { role: 'toggleDevTools' },
+      { type: 'separator' },
+      { role: 'zoomIn' }, { role: 'zoomOut' }, { role: 'resetZoom' },
+    ],
+  };
+
+  const template = process.platform === 'darwin'
+    ? [
+        {
+          label: 'Rundock',
+          submenu: [
+            { label: 'About Rundock', role: 'about' },
+            checkForUpdatesItem,
+            { type: 'separator' },
+            { label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: () => { app.quit(); } },
+          ],
+        },
+        editMenu,
+        viewMenu,
+      ]
+    : [
+        {
+          label: 'File',
+          submenu: [
+            { label: 'Quit', accelerator: 'CmdOrCtrl+Q', click: () => { app.quit(); } },
+          ],
+        },
+        editMenu,
+        viewMenu,
+        {
+          label: 'Help',
+          submenu: [
+            { label: 'About Rundock', role: 'about' },
+            checkForUpdatesItem,
+          ],
+        },
+      ];
+
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,22 @@
 {
   "name": "rundock",
-  "version": "0.7.2",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rundock",
-      "version": "0.7.2",
+      "version": "0.8.12",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "electron-updater": "^6.6.0",
         "marked": "^17.0.5",
         "ws": "^8.18.0"
       },
       "devDependencies": {
+        "dotenv": "^16.0.0",
         "electron": "^35.0.0",
-        "electron-builder": "^26.0.0",
-        "electron-updater": "^6.6.0"
+        "electron-builder": "^26.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -429,6 +430,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -450,6 +452,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -466,6 +469,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -480,6 +484,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -916,7 +921,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1141,7 +1145,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assert-plus": {
@@ -1336,7 +1339,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1730,7 +1732,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1774,7 +1777,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2252,7 +2254,6 @@
       "version": "6.8.3",
       "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
       "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "builder-util-runtime": "9.5.1",
@@ -2269,7 +2270,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -2284,7 +2284,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -2297,7 +2296,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2310,7 +2308,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -2323,6 +2320,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2343,6 +2341,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -2903,7 +2902,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3229,7 +3227,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3297,7 +3294,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -3311,7 +3307,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
@@ -3319,7 +3314,6 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -3641,6 +3635,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -3652,7 +3647,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -3975,7 +3969,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4005,6 +3998,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -4022,6 +4016,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -4213,6 +4208,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4281,7 +4277,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4614,6 +4609,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -4695,7 +4691,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rundock",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "A visual interface for AI agent teams. Built for people running their own businesses, powered by Claude Code.",
   "main": "electron/main.js",
   "scripts": {
@@ -77,7 +77,14 @@
     },
     "win": {
       "icon": "electron/build/icon.ico",
-      "target": [{ "target": "nsis", "arch": ["x64"] }]
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
     },
     "nsis": {
       "oneClick": true,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "dotenv": "^16.0.0",
     "electron": "^35.0.0",
     "electron-builder": "^26.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "appId": "ai.rundock.app",
     "productName": "Rundock",
     "directories": {
-      "output": "/tmp/rundock-dist"
+      "output": "dist-output"
     },
     "files": [
       "server.js",
@@ -74,6 +74,17 @@
           "path": "/Applications"
         }
       ]
+    },
+    "win": {
+      "icon": "electron/build/icon.ico",
+      "target": [{ "target": "nsis", "arch": ["x64"] }]
+    },
+    "nsis": {
+      "oneClick": true,
+      "perMachine": false,
+      "artifactName": "Rundock-${version}-Setup.exe",
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true
     },
     "publish": {
       "provider": "github",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,7 +41,7 @@ try {
   execFileSync(
     path.join(__dirname, '..', 'node_modules', '.bin', 'electron-builder'),
     args,
-    { stdio: 'inherit', cwd: path.join(__dirname, '..') }
+    { stdio: 'inherit', cwd: path.join(__dirname, '..'), shell: true }
   );
 } catch (err) {
   process.exit(err.status || 1);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,8 +25,15 @@ if (fs.existsSync(envPath)) {
   console.warn('[build] No .env file found. Signing and notarisation will be skipped.');
 }
 
-// Forward all CLI args to electron-builder
-const args = ['--mac', ...process.argv.slice(2)];
+function hasAppleCreds() {
+  return !!(process.env.CSC_LINK && process.env.APPLE_API_KEY);
+}
+
+const explicitMac = process.argv.includes('--mac');
+const explicitWin = process.argv.includes('--win');
+const platform = explicitMac ? '--mac' : explicitWin ? '--win' : hasAppleCreds() ? '--mac' : '--win';
+const extraArgs = process.argv.slice(2).filter(a => a !== '--mac' && a !== '--win');
+const args = [platform, ...extraArgs];
 
 console.log(`[build] Running: electron-builder ${args.join(' ')}`);
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -13,6 +13,9 @@
  *   6. Bump the download buttons in the Rundock Site repo to the new DMG
  *      and push (skipped if the site repo is dirty or not on main)
  *
+ * On Windows (no Apple credentials in .env), steps 2–4 and 6 are skipped.
+ * The build produces an NSIS .exe + latest.yml instead of DMG + ZIP.
+ *
  * Usage:
  *   node scripts/release.js <version>
  *   npm run release -- <version>
@@ -52,6 +55,17 @@ function hasAppleCreds() {
   return !!(process.env.CSC_LINK && process.env.APPLE_API_KEY);
 }
 
+function hasAnyAppleCred() {
+  return !!(
+    process.env.CSC_LINK ||
+    process.env.CSC_KEY_PASSWORD ||
+    process.env.APPLE_API_KEY ||
+    process.env.APPLE_API_KEY_ID ||
+    process.env.APPLE_API_ISSUER ||
+    process.env.APPLE_TEAM_ID
+  );
+}
+
 function loadEnv() {
   const envPath = path.join(ROOT, '.env');
   if (fs.existsSync(envPath)) {
@@ -61,7 +75,7 @@ function loadEnv() {
     log('env', 'No .env file found, proceeding without signing credentials.');
   }
 
-  if (hasAppleCreds()) {
+  if (hasAnyAppleCred()) {
     const required = [
       'APPLE_API_KEY',
       'APPLE_API_KEY_ID',
@@ -128,7 +142,7 @@ function submitNotarisation() {
   log('notarise', 'Submitting for Apple notarisation...');
 
   // Zip the .app for submission
-  const zipPath = '/tmp/rundock-dist/Rundock-notarize.zip';
+  const zipPath = path.join(DIST_DIR, 'Rundock-notarize.zip');
   try {
     execSync(
       `ditto -c -k --keepParent "${APP_PATH}" "${zipPath}"`,
@@ -544,7 +558,9 @@ if (hasAppleCreds()) {
   updateSiteDownloadUrls(version);
 }
 
-const dmgPath = path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`);
+const artifactPath = hasAppleCreds()
+  ? path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`)
+  : path.join(DIST_DIR, `Rundock-${version}-Setup.exe`);
 
 console.log('');
-log('done', `Release complete: ${dmgPath}`);
+log('done', `Release complete: ${artifactPath}`);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -31,8 +31,8 @@ const path = require('path');
 const fs = require('fs');
 
 const ROOT = path.join(__dirname, '..');
-const APP_PATH = '/tmp/rundock-dist/mac-arm64/Rundock.app';
-const DIST_DIR = '/tmp/rundock-dist';
+const DIST_DIR = path.join(ROOT, 'dist-output');
+const APP_PATH = path.join(DIST_DIR, 'mac-arm64', 'Rundock.app');
 const POLL_INTERVAL_MS = 30_000;
 
 // ---------------------------------------------------------------------------
@@ -48,26 +48,32 @@ function fail(step, msg) {
   process.exit(1);
 }
 
+function hasAppleCreds() {
+  return !!(process.env.CSC_LINK && process.env.APPLE_API_KEY);
+}
+
 function loadEnv() {
   const envPath = path.join(ROOT, '.env');
   if (fs.existsSync(envPath)) {
     require('dotenv').config({ path: envPath });
     log('env', 'Loaded .env');
   } else {
-    fail('env', 'No .env file found. Cannot sign or notarise without credentials.');
+    log('env', 'No .env file found, proceeding without signing credentials.');
   }
 
-  const required = [
-    'APPLE_API_KEY',
-    'APPLE_API_KEY_ID',
-    'APPLE_API_ISSUER',
-    'CSC_LINK',
-    'CSC_KEY_PASSWORD',
-    'APPLE_TEAM_ID',
-  ];
-  const missing = required.filter((k) => !process.env[k]);
-  if (missing.length) {
-    fail('env', `Missing required env vars: ${missing.join(', ')}`);
+  if (hasAppleCreds()) {
+    const required = [
+      'APPLE_API_KEY',
+      'APPLE_API_KEY_ID',
+      'APPLE_API_ISSUER',
+      'CSC_LINK',
+      'CSC_KEY_PASSWORD',
+      'APPLE_TEAM_ID',
+    ];
+    const missing = required.filter((k) => !process.env[k]);
+    if (missing.length) {
+      fail('env', `Missing required env vars: ${missing.join(', ')}`);
+    }
   }
 }
 
@@ -96,21 +102,26 @@ function setVersion() {
 }
 
 function build() {
-  log('build', 'Running electron-builder --mac');
+  const platform = hasAppleCreds() ? '--mac' : '--win';
+  log('build', `Running electron-builder ${platform}`);
   try {
     execFileSync(
       path.join(ROOT, 'node_modules', '.bin', 'electron-builder'),
-      ['--mac', '--publish', 'never'],
+      [platform, '--publish', 'never'],
       { stdio: 'inherit', cwd: ROOT }
     );
   } catch (err) {
     fail('build', `electron-builder exited with code ${err.status || 1}`);
   }
 
-  if (!fs.existsSync(APP_PATH)) {
-    fail('build', `Expected .app not found at ${APP_PATH}`);
+  if (hasAppleCreds()) {
+    if (!fs.existsSync(APP_PATH)) {
+      fail('build', `Expected .app not found at ${APP_PATH}`);
+    }
+    log('build', `Built ${APP_PATH}`);
+  } else {
+    log('build', `Built Windows artifacts in ${DIST_DIR}`);
   }
-  log('build', `Built ${APP_PATH}`);
 }
 
 function submitNotarisation() {
@@ -371,12 +382,17 @@ function commitAndPush(version) {
 
 function publishRelease(version) {
   const tag = `v${version}`;
-  const dmg = path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`);
-  const dmgBlockmap = `${dmg}.blockmap`;
-  const zip = path.join(DIST_DIR, `Rundock-${version}-arm64-mac.zip`);
-  const zipBlockmap = `${zip}.blockmap`;
-  const feed = path.join(DIST_DIR, 'latest-mac.yml');
-  const assets = [dmg, dmgBlockmap, zip, zipBlockmap, feed];
+  let assets;
+  if (hasAppleCreds()) {
+    const dmg = path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`);
+    const zip = path.join(DIST_DIR, `Rundock-${version}-arm64-mac.zip`);
+    const feed = path.join(DIST_DIR, 'latest-mac.yml');
+    assets = [dmg, `${dmg}.blockmap`, zip, `${zip}.blockmap`, feed];
+  } else {
+    const setup = path.join(DIST_DIR, `Rundock-${version}-Setup.exe`);
+    const feed = path.join(DIST_DIR, 'latest.yml');
+    assets = [setup, `${setup}.blockmap`, feed];
+  }
 
   for (const a of assets) {
     if (!fs.existsSync(a)) fail('publish', `Missing release artifact: ${a}`);
@@ -514,13 +530,19 @@ loadEnv();
 promoteUnreleasedChangelog(process.argv[2]);
 commitAndPush(process.argv[2]);
 build();
-const submissionId = submitNotarisation();
-pollNotarisation(submissionId);
-staple();
+
+if (hasAppleCreds()) {
+  const submissionId = submitNotarisation();
+  pollNotarisation(submissionId);
+  staple();
+}
 
 const version = process.argv[2];
 publishRelease(version);
-updateSiteDownloadUrls(version);
+
+if (hasAppleCreds()) {
+  updateSiteDownloadUrls(version);
+}
 
 const dmgPath = path.join(DIST_DIR, `Rundock-${version}-arm64.dmg`);
 


### PR DESCRIPTION
## Description

This PR adds Windows installer support to Rundock, allowing the application to be built and distributed as a Windows NSIS installer (.exe) alongside the existing macOS DMG distribution.

## Why

Rundock previously only supported macOS distribution. Windows users couldn't easily install or use the application. This change implements platform-aware build scripts that default to Windows builds when Apple signing credentials are absent, while preserving the existing macOS pipeline when credentials are present. The implementation includes platform-specific UI adaptations (title bar style, app menu structure) and automated Windows releases via GitHub Actions.

## Testing

- Built Windows installer locally using `node scripts/build.js --win`
- Verified NSIS installer creates desktop and Start Menu shortcuts
- Launched application on Windows - confirmed title bar renders correctly with default style (not hiddenInset)
- Verified app menu structure shows File/Edit/View/Help on Windows (vs Rundock/Edit/View on macOS)
- Tested "Check for Updates" appears under Help menu on Windows
- Verified platform detection in build scripts correctly defaults to Windows when Apple credentials absent
- Confirmed GitHub Actions workflow builds Windows installer on release publishing

## Checklist

- [x] Code changes are scoped to one logical concern
- [x] CHANGELOG.md updated under `## Unreleased` if user-visible
- [x] No accidental edits to `.env`, secrets, or build output