### PR TITLE
fix(server): dynamically expand MCP server scopes to satisfy Claude Code v2.1.166+ allow-rule validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
+## Unreleased
+
+**Name:** MCP Wildcard Fix
+
+### Fixed
+
+- **MCP tools are allowed without errors on Claude Code v2.1.166 and later.** Rundock previously passed `mcp__*` as a blanket allow rule for MCP tools. Claude Code v2.1.166 tightened wildcard validation: allow rules must name the specific server scope (e.g. `mcp__gmail__*`) rather than a global `mcp__*` wildcard. Rundock now reads `.claude/mcp.json` at startup and expands registered server names into per-server wildcard entries (e.g. `mcp__gmail__*,mcp__gcal__*`). Workspaces without an MCP config are unaffected.
+
 ## 0.8.11: Rich Markdown Editor & Find (2026-05-28)
 
 ### Added

--- a/server.js
+++ b/server.js
@@ -23,8 +23,42 @@ let WORKSPACE = process.env.WORKSPACE || null;
 const DISALLOWED_TOOLS_KNOWLEDGE = 'Write(*.js),Write(*.jsx),Write(*.ts),Write(*.tsx),Write(*.py),Write(*.sh),Write(*.bash),Write(*.rb),Write(*.pl),Write(*.exe),Write(*.dll),Write(*.so),Edit(*.js),Edit(*.jsx),Edit(*.ts),Edit(*.tsx),Edit(*.py),Edit(*.sh),Edit(*.bash),Edit(*.rb),Edit(*.pl),Edit(*.exe)';
 // Backward compat: DISALLOWED_TOOLS used by existing code paths
 const DISALLOWED_TOOLS = DISALLOWED_TOOLS_KNOWLEDGE;
-const ALLOWED_TOOLS_INTERACTIVE = 'Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill,mcp__*';
-const ALLOWED_TOOLS_LEGACY = 'Bash,WebFetch,WebSearch,mcp__*';
+
+/**
+ * Dynamically resolves registered MCP server scopes to satisfy 
+ * Claude Code v2.1.166+ strict wildcard validation patterns.
+ */
+function getMcpAllowedToolsString() {
+  try {
+    // Locate the standard Claude MCP setup manifest in the active working directory
+    const mcpConfigPath = path.join(process.cwd(), '.claude', 'mcp.json');
+
+    if (fs.existsSync(mcpConfigPath)) {
+      const configRaw = fs.readFileSync(mcpConfigPath, 'utf8');
+      const config = JSON.parse(configRaw);
+
+      if (config && config.mcpServers) {
+        const serverNames = Object.keys(config.mcpServers);
+        if (serverNames.length > 0) {
+          // Transforms ['gmail', 'gcal'] into ',mcp__gmail__*,mcp__gcal__*'
+          return ',' + serverNames.map(name => `mcp__${name}__*`).join(',');
+        }
+      }
+    }
+  } catch (error) {
+    // Fail silently to prevent throwing initialization noise during boot routines
+    console.warn('[Rundock] Note: Skipping dynamic MCP tool expansion:', error.message);
+  }
+  return '';
+}
+
+// Construct the base capabilities arrays dynamically
+const ALLOWED_TOOLS_INTERACTIVE = `Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill${getMcpAllowedToolsString()}`;
+const ALLOWED_TOOLS_LEGACY = `Bash,WebFetch,WebSearch${getMcpAllowedToolsString()}`;
+
+// const ALLOWED_TOOLS_INTERACTIVE = 'Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill,mcp__*';
+// const ALLOWED_TOOLS_LEGACY = 'Bash,WebFetch,WebSearch,mcp__*';
+
 
 // Returns the disallowed-tools string based on workspace mode.
 // Code mode: no file type restrictions (empty string).

--- a/server.js
+++ b/server.js
@@ -56,10 +56,6 @@ function getMcpAllowedToolsString() {
 const ALLOWED_TOOLS_INTERACTIVE = `Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill${getMcpAllowedToolsString()}`;
 const ALLOWED_TOOLS_LEGACY = `Bash,WebFetch,WebSearch${getMcpAllowedToolsString()}`;
 
-// const ALLOWED_TOOLS_INTERACTIVE = 'Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill,mcp__*';
-// const ALLOWED_TOOLS_LEGACY = 'Bash,WebFetch,WebSearch,mcp__*';
-
-
 // Returns the disallowed-tools string based on workspace mode.
 // Code mode: no file type restrictions (empty string).
 // Knowledge mode: block executable file writes.


### PR DESCRIPTION
## Description

Replaces the blanket `mcp__*` wildcard in `--allowedTools` with a dynamic per-server expansion. At startup, Rundock reads `.claude/mcp.json`, enumerates the registered server names, and constructs individual `mcp__<server>__*` entries (e.g. `mcp__gmail__*,mcp__gcal__*`). Workspaces without an MCP config are unaffected.

## Why

Closes #8.

Claude Code v2.1.166 tightened wildcard validation on allow rules. A global `mcp__*` wildcard is now rejected with:

```
Error: Ignoring --allowedTools rule "mcp__*": Wildcard tool name "mcp__*" is not supported in allow rules. An allow pattern must name the scope it widens — globs are permitted only in the tool position after a literal mcp__<server>__ prefix. Deny and ask rules accept wildcards anywhere.
```

This is a deliberate security constraint: a blanket allow rule would silently pre-approve tools from any new or compromised MCP server without user awareness. The fix satisfies the new validation while maintaining the same UX: MCP tools from configured servers are still auto-approved without per-invocation prompts.

## Testing

1. Add one or more MCP servers to `.claude/mcp.json`.
2. Start Rundock.
3. Confirm the warning no longer appears in server output.
4. Confirm MCP tools from registered servers are available and auto-approved in a conversation.
5. Remove `.claude/mcp.json` entirely and restart — confirm Rundock starts without errors and no MCP entries are added to the allow list.

## Checklist

- [x] Code changes are scoped to one logical concern
- [x] CHANGELOG.md updated under `## Unreleased`
- [x] No accidental edits to `.env`, secrets, or build output