### PR TITLE
Codex runtime: run agents on the Codex CLI

### DIFF
--- a/codex.js
+++ b/codex.js
@@ -175,10 +175,37 @@ function detectCodex(deps = {}) {
 // ordinary failures are never misclassified as quota.
 const CODEX_QUOTA_RE = /usage limit/i;
 function isCodexQuotaError(text) {
-  return typeof text === 'string' && CODEX_QUOTA_RE.test(text);
+  return classifyCodexError(text).kind === 'quota';
+}
+
+// Classifies a Codex CLI failure message so the server can surface guidance
+// instead of raw transport noise. Every pattern is keyed to a message
+// captured from a real failure; keep them narrow so ordinary failures fall
+// through to 'unknown' and surface verbatim.
+//
+// Kinds:
+//   quota    plan-limit exhaustion ("usage limit")
+//   model    the configured model is not available on this account
+//            (captured: 400 invalid_request_error "The 'gpt-5.3-codex' model
+//            is not supported when using Codex with a ChatGPT account.")
+//   auth     signed out: 401/missing-bearer transport noise or the CLI's own
+//            "not logged in" wording
+//   unknown  everything else
+const CODEX_MODEL_NAME_RE = /The '([^']+)' model is not supported/;
+const CODEX_MODEL_RE = /\bmodel\b[^.]*\bis not supported\b/i;
+const CODEX_AUTH_RE = /401 unauthorized|missing bearer or basic authentication|not (?:logged|signed) in/i;
+function classifyCodexError(text) {
+  if (typeof text !== 'string' || !text) return { kind: 'unknown', model: null };
+  if (CODEX_QUOTA_RE.test(text)) return { kind: 'quota', model: null };
+  if (CODEX_MODEL_RE.test(text)) {
+    const m = text.match(CODEX_MODEL_NAME_RE);
+    return { kind: 'model', model: m ? m[1] : null };
+  }
+  if (CODEX_AUTH_RE.test(text)) return { kind: 'auth', model: null };
+  return { kind: 'unknown', model: null };
 }
 
 module.exports = {
   buildCodexArgs, parseCodexLine, resolveCodexBin, detectCodex, isCodexQuotaError,
-  isValidThreadId,
+  classifyCodexError, isValidThreadId,
 };

--- a/codex.js
+++ b/codex.js
@@ -146,7 +146,7 @@ function detectCodex(deps = {}) {
   let version = null;
   try {
     const out = exec(`"${bin}" --version`, { timeout: 5000, encoding: 'utf-8' });
-    const m = String(out).match(/(\d+\.\d+(?:\.\d+)?)/);
+    const m = String(out).match(/(\d+\.\d+(?:\.\d+)?(?:-[A-Za-z0-9.]+)?)/);
     version = m ? m[1] : null;
   } catch (e) { /* installed but --version failed: keep version null */ }
 

--- a/codex.js
+++ b/codex.js
@@ -14,8 +14,14 @@
 //   - Only the official `codex` binary is ever spawned. No OpenAI/ChatGPT
 //     endpoints are called directly and no OAuth material is read: auth
 //     detection is the PRESENCE of auth.json, never its contents.
-//   - Codex runs inside its own sandbox (workspace-write). Approval/sandbox
-//     bypass flags are never passed; a test pins this.
+//   - workspace-write is REQUESTED on every spawn; effective enforcement is
+//     platform-dependent. macOS (Seatbelt) and Linux (Landlock) enforce it;
+//     native Windows cannot yet, and the CLI silently downgrades to a
+//     read-only sandbox there (verified live: the native AppContainer
+//     sandbox fails to initialise on ARM64). Windows writes therefore go
+//     through WRITE_FILE markers + Rundock permission cards instead (see
+//     parseWriteMarkers below). Approval/sandbox bypass flags are never
+//     passed; a test pins this.
 //
 // Normalised events returned by parseCodexLine():
 //   { type: 'session', threadId }                      thread.started
@@ -205,7 +211,33 @@ function classifyCodexError(text) {
   return { kind: 'unknown', model: null };
 }
 
+// ── Write-request markers (Windows) ─────────────────────────────────────────
+
+// The Codex CLI cannot enforce its write sandbox on native Windows: it
+// silently downgrades workspace-write to read-only (verified live; the
+// native AppContainer sandbox fails to initialise on ARM64). Rather than
+// leave Windows Codex agents read-only or pass bypass flags (pinned-never),
+// win32 spawns are instructed to request writes as markers in their
+// response. The server validates each request and performs the write itself
+// after the user approves a permission card. Mac/Linux spawns never get the
+// instruction and their markers are not honoured: the OS sandbox writes
+// directly there.
+const WRITE_MARKER_RE = /<!-- RUNDOCK:WRITE_FILE path="([^"\n]+)" -->\n([\s\S]*?)\n?<!-- \/RUNDOCK:WRITE_FILE -->/g;
+
+// Returns { cleanText, requests: [{ path, content }] }. cleanText replaces
+// each marker block with a short plain-language line so the conversation
+// shows intent without the payload; the card carries the full content.
+function parseWriteMarkers(text) {
+  if (typeof text !== 'string' || !text) return { cleanText: '', requests: [] };
+  const requests = [];
+  const cleanText = text.replace(WRITE_MARKER_RE, (m, p, content) => {
+    requests.push({ path: p, content });
+    return `[write requested: ${p}]`;
+  });
+  return { cleanText, requests };
+}
+
 module.exports = {
   buildCodexArgs, parseCodexLine, resolveCodexBin, detectCodex, isCodexQuotaError,
-  classifyCodexError, isValidThreadId,
+  classifyCodexError, isValidThreadId, parseWriteMarkers,
 };

--- a/codex.js
+++ b/codex.js
@@ -38,10 +38,20 @@ const { execSync } = require('node:child_process');
 // knowledge workspaces are frequently not git repositories and the CLI
 // refuses to run in one otherwise. The model flag is passed only when the
 // agent's frontmatter sets one; Codex's own default applies otherwise.
+// Thread ids appear in argv as a positional after the `resume` subcommand,
+// where the CLI still parses flags. A client-supplied id starting with a
+// hyphen could therefore smuggle flags (including the forbidden bypass
+// flags) into the invocation. Ids must start with an alphanumeric and stay
+// within a safe charset; anything else starts a fresh thread instead.
+const THREAD_ID_RE = /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/;
+function isValidThreadId(id) {
+  return typeof id === 'string' && THREAD_ID_RE.test(id);
+}
+
 function buildCodexArgs({ resumeThreadId, model } = {}) {
   const args = ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check'];
   if (model) args.push('--model', model);
-  if (resumeThreadId) args.push('resume', resumeThreadId);
+  if (resumeThreadId && isValidThreadId(resumeThreadId)) args.push('resume', resumeThreadId);
   args.push('-');
   return args;
 }
@@ -170,4 +180,5 @@ function isCodexQuotaError(text) {
 
 module.exports = {
   buildCodexArgs, parseCodexLine, resolveCodexBin, detectCodex, isCodexQuotaError,
+  isValidThreadId,
 };

--- a/codex.js
+++ b/codex.js
@@ -169,7 +169,43 @@ function detectCodex(deps = {}) {
   const codexHome = env.CODEX_HOME || path.join(homedir(), '.codex');
   const authenticated = !!exists(path.join(codexHome, 'auth.json'));
 
-  return { installed: true, authenticated, version };
+  // Windows only: whether the config declares a native sandbox (see
+  // hasWindowsSandboxConfig). null off-Windows (not applicable). Honours
+  // the RUNDOCK_TEST_PLATFORM seam for this field ONLY: binary resolution
+  // above must stay on the real platform or the probes break in CI.
+  const effectivePlatform = env.RUNDOCK_TEST_PLATFORM || platform;
+  const windowsSandbox = effectivePlatform === 'win32'
+    ? hasWindowsSandboxConfig({ homedir, env })
+    : null;
+
+  return { installed: true, authenticated, version, windowsSandbox };
+}
+
+// Presence-only scan of the Codex config for a [windows] table declaring a
+// sandbox. When declared, the CLI grants a real workspace-write policy on
+// Windows (in-process patch writes and sandboxed commands, workspace-
+// bounded), so Rundock's write-marker fallback stands down. When absent,
+// the CLI silently downgrades workspace-write to read-only (verified live)
+// and the marker fallback carries writes instead. The VALUE is never acted
+// on: any declared sandbox mode counts, mirroring the presence-only
+// principle used for auth detection.
+function hasWindowsSandboxConfig(deps = {}) {
+  const read = deps.readFileSync || fs.readFileSync;
+  const homedir = deps.homedir || os.homedir;
+  const env = deps.env || process.env;
+  try {
+    const cfgPath = path.join(env.CODEX_HOME || path.join(homedir(), '.codex'), 'config.toml');
+    const lines = String(read(cfgPath, 'utf-8')).split(/\r?\n/);
+    let inWindows = false;
+    for (const raw of lines) {
+      const line = raw.trim();
+      if (line.startsWith('[')) { inWindows = line === '[windows]'; continue; }
+      if (inWindows && /^sandbox\s*=/.test(line)) return true;
+    }
+    return false;
+  } catch (e) {
+    return false;
+  }
 }
 
 // ── Error classification ───────────────────────────────────────────────────
@@ -239,5 +275,5 @@ function parseWriteMarkers(text) {
 
 module.exports = {
   buildCodexArgs, parseCodexLine, resolveCodexBin, detectCodex, isCodexQuotaError,
-  classifyCodexError, isValidThreadId, parseWriteMarkers,
+  classifyCodexError, isValidThreadId, parseWriteMarkers, hasWindowsSandboxConfig,
 };

--- a/codex.js
+++ b/codex.js
@@ -1,0 +1,173 @@
+'use strict';
+// Codex runtime adapter.
+//
+// Rundock agents can run on the OpenAI Codex CLI (a user's ChatGPT plan)
+// alongside Claude Code. This module owns everything Codex-specific:
+//
+//   - buildCodexArgs():  argv for `codex exec --json` turns (fresh + resume)
+//   - parseCodexLine():  one JSONL line -> one normalised event, or null
+//   - detectCodex():     is the CLI installed / signed in / which version
+//   - resolveCodexBin(): absolute binary path, Windows .cmd shim aware
+//   - isCodexQuotaError(): classifies plan-limit errors for friendly surfacing
+//
+// Policy invariants (do not weaken):
+//   - Only the official `codex` binary is ever spawned. No OpenAI/ChatGPT
+//     endpoints are called directly and no OAuth material is read: auth
+//     detection is the PRESENCE of auth.json, never its contents.
+//   - Codex runs inside its own sandbox (workspace-write). Approval/sandbox
+//     bypass flags are never passed; a test pins this.
+//
+// Normalised events returned by parseCodexLine():
+//   { type: 'session', threadId }                      thread.started
+//   { type: 'text', text }                             item.completed (agent_message)
+//   { type: 'done', usage: {inputTokens, cachedInputTokens, outputTokens} }
+//                                                      turn.completed
+//   { type: 'error', message }                         turn.failed / error
+//   null                                               anything else (skip)
+
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+const { execSync } = require('node:child_process');
+
+// ── Argv construction ──────────────────────────────────────────────────────
+
+// Build argv for one Codex turn. The prompt travels via stdin (the trailing
+// `-`), matching how Rundock pipes prompts to Claude Code rather than putting
+// user content into argv. `--skip-git-repo-check` is required because
+// knowledge workspaces are frequently not git repositories and the CLI
+// refuses to run in one otherwise. The model flag is passed only when the
+// agent's frontmatter sets one; Codex's own default applies otherwise.
+function buildCodexArgs({ resumeThreadId, model } = {}) {
+  const args = ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check'];
+  if (model) args.push('--model', model);
+  if (resumeThreadId) args.push('resume', resumeThreadId);
+  args.push('-');
+  return args;
+}
+
+// ── Output parsing ─────────────────────────────────────────────────────────
+
+// Parse one line of `codex exec --json` output into a normalised event.
+// Unknown or malformed lines return null; callers may log and must skip.
+// The Codex CLI's output format can gain event types across versions, so
+// this parser is deliberately a whitelist of the four shapes Rundock needs.
+function parseCodexLine(line) {
+  if (!line || !line.trim()) return null;
+  let ev;
+  try { ev = JSON.parse(line); } catch (e) { return null; }
+  if (!ev || typeof ev !== 'object') return null;
+
+  switch (ev.type) {
+    case 'thread.started':
+      return { type: 'session', threadId: ev.thread_id };
+    case 'item.completed':
+      if (ev.item && ev.item.type === 'agent_message') {
+        return { type: 'text', text: ev.item.text };
+      }
+      return null; // command runs, reasoning steps etc: not user-facing
+    case 'turn.completed': {
+      const u = ev.usage || {};
+      return {
+        type: 'done',
+        usage: {
+          inputTokens: u.input_tokens || 0,
+          cachedInputTokens: u.cached_input_tokens || 0,
+          outputTokens: u.output_tokens || 0,
+        },
+      };
+    }
+    case 'turn.failed':
+      return { type: 'error', message: (ev.error && ev.error.message) || 'Codex turn failed' };
+    case 'error':
+      return { type: 'error', message: ev.message || 'Codex error' };
+    default:
+      return null;
+  }
+}
+
+// ── Binary resolution ──────────────────────────────────────────────────────
+
+// Resolve the absolute path of the codex binary. Mirrors the Claude binary
+// resolution: the absolute path lets Node spawn .cmd shims on Windows
+// WITHOUT `shell: true`, which would expose prompt-bearing argv to command
+// injection. On Windows, npm distributes `codex` as a .cmd shim, so the .cmd
+// branch is the EXPECTED case there; a standalone .exe is preferred when both
+// exist. On lookup failure the bare command is returned so spawn's 'error'
+// event surfaces the real ENOENT.
+function resolveCodexBin(deps = {}) {
+  const platform = deps.platform || process.platform;
+  const exec = deps.execSync || execSync;
+  const isWindows = platform === 'win32';
+  try {
+    const lookupCmd = isWindows ? 'where.exe codex' : 'which codex';
+    const output = exec(lookupCmd, { timeout: 5000, encoding: 'utf-8' }).trim();
+    if (!output) return 'codex';
+    if (isWindows) {
+      const candidates = output.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      const exe = candidates.find(c => c.toLowerCase().endsWith('.exe'));
+      const cmd = candidates.find(c => c.toLowerCase().endsWith('.cmd'));
+      return exe || cmd || candidates[0] || 'codex';
+    }
+    return output.split(/\r?\n/)[0].trim();
+  } catch (e) {
+    return 'codex';
+  }
+}
+
+// ── Detection ──────────────────────────────────────────────────────────────
+
+// Report whether Codex is usable on this machine:
+//   installed:     the CLI binary resolves
+//   authenticated: auth.json EXISTS under the Codex home. Presence only;
+//                  the file is never read or copied. Sign-in belongs to the
+//                  CLI (`codex login`), not to Rundock.
+//   version:       from `codex --version`, null if unparseable
+// The Codex home is $CODEX_HOME when set, else ~/.codex. Home resolution
+// goes through os.homedir() so Windows (USERPROFILE) works.
+function detectCodex(deps = {}) {
+  const exec = deps.execSync || execSync;
+  const exists = deps.existsSync || fs.existsSync;
+  const homedir = deps.homedir || os.homedir;
+  const env = deps.env || process.env;
+  const platform = deps.platform || process.platform;
+
+  const bin = resolveCodexBin({ execSync: exec, platform });
+  if (bin === 'codex') {
+    // Bare command means lookup failed: not installed (or not on PATH).
+    // A second probe distinguishes "on PATH but which failed" cheaply.
+    try {
+      exec(platform === 'win32' ? 'where.exe codex' : 'which codex', { timeout: 5000, encoding: 'utf-8' });
+    } catch (e) {
+      return { installed: false, authenticated: false, version: null };
+    }
+  }
+
+  let version = null;
+  try {
+    const out = exec(`"${bin}" --version`, { timeout: 5000, encoding: 'utf-8' });
+    const m = String(out).match(/(\d+\.\d+(?:\.\d+)?)/);
+    version = m ? m[1] : null;
+  } catch (e) { /* installed but --version failed: keep version null */ }
+
+  const codexHome = env.CODEX_HOME || path.join(homedir(), '.codex');
+  const authenticated = !!exists(path.join(codexHome, 'auth.json'));
+
+  return { installed: true, authenticated, version };
+}
+
+// ── Error classification ───────────────────────────────────────────────────
+
+// Detects the Codex CLI's plan-limit exhaustion wording so the UI can show a
+// friendly "limit reached" card instead of a raw error. Keyed on "usage
+// limit", the stable core of the message across observed variants. Extend
+// the pattern list as real-world variants are captured; keep it narrow so
+// ordinary failures are never misclassified as quota.
+const CODEX_QUOTA_RE = /usage limit/i;
+function isCodexQuotaError(text) {
+  return typeof text === 'string' && CODEX_QUOTA_RE.test(text);
+}
+
+module.exports = {
+  buildCodexArgs, parseCodexLine, resolveCodexBin, detectCodex, isCodexQuotaError,
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "dev": "node server.js",
     "test": "node --test $(find test -name '*.test.js')",
-    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=server.js --test-coverage-include=search.js --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage.lcov $(find test -name '*.test.js') && node test/tools/coverage-areas.js coverage.lcov",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=server.js --test-coverage-include=search.js --test-coverage-include=codex.js --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage.lcov $(find test -name '*.test.js') && node test/tools/coverage-areas.js coverage.lcov",
     "update": "git pull origin main && npm install && echo '\\n  Rundock updated. Run: npm start'",
     "electron": "electron .",
     "build:mac": "electron-builder --mac",

--- a/public/app.js
+++ b/public/app.js
@@ -306,6 +306,13 @@ function handle(d) {
           persistConversation(convo);
         }
       }
+      // Neutral notice: informational pill with NO side effects. Used for
+      // Codex write-request outcomes. Distinct from 'info', which doubles
+      // as the stale-session signal and clears the stored sessionId: that
+      // side effect must never fire for a routine notice.
+      if(d.subtype==='notice' && d.content && convoId) {
+        addSystemMsgToConvo(d.content, convoId, false);
+      }
       // Stale session: server is retrying fresh, clear the old sessionId
       if(d.subtype==='info' && d.content && convoId) {
         const convo = conversations.find(c => c.id === convoId);
@@ -2540,6 +2547,12 @@ function classifyRisk(toolName, input) {
     if (lowRisk) return 'low';
     return 'medium';
   }
+  if (toolName === 'WriteFile') {
+    // Codex write-request markers (Windows). Always high: every write gets
+    // its own card and "Always allow" is never offered. A standing allow
+    // here would let a prompt-injected agent write files ungated.
+    return 'high';
+  }
   if (toolName.startsWith('mcp__')) {
     // MCP reads auto-approve in the permission hook, so by the time a request
     // reaches the card it's a write or destructive action. Flag destructive ones
@@ -2574,6 +2587,14 @@ function describeToolRequest(toolName, input) {
     if (/(^|[;&|]\s*)(Remove-Item|ri|rm|del|erase|rmdir|rd)\b/i.test(cmd)) context = 'This will delete files';
     else if (/-Force\b/i.test(cmd)) context = 'This uses -Force and may overwrite or delete without confirmation';
     else if (/\b(iex|Invoke-Expression)\b/i.test(cmd)) context = 'This executes a downloaded or dynamic script';
+  } else if (toolName === 'WriteFile') {
+    // Codex write-request marker (Windows): the card IS the consent for the
+    // exact content shown, so the path leads and the payload is displayed.
+    const p = input.path || '';
+    const content = String(input.content || '');
+    summary = `Write ${p}`;
+    context = `${agentDisplayName(input.agent)} requested this file write. The content below will be written exactly as shown.`;
+    detail = content.length > 1500 ? content.slice(0, 1500) + `\n… (${content.length - 1500} more characters)` : content;
   } else if (toolName === 'Write') {
     summary = 'Create a file';
     detail = input.file_path || '';

--- a/public/app.js
+++ b/public/app.js
@@ -429,6 +429,12 @@ function handle(d) {
       if(d.subtype==='auth_error' && convoId) {
         renderAuthErrorCard(convoId);
       }
+      if(d.subtype==='keepalive' && convoId) {
+        // A runtime that emits no stream events (Codex) heartbeats instead;
+        // refresh the inactivity watchdog so long turns are not auto-finished.
+        const kaState = getConvoState(convoId);
+        if (kaState.isProcessing) kaState.lastStreamActivity = Date.now();
+      }
       if(d.subtype==='codex_quota' && convoId) {
         renderCodexQuotaCard(convoId, d);
         finishProcessing(convoId);

--- a/public/app.js
+++ b/public/app.js
@@ -439,6 +439,10 @@ function handle(d) {
         renderCodexQuotaCard(convoId, d);
         finishProcessing(convoId);
       }
+      if(d.subtype==='codex_guidance' && convoId) {
+        renderCodexGuidanceCard(convoId, d);
+        finishProcessing(convoId);
+      }
       if(d.subtype==='codex_error' && convoId) {
         renderCodexErrorPill(convoId, d);
         finishProcessing(convoId);
@@ -2309,6 +2313,24 @@ function renderCodexQuotaCard(convoId, d) {
     `<div class="auth-error-body">${name} has used this plan's Codex allowance for now. This is a plan limit, not a fault, and your conversation is safe. ${name} can pick this up once the limit resets; your Claude agents are unaffected.</div>` +
     (d.detail ? `<div class="codex-error-detail">Codex: ${esc(d.detail)}</div>` : '') +
     `<div class="auth-error-foot">Then resend your message. <a href="https://docs.rundock.ai/concepts/runtimes" target="_blank" rel="noopener">About runtimes and limits &#x2192;</a></div>`;
+  m.appendChild(el);
+  scrollBottom();
+}
+
+// Guidance card for actionable Codex failures (signed out, unavailable
+// model). Same visual grammar as the quota card: what happened, the concrete
+// fix, the CLI's own words attached for the curious.
+function renderCodexGuidanceCard(convoId, d) {
+  if (convoId && activeConversation?.id !== convoId) return;
+  const m = document.getElementById('messages');
+  if (!m) return;
+  const el = document.createElement('div');
+  el.className = 'auth-error-card';
+  el.innerHTML =
+    `<div class="auth-error-title">${esc(d.title || 'Codex needs attention')}</div>` +
+    `<div class="auth-error-body">${esc(d.body || '')}</div>` +
+    (d.detail ? `<div class="codex-error-detail">Codex: ${esc(d.detail)}</div>` : '') +
+    `<div class="auth-error-foot">Then resend your message. <a href="https://docs.rundock.ai/concepts/runtimes" target="_blank" rel="noopener">About runtimes &#x2192;</a></div>`;
   m.appendChild(el);
   scrollBottom();
 }

--- a/public/app.js
+++ b/public/app.js
@@ -28,6 +28,7 @@ const sunIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stro
 const moonIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
 
 let ws=null, agents=[], conversations=[], activeConversation=null, currentView='home', currentFilePath=null, skills=[], skillsLoaded=false, currentWorkspacePath=null, workspaceAnalysis=null, workspaceIsEmpty=false, workspaceMode='knowledge', setupComplete=true, conversationsLoaded=false, activeSidebarPill='all';
+let runtimeStatus = null; // { defaultRuntime, claude: {installed, authenticated, version}, codex: {...} }
 const agentLastActivity = {}; // { agentId: { time: Date, label: string } }
 // Per-conversation state: { convoId: { isProcessing, currentStreamingMsg, latestText } }
 const convoState = {};
@@ -428,6 +429,14 @@ function handle(d) {
       if(d.subtype==='auth_error' && convoId) {
         renderAuthErrorCard(convoId);
       }
+      if(d.subtype==='codex_quota' && convoId) {
+        renderCodexQuotaCard(convoId, d);
+        finishProcessing(convoId);
+      }
+      if(d.subtype==='codex_error' && convoId) {
+        renderCodexErrorPill(convoId, d);
+        finishProcessing(convoId);
+      }
       break;
     case 'stream_event':
       if(convoId && !isStaleProcess(d, convoId)) handleStreamEvent(d, convoId);
@@ -443,7 +452,12 @@ function handle(d) {
     case 'file_saved': document.getElementById('editor-status').textContent='Saved'; break;
     case 'agent_saved':
       if (!d.updated) setupComplete = true;
-      addSystemMsg('Agent "' + (d.agentId || '') + '" ' + (d.updated ? 'updated' : 'created'));
+      // Non-default runtimes are worth calling out on the confirmation pill.
+      addSystemMsg('Agent "' + (d.agentId || '') + '" ' + (d.updated ? 'updated' : 'created') + (d.runtime === 'codex' ? ' · runs on Codex' : ''));
+      break;
+    case 'runtime_status':
+      runtimeStatus = d;
+      renderRuntimesCard();
       break;
     case 'agent_error':
       addSystemMsg(d.message || 'Agent operation failed');
@@ -1262,10 +1276,11 @@ function showProfile(agentId) {
     }
     h+=`</div></div>`;
   }
-  // Routines + Configuration card
+  // Routines + Configuration card. Always rendered: the Runtime row appears
+  // for every agent, so the card always has content.
   const hasRoutines = a.routines && a.routines.length;
   const hasConnectors = a.capabilities?.connectors;
-  if(hasRoutines || hasConnectors || a.model) {
+  {
     h+=`<div class="profile-card">`;
     if(hasRoutines) {
       h+=`<div class="profile-card-section"><div class="profile-section-label">Routines</div>`;
@@ -1284,6 +1299,10 @@ function showProfile(agentId) {
     }
     const modelLabels = {opus:'Opus (most capable)',sonnet:'Sonnet (fast, efficient)',haiku:'Haiku (lightweight)'};
     if(a.model) h+=`<div class="profile-card-section"><div class="profile-section-label">Model</div><div class="profile-card-item">${modelLabels[a.model]||a.model}</div></div>`;
+    // Runtime is stated for every agent, not just Codex ones, so it reads as
+    // a fact about the agent rather than a special mark.
+    h+=`<div class="profile-card-section"><div class="profile-section-label">Runtime</div><div class="profile-card-item">${a.runtime === 'codex' ? 'Codex' : 'Claude Code'}</div></div>`;
+    if(a.runtime === 'codex') h+=`<div class="profile-card-section"><div class="profile-section-label">Permissions</div><div class="profile-card-text">${esc(a.displayName)} runs on Codex and uses Codex's built-in sandbox. Claude agents use Rundock's permission prompts.</div></div>`;
     h+=`</div>`;
   }
   // Instructions card (collapsible)
@@ -1421,6 +1440,28 @@ function createConversation(agentId, title) {
   return convo;
 }
 
+// One-time disclosure when the user starts their first conversation with a
+// Codex agent: the permission model differs from Claude agents and that is
+// stated plainly at the moment it matters. Shown once per agent, ever
+// (persisted on render, not on dismiss, so ignoring it doesn't nag later).
+function maybeShowCodexFirstRun(agent) {
+  if (!agent || agent.runtime !== 'codex') return;
+  const key = 'rundock:codexFirstRun:' + agent.id;
+  try {
+    if (localStorage.getItem(key)) return;
+    localStorage.setItem(key, '1');
+  } catch (e) { return; }
+  const m = document.getElementById('messages');
+  if (!m) return;
+  const el = document.createElement('div');
+  el.className = 'codex-firstrun-card';
+  el.innerHTML =
+    `<div class="codex-firstrun-title">Running on Codex</div>` +
+    `<div>${esc(agent.displayName)} runs on Codex and uses Codex's built-in sandbox, so you will not see Rundock's permission prompts in this conversation. Files outside this workspace stay protected by the sandbox.</div>` +
+    `<button class="codex-firstrun-dismiss" onclick="this.closest('.codex-firstrun-card').remove()">Got it</button>`;
+  m.appendChild(el);
+}
+
 function startConversation(agentId) {
   // Same principle as openConversation: starting a conversation navigates
   // to the Conversations section regardless of origin (agent profile, org
@@ -1441,6 +1482,9 @@ function startConversation(agentId) {
     h+=`</div></div>`;
     document.getElementById('messages').innerHTML=h;
   }
+
+  // After any placeholder content: the one-time Codex disclosure card.
+  maybeShowCodexFirstRun(agent);
 }
 
 // Start a Doc conversation with workspace analysis pre-loaded
@@ -2237,6 +2281,38 @@ function renderAuthErrorCard(convoId) {
 function copyAuthCmd(btn) {
   const done = () => { const t = btn.textContent; btn.textContent = 'copied'; setTimeout(() => { btn.textContent = t; }, 2000); };
   if (navigator.clipboard?.writeText) { navigator.clipboard.writeText('claude').then(done).catch(() => {}); }
+}
+
+function agentDisplayName(agentId) {
+  const a = agents.find(x => x.id === agentId);
+  return (a && a.displayName) || agentId || 'This agent';
+}
+
+// Plan-limit card for Codex agents. Same visual pattern as the Claude
+// auth-error card: a limit is expected and self-resolving, so it gets a calm
+// explanation with the CLI's own words attached, never a raw error.
+function renderCodexQuotaCard(convoId, d) {
+  if (convoId && activeConversation?.id !== convoId) return;
+  const m = document.getElementById('messages');
+  if (!m) return;
+  const name = esc(agentDisplayName(d._agent));
+  const el = document.createElement('div');
+  el.className = 'auth-error-card';
+  el.innerHTML =
+    `<div class="auth-error-title">ChatGPT plan limit reached</div>` +
+    `<div class="auth-error-body">${name} has used this plan's Codex allowance for now. This is a plan limit, not a fault, and your conversation is safe. ${name} can pick this up once the limit resets; your Claude agents are unaffected.</div>` +
+    (d.detail ? `<div class="codex-error-detail">Codex: ${esc(d.detail)}</div>` : '') +
+    `<div class="auth-error-foot">Then resend your message. <a href="https://docs.rundock.ai/concepts/runtimes" target="_blank" rel="noopener">About runtimes and limits &#x2192;</a></div>`;
+  m.appendChild(el);
+  scrollBottom();
+}
+
+// Classified Codex failure: a friendly pill with the CLI's verbatim text.
+// No "Error:" prefix; the sentence explains what happened in plain words.
+function renderCodexErrorPill(convoId, d) {
+  if (convoId && activeConversation?.id !== convoId) return;
+  const name = agentDisplayName(d._agent);
+  addSystemMsg(`${name}'s runtime hit a problem and this turn stopped.` + (d.detail ? ` Codex: ${d.detail}` : ''));
 }
 function addToolMsg(name) { const m=document.getElementById('messages'),d=document.createElement('div'); d.className='msg-tool'; d.innerHTML=`<span style="color:var(--working)">&#x2192;</span> Using ${esc(name)}`; m.appendChild(d); scrollBottom(); return d; }
 // ===== SESSION HISTORY =====
@@ -3299,7 +3375,11 @@ function renderSettingsSection(section) {
           <div class="mode-description" id="mode-description">${modeDesc}</div>
         </div>
       </div>
+      <div class="settings-card" id="runtimes-card">${runtimesCardHtml()}</div>
       <button class="settings-btn" onclick="changeWorkspace()">Change workspace</button>`;
+    // Refresh runtime state whenever the card becomes visible (the user may
+    // have just installed or signed in to a CLI).
+    if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'get_runtime_status' }));
   } else if (section === 'appearance') {
     const isLight = document.body.classList.contains('light');
     el.innerHTML = `<div class="settings-section-title">Appearance</div>
@@ -3327,6 +3407,42 @@ function renderSettingsSection(section) {
 function setWorkspaceMode(mode) {
   if (!ws || ws.readyState !== WebSocket.OPEN) return;
   ws.send(JSON.stringify({ type: 'set_workspace_mode', mode }));
+}
+
+// ── Runtimes card (settings › workspace) ──
+// One row per runtime with a unified status vocabulary. Status chips never
+// claim which plan backs the credentials (detection is presence-only); plan
+// language lives in the guidance copy. When Codex is absent, the guidance IS
+// the hint, and it appears nowhere else in the product.
+function runtimeRowHtml(label, st, isDefault) {
+  let dot, text;
+  if (!st || !st.installed) { dot = 'var(--idle)'; text = 'Not installed'; }
+  else if (st.authenticated === false) { dot = 'var(--attention)'; text = 'Not signed in'; }
+  else if (st.authenticated === true) { dot = 'var(--success)'; text = 'Signed in' + (st.version ? ' · v' + esc(st.version) : ''); }
+  else { dot = 'var(--idle)'; text = 'Installed' + (st.version ? ' · v' + esc(st.version) : ''); } // auth unknown: claim nothing
+  return `<div class="settings-row"><span class="settings-label">${label}</span>` +
+    `<span class="runtime-chip">${isDefault ? '<span class="runtime-default">Default</span>' : ''}` +
+    `<span class="runtime-dot" style="background:${dot}"></span>${text}</span></div>`;
+}
+
+function runtimesCardHtml() {
+  if (!runtimeStatus) {
+    return `<div class="settings-row"><span class="settings-label">Runtimes</span><span class="settings-value" style="font-family:inherit">Checking...</span></div>`;
+  }
+  let h = runtimeRowHtml('Claude Code', runtimeStatus.claude, runtimeStatus.defaultRuntime === 'claude');
+  h += runtimeRowHtml('Codex', runtimeStatus.codex, runtimeStatus.defaultRuntime === 'codex');
+  const cx = runtimeStatus.codex || {};
+  if (cx.installed && cx.authenticated === false) {
+    h += `<div class="runtime-guidance">Run <code>codex login</code> once. Your ChatGPT plan covers your agents via the official Codex CLI (July 2026).</div>`;
+  } else if (!cx.installed) {
+    h += `<div class="runtime-guidance">Want agents on your ChatGPT plan? Install the official Codex CLI, then sign in: <code>npm install -g @openai/codex</code> then <code>codex login</code></div>`;
+  }
+  return h;
+}
+
+function renderRuntimesCard() {
+  const el = document.getElementById('runtimes-card');
+  if (el) el.innerHTML = runtimesCardHtml();
 }
 
 function changeWorkspace() {
@@ -3460,6 +3576,7 @@ function onWorkspaceReady(dir, analysis, isEmpty, mode, scaffoldError, isSetupCo
   ws.send(JSON.stringify({ type: 'get_files' }));
   ws.send(JSON.stringify({ type: 'get_skills' }));
   ws.send(JSON.stringify({ type: 'get_conversations' }));
+  ws.send(JSON.stringify({ type: 'get_runtime_status' }));
   skillsLoaded = false;
   currentSkillId = null;
 

--- a/public/app.js
+++ b/public/app.js
@@ -3500,6 +3500,13 @@ function runtimesCardHtml() {
   } else if (!cx.installed) {
     h += `<div class="runtime-guidance">Want agents on your ChatGPT plan? Install the official Codex CLI, then sign in: <code>npm install -g @openai/codex</code> then <code>codex login</code></div>`;
   }
+  // windowsSandbox is only ever a boolean on Windows (null elsewhere), so
+  // this guidance self-limits to Windows machines. Without the native
+  // sandbox declared, Codex file writes arrive as approval cards; with it,
+  // agents write directly inside the sandbox, as on macOS.
+  if (cx.installed && cx.windowsSandbox === false) {
+    h += `<div class="runtime-guidance">Codex agents currently request each file write for your approval. For direct sandboxed writes, add to your Codex config (<code>%USERPROFILE%\\.codex\\config.toml</code>):<br><code>[windows]</code><br><code>sandbox = "unelevated"</code></div>`;
+  }
   return h;
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -3443,13 +3443,27 @@ function setWorkspaceMode(mode) {
 // language lives in the guidance copy. When Codex is absent, the guidance IS
 // the hint, and it appears nowhere else in the product.
 function runtimeRowHtml(label, st, isDefault) {
-  let dot, text;
-  if (!st || !st.installed) { dot = 'var(--idle)'; text = 'Not installed'; }
-  else if (st.authenticated === false) { dot = 'var(--attention)'; text = 'Not signed in'; }
-  else if (st.authenticated === true) { dot = 'var(--success)'; text = 'Signed in' + (st.version ? ' · v' + esc(st.version) : ''); }
-  else { dot = 'var(--idle)'; text = 'Installed' + (st.version ? ' · v' + esc(st.version) : ''); } // auth unknown: claim nothing
+  // Each state carries a hover tooltip explaining the evidence behind it:
+  // detection only checks what exists on disk (the CLI, its sign-in
+  // credentials) and claims nothing it cannot see. "Installed" in grey is
+  // deliberate: it means the CLI is present and sign-in state is unknown,
+  // not that something is wrong.
+  let dot, text, tip;
+  if (!st || !st.installed) {
+    dot = 'var(--idle)'; text = 'Not installed';
+    tip = 'The CLI for this runtime was not found on this machine.';
+  } else if (st.authenticated === false) {
+    dot = 'var(--attention)'; text = 'Not signed in';
+    tip = 'The CLI is installed, but no sign-in credentials were found on this machine. Run its login command to sign in.';
+  } else if (st.authenticated === true) {
+    dot = 'var(--success)'; text = 'Signed in' + (st.version ? ' · v' + esc(st.version) : '');
+    tip = 'The CLI is installed and sign-in credentials were found on this machine. Rundock checks that credentials exist; it never reads them.';
+  } else {
+    dot = 'var(--idle)'; text = 'Installed' + (st.version ? ' · v' + esc(st.version) : ''); // auth unknown: claim nothing
+    tip = 'The CLI is installed. Rundock cannot tell whether it is signed in, so it makes no claim either way. Agents on this runtime may still work.';
+  }
   return `<div class="settings-row"><span class="settings-label">${label}</span>` +
-    `<span class="runtime-chip">${isDefault ? '<span class="runtime-default">Default</span>' : ''}` +
+    `<span class="runtime-chip" title="${esc(tip)}" style="cursor:help">${isDefault ? '<span class="runtime-default">Default</span>' : ''}` +
     `<span class="runtime-dot" style="background:${dot}"></span>${text}</span></div>`;
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -266,6 +266,17 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
 .auth-error-copy:hover { color: var(--text-1); border-color: var(--text-2); }
 .auth-error-foot { margin-top: 8px; font-size: var(--caption); color: var(--text-2); }
 .auth-error-foot a { color: var(--working); }
+/* Codex runtime surfaces */
+.codex-error-detail { margin-top: 8px; font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: 11px; color: var(--text-2); word-break: break-word; }
+.codex-firstrun-card { align-self: center; max-width: 480px; margin: 8px auto; padding: 14px 16px; background: rgba(122,162,232,0.07); border: 1px solid rgba(122,162,232,0.35); border-radius: 12px; font-size: var(--caption); line-height: 1.6; color: var(--text-1); animation: fadeIn 0.2s ease; }
+.codex-firstrun-title { font-weight: 600; font-size: var(--caption); color: var(--working); margin-bottom: 4px; }
+.codex-firstrun-dismiss { margin-top: 8px; padding: 4px 12px; font-size: var(--label); font-weight: 600; border-radius: 6px; background: transparent; color: var(--text-2); border: 1px solid var(--border); cursor: pointer; }
+.codex-firstrun-dismiss:hover { color: var(--text-1); border-color: var(--text-2); }
+.runtime-chip { display: inline-flex; align-items: center; gap: 6px; font-size: var(--caption); color: var(--text-2); }
+.runtime-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+.runtime-default { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-2); border: 1px solid var(--border); padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
+.runtime-guidance { padding: 0 16px 14px; font-size: var(--caption); color: var(--text-2); line-height: 1.6; }
+.runtime-guidance code { font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: 11px; background: var(--elevated); padding: 2px 6px; border-radius: 4px; color: var(--text-1); }
 .msg-tool { align-self: flex-start; max-width: 85%; padding: 8px 12px; background: var(--card); border-left: 3px solid var(--working); border-radius: 0 8px 8px 0; font-size: var(--caption); color: var(--text-2); display: flex; align-items: center; gap: 8px; animation: fadeIn 0.2s ease; }
 .msg-tool.done { border-left-color: var(--success); }
 /* Activity summary */

--- a/server.js
+++ b/server.js
@@ -1172,16 +1172,33 @@ function executeRoutine(agent, routine, key) {
   // Notify connected clients
   broadcastRoutineUpdate();
 
+  let proc;
+  if (agent.runtime === 'codex') {
+    // Codex agents run their routines on Codex: exec mode is naturally
+    // one-shot, the routine prompt travels over stdin with the agent's
+    // instructions, and Codex's own sandbox applies (no bypass flags exist
+    // on this path). The agent's plan choice is honoured even for
+    // unattended work.
+    proc = spawnCodex(codexRuntime.buildCodexArgs({ model: agent.model || undefined }), {
+      cwd: WORKSPACE,
+      env: getSpawnEnv(null),
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+    proc.stdin.on('error', () => { /* EPIPE on early exit */ });
+    proc.stdin.write([readAgentInstructions(agent), buildSystemPrompt(agent), routine.prompt].filter(Boolean).join('\n\n'));
+    proc.stdin.end();
+  } else {
   // Routines run unattended (no user to approve), so bypass permissions.
   const args = [...getBareArgs(), ...modelArgs(agent), '--print', '--output-format', 'stream-json', '--verbose', '--dangerously-skip-permissions'];
   if (agent.id !== 'default') args.push('--agent', agent.id);
   args.push(routine.prompt);
 
-  const proc = spawnClaude(args, {
+  proc = spawnClaude(args, {
     cwd: WORKSPACE,
     env: getSpawnEnv(null),
     stdio: ['ignore', 'pipe', 'pipe']
   });
+  }
 
   proc.on('close', (code) => {
     const duration = Math.round((Date.now() - startTime) / 1000);
@@ -2672,7 +2689,12 @@ function handleDelegation(msg, processes) {
   // Plain specialists: conversational, user controls when to return
   const targetHasDirectReports = !!buildTeamRoster(targetAgent.id, true);
   let delegationContext;
-  if (isPlatformDelegate || isCodexDelegate) {
+  if (isCodexDelegate) {
+    // Transactional, and honest about the runtime's shape: a Codex exec
+    // process cannot stay in the conversation to wait for a user reply, so
+    // it must never promise to. Clarifications go through the handback.
+    delegationContext = 'DELEGATION CONTEXT:\nYou have been delegated a task by another agent. Complete the task fully in this single response; you cannot wait for follow-up messages in this session. Prefer sensible defaults over asking questions. When the task is done, post your final summary and output <!-- RUNDOCK:COMPLETE --> at the very end of the response. If you genuinely cannot proceed without an answer from the user, state the question clearly in your response and still output <!-- RUNDOCK:COMPLETE -->; the reply will reach you when the task is re-delegated. Only use <!-- RUNDOCK:RETURN --> if the request is genuinely outside your scope and you cannot help.';
+  } else if (isPlatformDelegate) {
     delegationContext = 'DELEGATION CONTEXT:\nYou have been delegated a task by another agent. Complete the task in a single response if possible. When the task is done (agent created, skill saved, file written, question answered, etc.), output <!-- RUNDOCK:COMPLETE --> at the very end of that same response. Do not wait for follow-up questions. Do not ask if there is anything else. Just complete the task, confirm what you did, and return immediately. If you genuinely need clarification before you can proceed, ask, but prefer using sensible defaults over asking.\n\nException: if you have proposed a plan and are waiting for the user to confirm before you execute (e.g. you asked them to say "go ahead"), do NOT emit COMPLETE. Stay in the conversation and wait for their response. Only emit COMPLETE once the task is genuinely finished: you executed the work, or you answered the question fully with no pending user decision.\n\nOnly use <!-- RUNDOCK:RETURN --> if the request is genuinely outside your scope and you cannot help. This is rare.';
   } else if (targetHasDirectReports) {
     delegationContext = 'DELEGATION CONTEXT:\nYou have been brought into this conversation by the orchestrator to run a task in your domain. You lead a support team and may delegate parts of the work to them. Do the real work, write the deliverables, and report the outcome.\n\nYou MUST hand control back using one of two markers, on its own line, as the very last thing in your response (after any final summary):\n\n- <!-- RUNDOCK:RETURN --> when the user asks for something outside your domain of expertise. Tell them briefly that this falls outside what you handle and you are handing them back so the right person can pick it up. Do NOT name other specialists or suggest who should handle it. Then emit the marker.\n\n- <!-- RUNDOCK:COMPLETE --> when the orchestrator\'s original delegated pipeline is finished end-to-end. All deliverables are written to their final locations and the workflow has reached its final status (for example content moved to Ready for Review, spec written and linked, final audit posted). Post your final summary first, then emit the marker.\n\nDo NOT emit either marker when you are pausing at a decision point to let the user choose between options, presenting drafts, hooks, options, or recommendations for user review, asking the user to confirm something before continuing, or waiting at a human gate midway through a multi-phase pipeline. Those are pauses, not completions. Stay in the conversation as the active agent and wait for the user\'s next message. You will pick up where you left off when they respond.\n\nReturning on completion is how control flows back up the chain. If you silently stop, the user\'s next message will be routed to the wrong agent.';
@@ -2716,7 +2738,7 @@ function handleDelegation(msg, processes) {
         cwd: WORKSPACE,
         env: getSpawnEnv(convoId),
         stdio: ['pipe', 'pipe', 'pipe']
-      }, (err) => handleChatSpawnError(err, convoId))
+      }, (err) => handleCodexSpawnError(err, convoId))
     : spawnClaude(delegateArgs, {
         cwd: WORKSPACE,
         env: getSpawnEnv(convoId),
@@ -2770,6 +2792,7 @@ function handleDelegation(msg, processes) {
     const codexPrompt = priorSessionId
       ? `${delegationContext}\n\n${contextWithHistory}`
       : [readAgentInstructions(targetAgent), fullPrompt, contextWithHistory].filter(Boolean).join('\n\n');
+    startCodexKeepalive(delegateEntry, convoId);
     wireCodexDelegate(delegateEntry, convoId, codexPrompt);
   } else {
   delegateProc.stdin.write(JSON.stringify({ type: 'user', message: { role: 'user', content: contextWithHistory } }) + '\n');
@@ -3906,11 +3929,22 @@ wss.on('connection', (ws) => {
           // The close handler will restore the original process
         } else if (current && !current.delegation && !current.exited && !current.scopeReturn) {
           // Specialist started directly (no delegation) emitted RETURN
-          // Server-side onResult should have caught this, but handle as fallback
-          console.log(`[ScopeReturn] convo=${convoId} end_delegation fallback for non-delegated specialist`);
-          current.scopeReturn = true;
-          try { current.process.kill(); } catch (e) {}
-          // The close handler will call handleScopeReturn
+          // Server-side onResult should have caught this, but handle as fallback.
+          // Stale-message guard: an orchestrator or platform agent never emits
+          // RETURN, so end_delegation landing on one means the handback already
+          // completed server-side (a fast-exiting delegate, e.g. Codex, can be
+          // restored before the client's marker scan round-trips). Killing the
+          // restored parent here would drop its session. Ignore instead.
+          const agentList = discoverAgents();
+          const currentAgent = agentList.find(a => a.id === current.agentId || a.name === current.agentId);
+          if (currentAgent && (currentAgent.type === 'orchestrator' || currentAgent.type === 'platform')) {
+            console.log(`[ScopeReturn] convo=${convoId} ignoring stale end_delegation: current agent ${current.agentId} is ${currentAgent.type}`);
+          } else {
+            console.log(`[ScopeReturn] convo=${convoId} end_delegation fallback for non-delegated specialist`);
+            current.scopeReturn = true;
+            try { current.process.kill(); } catch (e) {}
+            // The close handler will call handleScopeReturn
+          }
         }
       }
 
@@ -4712,20 +4746,32 @@ let _claudeAuthEvidence = null;
 // machine, whether they are signed in, and which one is the workspace
 // default. The default is Claude in this version: Doc and delegation run on
 // it, so a workspace cannot exist without it.
+let _claudeProbeCache = null;
+let _claudeProbeTime = 0;
 function getRuntimeStatus() {
   const { execSync } = require('child_process');
   const isWindows = process.platform === 'win32';
-  let claudeInstalled = true;
-  try {
-    execSync(isWindows ? 'where.exe claude' : 'which claude', { timeout: 5000, encoding: 'utf-8' });
-  } catch (e) { claudeInstalled = false; }
-  let claudeVersion = null;
-  if (claudeInstalled) {
+  // The install/version probe shells out (claude --version can take seconds)
+  // and this runs on the WebSocket handler path, so cache it. 60s keeps a
+  // fresh install visible quickly without blocking every settings open.
+  let claudeInstalled, claudeVersion;
+  if (_claudeProbeCache && (Date.now() - _claudeProbeTime) < 60000) {
+    ({ installed: claudeInstalled, version: claudeVersion } = _claudeProbeCache);
+  } else {
+    claudeInstalled = true;
     try {
-      const out = execSync(`"${resolveClaudeBin()}" --version`, { timeout: 5000, encoding: 'utf-8' });
-      const m = String(out).match(/(\d+\.\d+(?:\.\d+)?(?:-[A-Za-z0-9.]+)?)/);
-      claudeVersion = m ? m[1] : null;
-    } catch (e) { /* installed but --version failed */ }
+      execSync(isWindows ? 'where.exe claude' : 'which claude', { timeout: 5000, encoding: 'utf-8' });
+    } catch (e) { claudeInstalled = false; }
+    claudeVersion = null;
+    if (claudeInstalled) {
+      try {
+        const out = execSync(`"${resolveClaudeBin()}" --version`, { timeout: 5000, encoding: 'utf-8' });
+        const m = String(out).match(/(\d+\.\d+(?:\.\d+)?(?:-[A-Za-z0-9.]+)?)/);
+        claudeVersion = m ? m[1] : null;
+      } catch (e) { /* installed but --version failed */ }
+    }
+    _claudeProbeCache = { installed: claudeInstalled, version: claudeVersion };
+    _claudeProbeTime = Date.now();
   }
   // Fresh Codex detection (the user may have just installed or signed in),
   // and refresh the prompt-side cache while we have the answer.
@@ -4764,15 +4810,64 @@ function spawnCodex(args, options, onError) {
 // Surface a Codex failure once per process, classified: plan-limit exhaustion
 // becomes a structured quota message (the client renders a recovery card, the
 // same pattern as the Claude auth-error card); everything else becomes a
-// structured error message with the CLI's verbatim text attached.
+// structured error message with the CLI's verbatim text attached. The failure
+// is also persisted to the transcript, so a user who wasn't looking at the
+// conversation still finds out what happened when they open it.
 function sendCodexError(entry, convoId, message) {
   if (entry.errorSent) return;
   entry.errorSent = true;
-  const subtype = codexRuntime.isCodexQuotaError(message) ? 'codex_quota' : 'codex_error';
+  const isQuota = codexRuntime.isCodexQuotaError(message);
+  const subtype = isQuota ? 'codex_quota' : 'codex_error';
+  try {
+    const friendly = isQuota
+      ? 'This turn stopped: the ChatGPT plan limit was reached. It can be retried once the limit resets.'
+      : 'This turn stopped: the runtime hit a problem.';
+    appendTranscript(convoId, 'agent', entry.agentId, `${friendly}\nCodex: ${message}`);
+  } catch (e) { /* transcript persistence is best-effort */ }
   safeSend(JSON.stringify({
     type: 'system', subtype, detail: message,
     _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
   }));
+}
+
+// Spawn-failure copy for Codex processes. The generic Claude spawn-error
+// handler tells users to check their Claude Code install, which is the wrong
+// guidance for a Codex agent. Marks the entry so close handlers stay silent.
+function handleCodexSpawnError(err, convoId) {
+  const entry = chatProcesses.get(convoId);
+  if (entry) entry.spawnFailed = true;
+  let userMessage;
+  if (err.code === 'ENOENT') {
+    userMessage = 'The Codex CLI was not found on this machine. Install the official Codex CLI, then sign in: npm install -g @openai/codex then codex login';
+  } else if (err.code === 'EACCES') {
+    userMessage = "Couldn't start Codex: permission denied. Check your Codex CLI install.";
+  } else {
+    userMessage = `Couldn't start Codex: ${err.message}. Run codex --version to check your install.`;
+  }
+  safeSend(JSON.stringify({
+    type: 'system', subtype: 'info', content: userMessage, _conversationId: convoId,
+  }));
+  safeSend(JSON.stringify({
+    type: 'system', subtype: 'done', code: -1,
+    _agent: entry ? entry.agentId : undefined, _conversationId: convoId,
+    _processId: entry ? entry.processId : undefined,
+  }));
+}
+
+// Codex emits nothing between accepting the prompt and the final message, so
+// the client's stream-inactivity watchdog (90s) would otherwise conclude the
+// turn is dead mid-task. A periodic keepalive keeps the working state honest
+// while the process lives. Interval is overridable for tests.
+const CODEX_KEEPALIVE_MS = parseInt(process.env.RUNDOCK_CODEX_KEEPALIVE_MS || '', 10) || 25000;
+function startCodexKeepalive(entry, convoId) {
+  const timer = setInterval(() => {
+    if (entry.exited || entry.resultSent) { clearInterval(timer); return; }
+    safeSend(JSON.stringify({
+      type: 'system', subtype: 'keepalive',
+      _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+    }));
+  }, CODEX_KEEPALIVE_MS);
+  entry.process.on('close', () => clearInterval(timer));
 }
 
 // Deliver the completed Codex turn: persist the transcript, send the result
@@ -4934,7 +5029,7 @@ function startCodexTurn(convoId, msg, agentData) {
     cwd: WORKSPACE,
     env: getSpawnEnv(convoId),
     stdio: ['pipe', 'pipe', 'pipe'],
-  }, (err) => handleChatSpawnError(err, convoId));
+  }, (err) => handleCodexSpawnError(err, convoId));
 
   const entry = {
     process: proc, runtime: 'codex', processId, agentId: agentData.id,
@@ -4944,6 +5039,7 @@ function startCodexTurn(convoId, msg, agentData) {
     toolCalls: [], turnStartTime: Date.now(),
   };
   chatProcesses.set(convoId, entry);
+  startCodexKeepalive(entry, convoId);
 
   safeSend(JSON.stringify({
     type: 'system', subtype: 'process_started',
@@ -4978,7 +5074,9 @@ function startCodexTurn(convoId, msg, agentData) {
     entry.exited = true;
     const current = chatProcesses.get(convoId);
     if (current === entry) chatProcesses.delete(convoId);
-    if (entry.superseded) return; // a newer turn took over; stay silent
+    if (entry.superseded) return;   // a newer turn took over; stay silent
+    if (entry.spawnFailed) return;  // spawn-error handler already surfaced + done
+    if (entry.cancelled) return;    // user stopped the agent; stop handler already surfaced + done
     if (stdoutBuf.trim()) handleCodexEvent(entry, convoId, stdoutBuf); // unterminated last line
     if (!entry.resultSent && !entry.errorSent) {
       sendCodexError(entry, convoId, stderrBuf.trim() || `Codex exited unexpectedly (code ${code})`);

--- a/server.js
+++ b/server.js
@@ -51,7 +51,9 @@ function validateWriteRequest(workspaceDir, relPath, content, isCodeMode) {
   if (!(fullPath.startsWith(root + path.sep))) {
     return { ok: false, reason: 'path escapes the workspace' };
   }
-  const top = path.relative(root, fullPath).split(path.sep)[0];
+  // Case-insensitive: Windows filesystems are, so ".Claude/" must not slip
+  // past a case-sensitive name check.
+  const top = path.relative(root, fullPath).split(path.sep)[0].toLowerCase();
   if (top === '.claude' || top === '.rundock') {
     return { ok: false, reason: 'managed directory' };
   }
@@ -2902,10 +2904,13 @@ function handleDelegation(msg, processes) {
     // Codex takes the whole prompt over stdin: identity + platform rules +
     // delegation contract on a cold spawn (Codex has no --agent or
     // --append-system-prompt equivalent); contract + brief on a resumed
-    // thread (instructions are already in the thread).
+    // thread (instructions are already in the thread). Delegated turns get
+    // the same Windows write-marker fallback as direct chats: instruction
+    // on cold spawns, marker handling flagged on the entry either way.
+    delegateEntry.writeMarkersEnabled = codexWriteMarkersEnabled();
     const codexPrompt = codexResumeId
       ? `${delegationContext}\n\n${contextWithHistory}`
-      : [readAgentInstructions(targetAgent), fullPrompt, contextWithHistory].filter(Boolean).join('\n\n');
+      : [readAgentInstructions(targetAgent), fullPrompt, buildWindowsWriteNote(delegateEntry.writeMarkersEnabled), contextWithHistory].filter(Boolean).join('\n\n');
     startCodexKeepalive(delegateEntry, convoId);
     wireCodexDelegate(delegateEntry, convoId, codexPrompt);
   } else {
@@ -5045,6 +5050,42 @@ function startCodexKeepalive(entry, convoId) {
 // Deliver the completed Codex turn: persist the transcript, send the result
 // (with normalised token usage: subscription usage, never dollar costs) and
 // the done signal.
+// Whether Codex spawns on this machine need the write-marker fallback:
+// Windows without a declared native sandbox (the CLI silently downgrades
+// workspace-write to read-only there). Checked per spawn so a config edit
+// takes effect on the next turn. Shared by direct chats and delegated turns.
+function codexWriteMarkersEnabled() {
+  const codexPlatform = process.env.RUNDOCK_TEST_PLATFORM || process.platform;
+  return codexPlatform === 'win32' && !codexRuntime.hasWindowsSandboxConfig();
+}
+
+// The write-marker instruction for Codex prompts on Windows machines without
+// the native sandbox. Empty string when the fallback is not needed, so call
+// sites can join it unconditionally.
+function buildWindowsWriteNote(enabled) {
+  if (!enabled) return '';
+  return [
+    'WINDOWS FILE WRITES:',
+    'On this machine your sandbox is read-only: shell commands that write files will be rejected. To create or update a file, output a block in EXACTLY this format as part of your response:',
+    '<!-- RUNDOCK:WRITE_FILE path="relative/path/inside/workspace.md" -->',
+    '<the complete file content>',
+    '<!-- /RUNDOCK:WRITE_FILE -->',
+    'Rules: relative paths inside the workspace only; the content replaces the whole file; one block per file, multiple blocks allowed. The user approves each write AFTER your turn ends, so describe writes as requested, never as completed. Never claim a file was created. Do not attempt writes via shell commands.',
+  ].join('\n');
+}
+
+// Strip write markers from a finished Codex turn's text. Returns the display
+// text plus the parsed requests for the caller to dispatch AFTER sending its
+// result/handback (cards follow the message they belong to). Inert unless
+// the entry was spawned with the marker instruction.
+function extractCodexWriteRequests(entry, text) {
+  if (!entry.writeMarkersEnabled || !text || !text.includes('RUNDOCK:WRITE_FILE')) {
+    return { text, requests: [] };
+  }
+  const parsed = codexRuntime.parseWriteMarkers(text);
+  return { text: parsed.cleanText, requests: parsed.requests };
+}
+
 // Raise a permission card for a server-originated request (no hook HTTP
 // response to hold: the decision arrives via onDecision(allow, reason)).
 // Same card UI, same timeout, same cancel sweep as hook-originated requests.
@@ -5101,6 +5142,15 @@ function handleCodexWriteRequest(entry, convoId, req) {
       }
       try {
         fs.mkdirSync(path.dirname(v.fullPath), { recursive: true });
+        // Defence in depth against symlink traversal: the validated path is
+        // lexical; re-verify the REAL parent directory sits inside the
+        // workspace before writing, so a symlinked folder inside the
+        // workspace cannot redirect the write outside it.
+        const realParent = fs.realpathSync(path.dirname(v.fullPath));
+        const realRoot = fs.realpathSync(path.resolve(WORKSPACE));
+        if (!(realParent === realRoot || realParent.startsWith(realRoot + path.sep))) {
+          throw new Error('resolved target escapes the workspace');
+        }
         fs.writeFileSync(v.fullPath, req.content, 'utf-8');
         invalidateFileListCache();
         if (ensureSearchEngine()) {
@@ -5128,12 +5178,9 @@ function finishCodexTurn(entry, convoId) {
   // result, so the conversation shows the agent's message first and the
   // cards follow. Only turns that were given the marker instruction are
   // honoured (entry.writeMarkersEnabled).
-  let writeRequests = [];
-  if (entry.writeMarkersEnabled && text.includes('RUNDOCK:WRITE_FILE')) {
-    const parsed = codexRuntime.parseWriteMarkers(text);
-    text = parsed.cleanText;
-    writeRequests = parsed.requests;
-  }
+  const extracted = extractCodexWriteRequests(entry, text);
+  text = extracted.text;
+  const writeRequests = extracted.requests;
   if (text) appendTranscript(convoId, 'agent', entry.agentId, text);
   safeSend(JSON.stringify({
     type: 'result', result: text, is_error: false, usage: entry.usage,
@@ -5228,16 +5275,23 @@ function wireCodexDelegate(entry, convoId, prompt) {
       const hasReturn = /<!-- RUNDOCK:RETURN -->/.test(entry.responseText);
       if (hasComplete) entry.returnMarkerSeen = 'complete';
       else if (hasReturn) entry.returnMarkerSeen = 'return';
-      if (entry.responseText) appendTranscript(convoId, 'agent', entry.agentId, entry.responseText);
+      // Windows write markers: strip before the transcript, the result, and
+      // the handback injection (finalResponseText), so the orchestrator and
+      // the user both see the plain-language line, never raw marker soup.
+      // Cards dispatch after the result so they follow their message.
+      const extracted = extractCodexWriteRequests(entry, entry.responseText);
+      const displayText = extracted.text;
+      if (displayText) appendTranscript(convoId, 'agent', entry.agentId, displayText);
       safeSend(JSON.stringify({
-        type: 'result', result: entry.responseText, is_error: false, usage: ev.usage,
+        type: 'result', result: displayText, is_error: false, usage: ev.usage,
         _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
         _turnStartTime: entry.turnStartTime,
       }));
       entry.resultSent = true;
-      entry.finalResponseText = entry.responseText;
+      entry.finalResponseText = displayText;
       entry.responseText = '';
       entry.idle = true;
+      for (const req of extracted.requests) handleCodexWriteRequest(entry, convoId, req);
     } else if (ev.type === 'error') {
       sendCodexError(entry, convoId, ev.message);
     }
@@ -5294,17 +5348,8 @@ function startCodexTurn(convoId, msg, agentData) {
     stdio: ['pipe', 'pipe', 'pipe'],
   }, (err) => handleCodexSpawnError(err, convoId));
 
-  // Windows write markers: WITHOUT a [windows] sandbox declaration in the
-  // Codex config, the CLI silently downgrades workspace-write to read-only
-  // on native Windows, so win32 spawns are instructed to request writes as
-  // WRITE_FILE markers, which Rundock validates and performs itself behind
-  // a permission card. WITH the declaration, the CLI grants a real
-  // workspace-write policy (verified live) and the marker fallback stands
-  // down: the sandbox writes directly, as on macOS/Linux. Checked per spawn
-  // so a config edit takes effect on the next turn. The env var is a test
-  // seam so the flow is exercisable from any platform's CI.
-  const codexPlatform = process.env.RUNDOCK_TEST_PLATFORM || process.platform;
-  const writeMarkersEnabled = codexPlatform === 'win32' && !codexRuntime.hasWindowsSandboxConfig();
+  // Windows write markers: see codexWriteMarkersEnabled() for the policy.
+  const writeMarkersEnabled = codexWriteMarkersEnabled();
 
   const entry = {
     process: proc, runtime: 'codex', processId, agentId: agentData.id,
@@ -5321,14 +5366,7 @@ function startCodexTurn(convoId, msg, agentData) {
     _agent: agentData.id, _conversationId: convoId, _processId: processId,
   }));
 
-  const windowsWriteNote = writeMarkersEnabled ? [
-    'WINDOWS FILE WRITES:',
-    'On this machine your sandbox is read-only: shell commands that write files will be rejected. To create or update a file, output a block in EXACTLY this format as part of your response:',
-    '<!-- RUNDOCK:WRITE_FILE path="relative/path/inside/workspace.md" -->',
-    '<the complete file content>',
-    '<!-- /RUNDOCK:WRITE_FILE -->',
-    'Rules: relative paths inside the workspace only; the content replaces the whole file; one block per file, multiple blocks allowed. The user approves each write AFTER your turn ends, so describe writes as requested, never as completed. Never claim a file was created. Do not attempt writes via shell commands.',
-  ].join('\n') : '';
+  const windowsWriteNote = buildWindowsWriteNote(writeMarkersEnabled);
 
   // Prompt over stdin, never argv. First turns carry identity (the agent
   // file body) plus the platform rules; Claude gets these via --agent and

--- a/server.js
+++ b/server.js
@@ -4837,16 +4837,38 @@ function spawnCodex(args, options, onError) {
 function sendCodexError(entry, convoId, message) {
   if (entry.errorSent) return;
   entry.errorSent = true;
-  const isQuota = codexRuntime.isCodexQuotaError(message);
-  const subtype = isQuota ? 'codex_quota' : 'codex_error';
+  const classified = codexRuntime.classifyCodexError(message);
+  // Actionable failures (signed out, unavailable model) become guidance cards
+  // with a concrete fix; quota keeps its dedicated card; everything else
+  // surfaces verbatim as a classified error pill.
+  let subtype, friendly, guidance = null;
+  if (classified.kind === 'quota') {
+    subtype = 'codex_quota';
+    friendly = 'This turn stopped: the ChatGPT plan limit was reached. It can be retried once the limit resets.';
+  } else if (classified.kind === 'auth') {
+    subtype = 'codex_guidance';
+    guidance = {
+      title: 'Codex is not signed in',
+      body: 'This agent runs on Codex, but the Codex CLI is not signed in on this machine. Run codex login in a terminal, then resend your message.',
+    };
+    friendly = 'This turn stopped: Codex is not signed in on this machine. Run codex login in a terminal, then resend the message.';
+  } else if (classified.kind === 'model') {
+    subtype = 'codex_guidance';
+    const modelBit = classified.model ? `the model '${classified.model}'` : 'a model';
+    guidance = {
+      title: 'Model not available on this account',
+      body: `This agent is configured with ${modelBit}, which this Codex account does not offer. Edit the agent and remove the model field to use the account default, or pick a model your plan includes.`,
+    };
+    friendly = `This turn stopped: ${modelBit} is not available on this Codex account. Remove the agent's model field to use the account default, or pick an available model.`;
+  } else {
+    subtype = 'codex_error';
+    friendly = 'This turn stopped: the runtime hit a problem.';
+  }
   try {
-    const friendly = isQuota
-      ? 'This turn stopped: the ChatGPT plan limit was reached. It can be retried once the limit resets.'
-      : 'This turn stopped: the runtime hit a problem.';
     appendTranscript(convoId, 'agent', entry.agentId, `${friendly}\nCodex: ${message}`);
   } catch (e) { /* transcript persistence is best-effort */ }
   safeSend(JSON.stringify({
-    type: 'system', subtype, detail: message,
+    type: 'system', subtype, detail: message, ...(guidance || {}),
     _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
   }));
 }

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 const { WebSocketServer } = require('ws');
 const readline = require('readline');
+const codexRuntime = require('./codex.js');
 const PKG_VERSION = require('./package.json').version;
 const searchLib = require('./search.js');
 
@@ -840,7 +841,13 @@ function discoverAgents() {
           routines: routines,
           prompts: prompts.length > 0 ? prompts : null,
           skills: skills.length > 0 ? skills : null,
-          model: meta.model || DEFAULT_MODEL,
+          // Runtime is a strict two-value field: unknown values fall back to
+          // claude so a frontmatter typo can never strand an agent. Codex
+          // agents get no default model injected: the Codex CLI applies its
+          // own default, and Rundock only passes --model when the agent file
+          // sets one explicitly.
+          runtime: meta.runtime === 'codex' ? 'codex' : 'claude',
+          model: meta.runtime === 'codex' ? (meta.model || null) : (meta.model || DEFAULT_MODEL),
           order: orderNum,
           reportsTo: meta.reportsTo || null,
           instructions: instructions.substring(0, 2000),
@@ -871,6 +878,7 @@ function discoverAgents() {
         capabilities: null,
         routines: [],
         prompts: null,
+        runtime: 'claude',
         model: DEFAULT_MODEL,
         order: 0,
         instructions: content.substring(0, 2000),
@@ -916,6 +924,7 @@ function discoverAgents() {
       capabilities: null,
       routines: [],
       prompts: ['Help me set up this workspace', 'Create an agent for my team', 'What makes a workspace Rundock-ready?'],
+      runtime: 'claude',
       model: DEFAULT_MODEL,
       order: 99,
       instructions: '',
@@ -3091,6 +3100,21 @@ wss.on('connection', (ws) => {
           appendTranscript(convoId, 'user', 'user', msg.content);
         }
 
+        // ── RUNTIME ROUTING ────────────────────────────────────────────
+        // Codex agents run one process per turn (exec mode) instead of a
+        // long-lived stdin conversation. Route them before the interactive
+        // path; agents without runtime: codex are entirely unaffected.
+        {
+          const requestedAgent = msg.agent || 'default';
+          const agentList = discoverAgents();
+          const routedAgent = agentList.find(a => a.id === requestedAgent)
+            || agentList.find(a => a.fileName && a.fileName.replace('.md', '') === requestedAgent);
+          if (routedAgent && routedAgent.runtime === 'codex') {
+            startCodexTurn(convoId, msg, routedAgent);
+            return;
+          }
+        }
+
         // ── INTERACTIVE MODE (Deliverable A) ──────────────────────────
         // Process stays alive between messages. Follow-ups push to stdin.
         // --print is NOT used; Claude Code runs in interactive stream-json mode.
@@ -4589,6 +4613,203 @@ function spawnClaude(args, options, onError) {
     }
   });
   return proc;
+}
+
+// ===== CODEX RUNTIME =====
+// Agents with `runtime: codex` in their frontmatter run on the OpenAI Codex
+// CLI (the user's ChatGPT plan) instead of Claude Code. Codex conversations
+// run one sandboxed `codex exec --json` process per turn and resume the
+// thread on follow-ups; the thread id rides the same client rails as Claude
+// session ids, so the rest of the product treats both runtimes identically.
+// All Codex-specific parsing/argv/detection logic lives in codex.js.
+
+// Resolve the codex binary lazily and cache it, mirroring resolveClaudeBin.
+let _resolvedCodexBin = null;
+function resolveCodexBinCached() {
+  if (!_resolvedCodexBin) _resolvedCodexBin = codexRuntime.resolveCodexBin();
+  return _resolvedCodexBin;
+}
+
+// Spawn a Codex process with the same PID tracking and error guarantees as
+// spawnClaude. Note: no default model is injected; Codex applies its own
+// default unless the agent's frontmatter set one (already in args).
+function spawnCodex(args, options, onError) {
+  const proc = spawn(resolveCodexBinCached(), args, options);
+  if (proc.pid) {
+    registerChildPid(proc.pid);
+    proc.on('close', () => unregisterChildPid(proc.pid));
+  }
+  proc.on('error', (err) => {
+    try {
+      console.error(`[spawnCodex] spawn error code=${err.code || ''} msg=${err.message}`);
+      if (typeof onError === 'function') onError(err);
+    } catch (e) {
+      console.error('[spawnCodex] onError handler threw:', e);
+    }
+  });
+  return proc;
+}
+
+// Surface a Codex failure once per process, classified: plan-limit exhaustion
+// becomes a structured quota message (the client renders a recovery card, the
+// same pattern as the Claude auth-error card); everything else becomes a
+// structured error message with the CLI's verbatim text attached.
+function sendCodexError(entry, convoId, message) {
+  if (entry.errorSent) return;
+  entry.errorSent = true;
+  const subtype = codexRuntime.isCodexQuotaError(message) ? 'codex_quota' : 'codex_error';
+  safeSend(JSON.stringify({
+    type: 'system', subtype, detail: message,
+    _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+  }));
+}
+
+// Deliver the completed Codex turn: persist the transcript, send the result
+// (with normalised token usage: subscription usage, never dollar costs) and
+// the done signal.
+function finishCodexTurn(entry, convoId) {
+  if (entry.resultSent) return;
+  entry.resultSent = true;
+  const text = entry.responseText || '';
+  if (text) appendTranscript(convoId, 'agent', entry.agentId, text);
+  safeSend(JSON.stringify({
+    type: 'result', result: text, is_error: false, usage: entry.usage,
+    _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+    _turnStartTime: entry.turnStartTime,
+  }));
+  entry.doneSent = true;
+  safeSend(JSON.stringify({
+    type: 'system', subtype: 'done', code: 0,
+    _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+  }));
+}
+
+// Handle one parsed line of Codex output for a running turn.
+function handleCodexEvent(entry, convoId, line) {
+  const ev = codexRuntime.parseCodexLine(line);
+  if (!ev) {
+    if (line.trim()) console.log(`[Codex] convo=${convoId} skipped line: ${line.slice(0, 200)}`);
+    return;
+  }
+  switch (ev.type) {
+    case 'session':
+      entry.sessionId = ev.threadId;
+      // Same message shape the Claude init envelope produces: the client
+      // stores the id and sends it back as msg.sessionId on the next turn.
+      safeSend(JSON.stringify({
+        type: 'system', subtype: 'init', _sessionId: ev.threadId,
+        _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+      }));
+      break;
+    case 'text':
+      entry.responseText = entry.responseText ? entry.responseText + '\n' + ev.text : ev.text;
+      break;
+    case 'done':
+      entry.usage = ev.usage;
+      finishCodexTurn(entry, convoId);
+      break;
+    case 'error':
+      sendCodexError(entry, convoId, ev.message);
+      break;
+  }
+}
+
+// Read an agent's full instruction body from its file. Claude Code loads
+// agent files natively via --agent, but Codex has no equivalent, so the
+// instructions must travel inside the first-turn prompt. Falls back to the
+// (truncated) discovery snapshot if the file cannot be read.
+function readAgentInstructions(agentData) {
+  try {
+    if (agentData.fileName && WORKSPACE) {
+      const content = readNormalisedFile(path.join(WORKSPACE, '.claude', 'agents', agentData.fileName));
+      const bodyMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)/);
+      if (bodyMatch && bodyMatch[1].trim()) return bodyMatch[1].trim();
+    }
+  } catch (e) { /* fall through to snapshot */ }
+  return agentData.instructions || '';
+}
+
+// Run one Codex conversation turn. Each turn is its own process: fresh turns
+// carry the agent's instructions and the platform rules followed by the user
+// message; resumed turns send only the new message (instructions are never
+// re-injected, keeping resumed turns cheap).
+function startCodexTurn(convoId, msg, agentData) {
+  // A new user message supersedes a still-running turn: kill it and continue
+  // on the same thread. Mirrors the Claude path's stale-entry handling.
+  const existing = chatProcesses.get(convoId);
+  if (existing && !existing.exited) {
+    existing.superseded = true;
+    try { existing.process.kill(); } catch (e) { /* already dead */ }
+    chatProcesses.delete(convoId);
+  }
+
+  const resumeThreadId = msg.sessionId || null;
+  const args = codexRuntime.buildCodexArgs({ resumeThreadId, model: agentData.model || undefined });
+  const processId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+
+  console.log(`[Codex] convo=${convoId} proc=${processId} agent=${agentData.id} ${resumeThreadId ? `resume=${resumeThreadId}` : 'new thread'} model=${agentData.model || '(codex default)'}`);
+
+  const proc = spawnCodex(args, {
+    cwd: WORKSPACE,
+    env: getSpawnEnv(convoId),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }, (err) => handleChatSpawnError(err, convoId));
+
+  const entry = {
+    process: proc, runtime: 'codex', processId, agentId: agentData.id,
+    responseText: '', exited: false, resultSent: false, errorSent: false,
+    doneSent: false, superseded: false, usage: null,
+    sessionId: resumeThreadId, lastUserMessage: msg.content,
+    toolCalls: [], turnStartTime: Date.now(),
+  };
+  chatProcesses.set(convoId, entry);
+
+  safeSend(JSON.stringify({
+    type: 'system', subtype: 'process_started',
+    _agent: agentData.id, _conversationId: convoId, _processId: processId,
+  }));
+
+  // Prompt over stdin, never argv. First turns carry identity (the agent
+  // file body) plus the platform rules; Claude gets these via --agent and
+  // --append-system-prompt, which Codex does not support.
+  const prompt = resumeThreadId
+    ? msg.content
+    : [readAgentInstructions(agentData), buildSystemPrompt(agentData), msg.content].filter(Boolean).join('\n\n');
+  proc.stdin.on('error', () => { /* EPIPE on early exit: close handler reports */ });
+  proc.stdin.write(prompt);
+  proc.stdin.end();
+
+  let stdoutBuf = '';
+  proc.stdout.on('data', (chunk) => {
+    stdoutBuf += chunk.toString();
+    let nl;
+    while ((nl = stdoutBuf.indexOf('\n')) >= 0) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      handleCodexEvent(entry, convoId, line);
+    }
+  });
+
+  let stderrBuf = '';
+  proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+
+  proc.on('close', (code) => {
+    entry.exited = true;
+    const current = chatProcesses.get(convoId);
+    if (current === entry) chatProcesses.delete(convoId);
+    if (entry.superseded) return; // a newer turn took over; stay silent
+    if (stdoutBuf.trim()) handleCodexEvent(entry, convoId, stdoutBuf); // unterminated last line
+    if (!entry.resultSent && !entry.errorSent) {
+      sendCodexError(entry, convoId, stderrBuf.trim() || `Codex exited unexpectedly (code ${code})`);
+    }
+    if (!entry.doneSent) {
+      entry.doneSent = true;
+      safeSend(JSON.stringify({
+        type: 'system', subtype: 'done', code,
+        _agent: entry.agentId, _conversationId: convoId, _processId: processId,
+      }));
+    }
+  });
 }
 
 // Graceful shutdown: kill children on exit signals.

--- a/server.js
+++ b/server.js
@@ -5294,14 +5294,17 @@ function startCodexTurn(convoId, msg, agentData) {
     stdio: ['pipe', 'pipe', 'pipe'],
   }, (err) => handleCodexSpawnError(err, convoId));
 
-  // Windows write markers: the Codex CLI silently downgrades workspace-write
-  // to read-only on native Windows (no enforceable sandbox; verified live on
-  // ARM64 where the native sandbox fails to initialise). win32 spawns are
-  // instructed to request writes as WRITE_FILE markers, which Rundock
-  // validates and performs itself behind a permission card. The env var is
-  // a test seam so the flow is exercisable from any platform's CI.
+  // Windows write markers: WITHOUT a [windows] sandbox declaration in the
+  // Codex config, the CLI silently downgrades workspace-write to read-only
+  // on native Windows, so win32 spawns are instructed to request writes as
+  // WRITE_FILE markers, which Rundock validates and performs itself behind
+  // a permission card. WITH the declaration, the CLI grants a real
+  // workspace-write policy (verified live) and the marker fallback stands
+  // down: the sandbox writes directly, as on macOS/Linux. Checked per spawn
+  // so a config edit takes effect on the next turn. The env var is a test
+  // seam so the flow is exercisable from any platform's CI.
   const codexPlatform = process.env.RUNDOCK_TEST_PLATFORM || process.platform;
-  const writeMarkersEnabled = codexPlatform === 'win32';
+  const writeMarkersEnabled = codexPlatform === 'win32' && !codexRuntime.hasWindowsSandboxConfig();
 
   const entry = {
     process: proc, runtime: 'codex', processId, agentId: agentData.id,

--- a/server.js
+++ b/server.js
@@ -650,8 +650,14 @@ function buildSystemPrompt(agentData) {
   let isCodeMode = false;
   try { isCodeMode = readState().workspaceMode === 'code'; } catch (e) { /* default knowledge */ }
 
+  // The concrete review-annotation handle is injected per-agent because a
+  // derivation rule ("your agent name, lowercase") parses differently across
+  // runtimes: GPT-5 wrote its ROLE where Claude agents wrote their short
+  // name. displayName lowercased is the convention Claude agents settled on.
+  const annotationHandle = String(agentData?.displayName || agentData?.name || 'agent').toLowerCase();
+
   const baseRules = [
-    'You are inside Rundock, a visual interface for AI agent teams powered by Claude Code (docs.rundock.ai). Answer "what is Rundock" questions directly using that description, even if Rundock is outside your usual domain. Every agent should know this. For deeper meta questions (creator, licence, features, feedback), route the user to Doc or point at the docs.',
+    'You are inside Rundock, a visual interface for AI agent teams (docs.rundock.ai). Rundock runs agents on the Claude Code and Codex runtimes. Answer "what is Rundock" questions directly using that description, even if Rundock is outside your usual domain. Every agent should know this. For deeper meta questions (creator, licence, features, feedback), route the user to Doc or point at the docs.',
     '',
     'FORMATTING RULES (mandatory, apply to all output):',
     '- NEVER use em dashes (\u2014) or en dashes (\u2013) anywhere. This includes lists, headers, separators, and inline text. Wrong: "AI \u2014 your assistant". Right: "AI: your assistant". Use colons, full stops, commas, or restructure instead.',
@@ -672,7 +678,7 @@ function buildSystemPrompt(agentData) {
     'Never use Obsidian URIs, file:// links, markdown links to file paths, or absolute paths. Just use wikilinks.',
     '',
     'REVIEW ANNOTATIONS (markdown files):',
-    'When adding review feedback to a markdown file, write CriticMarkup constructs: {>>comment<<} {++insert++} {--delete--} {~~old~>new~~}. Anchor EVERY construct with an id suffix, {#c1} for comments and {#s1} for suggestions, continuing the file\'s existing numbering. Record metadata for every anchor in the YAML block at the end of the file (introduced by a line containing only ---): entries under comments: or suggestions: keyed by anchor id, each with by: <your agent name, lowercase> and at: <current ISO timestamp>. Reply to an existing comment with a new comments: entry carrying body: <your reply> and re: <parent id>. A construct without an anchor and metadata entry shows as Unattributed in the review panel; never leave one.',
+    `When adding review feedback to a markdown file, write CriticMarkup constructs: {>>comment<<} {++insert++} {--delete--} {~~old~>new~~}. Anchor EVERY construct with an id suffix, {#c1} for comments and {#s1} for suggestions, continuing the file's existing numbering. Your review-annotation handle is: ${annotationHandle} (use exactly this, never your role or a description). Record metadata for every anchor in the YAML block at the end of the file (introduced by a line containing only ---): entries under comments: or suggestions: keyed by anchor id, each with by: ${annotationHandle} and at: <current ISO timestamp>. Reply to an existing comment with a new comments: entry carrying body: <your reply> and re: <parent id>. A construct without an anchor and metadata entry shows as Unattributed in the review panel; never leave one.`,
     'When discussing a specific comment or suggestion with the user, refer to it by QUOTING it (the comment text, or the passage it anchors to), for example: your comment "needs a source before we publish". Never refer to items by anchor id (c9, s2) or by number: the numbers shown in the editor are positional and change as items resolve, so quoted text is the only reference that stays correct.',
     'For at: timestamps, run date -u +%Y-%m-%dT%H:%M:%SZ at most once per editing pass and reuse that one value for every entry you add in the pass (entries added together sharing a timestamp is correct; anchor ids make them unique). Never loop or sleep to manufacture distinct timestamps.',
     '',

--- a/server.js
+++ b/server.js
@@ -611,6 +611,40 @@ function findDirectReportMatch(agentId, toolInput) {
   return null;
 }
 
+// The impersonation guard's matcher. An Agent tool call whose explicit
+// subagent_type names an onTeam workspace agent OUTSIDE the caller's direct
+// reports must not fall through to Claude Code: the harness would spawn a
+// generic Claude subagent wearing that agent's name (no real spawn, no
+// runtime, no disclosure). For runtime: codex agents that silently bypasses
+// the user's runtime choice. Returns the off-roster workspace agent, or null.
+//
+// Explicit path ONLY (decision, Liam 2026-07-13): prompt-text mentions of
+// off-roster agents ("review what Cody wrote") are common and legitimate, so
+// the prompt word-scan stays direct-reports-only. Call this AFTER
+// findDirectReportMatch returns null; direct reports are excluded here too
+// so the two matchers never claim the same target.
+function findOffRosterWorkspaceMatch(agentId, toolInput) {
+  if (!toolInput.subagent_type) return null;
+  const wanted = String(toolInput.subagent_type).toLowerCase();
+  const allAgents = discoverAgents();
+  const leader = allAgents.find(x => x.id === agentId);
+  const isOrchestrator = leader?.type === 'orchestrator';
+  const match = allAgents.find(a =>
+    a.status === 'onTeam' && a.id !== agentId && (
+      a.name.toLowerCase() === wanted ||
+      (a.id && String(a.id).toLowerCase() === wanted) ||
+      (a.displayName && a.displayName.toLowerCase() === wanted)
+    )
+  );
+  if (!match) return null;
+  // Exclude direct reports (mirror of findDirectReportMatch's roster rules).
+  const isDirectReport =
+    match.reportsTo === agentId ||
+    match.reportsTo === leader?.name ||
+    (isOrchestrator && match.type === 'platform');
+  return isDirectReport ? null : match;
+}
+
 function buildSystemPrompt(agentData) {
   // Read workspace mode to adjust platform rules
   let isCodeMode = false;
@@ -2335,6 +2369,36 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
                     _intercepted: true, _parentSessionId: entry.sessionId, _parentAgentId: entry.agentId
                   }, chatProcesses);
                   safeSend(JSON.stringify({ type: 'system', subtype: 'done', code: 0, _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId }));
+                } else {
+                  // Impersonation guard: an explicit subagent_type naming a
+                  // workspace agent OUTSIDE this caller's direct reports must
+                  // not fall through, or Claude Code spawns a generic subagent
+                  // wearing that agent's name (for runtime: codex agents this
+                  // silently bypasses the user's runtime choice). Soft block:
+                  // kill the turn and resume the caller with a corrective
+                  // message so it recovers in-conversation.
+                  const offRoster = findOffRosterWorkspaceMatch(entry.agentId, toolInput);
+                  if (offRoster && entry.sessionId) {
+                    console.log(`[AgentIntercept] convo=${convoId} agent=${entry.agentId} blocking off-roster Agent tool target: ${offRoster.name}`);
+                    intercepted = true;
+                    if (entry.responseText) {
+                      const toolSummary = buildToolSummary(entry.toolCalls);
+                      const textWithTools = toolSummary ? toolSummary + '\n' + entry.responseText : entry.responseText;
+                      appendTranscript(convoId, 'agent', entry.agentId, textWithTools);
+                    } else {
+                      appendTranscript(convoId, 'agent', entry.agentId, buildToolSummary(entry.toolCalls), 'routing');
+                    }
+                    try { entry.process.kill('SIGKILL'); } catch (e) {}
+                    entry.exited = true;
+                    const offName = offRoster.displayName || offRoster.name;
+                    safeSend(JSON.stringify({ type: 'system', subtype: 'info', content: `Blocked a handoff to ${offName}: not one of this agent's direct reports.`, _conversationId: convoId }));
+                    const blockedEntry = spawnResumedProcess(convoId, entry.agentId, entry.sessionId, chatProcesses, {});
+                    blockedEntry.idle = false;
+                    safeSend(JSON.stringify({ type: 'system', subtype: 'process_started', _conversationId: convoId, _processId: blockedEntry.processId, _agent: entry.agentId, autoContinue: true }));
+                    const runtimeNote = offRoster.runtime === 'codex' ? ` ${offName} runs on a different runtime (Codex), which only their own leader can start.` : '';
+                    const blockPrompt = `[SYSTEM: delegation-blocked] Your Agent tool call named "${offName}" (${offRoster.name}), a workspace agent who is not one of your direct reports, so it was NOT run. No subagent may act as ${offName}.${runtimeNote} Do not retry the same call. If the task needs ${offName}, tell the user this needs routing through ${offName}'s leader and hand back. Otherwise continue without them.`;
+                    blockedEntry.process.stdin.write(JSON.stringify({ type: 'user', message: { role: 'user', content: blockPrompt } }) + '\n');
+                  }
                 }
               } catch (e) {
                 console.log(`[AgentIntercept] convo=${convoId} failed to parse Agent tool input: ${e.message}`);
@@ -5645,7 +5709,7 @@ module.exports._internal = {
   stripRundockMarkers, isSilentParkResponse, sanitizeSpecialistOutput,
   extractSnippet, buildToolSummary, isAuthError, isModelError,
   // rosters + prompts
-  findDirectReportMatch, buildTeamRoster, buildPeerRoster,
+  findDirectReportMatch, findOffRosterWorkspaceMatch, buildTeamRoster, buildPeerRoster,
   extractSelfDescription, buildSystemPrompt,
   // workspace analysis / scaffolding
   detectWorkspaceMode, isEmptyWorkspace, analyzeWorkspace,

--- a/server.js
+++ b/server.js
@@ -122,6 +122,11 @@ function getBareArgs() {
 function getSpawnEnv(convoId) {
   const env = { ...process.env, TERM: 'dumb', RUNDOCK: '1', RUNDOCK_PORT: String(ACTUAL_PORT) };
   if (convoId) env.RUNDOCK_CONVO_ID = convoId;
+  // Never let spawned agent processes inherit the test runner's coverage
+  // collection: a child killed mid-turn (e.g. a superseded Codex exec)
+  // leaves truncated coverage JSON that corrupts the runner's merge and
+  // intermittently fails npm run test:coverage.
+  delete env.NODE_V8_COVERAGE;
   // In the packaged app there is no system `node`, so the PreToolUse permission
   // hook is run with Rundock's bundled runtime (process.execPath) behaving as
   // Node via ELECTRON_RUN_AS_NODE. The hook is a child of the spawned claude

--- a/server.js
+++ b/server.js
@@ -734,11 +734,48 @@ function buildSystemPrompt(agentData) {
     ].join('\n');
   }
 
+  // Runtime awareness for platform agents (Doc): only when Codex is actually
+  // available. Doc creates agents on the default runtime without ceremony,
+  // offers the alternative once per plan, and never recommends a runtime that
+  // is not present on this machine. When Codex is absent this section is
+  // omitted entirely, so Doc never mentions it.
+  let runtimeSection = '';
+  if (agentData && agentData.type === 'platform') {
+    const cx = detectCodexCached();
+    if (cx.installed && cx.authenticated) {
+      runtimeSection = [
+        'RUNTIMES:',
+        'Two runtimes are available on this machine: Claude Code (the workspace default) and Codex (the user\'s ChatGPT plan, via the official Codex CLI).',
+        'When proposing or creating agents: create on Claude Code, the default, without asking. Mention once per plan that any agent can run on the user\'s ChatGPT plan instead, and let the user opt in; if they do, add `runtime: codex` to that agent\'s frontmatter.',
+        'For agents on Codex, omit the model field unless the user names a specific Codex model; Codex applies its own default. Never recommend a runtime or model that is not listed here.',
+        'Codex agents use Codex\'s built-in sandbox rather than Rundock\'s permission prompts, and the workspace orchestrator always runs on Claude Code.',
+      ].join('\n');
+    }
+  }
+
   const sections = [baseRules];
   if (delegationSection) sections.push(delegationSection);
   if (scopeSection) sections.push(scopeSection);
+  if (runtimeSection) sections.push(runtimeSection);
   sections.push(bashRules);
   return sections.join('\n\n');
+}
+
+// Codex detection with a short cache: buildSystemPrompt runs on every spawn
+// and detection shells out (which + --version). 30 seconds is fresh enough
+// for install/login state.
+let _codexDetectCache = null;
+let _codexDetectTime = 0;
+function detectCodexCached() {
+  const now = Date.now();
+  if (_codexDetectCache && (now - _codexDetectTime) < 30000) return _codexDetectCache;
+  try {
+    _codexDetectCache = codexRuntime.detectCodex();
+  } catch (e) {
+    _codexDetectCache = { installed: false, authenticated: false, version: null };
+  }
+  _codexDetectTime = now;
+  return _codexDetectCache;
 }
 
 // ===== AGENT DISCOVERY =====
@@ -2167,6 +2204,7 @@ function isModelError(text) {
 function sendAuthError(entry, convoId) {
   if (entry.authErrorSent) return;
   entry.authErrorSent = true;
+  _claudeAuthEvidence = false; // runtime status: sign-in is demonstrably broken
   safeSend(JSON.stringify({
     type: 'system', subtype: 'auth_error',
     _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId
@@ -2335,6 +2373,9 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
             sendAuthError(entry, convoId);
           } else if (parsed.is_error && isModelError(JSON.stringify(parsed))) {
             sendModelError(entry, convoId);
+          } else if (!parsed.is_error) {
+            // A successful turn is proof of a working sign-in (runtime status).
+            _claudeAuthEvidence = true;
           }
           // Attach server-tracked tool calls for activity summary
           parsed._toolCalls = entry.toolCalls || [];
@@ -3694,6 +3735,9 @@ wss.on('connection', (ws) => {
         try { agentList = discoverAgents(); } catch (e) { console.warn('  Agent discovery failed:', e.message); }
         ws.send(JSON.stringify({ type: 'agents', agents: agentList }));
       }
+      if (msg.type === 'get_runtime_status') {
+        ws.send(JSON.stringify({ type: 'runtime_status', ...getRuntimeStatus() }));
+      }
       if (msg.type === 'get_files') {
         if (!WORKSPACE) return;
         try { ws.send(JSON.stringify({ type: 'file_tree', tree: getFileTree(WORKSPACE) })); } catch (e) { console.warn('  File tree failed:', e.message); }
@@ -3963,7 +4007,10 @@ wss.on('connection', (ws) => {
               }
             }
             console.log(`[Agent] ${existed ? 'Updated' : 'Created'}: ${name}`);
-            ws.send(JSON.stringify({ type: 'agent_saved', agentId: name, updated: existed }));
+            // Tag the confirmation with the agent's runtime so the client can
+            // suffix the created pill for non-default runtimes.
+            const savedRuntime = parseAgentFrontmatter(msg.content).runtime === 'codex' ? 'codex' : 'claude';
+            ws.send(JSON.stringify({ type: 'agent_saved', agentId: name, updated: existed, runtime: savedRuntime }));
             // Invalidate BEFORE discovering so the broadcast reflects the new
             // file. A warm (<2s) cache otherwise omits the just-saved agent
             // from this first roster broadcast.
@@ -4652,6 +4699,46 @@ let _resolvedCodexBin = null;
 function resolveCodexBinCached() {
   if (!_resolvedCodexBin) _resolvedCodexBin = codexRuntime.resolveCodexBin();
   return _resolvedCodexBin;
+}
+
+// Claude sign-in state, from evidence the server already has rather than a
+// live probe (a probe costs a real model call and 15 seconds; a settings
+// render must never do that). null = no evidence yet, and the UI claims
+// nothing. Set true by any successful turn, false by the auth-error
+// classifier. Self-correcting in both directions.
+let _claudeAuthEvidence = null;
+
+// Runtime status for the settings surface: which runtimes exist on this
+// machine, whether they are signed in, and which one is the workspace
+// default. The default is Claude in this version: Doc and delegation run on
+// it, so a workspace cannot exist without it.
+function getRuntimeStatus() {
+  const { execSync } = require('child_process');
+  const isWindows = process.platform === 'win32';
+  let claudeInstalled = true;
+  try {
+    execSync(isWindows ? 'where.exe claude' : 'which claude', { timeout: 5000, encoding: 'utf-8' });
+  } catch (e) { claudeInstalled = false; }
+  let claudeVersion = null;
+  if (claudeInstalled) {
+    try {
+      const out = execSync(`"${resolveClaudeBin()}" --version`, { timeout: 5000, encoding: 'utf-8' });
+      const m = String(out).match(/(\d+\.\d+(?:\.\d+)?(?:-[A-Za-z0-9.]+)?)/);
+      claudeVersion = m ? m[1] : null;
+    } catch (e) { /* installed but --version failed */ }
+  }
+  // Fresh Codex detection (the user may have just installed or signed in),
+  // and refresh the prompt-side cache while we have the answer.
+  let codexStatus;
+  try { codexStatus = codexRuntime.detectCodex(); }
+  catch (e) { codexStatus = { installed: false, authenticated: false, version: null }; }
+  _codexDetectCache = codexStatus;
+  _codexDetectTime = Date.now();
+  return {
+    defaultRuntime: 'claude',
+    claude: { installed: claudeInstalled, authenticated: claudeInstalled ? _claudeAuthEvidence : false, version: claudeVersion },
+    codex: codexStatus,
+  };
 }
 
 // Spawn a Codex process with the same PID tracking and error guarantees as

--- a/server.js
+++ b/server.js
@@ -2383,6 +2383,7 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
                   // silently bypasses the user's runtime choice). Soft block:
                   // kill the turn and resume the caller with a corrective
                   // message so it recovers in-conversation.
+                  // KNOWN LIMITATION: without a captured sessionId the caller cannot be resumed, so the block does not fire and the call falls through (pre-fix behavior). In practice init always precedes tool_use, so sessionId is present. Narrow.
                   const offRoster = findOffRosterWorkspaceMatch(entry.agentId, toolInput);
                   if (offRoster && entry.sessionId) {
                     console.log(`[AgentIntercept] convo=${convoId} agent=${entry.agentId} blocking off-roster Agent tool target: ${offRoster.name}`);

--- a/server.js
+++ b/server.js
@@ -32,6 +32,38 @@ function isInsideWorkspace(targetPath) {
   return resolved === root || resolved.startsWith(root + path.sep);
 }
 
+// ── Codex write-request validation (Windows write markers) ──────────────────
+// Validates a WRITE_FILE request BEFORE any permission card is shown: a card
+// is never raised for something Rundock would refuse to do. Workspace-bound
+// by construction, managed directories excluded, knowledge-mode file types
+// enforced (defence in depth: the same policy the prompts state).
+const CODEX_WRITE_ALLOWED_EXT = new Set(['.md', '.markdown', '.yaml', '.yml', '.json', '.txt', '.csv']);
+const CODEX_WRITE_MAX_BYTES = 1024 * 1024;
+function validateWriteRequest(workspaceDir, relPath, content, isCodeMode) {
+  if (!workspaceDir) return { ok: false, reason: 'no workspace selected' };
+  const p = String(relPath || '').trim();
+  if (!p) return { ok: false, reason: 'empty path' };
+  if (path.isAbsolute(p) || p.split(/[\\/]/).includes('..')) {
+    return { ok: false, reason: 'path escapes the workspace' };
+  }
+  const root = path.resolve(workspaceDir);
+  const fullPath = path.resolve(root, p);
+  if (!(fullPath.startsWith(root + path.sep))) {
+    return { ok: false, reason: 'path escapes the workspace' };
+  }
+  const top = path.relative(root, fullPath).split(path.sep)[0];
+  if (top === '.claude' || top === '.rundock') {
+    return { ok: false, reason: 'managed directory' };
+  }
+  if (Buffer.byteLength(String(content == null ? '' : content), 'utf-8') > CODEX_WRITE_MAX_BYTES) {
+    return { ok: false, reason: 'content exceeds the 1 MB write limit' };
+  }
+  if (!isCodeMode && !CODEX_WRITE_ALLOWED_EXT.has(path.extname(fullPath).toLowerCase())) {
+    return { ok: false, reason: 'file type not supported in this workspace' };
+  }
+  return { ok: true, fullPath };
+}
+
 // Shared constants to avoid repetition across process spawn sites
 const DISALLOWED_TOOLS_KNOWLEDGE = 'Write(*.js),Write(*.jsx),Write(*.ts),Write(*.tsx),Write(*.py),Write(*.sh),Write(*.bash),Write(*.rb),Write(*.pl),Write(*.exe),Write(*.dll),Write(*.so),Edit(*.js),Edit(*.jsx),Edit(*.ts),Edit(*.tsx),Edit(*.py),Edit(*.sh),Edit(*.bash),Edit(*.rb),Edit(*.pl),Edit(*.exe)';
 // Backward compat: DISALLOWED_TOOLS used by existing code paths
@@ -3599,8 +3631,14 @@ wss.on('connection', (ws) => {
         if (pending) {
           clearTimeout(pending.timer);
           pendingPermissionRequests.delete(msg.requestId);
-          pending.res.writeHead(200, { 'Content-Type': 'application/json' });
-          pending.res.end(JSON.stringify({ allow: msg.allow }));
+          if (pending.res) {
+            // Hook-originated request: answer the held HTTP response.
+            pending.res.writeHead(200, { 'Content-Type': 'application/json' });
+            pending.res.end(JSON.stringify({ allow: msg.allow }));
+          } else if (pending.onDecision) {
+            // Server-originated request (e.g. Codex write markers): callback.
+            try { pending.onDecision(msg.allow === true, 'user'); } catch (e) { console.error('[Permission] onDecision threw:', e); }
+          }
           console.log(`[Permission] convo=${msg.conversationId} requestId=${msg.requestId} decision=${msg.allow ? 'allow' : 'deny'}`);
         } else {
           console.warn(`[Permission] No pending request for requestId=${msg.requestId} (expired or already resolved)`);
@@ -3624,8 +3662,12 @@ wss.on('connection', (ws) => {
               clearTimeout(pending.timer);
               pendingPermissionRequests.delete(reqId);
               try {
-                pending.res.writeHead(200, { 'Content-Type': 'application/json' });
-                pending.res.end(JSON.stringify({ allow: false, reason: 'cancelled' }));
+                if (pending.res) {
+                  pending.res.writeHead(200, { 'Content-Type': 'application/json' });
+                  pending.res.end(JSON.stringify({ allow: false, reason: 'cancelled' }));
+                } else if (pending.onDecision) {
+                  pending.onDecision(false, 'cancelled');
+                }
               } catch (e) {}
             }
           }
@@ -5003,10 +5045,95 @@ function startCodexKeepalive(entry, convoId) {
 // Deliver the completed Codex turn: persist the transcript, send the result
 // (with normalised token usage: subscription usage, never dollar costs) and
 // the done signal.
+// Raise a permission card for a server-originated request (no hook HTTP
+// response to hold: the decision arrives via onDecision(allow, reason)).
+// Same card UI, same timeout, same cancel sweep as hook-originated requests.
+function requestServerPermission({ convoId, toolName, toolInput, onDecision }) {
+  const requestId = 'perm-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+  pendingPermissionRequests.set(requestId, {
+    onDecision,
+    conversationId: convoId,
+    toolName,
+    toolInput,
+    timer: setTimeout(() => {
+      const pending = pendingPermissionRequests.get(requestId);
+      if (pending) {
+        pendingPermissionRequests.delete(requestId);
+        console.log(`[Permission] Auto-denied (timeout): ${toolName} convo=${convoId} requestId=${requestId}`);
+        safeSend(JSON.stringify({ type: 'permission_timeout', requestId, _conversationId: convoId }));
+        try { pending.onDecision(false, 'timeout'); } catch (e) {}
+      }
+    }, PERMISSION_TIMEOUT_MS),
+  });
+  safeSend(JSON.stringify({
+    type: 'control_request',
+    request_id: requestId,
+    request: { subtype: 'can_use_tool', tool_name: toolName, input: toolInput || {} },
+    _conversationId: convoId,
+  }));
+  console.log(`[Permission] Server request: ${toolName} convo=${convoId} requestId=${requestId}`);
+}
+
+// One WRITE_FILE request from a Windows Codex turn: validate, card, write.
+// Invalid requests are refused WITHOUT a card (a card is never raised for
+// something Rundock would not do); the refusal is recorded so the user and
+// the resumed thread can see what happened.
+function handleCodexWriteRequest(entry, convoId, req) {
+  let isCodeMode = false;
+  try { isCodeMode = readState().workspaceMode === 'code'; } catch (e) {}
+  const v = validateWriteRequest(WORKSPACE, req.path, req.content, isCodeMode);
+  if (!v.ok) {
+    console.log(`[CodexWrite] convo=${convoId} refused without card: ${req.path} (${v.reason})`);
+    appendTranscript(convoId, 'agent', entry.agentId, `Write of ${req.path} refused: ${v.reason}.`);
+    safeSend(JSON.stringify({ type: 'system', subtype: 'notice', content: `Refused a file write from ${entry.agentId}: ${req.path} (${v.reason}).`, _conversationId: convoId }));
+    return;
+  }
+  requestServerPermission({
+    convoId,
+    toolName: 'WriteFile',
+    toolInput: { path: req.path, content: req.content, agent: entry.agentId },
+    onDecision: (allow, reason) => {
+      if (!allow) {
+        console.log(`[CodexWrite] convo=${convoId} not approved (${reason}): ${req.path}`);
+        appendTranscript(convoId, 'agent', entry.agentId, `Write of ${req.path} not approved.`);
+        safeSend(JSON.stringify({ type: 'system', subtype: 'notice', content: `Write of ${req.path} was not approved.`, _conversationId: convoId }));
+        return;
+      }
+      try {
+        fs.mkdirSync(path.dirname(v.fullPath), { recursive: true });
+        fs.writeFileSync(v.fullPath, req.content, 'utf-8');
+        invalidateFileListCache();
+        if (ensureSearchEngine()) {
+          try { searchEngine.noteFileSaved(WORKSPACE, req.path); } catch (e) { /* reconcile catches up */ }
+        }
+        appendTranscript(convoId, 'agent', entry.agentId, `Created ${req.path} (approved).`);
+        safeSend(JSON.stringify({ type: 'system', subtype: 'notice', content: `Created [[${req.path}]] (approved write from ${entry.agentId}).`, _conversationId: convoId }));
+        safeSend(JSON.stringify({ type: 'file_saved', path: req.path }));
+        console.log(`[CodexWrite] convo=${convoId} wrote ${req.path} (${Buffer.byteLength(req.content, 'utf-8')} bytes)`);
+      } catch (e) {
+        console.error(`[CodexWrite] convo=${convoId} write failed: ${e.message}`);
+        appendTranscript(convoId, 'agent', entry.agentId, `Write of ${req.path} failed: ${e.message}`);
+        safeSend(JSON.stringify({ type: 'system', subtype: 'notice', content: `Write of ${req.path} failed: ${e.message}`, _conversationId: convoId }));
+      }
+    },
+  });
+}
+
 function finishCodexTurn(entry, convoId) {
   if (entry.resultSent) return;
   entry.resultSent = true;
-  const text = entry.responseText || '';
+  let text = entry.responseText || '';
+  // Windows write markers: strip from the displayed/persisted text, then
+  // dispatch each request through validation + permission card AFTER the
+  // result, so the conversation shows the agent's message first and the
+  // cards follow. Only turns that were given the marker instruction are
+  // honoured (entry.writeMarkersEnabled).
+  let writeRequests = [];
+  if (entry.writeMarkersEnabled && text.includes('RUNDOCK:WRITE_FILE')) {
+    const parsed = codexRuntime.parseWriteMarkers(text);
+    text = parsed.cleanText;
+    writeRequests = parsed.requests;
+  }
   if (text) appendTranscript(convoId, 'agent', entry.agentId, text);
   safeSend(JSON.stringify({
     type: 'result', result: text, is_error: false, usage: entry.usage,
@@ -5018,6 +5145,7 @@ function finishCodexTurn(entry, convoId) {
     type: 'system', subtype: 'done', code: 0,
     _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
   }));
+  for (const req of writeRequests) handleCodexWriteRequest(entry, convoId, req);
 }
 
 // Handle one parsed line of Codex output for a running turn.
@@ -5166,10 +5294,19 @@ function startCodexTurn(convoId, msg, agentData) {
     stdio: ['pipe', 'pipe', 'pipe'],
   }, (err) => handleCodexSpawnError(err, convoId));
 
+  // Windows write markers: the Codex CLI silently downgrades workspace-write
+  // to read-only on native Windows (no enforceable sandbox; verified live on
+  // ARM64 where the native sandbox fails to initialise). win32 spawns are
+  // instructed to request writes as WRITE_FILE markers, which Rundock
+  // validates and performs itself behind a permission card. The env var is
+  // a test seam so the flow is exercisable from any platform's CI.
+  const codexPlatform = process.env.RUNDOCK_TEST_PLATFORM || process.platform;
+  const writeMarkersEnabled = codexPlatform === 'win32';
+
   const entry = {
     process: proc, runtime: 'codex', processId, agentId: agentData.id,
     responseText: '', exited: false, resultSent: false, errorSent: false,
-    doneSent: false, superseded: false, usage: null,
+    doneSent: false, superseded: false, usage: null, writeMarkersEnabled,
     sessionId: resumeThreadId, lastUserMessage: msg.content,
     toolCalls: [], turnStartTime: Date.now(),
   };
@@ -5181,12 +5318,21 @@ function startCodexTurn(convoId, msg, agentData) {
     _agent: agentData.id, _conversationId: convoId, _processId: processId,
   }));
 
+  const windowsWriteNote = writeMarkersEnabled ? [
+    'WINDOWS FILE WRITES:',
+    'On this machine your sandbox is read-only: shell commands that write files will be rejected. To create or update a file, output a block in EXACTLY this format as part of your response:',
+    '<!-- RUNDOCK:WRITE_FILE path="relative/path/inside/workspace.md" -->',
+    '<the complete file content>',
+    '<!-- /RUNDOCK:WRITE_FILE -->',
+    'Rules: relative paths inside the workspace only; the content replaces the whole file; one block per file, multiple blocks allowed. The user approves each write AFTER your turn ends, so describe writes as requested, never as completed. Never claim a file was created. Do not attempt writes via shell commands.',
+  ].join('\n') : '';
+
   // Prompt over stdin, never argv. First turns carry identity (the agent
   // file body) plus the platform rules; Claude gets these via --agent and
   // --append-system-prompt, which Codex does not support.
   const prompt = resumeThreadId
     ? msg.content
-    : [readAgentInstructions(agentData), buildSystemPrompt(agentData), msg.content].filter(Boolean).join('\n\n');
+    : [readAgentInstructions(agentData), buildSystemPrompt(agentData), windowsWriteNote, msg.content].filter(Boolean).join('\n\n');
   proc.stdin.on('error', () => { /* EPIPE on early exit: close handler reports */ });
   proc.stdin.write(prompt);
   proc.stdin.end();
@@ -5714,7 +5860,7 @@ module.exports._internal = {
   parseRoutines, parsePrompts, parseSkills, readNormalisedFile, titleCase,
   // markers + text helpers
   stripRundockMarkers, isSilentParkResponse, sanitizeSpecialistOutput,
-  extractSnippet, buildToolSummary, isAuthError, isModelError,
+  extractSnippet, buildToolSummary, isAuthError, isModelError, validateWriteRequest,
   // rosters + prompts
   findDirectReportMatch, findOffRosterWorkspaceMatch, buildTeamRoster, buildPeerRoster,
   extractSelfDescription, buildSystemPrompt,

--- a/server.js
+++ b/server.js
@@ -2619,13 +2619,19 @@ function handleDelegation(msg, processes) {
   // Spawn delegate process
   const delegateProcessId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
   const isPlatformDelegate = targetAgent.type === 'platform';
+  // Codex delegates are transactional: exec mode runs one process per turn,
+  // so a delegated task is briefed, completed in one response, and control
+  // returns to the parent with the output injected (the shared close handler
+  // below). Direct conversations with Codex agents remain conversational via
+  // thread resume; only the delegated flow is single-shot.
+  const isCodexDelegate = targetAgent.runtime === 'codex';
 
   // Platform delegates (Doc): transactional, auto-return after task completion
   // Specialists with direct reports: multi-step pipeline, return when the pipeline is complete
   // Plain specialists: conversational, user controls when to return
   const targetHasDirectReports = !!buildTeamRoster(targetAgent.id, true);
   let delegationContext;
-  if (isPlatformDelegate) {
+  if (isPlatformDelegate || isCodexDelegate) {
     delegationContext = 'DELEGATION CONTEXT:\nYou have been delegated a task by another agent. Complete the task in a single response if possible. When the task is done (agent created, skill saved, file written, question answered, etc.), output <!-- RUNDOCK:COMPLETE --> at the very end of that same response. Do not wait for follow-up questions. Do not ask if there is anything else. Just complete the task, confirm what you did, and return immediately. If you genuinely need clarification before you can proceed, ask, but prefer using sensible defaults over asking.\n\nException: if you have proposed a plan and are waiting for the user to confirm before you execute (e.g. you asked them to say "go ahead"), do NOT emit COMPLETE. Stay in the conversation and wait for their response. Only emit COMPLETE once the task is genuinely finished: you executed the work, or you answered the question fully with no pending user decision.\n\nOnly use <!-- RUNDOCK:RETURN --> if the request is genuinely outside your scope and you cannot help. This is rare.';
   } else if (targetHasDirectReports) {
     delegationContext = 'DELEGATION CONTEXT:\nYou have been brought into this conversation by the orchestrator to run a task in your domain. You lead a support team and may delegate parts of the work to them. Do the real work, write the deliverables, and report the outcome.\n\nYou MUST hand control back using one of two markers, on its own line, as the very last thing in your response (after any final summary):\n\n- <!-- RUNDOCK:RETURN --> when the user asks for something outside your domain of expertise. Tell them briefly that this falls outside what you handle and you are handing them back so the right person can pick it up. Do NOT name other specialists or suggest who should handle it. Then emit the marker.\n\n- <!-- RUNDOCK:COMPLETE --> when the orchestrator\'s original delegated pipeline is finished end-to-end. All deliverables are written to their final locations and the workflow has reached its final status (for example content moved to Ready for Review, spec written and linked, final audit posted). Post your final summary first, then emit the marker.\n\nDo NOT emit either marker when you are pausing at a decision point to let the user choose between options, presenting drafts, hooks, options, or recommendations for user review, asking the user to confirm something before continuing, or waiting at a human gate midway through a multi-phase pipeline. Those are pauses, not completions. Stay in the conversation as the active agent and wait for the user\'s next message. You will pick up where you left off when they respond.\n\nReturning on completion is how control flows back up the chain. If you silently stop, the user\'s next message will be routed to the wrong agent.';
@@ -2662,16 +2668,22 @@ function handleDelegation(msg, processes) {
     ...(priorSessionId ? ['--resume', priorSessionId] : []),
     '--agent', targetAgent.name];
 
-  console.log(`[Delegate] convo=${convoId} from=${originalAgentId} to=${targetAgent.id} proc=${delegateProcessId}${priorSessionId ? ` resume=${priorSessionId}` : ''}`);
+  console.log(`[Delegate] convo=${convoId} from=${originalAgentId} to=${targetAgent.id} proc=${delegateProcessId} runtime=${targetAgent.runtime}${priorSessionId ? ` resume=${priorSessionId}` : ''}`);
 
-  const delegateProc = spawnClaude(delegateArgs, {
-    cwd: WORKSPACE,
-    env: getSpawnEnv(convoId),
-    stdio: ['pipe', 'pipe', 'pipe']
-  }, (err) => handleChatSpawnError(err, convoId));
+  const delegateProc = isCodexDelegate
+    ? spawnCodex(codexRuntime.buildCodexArgs({ resumeThreadId: priorSessionId, model: targetAgent.model || undefined }), {
+        cwd: WORKSPACE,
+        env: getSpawnEnv(convoId),
+        stdio: ['pipe', 'pipe', 'pipe']
+      }, (err) => handleChatSpawnError(err, convoId))
+    : spawnClaude(delegateArgs, {
+        cwd: WORKSPACE,
+        env: getSpawnEnv(convoId),
+        stdio: ['pipe', 'pipe', 'pipe']
+      }, (err) => handleChatSpawnError(err, convoId));
 
   const delegateEntry = {
-    process: delegateProc, buffer: '', processId: delegateProcessId,
+    process: delegateProc, runtime: targetAgent.runtime, buffer: '', processId: delegateProcessId,
     agentId: targetAgent.id, responseText: '', exited: false, resultSent: false, idle: false,
     isPlatformDelegate, lastUserMessage: msg.context, receivedFollowUp: false,
     isIntercepted,
@@ -2708,6 +2720,17 @@ function handleDelegation(msg, processes) {
   const contextWithHistory = transcript
     ? `CONVERSATION SO FAR:\n${transcript}\n\nYOUR TASK:\n${msg.context}`
     : `[DELEGATION BRIEF]\n${msg.context}`;
+
+  if (isCodexDelegate) {
+    // Codex takes the whole prompt over stdin: identity + platform rules +
+    // delegation contract on a cold spawn (Codex has no --agent or
+    // --append-system-prompt equivalent); contract + brief on a resumed
+    // thread (instructions are already in the thread).
+    const codexPrompt = priorSessionId
+      ? `${delegationContext}\n\n${contextWithHistory}`
+      : [readAgentInstructions(targetAgent), fullPrompt, contextWithHistory].filter(Boolean).join('\n\n');
+    wireCodexDelegate(delegateEntry, convoId, codexPrompt);
+  } else {
   delegateProc.stdin.write(JSON.stringify({ type: 'user', message: { role: 'user', content: contextWithHistory } }) + '\n');
 
   wireProcessHandlers(delegateEntry, convoId, null, {
@@ -2765,6 +2788,7 @@ function handleDelegation(msg, processes) {
       e.idle = true;
     }
   });
+  }
 
   delegateProc.on('close', (code) => {
     if (delegateEntry.spawnFailed) return; // error handler already surfaced
@@ -4727,6 +4751,76 @@ function readAgentInstructions(agentData) {
     }
   } catch (e) { /* fall through to snapshot */ }
   return agentData.instructions || '';
+}
+
+// Wire a Codex delegate process. The prompt goes in whole over stdin; output
+// events deliver the specialist's result and record any handoff marker on the
+// SAME entry fields Claude delegates use (returnMarkerSeen,
+// finalResponseText), so the shared delegate close handler in
+// handleDelegation performs restoration identically for both runtimes.
+// This function sends the result message; the close handler owns
+// agent_switch/done and parent restoration.
+function wireCodexDelegate(entry, convoId, prompt) {
+  const proc = entry.process;
+  proc.stdin.on('error', () => { /* EPIPE on early exit: close handler reports */ });
+  proc.stdin.write(prompt);
+  proc.stdin.end();
+
+  let stdoutBuf = '';
+  const handleLine = (line) => {
+    const ev = codexRuntime.parseCodexLine(line);
+    if (!ev) {
+      if (line.trim()) console.log(`[Codex] convo=${convoId} delegate skipped line: ${line.slice(0, 200)}`);
+      return;
+    }
+    if (ev.type === 'session') {
+      entry.sessionId = ev.threadId;
+      safeSend(JSON.stringify({
+        type: 'system', subtype: 'init', _sessionId: ev.threadId,
+        _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+      }));
+    } else if (ev.type === 'text') {
+      entry.responseText = entry.responseText ? entry.responseText + '\n' + ev.text : ev.text;
+    } else if (ev.type === 'done') {
+      // Marker scan, COMPLETE priority: same contract as the Claude
+      // delegate onResult handler.
+      const hasComplete = /<!-- RUNDOCK:COMPLETE -->/.test(entry.responseText);
+      const hasReturn = /<!-- RUNDOCK:RETURN -->/.test(entry.responseText);
+      if (hasComplete) entry.returnMarkerSeen = 'complete';
+      else if (hasReturn) entry.returnMarkerSeen = 'return';
+      if (entry.responseText) appendTranscript(convoId, 'agent', entry.agentId, entry.responseText);
+      safeSend(JSON.stringify({
+        type: 'result', result: entry.responseText, is_error: false, usage: ev.usage,
+        _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
+        _turnStartTime: entry.turnStartTime,
+      }));
+      entry.resultSent = true;
+      entry.finalResponseText = entry.responseText;
+      entry.responseText = '';
+      entry.idle = true;
+    } else if (ev.type === 'error') {
+      sendCodexError(entry, convoId, ev.message);
+    }
+  };
+
+  proc.stdout.on('data', (chunk) => {
+    stdoutBuf += chunk.toString();
+    let nl;
+    while ((nl = stdoutBuf.indexOf('\n')) >= 0) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      handleLine(line);
+    }
+  });
+
+  let stderrBuf = '';
+  proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+  proc.on('close', () => {
+    if (stdoutBuf.trim()) handleLine(stdoutBuf); // unterminated last line
+    if (!entry.resultSent && !entry.errorSent && !entry.cancelled) {
+      sendCodexError(entry, convoId, stderrBuf.trim() || 'Codex exited unexpectedly');
+    }
+  });
 }
 
 // Run one Codex conversation turn. Each turn is its own process: fresh turns

--- a/server.js
+++ b/server.js
@@ -1179,10 +1179,12 @@ function executeRoutine(agent, routine, key) {
     // instructions, and Codex's own sandbox applies (no bypass flags exist
     // on this path). The agent's plan choice is honoured even for
     // unattended work.
+    // stdout/stderr are ignored: nothing consumes them on the routine path,
+    // and a chatty run would otherwise fill the pipe buffer and deadlock.
     proc = spawnCodex(codexRuntime.buildCodexArgs({ model: agent.model || undefined }), {
       cwd: WORKSPACE,
       env: getSpawnEnv(null),
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'ignore', 'ignore']
     });
     proc.stdin.on('error', () => { /* EPIPE on early exit */ });
     proc.stdin.write([readAgentInstructions(agent), buildSystemPrompt(agent), routine.prompt].filter(Boolean).join('\n\n'));
@@ -2578,6 +2580,7 @@ function spawnResumedProcess(convoId, agentId, sessionId, processes, opts = {}) 
     responseText: '', exited: false, resultSent: false,
     pendingAgentTool: null, toolCalls: [], turnStartTime: Date.now(),
     idle: true, scopeReturnSource: opts.scopeReturnSource || null,
+    handbackAt: Date.now(), // stale end_delegation guard
   };
   processes.set(convoId, entry);
 
@@ -2733,8 +2736,11 @@ function handleDelegation(msg, processes) {
 
   console.log(`[Delegate] convo=${convoId} from=${originalAgentId} to=${targetAgent.id} proc=${delegateProcessId} runtime=${targetAgent.runtime}${priorSessionId ? ` resume=${priorSessionId}` : ''}`);
 
+  // Normalised for the codex path: argv and prompt must agree on whether
+  // this is a resume (see startCodexTurn for the identity-loss hazard).
+  const codexResumeId = isCodexDelegate && codexRuntime.isValidThreadId(priorSessionId) ? priorSessionId : null;
   const delegateProc = isCodexDelegate
-    ? spawnCodex(codexRuntime.buildCodexArgs({ resumeThreadId: priorSessionId, model: targetAgent.model || undefined }), {
+    ? spawnCodex(codexRuntime.buildCodexArgs({ resumeThreadId: codexResumeId, model: targetAgent.model || undefined }), {
         cwd: WORKSPACE,
         env: getSpawnEnv(convoId),
         stdio: ['pipe', 'pipe', 'pipe']
@@ -2789,7 +2795,7 @@ function handleDelegation(msg, processes) {
     // delegation contract on a cold spawn (Codex has no --agent or
     // --append-system-prompt equivalent); contract + brief on a resumed
     // thread (instructions are already in the thread).
-    const codexPrompt = priorSessionId
+    const codexPrompt = codexResumeId
       ? `${delegationContext}\n\n${contextWithHistory}`
       : [readAgentInstructions(targetAgent), fullPrompt, contextWithHistory].filter(Boolean).join('\n\n');
     startCodexKeepalive(delegateEntry, convoId);
@@ -2907,6 +2913,7 @@ function handleDelegation(msg, processes) {
 
         orchestratorEntry.idle = true;
         orchestratorEntry.delegation = null;
+        orchestratorEntry.handbackAt = Date.now(); // stale end_delegation guard
         processes.set(convoId, orchestratorEntry);
 
         safeSend(JSON.stringify({
@@ -2990,7 +2997,8 @@ function handleDelegation(msg, processes) {
         // Tag with returning specialist so handleDelegation's scopeReturnSource
         // guard blocks immediate re-delegation to the same agent. Only set for
         // out-of-scope returns; pipeline-complete should allow re-delegation.
-        scopeReturnSource: isOutOfScope ? delegateEntry.agentId : null
+        scopeReturnSource: isOutOfScope ? delegateEntry.agentId : null,
+        handbackAt: Date.now() // stale end_delegation guard
       };
       processes.set(convoId, resumeEntry);
 
@@ -3098,6 +3106,7 @@ function handleDelegation(msg, processes) {
     } else if (orig && !orig.exited) {
       orig.idle = true;
       orig.delegation = null;
+      orig.handbackAt = Date.now(); // stale end_delegation guard
       processes.set(convoId, orig);
       console.log(`[Delegate] convo=${convoId} delegate exited, restored ${delegateEntry.delegation.originalAgentId}`);
       safeSend(JSON.stringify({
@@ -3930,15 +3939,20 @@ wss.on('connection', (ws) => {
         } else if (current && !current.delegation && !current.exited && !current.scopeReturn) {
           // Specialist started directly (no delegation) emitted RETURN
           // Server-side onResult should have caught this, but handle as fallback.
-          // Stale-message guard: an orchestrator or platform agent never emits
-          // RETURN, so end_delegation landing on one means the handback already
-          // completed server-side (a fast-exiting delegate, e.g. Codex, can be
-          // restored before the client's marker scan round-trips). Killing the
-          // restored parent here would drop its session. Ignore instead.
+          // Stale-message guard, two signals:
+          // 1. An entry restored/respawned by a delegate close handler within
+          //    the last 15s (handbackAt): a fast-exiting delegate (e.g. Codex)
+          //    can be handed back server-side before the client's marker scan
+          //    round-trips, so the late end_delegation refers to a handback
+          //    that already happened, for ANY parent type. Killing the
+          //    restored parent would drop its session.
+          // 2. An orchestrator or platform agent never emits RETURN, so the
+          //    fallback can never be legitimate for one.
+          const recentlyHandedBack = current.handbackAt && (Date.now() - current.handbackAt) < 15000;
           const agentList = discoverAgents();
           const currentAgent = agentList.find(a => a.id === current.agentId || a.name === current.agentId);
-          if (currentAgent && (currentAgent.type === 'orchestrator' || currentAgent.type === 'platform')) {
-            console.log(`[ScopeReturn] convo=${convoId} ignoring stale end_delegation: current agent ${current.agentId} is ${currentAgent.type}`);
+          if (recentlyHandedBack || (currentAgent && (currentAgent.type === 'orchestrator' || currentAgent.type === 'platform'))) {
+            console.log(`[ScopeReturn] convo=${convoId} ignoring stale end_delegation for ${current.agentId} (${recentlyHandedBack ? 'recent handback' : currentAgent.type})`);
           } else {
             console.log(`[ScopeReturn] convo=${convoId} end_delegation fallback for non-delegated specialist`);
             current.scopeReturn = true;
@@ -4754,8 +4768,10 @@ function getRuntimeStatus() {
   // The install/version probe shells out (claude --version can take seconds)
   // and this runs on the WebSocket handler path, so cache it. 60s keeps a
   // fresh install visible quickly without blocking every settings open.
+  // A cached "not installed" is never trusted: the user may have just
+  // installed, and that is exactly when they will open settings to check.
   let claudeInstalled, claudeVersion;
-  if (_claudeProbeCache && (Date.now() - _claudeProbeTime) < 60000) {
+  if (_claudeProbeCache && _claudeProbeCache.installed && (Date.now() - _claudeProbeTime) < 60000) {
     ({ installed: claudeInstalled, version: claudeVersion } = _claudeProbeCache);
   } else {
     claudeInstalled = true;
@@ -4836,6 +4852,22 @@ function sendCodexError(entry, convoId, message) {
 function handleCodexSpawnError(err, convoId) {
   const entry = chatProcesses.get(convoId);
   if (entry) entry.spawnFailed = true;
+  // Same 30s per-conversation dedupe as the Claude spawn-error handler, so
+  // retries against a missing binary do not stack pills. Keys are prefixed
+  // to keep the two runtimes' dedupe windows independent.
+  const dedupeKey = `codex:${convoId || ''}`;
+  const last = recentSpawnErrors.get(dedupeKey);
+  const now = Date.now();
+  if (last && last.code === err.code && (now - last.ts) < 30000) {
+    console.error(`[SpawnError] convo=${convoId} codex code=${err.code} (deduped within 30s)`);
+    safeSend(JSON.stringify({
+      type: 'system', subtype: 'done', code: -1,
+      _agent: entry ? entry.agentId : undefined, _conversationId: convoId,
+      _processId: entry ? entry.processId : undefined,
+    }));
+    return;
+  }
+  recentSpawnErrors.set(dedupeKey, { code: err.code, ts: now });
   let userMessage;
   if (err.code === 'ENOENT') {
     userMessage = 'The Codex CLI was not found on this machine. Install the official Codex CLI, then sign in: npm install -g @openai/codex then codex login';
@@ -4861,7 +4893,7 @@ function handleCodexSpawnError(err, convoId) {
 const CODEX_KEEPALIVE_MS = parseInt(process.env.RUNDOCK_CODEX_KEEPALIVE_MS || '', 10) || 25000;
 function startCodexKeepalive(entry, convoId) {
   const timer = setInterval(() => {
-    if (entry.exited || entry.resultSent) { clearInterval(timer); return; }
+    if (entry.exited || entry.resultSent || entry.spawnFailed) { clearInterval(timer); return; }
     safeSend(JSON.stringify({
       type: 'system', subtype: 'keepalive',
       _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId,
@@ -4998,6 +5030,7 @@ function wireCodexDelegate(entry, convoId, prompt) {
   let stderrBuf = '';
   proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
   proc.on('close', () => {
+    if (entry.spawnFailed) return; // spawn-error handler already surfaced
     if (stdoutBuf.trim()) handleLine(stdoutBuf); // unterminated last line
     if (!entry.resultSent && !entry.errorSent && !entry.cancelled) {
       sendCodexError(entry, convoId, stderrBuf.trim() || 'Codex exited unexpectedly');
@@ -5019,7 +5052,11 @@ function startCodexTurn(convoId, msg, agentData) {
     chatProcesses.delete(convoId);
   }
 
-  const resumeThreadId = msg.sessionId || null;
+  // Normalise once: an invalid session id (hostile client, corrupted
+  // persistence) must produce a FULL fresh turn, instructions included. If
+  // only argv dropped the id, the prompt would still be built resume-shaped
+  // and the agent would run without its identity.
+  const resumeThreadId = codexRuntime.isValidThreadId(msg.sessionId) ? msg.sessionId : null;
   const args = codexRuntime.buildCodexArgs({ resumeThreadId, model: agentData.model || undefined });
   const processId = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
 

--- a/test/fixtures/codex-jsonl.js
+++ b/test/fixtures/codex-jsonl.js
@@ -1,0 +1,57 @@
+'use strict';
+// Codex CLI `exec --json` JSONL event fixtures.
+//
+// Shapes follow the Codex CLI's documented JSON output: one JSON object per
+// line, four event types that matter to Rundock (thread.started,
+// item.completed with an agent_message item, turn.completed, turn.failed)
+// plus a bare error form. Anything else is noise to be skipped.
+//
+// These fixtures are the single source of truth for both the unit tests and
+// the stub codex binary, so the parser and the integration harness can never
+// drift apart. Validate against a real `codex` binary when changing them.
+
+function threadStarted(threadId) {
+  return { type: 'thread.started', thread_id: threadId };
+}
+
+function agentMessage(text) {
+  return { type: 'item.completed', item: { type: 'agent_message', text } };
+}
+
+// A non-message item completion (e.g. a command run or reasoning step).
+// Rundock ignores these; only the final agent message is user-facing.
+function otherItem(itemType = 'command_execution') {
+  return { type: 'item.completed', item: { type: itemType, command: 'ls' } };
+}
+
+function turnCompleted(usage = {}) {
+  return {
+    type: 'turn.completed',
+    usage: {
+      input_tokens: usage.input ?? 100,
+      cached_input_tokens: usage.cached ?? 0,
+      output_tokens: usage.output ?? 50,
+    },
+  };
+}
+
+function turnFailed(message) {
+  return { type: 'turn.failed', error: { message } };
+}
+
+function bareError(message) {
+  return { type: 'error', message };
+}
+
+// The quota-exhaustion message the CLI emits when a ChatGPT plan's Codex
+// allowance is used up. Wording varies; the classifier keys on "usage limit".
+const QUOTA_MESSAGE = "You've hit your usage limit. Try again at 3pm.";
+
+function toLines(events) {
+  return events.map(e => JSON.stringify(e)).join('\n') + '\n';
+}
+
+module.exports = {
+  threadStarted, agentMessage, otherItem, turnCompleted, turnFailed, bareError,
+  toLines, QUOTA_MESSAGE,
+};

--- a/test/helpers/harness.js
+++ b/test/helpers/harness.js
@@ -10,6 +10,7 @@ const assert = require('node:assert');
 const { makeWorkspace, makeTempDir, standardTeam } = require('./workspace.js');
 
 const STUB_DIR = path.join(__dirname, 'stub-claude');
+const CODEX_STUB_DIR = path.join(__dirname, 'stub-codex');
 
 let srv = null;
 let internal = null;
@@ -28,7 +29,7 @@ async function boot(opts = {}) {
   assert.strictEqual(srv, null, 'boot() must only be called once per test file');
 
   // Environment isolation. Must happen before server.js is required.
-  process.env.PATH = STUB_DIR + path.delimiter + process.env.PATH;
+  process.env.PATH = STUB_DIR + path.delimiter + CODEX_STUB_DIR + path.delimiter + process.env.PATH;
   const tempHome = makeTempDir('rundock-test-home-');
   process.env.HOME = tempHome;
   // RUNDOCK_ELECTRON routes the recent-workspaces file into $HOME (now a temp
@@ -42,10 +43,14 @@ async function boot(opts = {}) {
   internal = srv._internal;
   internal.setWorkspace(workspaceDir);
 
-  // Hard safety gate: never run integration scenarios against a real claude.
+  // Hard safety gate: never run integration scenarios against a real claude
+  // or a real codex.
   const resolved = internal.resolveClaudeBin();
   assert.strictEqual(resolved, path.join(STUB_DIR, 'claude'),
     `stub claude not resolved (got: ${resolved}). Refusing to run against a real binary.`);
+  const codexResolved = require('../../codex.js').resolveCodexBin();
+  assert.strictEqual(codexResolved, path.join(CODEX_STUB_DIR, 'codex'),
+    `stub codex not resolved (got: ${codexResolved}). Refusing to run against a real binary.`);
 
   port = await srv.startServer({ port: 0 });
   return { internal, port, workspaceDir };
@@ -53,6 +58,10 @@ async function boot(opts = {}) {
 
 function writeScenario(rules) {
   fs.writeFileSync(path.join(workspaceDir, 'stub-scenario.json'), JSON.stringify({ rules }, null, 2));
+}
+
+function writeCodexScenario(rules) {
+  fs.writeFileSync(path.join(workspaceDir, 'stub-codex-scenario.json'), JSON.stringify({ rules }, null, 2));
 }
 
 function readInvocations() {
@@ -172,10 +181,10 @@ function freshConvoId(prefix = 'it') {
 }
 
 module.exports = {
-  boot, shutdown, connect, writeScenario, readInvocations, clearInvocations,
+  boot, shutdown, connect, writeScenario, writeCodexScenario, readInvocations, clearInvocations,
   delay, freshConvoId, reapConvo,
   get internal() { return internal; },
   get port() { return port; },
   get workspaceDir() { return workspaceDir; },
-  STUB_DIR,
+  STUB_DIR, CODEX_STUB_DIR,
 };

--- a/test/helpers/stub-claude/claude
+++ b/test/helpers/stub-claude/claude
@@ -41,6 +41,15 @@ const readline = require('readline');
 const fx = require(path.join(__dirname, '..', '..', 'fixtures', 'stream-json.js'));
 
 const argv = process.argv.slice(2);
+
+// Version probe: answer immediately without touching stdin or the scenario,
+// so runtime detection never hangs on the stub. No invocation is logged for
+// version probes (they are not conversation spawns).
+if (argv.includes('--version')) {
+  process.stdout.write('0.0.0-stub (Claude Code)\n');
+  process.exit(0);
+}
+
 function argValue(flag) {
   const i = argv.indexOf(flag);
   return i >= 0 ? argv[i + 1] : null;

--- a/test/helpers/stub-codex/codex
+++ b/test/helpers/stub-codex/codex
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+'use strict';
+// Stub `codex` binary for the Rundock test suite.
+//
+// Mimics `codex exec --json`: reads the prompt from stdin (the trailing `-`
+// argument), emits scripted JSONL events on stdout, exits when the turn ends.
+// One process per turn, exactly like the real CLI's exec mode. No network.
+//
+// Injection: the test harness prepends this directory to PATH, so the
+// server's codex binary resolution (`which codex`) finds this stub with zero
+// production changes.
+//
+// Scripting: reads `stub-codex-scenario.json` from cwd (the server spawns
+// codex with cwd = workspace, so scenarios live in the test workspace).
+// Scenario format:
+//   { "rules": [ {
+//       "match": { "promptIncludes": "a" | ["a","b"] },
+//       "threadId": "cthr_fixed",       // default: resume id, else generated
+//       "text": "final agent message",
+//       "usage": { "input": 100, "cached": 0, "output": 50 },
+//       "failMessage": "...",           // emit turn.failed instead of a message
+//       "noise": true,                  // emit unknown + malformed lines first
+//       "crash": 1,                     // exit with this code, no events at all
+//       "delayMs": 0
+//   } ] }
+// First matching rule wins. Every invocation is appended to
+// `stub-invocations.jsonl` (cwd) including the full stdin prompt, for
+// spawn-argument and prompt-content assertions.
+//
+// Event shapes come from test/fixtures/codex-jsonl.js: the SAME fixtures the
+// parser unit tests pin, so stub and parser can never drift apart.
+
+const fs = require('fs');
+const path = require('path');
+const fx = require(path.join(__dirname, '..', '..', 'fixtures', 'codex-jsonl.js'));
+
+const argv = process.argv.slice(2);
+function argValue(flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : null;
+}
+const MODEL = argValue('--model');
+const resumeIdx = argv.indexOf('resume');
+const RESUME = resumeIdx >= 0 ? argv[resumeIdx + 1] : null;
+
+const SCENARIO_FILE = path.join(process.cwd(), 'stub-codex-scenario.json');
+const LOG_FILE = path.join(process.cwd(), 'stub-invocations.jsonl');
+
+process.stdout.on('error', () => {});
+function writeOut(s) {
+  try { process.stdout.write(s); } catch (e) { /* killed mid-write */ }
+}
+
+function loadRules() {
+  try {
+    return JSON.parse(fs.readFileSync(SCENARIO_FILE, 'utf-8')).rules || [];
+  } catch (e) {
+    return [];
+  }
+}
+
+function matches(rule, prompt) {
+  const m = rule.match || {};
+  const includes = m.promptIncludes == null ? [] : [].concat(m.promptIncludes);
+  for (const s of includes) if (!prompt.includes(s)) return false;
+  return true;
+}
+
+// Read the entire prompt from stdin, then play the matching rule.
+let prompt = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', (c) => { prompt += c; });
+process.stdin.on('end', () => {
+  // Record the invocation for spawn-arg and prompt-content assertions.
+  try {
+    fs.appendFileSync(LOG_FILE, JSON.stringify({
+      bin: 'codex', pid: process.pid, ts: Date.now(),
+      model: MODEL, resume: RESUME, argv, prompt,
+      env: {
+        RUNDOCK: process.env.RUNDOCK || null,
+        RUNDOCK_CONVO_ID: process.env.RUNDOCK_CONVO_ID || null,
+        RUNDOCK_PORT: process.env.RUNDOCK_PORT || null,
+      },
+    }) + '\n');
+  } catch (e) { /* logging is best-effort */ }
+
+  const rule = loadRules().find(r => matches(r, prompt)) || {
+    text: `STUB-CODEX-NO-RULE prompt=${prompt.slice(0, 120)}`,
+  };
+
+  const run = () => {
+    if (rule.crash != null) {
+      process.exit(typeof rule.crash === 'number' ? rule.crash : 1);
+      return;
+    }
+    const threadId = RESUME || rule.threadId || `cthr_${process.pid}`;
+    const events = [fx.threadStarted(threadId)];
+    if (rule.noise) {
+      // Format-drift resilience: unknown event types and malformed JSON must
+      // be skipped by the consumer without breaking the turn.
+      writeOut(JSON.stringify({ type: 'turn.started' }) + '\n');
+      writeOut('{not json at all\n');
+    }
+    if (rule.failMessage) {
+      events.push(fx.turnFailed(rule.failMessage));
+    } else {
+      events.push(fx.agentMessage(rule.text || ''));
+      events.push(fx.turnCompleted(rule.usage || {}));
+    }
+    for (const e of events) writeOut(JSON.stringify(e) + '\n');
+    process.exit(rule.failMessage ? 1 : 0);
+  };
+
+  if (rule.delayMs > 0) setTimeout(run, rule.delayMs);
+  else run();
+});

--- a/test/helpers/stub-codex/codex
+++ b/test/helpers/stub-codex/codex
@@ -96,19 +96,28 @@ process.stdin.on('end', () => {
     text: `STUB-CODEX-NO-RULE prompt=${prompt.slice(0, 120)}`,
   };
 
-  const run = () => {
-    if (rule.crash != null) {
-      process.exit(typeof rule.crash === 'number' ? rule.crash : 1);
-      return;
-    }
-    const threadId = RESUME || rule.threadId || `cthr_${process.pid}`;
-    const events = [fx.threadStarted(threadId)];
+  if (rule.crash != null) {
+    // Abnormal death before any output, optionally delayed.
+    const code = typeof rule.crash === 'number' ? rule.crash : 1;
+    if (rule.delayMs > 0) setTimeout(() => process.exit(code), rule.delayMs);
+    else process.exit(code);
+    return;
+  }
+
+  // Like the real CLI: the thread is announced as soon as the turn starts;
+  // delayMs simulates a LONG-RUNNING turn (work happening), not a slow start.
+  // Tests that supersede or heartbeat a mid-flight turn depend on this shape.
+  const threadId = RESUME || rule.threadId || `cthr_${process.pid}`;
+  writeOut(JSON.stringify(fx.threadStarted(threadId)) + '\n');
+
+  const finish = () => {
     if (rule.noise) {
       // Format-drift resilience: unknown event types and malformed JSON must
       // be skipped by the consumer without breaking the turn.
       writeOut(JSON.stringify({ type: 'turn.started' }) + '\n');
       writeOut('{not json at all\n');
     }
+    const events = [];
     if (rule.failMessage) {
       events.push(fx.turnFailed(rule.failMessage));
     } else {
@@ -119,6 +128,6 @@ process.stdin.on('end', () => {
     process.exit(rule.failMessage ? 1 : 0);
   };
 
-  if (rule.delayMs > 0) setTimeout(run, rule.delayMs);
-  else run();
+  if (rule.delayMs > 0) setTimeout(finish, rule.delayMs);
+  else finish();
 });

--- a/test/helpers/stub-codex/codex
+++ b/test/helpers/stub-codex/codex
@@ -35,6 +35,14 @@ const path = require('path');
 const fx = require(path.join(__dirname, '..', '..', 'fixtures', 'codex-jsonl.js'));
 
 const argv = process.argv.slice(2);
+
+// Version probe: answer immediately without touching stdin or the scenario,
+// so runtime detection never hangs on the stub.
+if (argv.includes('--version')) {
+  process.stdout.write('codex-cli 0.0.0-stub\n');
+  process.exit(0);
+}
+
 function argValue(flag) {
   const i = argv.indexOf(flag);
   return i >= 0 ? argv[i + 1] : null;

--- a/test/helpers/workspace.js
+++ b/test/helpers/workspace.js
@@ -53,7 +53,7 @@ function makeWorkspace(opts = {}) {
 
 // Standard team used across suites: one orchestrator, one lead with a direct
 // report, two plain specialists. Mirrors the shape of a real Rundock workspace.
-function agentFile({ name, displayName, role, type, order, reportsTo, model, description, prompts, routines, skills, capabilities, body }) {
+function agentFile({ name, displayName, role, type, order, reportsTo, model, runtime, description, prompts, routines, skills, capabilities, body }) {
   const lines = ['---', `name: ${name}`];
   if (displayName) lines.push(`displayName: ${displayName}`);
   if (role) lines.push(`role: ${role}`);
@@ -62,6 +62,7 @@ function agentFile({ name, displayName, role, type, order, reportsTo, model, des
   if (order !== undefined) lines.push(`order: ${order}`);
   if (reportsTo) lines.push(`reportsTo: ${reportsTo}`);
   if (model) lines.push(`model: ${model}`);
+  if (runtime) lines.push(`runtime: ${runtime}`);
   if (capabilities) {
     lines.push('capabilities:');
     for (const [k, v] of Object.entries(capabilities)) lines.push(`  ${k}: ${v}`);

--- a/test/integration/codex-chat.test.js
+++ b/test/integration/codex-chat.test.js
@@ -1,0 +1,206 @@
+'use strict';
+// Integration: conversations with agents that run on the Codex runtime.
+// Real server.js, real WebSocket, real child processes against the stub
+// codex binary; no real Codex CLI and no network.
+//
+// The contract under test: a `runtime: codex` agent behaves like any other
+// agent in the conversation UI (process_started, session id, result, done,
+// transcript), while the server spawns one sandboxed `codex exec --json`
+// process per turn and resumes the thread on follow-ups.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+const fx = require('../fixtures/codex-jsonl.js');
+
+let client;
+
+function teamWithCodexAgents() {
+  return {
+    ...standardTeam(),
+    'researcher': agentFile({
+      name: 'researcher', displayName: 'Ida', role: 'Researcher',
+      description: 'Researches suppliers', type: 'specialist', order: 5,
+      reportsTo: 'chief-of-staff', runtime: 'codex',
+      body: 'You are Ida, the researcher.\n\nYou research suppliers.',
+    }),
+    'summariser': agentFile({
+      name: 'summariser', displayName: 'Sam', role: 'Summariser',
+      description: 'Summarises documents', type: 'specialist', order: 6,
+      reportsTo: 'chief-of-staff', runtime: 'codex', model: 'gpt-5.3-codex',
+      body: 'You are Sam, the summariser.',
+    }),
+  };
+}
+
+before(async () => {
+  await h.boot({ agents: teamWithCodexAgents() });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+function transcript(convoId) {
+  return JSON.parse(fs.readFileSync(path.join(h.workspaceDir, '.rundock', 'transcripts', `${convoId}.json`), 'utf-8'));
+}
+
+describe('codex agent conversation', () => {
+  test('first turn: sandboxed exec spawn, session id surfaced, result and done delivered, transcript persisted', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'first codex question' }, text: 'Answer from Ida.', usage: { input: 1200, cached: 800, output: 340 } },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'first codex question' });
+
+    const { msg: started } = await client.waitForEvent('system', 'process_started', convoId);
+    assert.strictEqual(started._agent, 'researcher');
+
+    // Thread id rides the same rails as Claude session ids
+    const { msg: init } = await client.waitForEvent('system', 'init', convoId);
+    assert.ok(init._sessionId && init._sessionId.startsWith('cthr_'), `thread id surfaced (got ${init._sessionId})`);
+
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'codex result' });
+    assert.strictEqual(result.result, 'Answer from Ida.');
+    assert.strictEqual(result.is_error, false);
+    assert.strictEqual(result._agent, 'researcher');
+    // Usage is recorded as normalised token counts (subscription usage; no dollar costs)
+    assert.deepStrictEqual(result.usage, { inputTokens: 1200, cachedInputTokens: 800, outputTokens: 340 });
+
+    await client.waitForEvent('system', 'done', convoId);
+
+    // Spawn contract: sandboxed, no bypass flags, no model unless set, prompt on stdin
+    const inv = h.readInvocations();
+    assert.strictEqual(inv.length, 1, 'exactly one codex spawn');
+    assert.strictEqual(inv[0].bin, 'codex');
+    assert.deepStrictEqual(inv[0].argv, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-']);
+    assert.strictEqual(inv[0].env.RUNDOCK, '1');
+    assert.strictEqual(inv[0].env.RUNDOCK_CONVO_ID, convoId);
+    // First turn carries the agent's identity followed by the user message
+    assert.ok(inv[0].prompt.includes('You are Ida'), 'system prompt prepended on first turn');
+    assert.ok(inv[0].prompt.includes('first codex question'), 'user content present');
+
+    // Transcript persisted both sides
+    const t = transcript(convoId);
+    assert.deepStrictEqual(t.map(e => [e.role, e.agent]), [['user', 'user'], ['agent', 'researcher']]);
+    assert.ok(t[1].text.includes('Answer from Ida.'));
+  });
+
+  test('follow-up turn resumes the thread without re-sending instructions', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'question one' }, threadId: 'cthr_resume_me', text: 'First.' },
+      { match: { promptIncludes: 'question two' }, text: 'Second.' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'question one' });
+    const { msg: init } = await client.waitForEvent('system', 'init', convoId);
+    assert.strictEqual(init._sessionId, 'cthr_resume_me');
+    await client.waitForEvent('system', 'done', convoId);
+
+    // The client sends the stored session id back on the next turn
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'question two', sessionId: 'cthr_resume_me' });
+    const { msg: result2 } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, label: 'resumed result' });
+    assert.strictEqual(result2.result, 'Second.');
+
+    const inv = h.readInvocations();
+    assert.strictEqual(inv.length, 2, 'one spawn per turn');
+    assert.deepStrictEqual(inv[1].argv, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', 'resume', 'cthr_resume_me', '-']);
+    // Resumed turns send only the new message: instructions are not re-injected
+    assert.ok(!inv[1].prompt.includes('You are Ida'), 'no instruction re-injection on resume');
+    assert.ok(inv[1].prompt.includes('question two'));
+  });
+
+  test('agent with an explicit model passes the model flag', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'summarise this' }, text: 'Summary.' }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'summariser', content: 'summarise this' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const inv = h.readInvocations();
+    assert.deepStrictEqual(inv[0].argv, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '--model', 'gpt-5.3-codex', '-']);
+  });
+
+  test('unknown and malformed output lines are skipped without breaking the turn', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'noisy' }, text: 'Still fine.', noise: true }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'noisy output please' });
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'noisy result' });
+    assert.strictEqual(result.result, 'Still fine.');
+    await client.waitForEvent('system', 'done', convoId);
+  });
+
+  test('quota exhaustion surfaces as a structured quota message, not a raw error', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'over quota' }, failMessage: fx.QUOTA_MESSAGE }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'over quota question' });
+
+    const { msg: quota } = await client.waitForEvent('system', 'codex_quota', convoId);
+    assert.strictEqual(quota._agent, 'researcher');
+    // Verbatim CLI text travels with the structured message for the UI card
+    assert.strictEqual(quota.detail, fx.QUOTA_MESSAGE);
+
+    await client.waitForEvent('system', 'done', convoId);
+    // No raw error message alongside the structured one
+    const raw = client.messages.filter(m => m.type === 'error' && m._conversationId === convoId);
+    assert.deepStrictEqual(raw, []);
+  });
+
+  test('a classified runtime failure surfaces as a friendly pill with the verbatim detail', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'blocked write' }, failMessage: 'sandbox denied write to /etc/hosts' }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'blocked write please' });
+
+    const { msg: err } = await client.waitForEvent('system', 'codex_error', convoId);
+    assert.strictEqual(err._agent, 'researcher');
+    assert.strictEqual(err.detail, 'sandbox denied write to /etc/hosts');
+
+    await client.waitForEvent('system', 'done', convoId);
+  });
+
+  test('an abnormal exit with no events still completes the turn with a friendly error', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'crash now' }, crash: 1 }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'crash now please' });
+
+    const { msg: err } = await client.waitForEvent('system', 'codex_error', convoId);
+    assert.strictEqual(err._agent, 'researcher');
+    await client.waitForEvent('system', 'done', convoId);
+  });
+
+  test('a new user message while a codex turn is running supersedes it (old process killed, thread resumed)', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'slow question' }, threadId: 'cthr_slow', text: 'Too late.', delayMs: 4000 },
+      { match: { promptIncludes: 'impatient follow-up' }, text: 'Quick answer.' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'slow question' });
+    await client.waitForEvent('system', 'init', convoId);
+
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'impatient follow-up', sessionId: 'cthr_slow' });
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, label: 'superseding result' });
+    assert.strictEqual(result.result, 'Quick answer.');
+
+    const inv = h.readInvocations();
+    assert.strictEqual(inv.length, 2, 'two spawns: superseded + superseding');
+    assert.deepStrictEqual(inv[1].argv.slice(-3), ['resume', 'cthr_slow', '-']);
+  });
+});

--- a/test/integration/codex-chat.test.js
+++ b/test/integration/codex-chat.test.js
@@ -37,7 +37,8 @@ function teamWithCodexAgents() {
 }
 
 before(async () => {
-  await h.boot({ agents: teamWithCodexAgents() });
+  // Fast keepalive so the heartbeat is observable within test timeouts.
+  await h.boot({ agents: teamWithCodexAgents(), env: { RUNDOCK_CODEX_KEEPALIVE_MS: '500' } });
   client = await h.connect();
 });
 after(async () => h.shutdown());
@@ -181,6 +182,49 @@ describe('codex agent conversation', () => {
     const { msg: err } = await client.waitForEvent('system', 'codex_error', convoId);
     assert.strictEqual(err._agent, 'researcher');
     await client.waitForEvent('system', 'done', convoId);
+  });
+
+  test('routines on a codex agent run on Codex, sandboxed, never on the Claude plan', async () => {
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'routine work now' }, text: 'routine done.' }]);
+    const agent = h.internal.discoverAgents().find(a => a.id === 'researcher');
+    h.internal.executeRoutine(agent, { name: 'nightly-check', schedule: 'daily 09:00', prompt: 'routine work now' }, 'codex-routine-key');
+
+    let inv = [];
+    for (let i = 0; i < 40 && inv.length === 0; i++) { await h.delay(100); inv = h.readInvocations(); }
+    assert.strictEqual(inv.length, 1, 'one routine spawn');
+    assert.strictEqual(inv[0].bin, 'codex', 'routine ran on codex, not claude');
+    assert.deepStrictEqual(inv[0].argv, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-']);
+    assert.ok(inv[0].prompt.includes('routine work now'), 'routine prompt delivered');
+    assert.ok(inv[0].prompt.includes('You are Ida'), 'agent identity delivered');
+  });
+
+  test('long turns heartbeat: keepalives flow while the process runs, so the client watchdog stays quiet', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'slow heartbeat' }, text: 'Done at last.', delayMs: 1400 }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'slow heartbeat question' });
+    await client.waitForEvent('system', 'keepalive', convoId, { label: 'first keepalive' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'slow result' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const beats = client.messages.filter(m => m.type === 'system' && m.subtype === 'keepalive' && m._conversationId === convoId);
+    assert.ok(beats.length >= 1, 'at least one heartbeat during the slow turn');
+  });
+
+  test('a failed turn is persisted to the transcript so an unwatched conversation still learns of it', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.writeCodexScenario([{ match: { promptIncludes: 'persist failure' }, failMessage: fx.QUOTA_MESSAGE }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'persist failure please' });
+    await client.waitForEvent('system', 'codex_quota', convoId);
+    await client.waitForEvent('system', 'done', convoId);
+
+    const t = transcript(convoId);
+    const failureRow = t.find(e => e.agent === 'researcher' && e.text.includes('plan limit'));
+    assert.ok(failureRow, 'failure persisted');
+    assert.ok(failureRow.text.includes(fx.QUOTA_MESSAGE), 'verbatim CLI text persisted');
   });
 
   test('a new user message while a codex turn is running supersedes it (old process killed, thread resumed)', async () => {

--- a/test/integration/codex-chat.test.js
+++ b/test/integration/codex-chat.test.js
@@ -158,6 +158,40 @@ describe('codex agent conversation', () => {
     assert.deepStrictEqual(raw, []);
   });
 
+  test('an unavailable-model 400 surfaces as guidance naming the model and the fix', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    // Real message captured live from a ChatGPT account with an unavailable model configured.
+    const raw = '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}}';
+    h.writeCodexScenario([{ match: { promptIncludes: 'bad model' }, failMessage: raw }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'bad model please' });
+
+    const { msg: err } = await client.waitForEvent('system', 'codex_guidance', convoId);
+    assert.strictEqual(err._agent, 'researcher');
+    assert.strictEqual(err.detail, raw, 'verbatim CLI text travels with the guidance');
+    assert.match(err.title, /model/i);
+    assert.match(err.body, /gpt-5\.3-codex/, 'guidance names the configured model');
+    assert.match(err.body, /remove the model field/i, 'guidance states the fix');
+    await client.waitForEvent('system', 'done', convoId);
+  });
+
+  test('a signed-out 401 surfaces as guidance pointing at codex login, not transport noise', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    // Real message captured live from a logged-out CLI failing mid-connection.
+    const raw = 'Reconnecting... 2/5 (unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: wss://api.openai.com/v1/responses, cf-ray: a1ab5b883bdb63c9-LHR)';
+    h.writeCodexScenario([{ match: { promptIncludes: 'signed out' }, failMessage: raw }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'signed out please' });
+
+    const { msg: err } = await client.waitForEvent('system', 'codex_guidance', convoId);
+    assert.strictEqual(err._agent, 'researcher');
+    assert.match(err.title, /signed in/i);
+    assert.match(err.body, /codex login/, 'guidance names the command');
+    await client.waitForEvent('system', 'done', convoId);
+  });
+
   test('a classified runtime failure surfaces as a friendly pill with the verbatim detail', async () => {
     const convoId = h.freshConvoId('cdx');
     h.clearInvocations();

--- a/test/integration/codex-chat.test.js
+++ b/test/integration/codex-chat.test.js
@@ -184,6 +184,20 @@ describe('codex agent conversation', () => {
     await client.waitForEvent('system', 'done', convoId);
   });
 
+  test('an invalid session id produces a full fresh turn: no resume in argv AND instructions in the prompt', async () => {
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'suspicious resume' }, text: 'Fresh anyway.' }]);
+
+    // A flag-shaped session id must neither reach argv nor leave the prompt resume-shaped.
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'suspicious resume question', sessionId: '--dangerously-bypass-approvals-and-sandbox' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const inv = h.readInvocations();
+    assert.deepStrictEqual(inv[0].argv, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-'], 'no resume, no smuggled flags');
+    assert.ok(inv[0].prompt.includes('You are Ida'), 'fresh turn carries the agent identity');
+  });
+
   test('routines on a codex agent run on Codex, sandboxed, never on the Claude plan', async () => {
     h.clearInvocations();
     h.writeCodexScenario([{ match: { promptIncludes: 'routine work now' }, text: 'routine done.' }]);
@@ -230,8 +244,11 @@ describe('codex agent conversation', () => {
   test('a new user message while a codex turn is running supersedes it (old process killed, thread resumed)', async () => {
     const convoId = h.freshConvoId('cdx');
     h.clearInvocations();
+    // The slow turn's delay is a race margin, not a duration under test: it
+    // only needs to outlast the supersede round-trip, including when the
+    // whole suite runs in parallel on a loaded machine.
     h.writeCodexScenario([
-      { match: { promptIncludes: 'slow question' }, threadId: 'cthr_slow', text: 'Too late.', delayMs: 4000 },
+      { match: { promptIncludes: 'slow question' }, threadId: 'cthr_slow', text: 'Too late.', delayMs: 15000 },
       { match: { promptIncludes: 'impatient follow-up' }, text: 'Quick answer.' },
     ]);
 
@@ -240,7 +257,7 @@ describe('codex agent conversation', () => {
 
     const since = client.messages.length;
     client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'impatient follow-up', sessionId: 'cthr_slow' });
-    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, label: 'superseding result' });
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, timeout: 12000, label: 'superseding result' });
     assert.strictEqual(result.result, 'Quick answer.');
 
     const inv = h.readInvocations();

--- a/test/integration/codex-chat.test.js
+++ b/test/integration/codex-chat.test.js
@@ -140,6 +140,28 @@ describe('codex agent conversation', () => {
     await client.waitForEvent('system', 'done', convoId);
   });
 
+  test('non-Windows spawns get no write-marker instruction and markers pass through as literal text', async () => {
+    // Companion to codex-write-markers.test.js (which boots with the win32
+    // platform seam). On Mac/Linux the OS sandbox writes directly, so the
+    // marker path must be fully inert: no instruction in the prompt, no
+    // card, marker text displayed verbatim.
+    const convoId = h.freshConvoId('cdx');
+    h.clearInvocations();
+    const markerText = '<!-- RUNDOCK:WRITE_FILE path="x.md" -->\nhello\n<!-- /RUNDOCK:WRITE_FILE -->';
+    h.writeCodexScenario([{ match: { promptIncludes: 'marker passthrough' }, text: markerText }]);
+
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'marker passthrough please' });
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, label: 'result' });
+    assert.strictEqual(result.result, markerText, 'marker text untouched off-Windows');
+    await client.waitForEvent('system', 'done', convoId);
+
+    const inv = h.readInvocations().find(i => i.argv && i.argv[0] === 'exec');
+    assert.ok(!inv.prompt.includes('WINDOWS FILE WRITES'), 'no marker instruction off-Windows');
+    const cards = client.messages.slice(since).filter(m => m.type === 'control_request' && m._conversationId === convoId);
+    assert.deepStrictEqual(cards, [], 'no permission card off-Windows');
+  });
+
   test('quota exhaustion surfaces as a structured quota message, not a raw error', async () => {
     const convoId = h.freshConvoId('cdx');
     h.clearInvocations();

--- a/test/integration/codex-delegation.test.js
+++ b/test/integration/codex-delegation.test.js
@@ -29,6 +29,13 @@ function team() {
       reportsTo: 'chief-of-staff', runtime: 'codex',
       body: 'You are Ida, the researcher.\n\nYou research suppliers.',
     }),
+    // A codex sub-agent under a lead, for the specialist-parent handback case.
+    'summary-bot': agentFile({
+      name: 'summary-bot', displayName: 'Sumo', role: 'Summariser',
+      description: 'Summarises for the content lead', type: 'specialist', order: 2.1,
+      reportsTo: 'content-lead', runtime: 'codex',
+      body: 'You are Sumo, the summariser.',
+    }),
   };
 }
 
@@ -137,6 +144,41 @@ describe('delegation to a codex specialist', () => {
     assert.strictEqual(entryAfter.agentId, 'chief-of-staff');
     assert.strictEqual(entryAfter.exited, false, 'orchestrator process not killed');
     assert.strictEqual(entryAfter.scopeReturn || false, false, 'no scope return forced on the orchestrator');
+    h.reapConvo(convoId);
+  });
+
+  test('stale end_delegation also spares a restored SPECIALIST parent (lead), not just orchestrators', async () => {
+    // Same race as above, but the delegating parent is a lead (type
+    // specialist). The guard must key on the recent handback, not on the
+    // parent's type.
+    const convoId = h.freshConvoId('cdel');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'content-lead', promptIncludes: 'lead-race please' },
+        turn: [{ agentTool: { subagent_type: 'summary-bot', prompt: 'lead-race brief' } }],
+      },
+      {
+        match: { agent: 'content-lead', promptIncludes: ['[SYSTEM: pipeline-complete]', 'LEAD-RACE-OUT'] },
+        turn: [{ text: '<silent>' }],
+      },
+    ]);
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'lead-race brief' }, text: 'LEAD-RACE-OUT done. <!-- RUNDOCK:COMPLETE -->' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'content-lead', content: 'lead-race please' });
+    const { index: startedIdx } = await client.waitFor(m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m._agent === 'content-lead' && m.autoContinue, { label: 'lead restart' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead', { since: startedIdx + 1, label: 'resumed lead result' });
+
+    client.send({ type: 'end_delegation', conversationId: convoId });
+    await h.delay(400);
+
+    const entryAfter = h.internal.chatProcesses.get(convoId);
+    assert.ok(entryAfter, 'lead entry survives the stale message');
+    assert.strictEqual(entryAfter.agentId, 'content-lead');
+    assert.strictEqual(entryAfter.exited, false, 'lead process not killed');
+    assert.strictEqual(entryAfter.scopeReturn || false, false, 'no scope return forced on the lead');
     h.reapConvo(convoId);
   });
 

--- a/test/integration/codex-delegation.test.js
+++ b/test/integration/codex-delegation.test.js
@@ -1,0 +1,133 @@
+'use strict';
+// Integration: a Claude orchestrator delegating to a specialist that runs on
+// the Codex runtime. The orchestrator's Agent tool call is intercepted as
+// usual; the delegate turn runs as one sandboxed codex exec process; handback
+// markers round-trip through the same restoration machinery as Claude
+// delegates; the transcript persists both sides.
+//
+// Codex delegates are transactional by design: exec mode runs one turn per
+// process, so a delegated task is briefed, completed, and control returns to
+// the orchestrator with the specialist's output injected. Direct
+// conversations with Codex agents remain fully conversational (thread
+// resume); only the delegated flow is single-shot.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+
+let client;
+
+function team() {
+  return {
+    ...standardTeam(),
+    'researcher': agentFile({
+      name: 'researcher', displayName: 'Ida', role: 'Researcher',
+      description: 'Researches suppliers', type: 'specialist', order: 5,
+      reportsTo: 'chief-of-staff', runtime: 'codex',
+      body: 'You are Ida, the researcher.\n\nYou research suppliers.',
+    }),
+  };
+}
+
+before(async () => {
+  await h.boot({ agents: team() });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+function transcript(convoId) {
+  return JSON.parse(fs.readFileSync(path.join(h.workspaceDir, '.rundock', 'transcripts', `${convoId}.json`), 'utf-8'));
+}
+
+describe('delegation to a codex specialist', () => {
+  test('COMPLETE handback: brief delivered, output injected into the silently parked parent, transcript persists', async () => {
+    const convoId = h.freshConvoId('cdel');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'codex-del please' },
+        turn: [{ agentTool: { subagent_type: 'researcher', prompt: 'codex-del brief' } }],
+      },
+      {
+        // The parked parent receives the pipeline-complete prompt WITH the
+        // specialist's output and WITHOUT the marker.
+        match: { agent: 'chief-of-staff', promptIncludes: ['[SYSTEM: pipeline-complete]', 'CODEX-PAYLOAD-42'], promptExcludes: 'RUNDOCK:COMPLETE' },
+        turn: [{ text: '<silent>' }],
+      },
+    ]);
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'codex-del brief' }, text: 'CODEX-PAYLOAD-42 delivered. <!-- RUNDOCK:COMPLETE -->' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'codex-del please' });
+
+    // Switch to the codex delegate, its result arrives, then switch back.
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId && m.toAgent === 'researcher', { label: 'to codex delegate' });
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'researcher', { label: 'codex delegate result' });
+    assert.ok(result.result.includes('CODEX-PAYLOAD-42'), 'specialist output delivered to the client');
+
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'back to parent' });
+    const { msg: started, index: startedIdx } = await client.waitFor(m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m._agent === 'chief-of-staff' && m.autoContinue, { label: 'parent restart' });
+    assert.strictEqual(started.silent, true, 'pipeline-complete restart is silent');
+
+    // Wait for the resumed parent's (silent) result so its invocation is
+    // logged before spawn-argument assertions run.
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'chief-of-staff', { since: startedIdx + 1, label: 'resumed parent result' });
+
+    // The delegate spawn was a codex exec process carrying identity + brief.
+    const codexInv = h.readInvocations().find(i => i.bin === 'codex');
+    assert.ok(codexInv, 'codex delegate spawn recorded');
+    assert.deepStrictEqual(codexInv.argv, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-']);
+    assert.ok(codexInv.prompt.includes('You are Ida'), 'agent identity in the delegate prompt');
+    assert.ok(codexInv.prompt.includes('DELEGATION CONTEXT'), 'delegation contract in the delegate prompt');
+    assert.ok(codexInv.prompt.includes('codex-del brief'), 'brief in the delegate prompt');
+
+    // Parent resumed its own session.
+    const cosResume = h.readInvocations().filter(i => i.agent === 'chief-of-staff' && i.resume);
+    assert.strictEqual(cosResume.length, 1, 'parent restarted with --resume');
+
+    // Transcript has the user turn, the orchestrator routing turn, and the specialist output.
+    const t = transcript(convoId);
+    assert.ok(t.some(e => e.agent === 'researcher' && e.text.includes('CODEX-PAYLOAD-42')), 'specialist output persisted');
+    assert.ok(!t.some(e => e.text.includes('<silent>')), 'silent park filtered from transcript');
+
+    // Parent is parked idle as the active entry.
+    const entry = h.internal.chatProcesses.get(convoId);
+    assert.strictEqual(entry.agentId, 'chief-of-staff');
+    assert.strictEqual(entry.idle, true);
+    h.reapConvo(convoId);
+  });
+
+  test('RETURN handback: out-of-scope delegate routes the pending request back through the parent', async () => {
+    const convoId = h.freshConvoId('cdel');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'wrong-domain please' },
+        turn: [{ agentTool: { subagent_type: 'researcher', prompt: 'wrong-domain brief' } }],
+      },
+      {
+        // RETURN path: parent is resumed with a routing request carrying the
+        // specialist's explanation.
+        match: { agent: 'chief-of-staff', promptIncludes: ['outside their scope', 'OUT-OF-SCOPE-NOTE'] },
+        turn: [{ text: 'Routing to the right person.' }],
+      },
+    ]);
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'wrong-domain brief' }, text: 'OUT-OF-SCOPE-NOTE: this falls outside what I handle. <!-- RUNDOCK:RETURN -->' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'wrong-domain please' });
+
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'researcher', { label: 'codex delegate result' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'back to parent' });
+
+    // The resumed parent answers the routing prompt visibly (not silent).
+    const { msg: routed } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'chief-of-staff' && m.result === 'Routing to the right person.', { label: 'routing result' });
+    assert.ok(routed);
+    h.reapConvo(convoId);
+  });
+});

--- a/test/integration/codex-delegation.test.js
+++ b/test/integration/codex-delegation.test.js
@@ -101,6 +101,45 @@ describe('delegation to a codex specialist', () => {
     h.reapConvo(convoId);
   });
 
+  test('stale end_delegation after a codex handback never kills the restored orchestrator', async () => {
+    // A codex delegate exits immediately after its result, so the server can
+    // restore the parent BEFORE the browser's marker scan sends
+    // end_delegation. That late message must be ignored, not treated as an
+    // out-of-scope return from the orchestrator itself.
+    const convoId = h.freshConvoId('cdel');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'stale-race please' },
+        turn: [{ agentTool: { subagent_type: 'researcher', prompt: 'stale-race brief' } }],
+      },
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: ['[SYSTEM: pipeline-complete]', 'STALE-RACE-OUT'] },
+        turn: [{ text: '<silent>' }],
+      },
+    ]);
+    h.writeCodexScenario([
+      { match: { promptIncludes: 'stale-race brief' }, text: 'STALE-RACE-OUT done. <!-- RUNDOCK:COMPLETE -->' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'stale-race please' });
+    const { index: startedIdx } = await client.waitFor(m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m._agent === 'chief-of-staff' && m.autoContinue, { label: 'parent restart' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'chief-of-staff', { since: startedIdx + 1, label: 'resumed parent result' });
+
+    // The browser would now send end_delegation from its RETURN/COMPLETE scan.
+    const entryBefore = h.internal.chatProcesses.get(convoId);
+    assert.strictEqual(entryBefore.agentId, 'chief-of-staff');
+    client.send({ type: 'end_delegation', conversationId: convoId });
+    await h.delay(400);
+
+    const entryAfter = h.internal.chatProcesses.get(convoId);
+    assert.ok(entryAfter, 'orchestrator entry survives the stale message');
+    assert.strictEqual(entryAfter.agentId, 'chief-of-staff');
+    assert.strictEqual(entryAfter.exited, false, 'orchestrator process not killed');
+    assert.strictEqual(entryAfter.scopeReturn || false, false, 'no scope return forced on the orchestrator');
+    h.reapConvo(convoId);
+  });
+
   test('RETURN handback: out-of-scope delegate routes the pending request back through the parent', async () => {
     const convoId = h.freshConvoId('cdel');
     h.clearInvocations();

--- a/test/integration/codex-delegation.test.js
+++ b/test/integration/codex-delegation.test.js
@@ -211,4 +211,36 @@ describe('delegation to a codex specialist', () => {
     assert.ok(routed);
     h.reapConvo(convoId);
   });
+
+  test('off-roster codex target is soft-blocked: no Claude impersonation, corrective prompt names the runtime', async () => {
+    // The observed live failure: a specialist names a codex agent outside its
+    // direct reports. Pre-fix, Claude Code spawned a Claude subagent wearing
+    // the codex agent's name, silently bypassing the user's runtime choice.
+    // Ida (researcher, runtime: codex) reports to chief-of-staff, not Penn.
+    const convoId = h.freshConvoId('cdel');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'content-lead', promptIncludes: 'codex-offroster please' },
+        turn: [{ agentTool: { subagent_type: 'researcher', prompt: 'codex-offroster brief' } }],
+      },
+      {
+        // The corrective prompt must state the reason AND flag the runtime.
+        match: { agent: 'content-lead', promptIncludes: ['[SYSTEM: delegation-blocked]', 'not one of your direct reports', 'different runtime (Codex)'] },
+        turn: [{ text: 'Acknowledged: Ida runs on Codex under another leader.' }],
+      },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'content-lead', content: 'codex-offroster please' });
+
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'info' && m._conversationId === convoId && /Blocked a handoff to Ida/.test(m.content || ''), { label: 'block pill' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead' && /runs on Codex under another leader/.test(m.result || ''), { label: 'resumed caller result' });
+
+    // Neither a codex exec process nor a Claude stand-in for Ida ever ran.
+    const invs = h.readInvocations();
+    assert.strictEqual(invs.find(i => i.argv && i.argv[0] === 'exec'), undefined, 'no codex process spawned');
+    assert.strictEqual(invs.find(i => i.agent === 'researcher'), undefined, 'no Claude process wearing the codex agent name');
+
+    h.reapConvo(convoId);
+  });
 });

--- a/test/integration/codex-sandbox-config.test.js
+++ b/test/integration/codex-sandbox-config.test.js
@@ -1,0 +1,74 @@
+'use strict';
+// Integration: on Windows WITH a [windows] sandbox declared in the Codex
+// config, the CLI grants a real workspace-write policy and writes directly
+// (verified live), so the write-marker fallback must stand down entirely:
+// no instruction in the prompt, markers pass through as literal text, no
+// permission card. Companion files: codex-write-markers.test.js (win32
+// WITHOUT the config: markers active) and codex-chat.test.js (non-Windows:
+// always inert).
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+
+let client;
+
+// A codex home whose config declares the native Windows sandbox. Created
+// before boot so the server's per-spawn check sees it from turn one.
+const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-home-'));
+fs.writeFileSync(path.join(codexHome, 'config.toml'), '[windows]\nsandbox = "unelevated"\n');
+
+function team() {
+  return {
+    ...standardTeam(),
+    'researcher': agentFile({
+      name: 'researcher', displayName: 'Ida', role: 'Researcher',
+      description: 'Researches suppliers', type: 'specialist', order: 5,
+      reportsTo: 'chief-of-staff', runtime: 'codex',
+      body: 'You are Ida, the researcher.',
+    }),
+  };
+}
+
+before(async () => {
+  await h.boot({ agents: team(), env: { RUNDOCK_TEST_PLATFORM: 'win32', CODEX_HOME: codexHome } });
+  client = await h.connect();
+});
+after(async () => {
+  await h.shutdown();
+  try { fs.rmSync(codexHome, { recursive: true, force: true }); } catch (e) {}
+});
+
+describe('codex on win32 with the native sandbox configured', () => {
+  test('marker fallback stands down: no instruction, literal pass-through, no card', async () => {
+    const convoId = h.freshConvoId('csc');
+    h.clearInvocations();
+    const markerText = '<!-- RUNDOCK:WRITE_FILE path="x.md" -->\nhello\n<!-- /RUNDOCK:WRITE_FILE -->';
+    h.writeCodexScenario([{ match: { promptIncludes: 'sandboxed question' }, text: markerText }]);
+
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'sandboxed question please' });
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, label: 'result' });
+    assert.strictEqual(result.result, markerText, 'marker text untouched when the sandbox is declared');
+    await client.waitForEvent('system', 'done', convoId);
+
+    const inv = h.readInvocations().find(i => i.argv && i.argv[0] === 'exec');
+    assert.ok(!inv.prompt.includes('WINDOWS FILE WRITES'), 'no marker instruction when the sandbox is declared');
+    const cards = client.messages.slice(since).filter(m => m.type === 'control_request' && m._conversationId === convoId);
+    assert.deepStrictEqual(cards, [], 'no permission card');
+
+    h.reapConvo(convoId);
+  });
+
+  test('runtime status reports the sandbox declaration', async () => {
+    client.send({ type: 'get_runtime_status' });
+    const { msg: status } = await client.waitFor(m => m.type === 'runtime_status', { label: 'runtime status' });
+    // The codex stub is on PATH and the fake auth home has no auth.json;
+    // what matters here is the windowsSandbox field derived from config.toml.
+    assert.strictEqual(status.codex.windowsSandbox, true);
+  });
+});

--- a/test/integration/codex-write-markers.test.js
+++ b/test/integration/codex-write-markers.test.js
@@ -126,6 +126,80 @@ describe('codex write markers on win32', () => {
     h.reapConvo(convoId);
   });
 
+  test('DELEGATED codex turns get the instruction and the marker flow: clean handback, card, approved write', async () => {
+    // The delegated path has its own done-handler (wireCodexDelegate), so it
+    // must be pinned separately from direct chats: raw marker text must never
+    // reach the transcript, the result, or the parent's handback injection.
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    const content = 'Delegated write body.';
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'delegate a write' },
+        turn: [{ agentTool: { subagent_type: 'researcher', prompt: 'delegated write brief' } }],
+      },
+      {
+        // Parent resumes with the CLEAN text injected, never raw marker soup.
+        match: { agent: 'chief-of-staff', promptIncludes: ['[SYSTEM: pipeline-complete]', '[write requested: delegated.md]'], promptExcludes: 'RUNDOCK:WRITE_FILE' },
+        turn: [{ text: '<silent>' }],
+      },
+    ]);
+    h.writeCodexScenario([{
+      match: { promptIncludes: 'delegated write brief' },
+      text: `Prepared the file.\n\n${MARKER('delegated.md', content)}\n<!-- RUNDOCK:COMPLETE -->`,
+    }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'delegate a write please' });
+
+    // Delegate result arrives clean
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'researcher', { label: 'delegate result' });
+    assert.ok(!result.result.includes('RUNDOCK:WRITE_FILE'), 'marker stripped from delegate result');
+    assert.ok(result.result.includes('[write requested: delegated.md]'));
+
+    // The cold delegate spawn carried the instruction
+    const codexInv = h.readInvocations().find(i => i.argv && i.argv[0] === 'exec');
+    assert.ok(codexInv.prompt.includes('WINDOWS FILE WRITES'), 'delegated cold spawn carries the instruction');
+
+    // Card arrives and Allow lands the exact bytes
+    const { msg: card } = await client.waitFor(m => m.type === 'control_request' && m._conversationId === convoId && m.request.input.path === 'delegated.md', { label: 'delegated write card' });
+    client.send({ type: 'permission_response', requestId: card.request_id, conversationId: convoId, allow: true });
+    await client.waitFor(m => m.type === 'file_saved' && m.path === 'delegated.md', { label: 'delegated file saved' });
+    assert.strictEqual(fs.readFileSync(path.join(h.workspaceDir, 'delegated.md'), 'utf-8'), content);
+
+    // Parent parked silently with the clean injection (scenario rule 2 only
+    // matches when the prompt excludes raw markers, so reaching silent-park
+    // proves the sanitised handback)
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m._agent === 'chief-of-staff' && m.autoContinue, { label: 'parent restart' });
+
+    h.reapConvo(convoId);
+  });
+
+  test('a symlinked directory inside the workspace cannot redirect an approved write outside it', async () => {
+    // validateWriteRequest is lexical; the write path re-verifies the REAL
+    // parent directory before writing. A symlink planted inside the
+    // workspace pointing outside must fail at that second check.
+    const outside = fs.mkdtempSync(path.join(require('node:os').tmpdir(), 'outside-'));
+    fs.symlinkSync(outside, path.join(h.workspaceDir, 'linked'), 'dir');
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    h.writeCodexScenario([{
+      match: { promptIncludes: 'write through link' },
+      text: MARKER('linked/evil.md', 'escaped'),
+    }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'write through link please' });
+    const { msg: card } = await client.waitFor(m => m.type === 'control_request' && m._conversationId === convoId, { label: 'write card' });
+    client.send({ type: 'permission_response', requestId: card.request_id, conversationId: convoId, allow: true });
+
+    const { msg: failNotice } = await client.waitFor(m => m.type === 'system' && m.subtype === 'notice' && m._conversationId === convoId && /failed/.test(m.content || ''), { label: 'write failure notice' });
+    assert.match(failNotice.content, /escapes the workspace/);
+    assert.ok(!fs.existsSync(path.join(outside, 'evil.md')), 'nothing written outside the workspace');
+
+    fs.rmSync(outside, { recursive: true, force: true });
+    try { fs.unlinkSync(path.join(h.workspaceDir, 'linked')); } catch (e) {}
+    h.reapConvo(convoId);
+  });
+
   test('two markers in one turn produce two cards; each resolves independently', async () => {
     const convoId = h.freshConvoId('cwm');
     h.clearInvocations();

--- a/test/integration/codex-write-markers.test.js
+++ b/test/integration/codex-write-markers.test.js
@@ -1,0 +1,152 @@
+'use strict';
+// Integration: Windows Codex write-request markers (Option F), end to end
+// against the codex stub with the platform seam forcing win32 behaviour.
+// The Codex CLI cannot enforce its write sandbox on native Windows, so
+// win32 codex spawns are instructed to emit WRITE_FILE markers; the server
+// validates each request, raises a permission card, and performs approved
+// writes itself. Companion in codex-chat.test.js pins that non-Windows
+// spawns get neither the instruction nor marker handling.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+
+let client;
+
+function team() {
+  return {
+    ...standardTeam(),
+    'researcher': agentFile({
+      name: 'researcher', displayName: 'Ida', role: 'Researcher',
+      description: 'Researches suppliers', type: 'specialist', order: 5,
+      reportsTo: 'chief-of-staff', runtime: 'codex',
+      body: 'You are Ida, the researcher.',
+    }),
+  };
+}
+
+const MARKER = (p, c) => `<!-- RUNDOCK:WRITE_FILE path="${p}" -->\n${c}\n<!-- /RUNDOCK:WRITE_FILE -->`;
+
+before(async () => {
+  await h.boot({ agents: team(), env: { RUNDOCK_TEST_PLATFORM: 'win32' } });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+function transcript(convoId) {
+  return JSON.parse(fs.readFileSync(path.join(h.workspaceDir, '.rundock', 'transcripts', `${convoId}.json`), 'utf-8'));
+}
+
+describe('codex write markers on win32', () => {
+  test('first-turn prompt carries the WINDOWS FILE WRITES instruction', async () => {
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    h.writeCodexScenario([{ match: { promptIncludes: 'plain question' }, text: 'Plain answer.' }]);
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'plain question' });
+    await client.waitForEvent('system', 'done', convoId);
+    const inv = h.readInvocations().find(i => i.argv && i.argv[0] === 'exec');
+    assert.ok(inv.prompt.includes('WINDOWS FILE WRITES'), 'marker instruction in first-turn prompt');
+    assert.ok(inv.prompt.includes('RUNDOCK:WRITE_FILE'), 'format example included');
+    h.reapConvo(convoId);
+  });
+
+  test('approved write: card raised, exact bytes on disk, marker stripped from the displayed result', async () => {
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    const content = '# Synthesis\n\nTheme: systems earn value through use.';
+    h.writeCodexScenario([{
+      match: { promptIncludes: 'write the synthesis' },
+      text: `I prepared the file.\n\n${MARKER('Research Notes/Synthesis.md', content)}`,
+    }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'write the synthesis please' });
+
+    // Result arrives with the marker replaced by the plain-language line
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'clean result' });
+    assert.ok(!result.result.includes('RUNDOCK:WRITE_FILE'), 'marker stripped');
+    assert.ok(result.result.includes('[write requested: Research Notes/Synthesis.md]'));
+
+    // Card arrives AFTER the result, as a WriteFile control_request
+    const { msg: card } = await client.waitFor(m => m.type === 'control_request' && m._conversationId === convoId, { label: 'write card' });
+    assert.strictEqual(card.request.tool_name, 'WriteFile');
+    assert.strictEqual(card.request.input.path, 'Research Notes/Synthesis.md');
+    assert.strictEqual(card.request.input.content, content);
+
+    // Approve: exact bytes land on disk, confirmation pill + file_saved fire
+    client.send({ type: 'permission_response', requestId: card.request_id, conversationId: convoId, allow: true });
+    await client.waitFor(m => m.type === 'file_saved' && m.path === 'Research Notes/Synthesis.md', { label: 'file saved' });
+    const onDisk = fs.readFileSync(path.join(h.workspaceDir, 'Research Notes', 'Synthesis.md'), 'utf-8');
+    assert.strictEqual(onDisk, content, 'byte-exact write');
+    const t = transcript(convoId);
+    assert.ok(t.find(e => e.text === 'Created Research Notes/Synthesis.md (approved).'));
+
+    h.reapConvo(convoId);
+  });
+
+  test('denied write: no file, refusal recorded in the transcript', async () => {
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    h.writeCodexScenario([{
+      match: { promptIncludes: 'write denied-note' },
+      text: MARKER('denied-note.md', 'should never land'),
+    }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'write denied-note please' });
+    const { msg: card } = await client.waitFor(m => m.type === 'control_request' && m._conversationId === convoId, { label: 'write card' });
+    client.send({ type: 'permission_response', requestId: card.request_id, conversationId: convoId, allow: false });
+
+    // Deny is user-visible as a notice pill (event-driven signal)
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'notice' && m._conversationId === convoId && /not approved/.test(m.content || ''), { label: 'deny notice' });
+    assert.ok(!fs.existsSync(path.join(h.workspaceDir, 'denied-note.md')), 'no file on deny');
+    assert.ok(transcript(convoId).some(e => e.text === 'Write of denied-note.md not approved.'), 'deny recorded for the resumed thread');
+
+    h.reapConvo(convoId);
+  });
+
+  test('traversal request is refused without a card', async () => {
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    h.writeCodexScenario([{
+      match: { promptIncludes: 'write escape' },
+      text: MARKER('../escape.md', 'outside'),
+    }]);
+
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'write escape please' });
+    const { msg: info } = await client.waitFor(m => m.type === 'system' && m.subtype === 'notice' && m._conversationId === convoId && /Refused a file write/.test(m.content || ''), { since, label: 'refusal pill' });
+    assert.match(info.content, /escapes the workspace/);
+    // No card was ever raised for it
+    const cards = client.messages.slice(since).filter(m => m.type === 'control_request' && m._conversationId === convoId);
+    assert.deepStrictEqual(cards, []);
+    assert.ok(!fs.existsSync(path.join(h.workspaceDir, '..', 'escape.md')), 'nothing written outside');
+
+    h.reapConvo(convoId);
+  });
+
+  test('two markers in one turn produce two cards; each resolves independently', async () => {
+    const convoId = h.freshConvoId('cwm');
+    h.clearInvocations();
+    h.writeCodexScenario([{
+      match: { promptIncludes: 'write both' },
+      text: `${MARKER('one.md', 'first')}\n${MARKER('two.md', 'second')}`,
+    }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'write both please' });
+    const { msg: cardA } = await client.waitFor(m => m.type === 'control_request' && m._conversationId === convoId && m.request.input.path === 'one.md', { label: 'card one' });
+    const { msg: cardB } = await client.waitFor(m => m.type === 'control_request' && m._conversationId === convoId && m.request.input.path === 'two.md', { label: 'card two' });
+
+    client.send({ type: 'permission_response', requestId: cardA.request_id, conversationId: convoId, allow: true });
+    client.send({ type: 'permission_response', requestId: cardB.request_id, conversationId: convoId, allow: false });
+
+    await client.waitFor(m => m.type === 'file_saved' && m.path === 'one.md', { label: 'first saved' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'notice' && m._conversationId === convoId && /two\.md was not approved/.test(m.content || ''), { label: 'second denied' });
+    assert.ok(transcript(convoId).some(e => e.text === 'Write of two.md not approved.'));
+    assert.strictEqual(fs.readFileSync(path.join(h.workspaceDir, 'one.md'), 'utf-8'), 'first');
+    assert.ok(!fs.existsSync(path.join(h.workspaceDir, 'two.md')));
+
+    h.reapConvo(convoId);
+  });
+});

--- a/test/integration/delegation.test.js
+++ b/test/integration/delegation.test.js
@@ -178,6 +178,61 @@ describe('Agent-tool interception', () => {
     h.reapConvo(convoId);
   });
 
+  test('off-roster Agent tool target is soft-blocked: no impersonation, caller resumed with a corrective message', async () => {
+    // The impersonation gap: Penn (content-lead) explicitly names Des
+    // (lead-designer), who reports to chief-of-staff, not to Penn. Pre-fix
+    // this fell through to Claude Code, which spawned a generic subagent
+    // wearing Des's name. Post-fix the call is blocked and Penn is resumed
+    // with a corrective system message.
+    const convoId = h.freshConvoId('int');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'content-lead', promptIncludes: 'offroster please' },
+        turn: [
+          { text: 'Handing to Des.' },
+          { agentTool: { subagent_type: 'lead-designer', prompt: 'offroster design brief' } },
+        ],
+      },
+      {
+        // Matching on all three strings proves the corrective prompt reached
+        // the resumed caller with the reason and the blocked target named.
+        match: { agent: 'content-lead', promptIncludes: ['[SYSTEM: delegation-blocked]', 'not one of your direct reports', 'lead-designer'] },
+        turn: [{ text: 'Understood: Des is outside my team, routing back.' }],
+      },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'content-lead', content: 'offroster please' });
+
+    // The user sees the block explained
+    const { msg: info } = await client.waitFor(m => m.type === 'system' && m.subtype === 'info' && m._conversationId === convoId && /Blocked a handoff/.test(m.content || ''), { label: 'block pill' });
+    assert.match(info.content, /Des/);
+
+    // The caller is resumed and answers the corrective prompt
+    const { msg: result } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead' && /routing back/.test(m.result || ''), { label: 'resumed caller result' });
+    assert.ok(result);
+
+    const invs = h.readInvocations();
+    // Des was never spawned: no impersonation, no real delegation either
+    assert.strictEqual(invs.find(i => i.agent === 'lead-designer'), undefined, 'off-roster target must not be spawned');
+    // The caller was resumed with its own session (the corrective prompt's
+    // content is proven by the scenario match above: the resumed stub only
+    // answers when the prompt carries the reason and the blocked target)
+    const resumed = invs.find(i => i.agent === 'content-lead' && i.resume);
+    assert.ok(resumed, 'caller resumed via --resume');
+    assert.ok(resumed.resume.includes('stub-content-lead'), 'resumed the caller session');
+
+    // No agent_switch ever fired: the conversation never left Penn
+    const switches = client.messages.filter(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId);
+    assert.deepStrictEqual(switches, []);
+
+    // Penn's pre-block prose survived into the transcript
+    const t = transcript(convoId);
+    assert.ok(t.find(e => e.agent === 'content-lead' && e.text.includes('Handing to Des.')));
+
+    h.reapConvo(convoId);
+  });
+
   test('COMPLETE gate: intercepted delegate finishing restarts the parent via --resume, parked silently, with sanitized output injected', async () => {
     const convoId = h.freshConvoId('int');
     h.clearInvocations();

--- a/test/integration/runtime-status.test.js
+++ b/test/integration/runtime-status.test.js
@@ -1,0 +1,91 @@
+'use strict';
+// Integration: runtime status reporting for the settings surface, and the
+// runtime tag on agent-saved confirmations.
+//
+// Status honesty rules under test:
+// - Codex reports the full three-state vocabulary from presence checks
+//   (binary on PATH, auth.json exists under the Codex home; never read).
+// - Claude auth is reported from evidence the server already has: null
+//   before any evidence (the UI claims nothing), true after a successful
+//   turn. No live probe is ever run for a settings render.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+
+let client;
+
+before(async () => {
+  await h.boot({ agents: standardTeam() });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+describe('runtime status', () => {
+  test('reports both runtimes with versions; codex not signed in without auth.json; claude auth unknown before evidence', async () => {
+    const since = client.messages.length;
+    client.send({ type: 'get_runtime_status' });
+    const { msg } = await client.waitFor(m => m.type === 'runtime_status', { since, label: 'runtime_status' });
+
+    assert.strictEqual(msg.defaultRuntime, 'claude');
+    assert.strictEqual(msg.claude.installed, true);
+    assert.strictEqual(msg.claude.version, '0.0.0-stub');
+    assert.strictEqual(msg.claude.authenticated, null, 'no auth claim without evidence');
+    assert.strictEqual(msg.codex.installed, true);
+    assert.strictEqual(msg.codex.version, '0.0.0-stub');
+    assert.strictEqual(msg.codex.authenticated, false, 'no auth.json yet');
+  });
+
+  test('codex reports signed in once auth.json exists (presence only)', async () => {
+    fs.mkdirSync(path.join(os.homedir(), '.codex'), { recursive: true });
+    fs.writeFileSync(path.join(os.homedir(), '.codex', 'auth.json'), '{}');
+
+    const since = client.messages.length;
+    client.send({ type: 'get_runtime_status' });
+    const { msg } = await client.waitFor(m => m.type === 'runtime_status', { since, label: 'runtime_status' });
+    assert.strictEqual(msg.codex.authenticated, true);
+  });
+
+  test('claude auth flips to true after a successful turn (evidence-based)', async () => {
+    const convoId = h.freshConvoId('rt');
+    h.writeScenario([{ match: {}, turn: [{ text: 'evidence.' }] }]);
+    client.send({ type: 'chat', conversationId: convoId, agent: 'lead-designer', content: 'evidence please' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const since = client.messages.length;
+    client.send({ type: 'get_runtime_status' });
+    const { msg } = await client.waitFor(m => m.type === 'runtime_status', { since, label: 'runtime_status' });
+    assert.strictEqual(msg.claude.authenticated, true);
+  });
+});
+
+describe('platform agent runtime awareness', () => {
+  test('Doc gets the RUNTIMES prompt section only when Codex is signed in; specialists never do', () => {
+    // auth.json exists from the earlier test, so Codex reports signed in.
+    const platformPrompt = h.internal.buildSystemPrompt({ id: 'doc', type: 'platform', displayName: 'Doc' });
+    assert.ok(platformPrompt.includes('RUNTIMES:'), 'platform agent prompt carries runtime availability');
+    assert.ok(platformPrompt.includes('runtime: codex'), 'frontmatter opt-in instruction present');
+    assert.ok(platformPrompt.includes('without asking'), 'default-without-ceremony instruction present');
+
+    const specialistPrompt = h.internal.buildSystemPrompt({ id: 'writer', type: 'specialist', displayName: 'Writer' });
+    assert.ok(!specialistPrompt.includes('RUNTIMES:'), 'specialists get no runtime section');
+  });
+});
+
+describe('agent_saved runtime tag', () => {
+  test('saving a codex agent reports runtime codex; a claude agent reports claude', async () => {
+    let since = client.messages.length;
+    client.send({ type: 'save_agent', name: 'codex-writer', content: agentFile({ name: 'codex-writer', type: 'specialist', order: 7, runtime: 'codex' }) });
+    const { msg: saved } = await client.waitFor(m => m.type === 'agent_saved' && m.agentId === 'codex-writer', { since, label: 'codex agent_saved' });
+    assert.strictEqual(saved.runtime, 'codex');
+
+    since = client.messages.length;
+    client.send({ type: 'save_agent', name: 'plain-writer', content: agentFile({ name: 'plain-writer', type: 'specialist', order: 8 }) });
+    const { msg: saved2 } = await client.waitFor(m => m.type === 'agent_saved' && m.agentId === 'plain-writer', { since, label: 'claude agent_saved' });
+    assert.strictEqual(saved2.runtime, 'claude');
+  });
+});

--- a/test/integration/runtime-status.test.js
+++ b/test/integration/runtime-status.test.js
@@ -38,6 +38,11 @@ describe('runtime status', () => {
     assert.strictEqual(msg.codex.installed, true);
     assert.strictEqual(msg.codex.version, '0.0.0-stub');
     assert.strictEqual(msg.codex.authenticated, false, 'no auth.json yet');
+
+    // Invisibility: while Codex is not signed in, platform agents get no
+    // runtime section, so Doc never mentions Codex unprompted.
+    const docPrompt = h.internal.buildSystemPrompt({ id: 'doc', type: 'platform', displayName: 'Doc' });
+    assert.ok(!docPrompt.includes('RUNTIMES:'), 'no runtime section before Codex is available');
   });
 
   test('codex reports signed in once auth.json exists (presence only)', async () => {

--- a/test/integration/spawn-argv-freeze.test.js
+++ b/test/integration/spawn-argv-freeze.test.js
@@ -1,0 +1,162 @@
+'use strict';
+// Argv freeze: pins the EXACT command line Rundock uses to spawn Claude Code
+// processes, for every reachable spawn path.
+//
+// Why this exists: the spawn path is safety-critical (permission modes, tool
+// allow/deny lists, sandbox posture all travel through argv) and it is about
+// to grow a second runtime behind an internal seam. Any refactor that changes
+// how Claude Code is invoked, even by reordering flags, must be a deliberate,
+// reviewed decision that updates this file, never an accident.
+//
+// How it works: the stub binary records every invocation's full argv to
+// stub-invocations.jsonl. Each test drives a real flow, then asserts the
+// complete argv array against an explicit expectation. Values that are
+// legitimately dynamic (workspace paths, system prompt bodies, session ids)
+// are masked to a `<flag>` placeholder; everything else is asserted verbatim.
+//
+// If you changed the spawn path on purpose: update the expected arrays here
+// in the same commit, and say why in the commit message.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+
+let client;
+
+before(async () => {
+  await h.boot();
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+// Flags whose values are dynamic by design. The flag's presence and position
+// stay frozen; only the value is masked.
+const DYNAMIC_VALUE_FLAGS = new Set([
+  '--add-dir', '--settings', '--mcp-config', '--append-system-prompt', '--resume',
+]);
+
+function maskArgv(argv) {
+  const out = [];
+  for (let i = 0; i < argv.length; i++) {
+    out.push(argv[i]);
+    if (DYNAMIC_VALUE_FLAGS.has(argv[i]) && i + 1 < argv.length) {
+      out.push(`<${argv[i].slice(2)}>`);
+      i++;
+    }
+  }
+  return out;
+}
+
+// These two strings are part of the product's permission posture. If either
+// changes, that is a permissions change and must be reviewed as one.
+const ALLOWED_TOOLS_INTERACTIVE = 'Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill';
+const DISALLOWED_TOOLS_KNOWLEDGE = 'Write(*.js),Write(*.jsx),Write(*.ts),Write(*.tsx),Write(*.py),Write(*.sh),Write(*.bash),Write(*.rb),Write(*.pl),Write(*.exe),Write(*.dll),Write(*.so),Edit(*.js),Edit(*.jsx),Edit(*.ts),Edit(*.tsx),Edit(*.py),Edit(*.sh),Edit(*.bash),Edit(*.rb),Edit(*.pl),Edit(*.exe)';
+
+describe('spawn argv freeze', () => {
+  test('precondition: server startup scaffolds the permission hook settings; no .mcp.json', () => {
+    // scaffoldWorkspace() runs inside startServer() and writes the PreToolUse
+    // permission hook into .claude/settings.local.json, so --settings is part
+    // of every spawn in a running server. .mcp.json is user-provided and absent.
+    assert.ok(fs.existsSync(path.join(h.workspaceDir, '.claude', 'settings.local.json')));
+    assert.ok(!fs.existsSync(path.join(h.workspaceDir, '.mcp.json')));
+  });
+
+  test('interactive chat spawn: full argv frozen', async () => {
+    const convoId = h.freshConvoId('frz');
+    h.clearInvocations();
+    h.writeScenario([{ match: { agent: 'lead-designer' }, turn: [{ text: 'frozen.' }] }]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'lead-designer', content: 'freeze interactive path' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const inv = h.readInvocations();
+    assert.strictEqual(inv.length, 1, 'exactly one spawn');
+    assert.deepStrictEqual(maskArgv(inv[0].argv), [
+      '--add-dir', '<add-dir>',
+      '--settings', '<settings>',
+      '--model', 'sonnet',
+      '--output-format', 'stream-json',
+      '--input-format', 'stream-json',
+      '--verbose',
+      '--include-partial-messages',
+      '--permission-mode', 'acceptEdits',
+      '--allowed-tools', ALLOWED_TOOLS_INTERACTIVE,
+      '--disallowed-tools', DISALLOWED_TOOLS_KNOWLEDGE,
+      '--append-system-prompt', '<append-system-prompt>',
+      '--agent', 'lead-designer',
+    ]);
+    // Environment contract for spawned processes
+    assert.strictEqual(inv[0].env.RUNDOCK, '1');
+    assert.strictEqual(inv[0].env.RUNDOCK_CONVO_ID, convoId);
+    assert.ok(inv[0].env.RUNDOCK_PORT, 'RUNDOCK_PORT set');
+  });
+
+  test('delegation delegate spawn: full argv frozen', async () => {
+    const convoId = h.freshConvoId('frz');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'freeze delegate path' },
+        turn: [{ agentTool: { subagent_type: 'content-lead', prompt: 'freeze delegate brief' } }],
+      },
+      {
+        match: { agent: 'content-lead', promptIncludes: 'freeze delegate brief' },
+        turn: [{ text: 'delegate frozen.' }],
+      },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'freeze delegate path' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead',
+      { label: 'delegate result' });
+
+    const delegateInv = h.readInvocations().find(i => i.agent === 'content-lead');
+    assert.ok(delegateInv, 'delegate spawn recorded');
+    assert.deepStrictEqual(maskArgv(delegateInv.argv), [
+      '--add-dir', '<add-dir>',
+      '--settings', '<settings>',
+      '--model', 'sonnet',
+      '--output-format', 'stream-json',
+      '--input-format', 'stream-json',
+      '--verbose',
+      '--include-partial-messages',
+      '--permission-mode', 'acceptEdits',
+      '--allowed-tools', ALLOWED_TOOLS_INTERACTIVE,
+      '--disallowed-tools', DISALLOWED_TOOLS_KNOWLEDGE,
+      '--append-system-prompt', '<append-system-prompt>',
+      '--agent', 'content-lead',
+    ]);
+
+    h.reapConvo(convoId);
+  });
+
+  test('routine spawn: full argv frozen (print mode, prompt as positional)', async () => {
+    h.clearInvocations();
+    h.writeScenario([{ match: {}, turn: [{ text: 'routine frozen.' }] }]);
+
+    const agents = h.internal.discoverAgents();
+    const agent = agents.find(a => a.id === 'content-lead');
+    assert.ok(agent, 'fixture agent present');
+    h.internal.executeRoutine(agent, { name: 'freeze-check', schedule: 'daily 09:00', prompt: 'freeze routine path' }, 'freeze-key');
+
+    // The routine process exits on its own (print mode). Poll for the record.
+    let inv = [];
+    for (let i = 0; i < 40 && inv.length === 0; i++) {
+      await h.delay(100);
+      inv = h.readInvocations();
+    }
+    assert.strictEqual(inv.length, 1, 'exactly one routine spawn');
+    assert.deepStrictEqual(maskArgv(inv[0].argv), [
+      '--add-dir', '<add-dir>',
+      '--settings', '<settings>',
+      '--model', 'sonnet',
+      '--print',
+      '--output-format', 'stream-json',
+      '--verbose',
+      '--dangerously-skip-permissions',
+      '--agent', 'content-lead',
+      'freeze routine path',
+    ]);
+  });
+});

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -106,7 +106,7 @@ function main() {
   console.log('\n===== server.js coverage by functional area =====\n');
   console.log(`OVERALL server.js: ${pct(fileCovered, fileTotal)}  (${fileCovered}/${fileTotal} executable lines)`);
   // Sibling modules included in coverage get their own overall line.
-  for (const extra of ['codex.js']) {
+  for (const extra of ['codex.js', 'search.js']) {
     const extraHits = parseLcov(lcovPath, extra);
     if (extraHits) {
       let t = 0, c2 = 0;

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -17,35 +17,58 @@ const path = require('path');
 
 const lcovPath = process.argv[2] || 'coverage.lcov';
 const targetFile = 'server.js';
+const serverSrcPath = path.join(__dirname, '..', '..', 'server.js');
 
-// Functional areas, by server.js line range (inclusive). Ranges trace the
-// current server.js; they are documentation of intent, not load-bearing.
-const AREAS = [
-  ['Delegation / orchestration engine', 2035, 2788],
-  ['  - wireProcessHandlers (stream-json + interception)', 2035, 2189],
-  ['  - handleScopeReturn', 2202, 2312],
-  ['  - handleDelegation', 2315, 2788],
-  ['Scheduler (getNextRun + startScheduler + executeRoutine)', 992, 1084],
-  ['Permission bridge (/api/permission-request + responses)', 1766, 1815],
-  ['Agent / skill discovery + frontmatter parsing', 715, 988],
-  ['Skill discovery', 3875, 3993],
-  ['System prompt + roster builders', 449, 705],
-  ['Workspace analysis (Seven Signals)', 1108, 1396],
-  ['Workspace mode detection + scaffolding', 1434, 1724],
-  ['Transcripts + persistence helpers', 1875, 1952],
-  ['Conversation / state persistence', 152, 206],
-  ['HTTP request router', 1733, 1837],
-  ['WebSocket message handlers', 2795, 3862],
-  ['Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', 4088, 4213],
+// Functional areas, located by ANCHOR PATTERNS rather than hardcoded line
+// numbers, so edits elsewhere in server.js cannot silently shift an area onto
+// unrelated code. Each area runs from the line matching `start` to the line
+// BEFORE the one matching `end` (both regexes, matched against whole lines).
+const AREA_DEFS = [
+  ['Delegation / orchestration engine', /^function wireProcessHandlers\(/, /^wss\.on\('connection'/],
+  ['  - wireProcessHandlers (stream-json + interception)', /^function wireProcessHandlers\(/, /^function handleScopeReturn/],
+  ['  - handleScopeReturn', /^function handleScopeReturn/, /^function handleDelegation/],
+  ['  - handleDelegation', /^function handleDelegation/, /^wss\.on\('connection'/],
+  ['Scheduler (getNextRun + startScheduler + executeRoutine)', /^function startScheduler\(/, /^function analyzeWorkspace/],
+  ['Agent discovery + frontmatter parsing', /^\/\/ ===== AGENT DISCOVERY =====/, /^function startScheduler\(/],
+  ['Skill discovery', /^function discoverSkills\(/, /^function getFileTree\(/],
+  ['System prompt + roster builders', /^function buildSystemPrompt\(/, /^\/\/ ===== AGENT DISCOVERY =====/],
+  ['Workspace analysis (Seven Signals)', /^function analyzeWorkspace\(/, /^function muteHooks\(/],
+  ['Workspace mode detection + scaffolding', /^function muteHooks\(/, /^const server = http\.createServer/],
+  ['Transcripts + persistence helpers', /^function loadTranscript\(/, /^function safeSend\(/],
+  ['Conversation / state persistence', /^function readConversations\(/, /^function readState\(/],
+  ['HTTP request router (incl. permission bridge)', /^const server = http\.createServer/, /^function loadTranscript\(/],
+  ['WebSocket message handlers', /^wss\.on\('connection'/, /^function discoverSkills\(/],
+  ['Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', /^function resolveClaudeBin\(/, /^\/\/ ===== CODEX RUNTIME =====/],
+  ['Codex runtime (status, turns, delegate wiring)', /^\/\/ ===== CODEX RUNTIME =====/, /^\/\/ Graceful shutdown/],
 ];
 
-function parseLcov(file) {
+// Resolve anchor patterns to line ranges against the current source.
+function resolveAreas() {
+  const lines = fs.readFileSync(serverSrcPath, 'utf-8').split('\n');
+  const findLine = (re) => {
+    for (let i = 0; i < lines.length; i++) if (re.test(lines[i])) return i + 1;
+    return null;
+  };
+  const areas = [];
+  for (const [label, startRe, endRe] of AREA_DEFS) {
+    const start = findLine(startRe);
+    const end = findLine(endRe);
+    if (start == null || end == null || end <= start) {
+      console.warn(`coverage-areas: could not resolve "${label}" (start=${start}, end=${end}); anchors need updating`);
+      continue;
+    }
+    areas.push([label, start, end - 1]);
+  }
+  return areas;
+}
+
+function parseLcov(file, wantedFile) {
   const text = fs.readFileSync(file, 'utf-8');
   const records = text.split('end_of_record');
   for (const rec of records) {
     const sfMatch = rec.match(/SF:(.*)/);
     if (!sfMatch) continue;
-    if (path.basename(sfMatch[1].trim()) !== targetFile) continue;
+    if (path.basename(sfMatch[1].trim()) !== wantedFile) continue;
     const hits = new Map(); // line -> count
     for (const m of rec.matchAll(/^DA:(\d+),(\d+)/gm)) {
       hits.set(parseInt(m[1], 10), parseInt(m[2], 10));
@@ -72,7 +95,7 @@ function main() {
     console.error(`coverage-areas: ${lcovPath} not found. Run npm run test:coverage.`);
     process.exit(1);
   }
-  const hits = parseLcov(lcovPath);
+  const hits = parseLcov(lcovPath, targetFile);
   if (!hits) {
     console.error(`coverage-areas: no ${targetFile} record in ${lcovPath}`);
     process.exit(1);
@@ -81,11 +104,21 @@ function main() {
   for (const [, c] of hits) { fileTotal++; if (c > 0) fileCovered++; }
 
   console.log('\n===== server.js coverage by functional area =====\n');
-  console.log(`OVERALL server.js: ${pct(fileCovered, fileTotal)}  (${fileCovered}/${fileTotal} executable lines)\n`);
+  console.log(`OVERALL server.js: ${pct(fileCovered, fileTotal)}  (${fileCovered}/${fileTotal} executable lines)`);
+  // Sibling modules included in coverage get their own overall line.
+  for (const extra of ['codex.js']) {
+    const extraHits = parseLcov(lcovPath, extra);
+    if (extraHits) {
+      let t = 0, c2 = 0;
+      for (const [, c] of extraHits) { t++; if (c > 0) c2++; }
+      console.log(`OVERALL ${extra}: ${pct(c2, t)}  (${c2}/${t} executable lines)`);
+    }
+  }
+  console.log('');
   const pad = (s, n) => (s + ' '.repeat(n)).slice(0, n);
   console.log(pad('Area', 58) + pad('Lines', 10) + pad('Covered', 10) + 'Coverage');
   console.log('-'.repeat(88));
-  for (const [label, start, end] of AREAS) {
+  for (const [label, start, end] of resolveAreas()) {
     const { total, covered } = areaCoverage(hits, start, end);
     console.log(pad(label, 58) + pad(`${start}-${end}`, 10) + pad(`${covered}/${total}`, 10) + pct(covered, total));
   }

--- a/test/unit/codex-runtime.test.js
+++ b/test/unit/codex-runtime.test.js
@@ -114,6 +114,16 @@ describe('buildCodexArgs', () => {
       }
     }
   });
+
+  test('malformed thread ids are rejected: no flag smuggling through the resume positional', () => {
+    // A hostile client-supplied session id must never reach argv.
+    const hostile = codex.buildCodexArgs({ resumeThreadId: '--dangerously-bypass-approvals-and-sandbox' });
+    assert.deepStrictEqual(hostile, ['exec', '--json', '--sandbox', 'workspace-write', '--skip-git-repo-check', '-']);
+    const spacey = codex.buildCodexArgs({ resumeThreadId: 'thr abc' });
+    assert.ok(!spacey.includes('resume'), 'ids with spaces rejected');
+    // Legitimate ids still resume.
+    assert.ok(codex.buildCodexArgs({ resumeThreadId: 'cthr_01HXYZ.9-a' }).includes('resume'));
+  });
 });
 
 describe('detectCodex', () => {

--- a/test/unit/codex-runtime.test.js
+++ b/test/unit/codex-runtime.test.js
@@ -147,7 +147,7 @@ describe('detectCodex', () => {
         return '/usr/local/bin/codex\n';
       },
     }));
-    assert.deepStrictEqual(d, { installed: true, authenticated: false, version: '0.48.0' });
+    assert.deepStrictEqual(d, { installed: true, authenticated: false, version: '0.48.0', windowsSandbox: null });
   });
 
   test('signed in: auth.json present under the default home', () => {
@@ -155,7 +155,7 @@ describe('detectCodex', () => {
       execSync: (cmd) => cmd.includes('--version') ? 'codex-cli 0.48.0\n' : '/usr/local/bin/codex\n',
       existsSync: (p) => p === path.join('/home/tester', '.codex', 'auth.json'),
     }));
-    assert.deepStrictEqual(d, { installed: true, authenticated: true, version: '0.48.0' });
+    assert.deepStrictEqual(d, { installed: true, authenticated: true, version: '0.48.0', windowsSandbox: null });
   });
 
   test('CODEX_HOME overrides the default auth location', () => {

--- a/test/unit/codex-runtime.test.js
+++ b/test/unit/codex-runtime.test.js
@@ -1,0 +1,216 @@
+'use strict';
+// Unit tests for the Codex runtime adapter: line parsing, argv construction,
+// binary/auth detection, and quota-error classification.
+//
+// Everything here is pure or dependency-injected; no processes are spawned
+// and no real home directory is read.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const fx = require('../fixtures/codex-jsonl.js');
+const codex = require('../../codex.js');
+
+describe('parseCodexLine', () => {
+  test('thread.started -> session event with thread id', () => {
+    const ev = codex.parseCodexLine(JSON.stringify(fx.threadStarted('thr_abc123')));
+    assert.deepStrictEqual(ev, { type: 'session', threadId: 'thr_abc123' });
+  });
+
+  test('item.completed agent_message -> text event', () => {
+    const ev = codex.parseCodexLine(JSON.stringify(fx.agentMessage('Hello from Codex.')));
+    assert.deepStrictEqual(ev, { type: 'text', text: 'Hello from Codex.' });
+  });
+
+  test('item.completed with a non-message item is skipped', () => {
+    assert.strictEqual(codex.parseCodexLine(JSON.stringify(fx.otherItem())), null);
+    assert.strictEqual(codex.parseCodexLine(JSON.stringify(fx.otherItem('reasoning'))), null);
+  });
+
+  test('turn.completed -> done event carrying normalised usage', () => {
+    const ev = codex.parseCodexLine(JSON.stringify(fx.turnCompleted({ input: 1200, cached: 800, output: 340 })));
+    assert.deepStrictEqual(ev, {
+      type: 'done',
+      usage: { inputTokens: 1200, cachedInputTokens: 800, outputTokens: 340 },
+    });
+  });
+
+  test('turn.completed with missing usage fields still emits done with zeroed usage', () => {
+    const ev = codex.parseCodexLine(JSON.stringify({ type: 'turn.completed' }));
+    assert.deepStrictEqual(ev, {
+      type: 'done',
+      usage: { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 },
+    });
+  });
+
+  test('turn.failed -> error event with the message', () => {
+    const ev = codex.parseCodexLine(JSON.stringify(fx.turnFailed('sandbox denied write')));
+    assert.deepStrictEqual(ev, { type: 'error', message: 'sandbox denied write' });
+  });
+
+  test('turn.failed without an error object falls back to a generic message', () => {
+    const ev = codex.parseCodexLine(JSON.stringify({ type: 'turn.failed' }));
+    assert.deepStrictEqual(ev, { type: 'error', message: 'Codex turn failed' });
+  });
+
+  test('bare error event -> error event', () => {
+    const ev = codex.parseCodexLine(JSON.stringify(fx.bareError('boom')));
+    assert.deepStrictEqual(ev, { type: 'error', message: 'boom' });
+  });
+
+  test('unknown event types are skipped', () => {
+    assert.strictEqual(codex.parseCodexLine(JSON.stringify({ type: 'turn.started' })), null);
+    assert.strictEqual(codex.parseCodexLine(JSON.stringify({ type: 'item.started', item: {} })), null);
+  });
+
+  test('malformed JSON, empty and whitespace lines are skipped, never throw', () => {
+    assert.strictEqual(codex.parseCodexLine('{not json'), null);
+    assert.strictEqual(codex.parseCodexLine(''), null);
+    assert.strictEqual(codex.parseCodexLine('   '), null);
+    assert.strictEqual(codex.parseCodexLine('null'), null);
+    assert.strictEqual(codex.parseCodexLine('42'), null);
+  });
+});
+
+describe('buildCodexArgs', () => {
+  test('fresh turn: exec --json with sandbox, git check skipped, prompt on stdin', () => {
+    assert.deepStrictEqual(codex.buildCodexArgs({}), [
+      'exec', '--json',
+      '--sandbox', 'workspace-write',
+      '--skip-git-repo-check',
+      '-',
+    ]);
+  });
+
+  test('model flag only when a model is set', () => {
+    assert.deepStrictEqual(codex.buildCodexArgs({ model: 'gpt-5.3-codex' }), [
+      'exec', '--json',
+      '--sandbox', 'workspace-write',
+      '--skip-git-repo-check',
+      '--model', 'gpt-5.3-codex',
+      '-',
+    ]);
+  });
+
+  test('resume turn: resume subcommand with the thread id', () => {
+    assert.deepStrictEqual(codex.buildCodexArgs({ resumeThreadId: 'thr_abc123' }), [
+      'exec', '--json',
+      '--sandbox', 'workspace-write',
+      '--skip-git-repo-check',
+      'resume', 'thr_abc123',
+      '-',
+    ]);
+  });
+
+  test('never emits approval or sandbox bypass flags', () => {
+    const variants = [
+      codex.buildCodexArgs({}),
+      codex.buildCodexArgs({ model: 'gpt-5.3-codex' }),
+      codex.buildCodexArgs({ resumeThreadId: 'thr_x' }),
+    ];
+    for (const args of variants) {
+      for (const a of args) {
+        assert.ok(!/bypass|yolo|full-auto|dangerously/i.test(a), `forbidden flag in argv: ${a}`);
+      }
+    }
+  });
+});
+
+describe('detectCodex', () => {
+  const fakeDeps = (overrides = {}) => ({
+    execSync: overrides.execSync || (() => { throw new Error('not found'); }),
+    existsSync: overrides.existsSync || (() => false),
+    homedir: overrides.homedir || (() => '/home/tester'),
+    env: overrides.env || {},
+    platform: overrides.platform || 'darwin',
+  });
+
+  test('not installed: binary lookup fails', () => {
+    const d = codex.detectCodex(fakeDeps());
+    assert.deepStrictEqual(d, { installed: false, authenticated: false, version: null });
+  });
+
+  test('installed but not signed in: binary found, no auth.json', () => {
+    const d = codex.detectCodex(fakeDeps({
+      execSync: (cmd) => {
+        if (cmd.includes('--version')) return 'codex-cli 0.48.0\n';
+        return '/usr/local/bin/codex\n';
+      },
+    }));
+    assert.deepStrictEqual(d, { installed: true, authenticated: false, version: '0.48.0' });
+  });
+
+  test('signed in: auth.json present under the default home', () => {
+    const d = codex.detectCodex(fakeDeps({
+      execSync: (cmd) => cmd.includes('--version') ? 'codex-cli 0.48.0\n' : '/usr/local/bin/codex\n',
+      existsSync: (p) => p === path.join('/home/tester', '.codex', 'auth.json'),
+    }));
+    assert.deepStrictEqual(d, { installed: true, authenticated: true, version: '0.48.0' });
+  });
+
+  test('CODEX_HOME overrides the default auth location', () => {
+    const d = codex.detectCodex(fakeDeps({
+      execSync: (cmd) => cmd.includes('--version') ? 'codex-cli 0.48.0\n' : '/usr/local/bin/codex\n',
+      env: { CODEX_HOME: '/custom/codex-home' },
+      existsSync: (p) => p === path.join('/custom/codex-home', 'auth.json'),
+    }));
+    assert.strictEqual(d.authenticated, true);
+  });
+
+  test('version parse tolerates unexpected output', () => {
+    const d = codex.detectCodex(fakeDeps({
+      execSync: (cmd) => cmd.includes('--version') ? 'something odd\n' : '/usr/local/bin/codex\n',
+    }));
+    assert.strictEqual(d.installed, true);
+    assert.strictEqual(d.version, null);
+  });
+});
+
+describe('resolveCodexBin', () => {
+  test('unix: returns the trimmed which output', () => {
+    const bin = codex.resolveCodexBin({
+      platform: 'darwin',
+      execSync: () => '/opt/homebrew/bin/codex\n',
+    });
+    assert.strictEqual(bin, '/opt/homebrew/bin/codex');
+  });
+
+  test('windows: prefers .exe over .cmd when both are present', () => {
+    const bin = codex.resolveCodexBin({
+      platform: 'win32',
+      execSync: () => 'C:\\Users\\t\\AppData\\Roaming\\npm\\codex.cmd\r\nC:\\tools\\codex.exe\r\n',
+    });
+    assert.strictEqual(bin, 'C:\\tools\\codex.exe');
+  });
+
+  test('windows: npm ships only a .cmd shim; the absolute .cmd path is used (never shell: true)', () => {
+    const bin = codex.resolveCodexBin({
+      platform: 'win32',
+      execSync: () => 'C:\\Users\\t\\AppData\\Roaming\\npm\\codex.cmd\r\n',
+    });
+    assert.strictEqual(bin, 'C:\\Users\\t\\AppData\\Roaming\\npm\\codex.cmd');
+  });
+
+  test('lookup failure returns the bare command so spawn surfaces ENOENT', () => {
+    const bin = codex.resolveCodexBin({
+      platform: 'darwin',
+      execSync: () => { throw new Error('not found'); },
+    });
+    assert.strictEqual(bin, 'codex');
+  });
+});
+
+describe('isCodexQuotaError', () => {
+  test("recognises the CLI's usage-limit wording", () => {
+    assert.strictEqual(codex.isCodexQuotaError(fx.QUOTA_MESSAGE), true);
+    assert.strictEqual(codex.isCodexQuotaError('usage limit reached, resets 15:00'), true);
+    assert.strictEqual(codex.isCodexQuotaError('You have hit your usage limit.'), true);
+  });
+
+  test('does not classify ordinary failures as quota', () => {
+    assert.strictEqual(codex.isCodexQuotaError('sandbox denied write to /etc/hosts'), false);
+    assert.strictEqual(codex.isCodexQuotaError('unknown thread thr_x'), false);
+    assert.strictEqual(codex.isCodexQuotaError(''), false);
+    assert.strictEqual(codex.isCodexQuotaError(null), false);
+  });
+});

--- a/test/unit/codex-runtime.test.js
+++ b/test/unit/codex-runtime.test.js
@@ -224,3 +224,48 @@ describe('isCodexQuotaError', () => {
     assert.strictEqual(codex.isCodexQuotaError(null), false);
   });
 });
+
+describe('classifyCodexError', () => {
+  // Real message captured live: a ChatGPT account with an unavailable model
+  // configured returns a raw invalid_request_error JSON blob.
+  const MODEL_400 = '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}}';
+  // Real message captured live: logged-out CLI fails mid-connection with
+  // reconnect/transport noise wrapping a 401.
+  const AUTH_401 = 'Reconnecting... 2/5 (unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: wss://api.openai.com/v1/responses, cf-ray: a1ab5b883bdb63c9-LHR)';
+
+  test('classifies an unavailable-model 400 and extracts the model name', () => {
+    const c = codex.classifyCodexError(MODEL_400);
+    assert.strictEqual(c.kind, 'model');
+    assert.strictEqual(c.model, 'gpt-5.3-codex');
+  });
+
+  test('classifies model errors without an extractable name', () => {
+    const c = codex.classifyCodexError('The requested model is not supported on this plan.');
+    assert.strictEqual(c.kind, 'model');
+    assert.strictEqual(c.model, null);
+  });
+
+  test('classifies signed-out transport failures as auth', () => {
+    assert.strictEqual(codex.classifyCodexError(AUTH_401).kind, 'auth');
+    assert.strictEqual(codex.classifyCodexError('Missing bearer or basic authentication in header').kind, 'auth');
+    assert.strictEqual(codex.classifyCodexError('Error: not logged in. Please run codex login.').kind, 'auth');
+  });
+
+  test('classifies quota wording as quota (isCodexQuotaError agrees)', () => {
+    assert.strictEqual(codex.classifyCodexError(fx.QUOTA_MESSAGE).kind, 'quota');
+    assert.strictEqual(codex.isCodexQuotaError(fx.QUOTA_MESSAGE), true);
+  });
+
+  test('leaves ordinary failures unclassified', () => {
+    assert.strictEqual(codex.classifyCodexError('sandbox denied write to /etc/hosts').kind, 'unknown');
+    assert.strictEqual(codex.classifyCodexError('unknown thread thr_x').kind, 'unknown');
+    assert.strictEqual(codex.classifyCodexError('').kind, 'unknown');
+    assert.strictEqual(codex.classifyCodexError(null).kind, 'unknown');
+  });
+
+  test('a 400 mentioning 401-free auth words does not misclassify as model', () => {
+    // Guard: auth match must not swallow model errors and vice versa.
+    assert.strictEqual(codex.classifyCodexError(MODEL_400).kind, 'model');
+    assert.strictEqual(codex.classifyCodexError(AUTH_401).kind, 'auth');
+  });
+});

--- a/test/unit/codex-write-requests.test.js
+++ b/test/unit/codex-write-requests.test.js
@@ -126,4 +126,10 @@ describe('validateWriteRequest', () => {
     assert.strictEqual(srv.validateWriteRequest(ws, '.claude/agents/evil.md', 'x', false).ok, false);
     assert.strictEqual(srv.validateWriteRequest(ws, '.rundock/state.json', 'x', false).ok, false);
   });
+
+  test('managed-directory check is case-insensitive (Windows filesystems are)', () => {
+    assert.strictEqual(srv.validateWriteRequest(ws, '.Claude/agents/evil.md', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, '.RUNDOCK/state.json', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, '.ClAuDe/skills/x.md', 'x', false).ok, false);
+  });
 });

--- a/test/unit/codex-write-requests.test.js
+++ b/test/unit/codex-write-requests.test.js
@@ -1,0 +1,98 @@
+'use strict';
+// Option F: write-request markers for Windows Codex agents.
+// The Codex CLI cannot enforce its write sandbox on Windows (silent
+// downgrade to read-only), so win32 Codex agents emit WRITE_FILE markers
+// and Rundock performs the write itself after a permission card.
+// Parser lives in codex.js; validation lives in server.js (_internal).
+const { test, describe, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const codex = require('../../codex.js');
+const { _internal: srv } = require('../../server.js');
+const { makeWorkspace, cleanup } = require('../helpers/workspace.js');
+
+after(cleanup);
+
+const MARKER = (p, c) => `<!-- RUNDOCK:WRITE_FILE path="${p}" -->\n${c}\n<!-- /RUNDOCK:WRITE_FILE -->`;
+
+describe('parseWriteMarkers', () => {
+  test('extracts a single request and substitutes a plain-language line', () => {
+    const text = `I prepared the synthesis.\n\n${MARKER('Research Notes/Synthesis.md', '# Synthesis\n\nBody.')}\n\nDone describing.`;
+    const { cleanText, requests } = codex.parseWriteMarkers(text);
+    assert.strictEqual(requests.length, 1);
+    assert.strictEqual(requests[0].path, 'Research Notes/Synthesis.md');
+    assert.strictEqual(requests[0].content, '# Synthesis\n\nBody.');
+    assert.ok(!cleanText.includes('RUNDOCK:WRITE_FILE'), 'marker stripped from display text');
+    assert.ok(cleanText.includes('[write requested: Research Notes/Synthesis.md]'));
+    assert.ok(cleanText.includes('I prepared the synthesis.'));
+    assert.ok(cleanText.includes('Done describing.'));
+  });
+
+  test('extracts multiple requests in order', () => {
+    const text = `${MARKER('a.md', 'A')}\nmiddle\n${MARKER('b.md', 'B')}`;
+    const { requests } = codex.parseWriteMarkers(text);
+    assert.deepStrictEqual(requests.map(r => r.path), ['a.md', 'b.md']);
+    assert.deepStrictEqual(requests.map(r => r.content), ['A', 'B']);
+  });
+
+  test('content keeps interior blank lines and markdown exactly', () => {
+    const body = '# Title\n\npara one\n\n- list\n- items\n';
+    const { requests } = codex.parseWriteMarkers(MARKER('x.md', body));
+    // Trailing newline inside the block is preserved minus the final separator
+    assert.ok(requests[0].content.startsWith('# Title\n\npara one'));
+    assert.ok(requests[0].content.includes('- items'));
+  });
+
+  test('text without markers passes through untouched', () => {
+    const text = 'Nothing to see here.\nJust prose.';
+    const out = codex.parseWriteMarkers(text);
+    assert.strictEqual(out.cleanText, text);
+    assert.deepStrictEqual(out.requests, []);
+  });
+
+  test('null/empty input is safe', () => {
+    assert.deepStrictEqual(codex.parseWriteMarkers(''), { cleanText: '', requests: [] });
+    assert.deepStrictEqual(codex.parseWriteMarkers(null), { cleanText: '', requests: [] });
+  });
+});
+
+describe('validateWriteRequest', () => {
+  const ws = makeWorkspace({ claudeMd: '# x' });
+
+  test('accepts a relative markdown path inside the workspace', () => {
+    const v = srv.validateWriteRequest(ws, 'Research Notes/Synthesis.md', 'content', false);
+    assert.strictEqual(v.ok, true);
+    assert.strictEqual(v.fullPath, path.join(ws, 'Research Notes', 'Synthesis.md'));
+  });
+
+  test('rejects traversal and absolute paths without exception', () => {
+    assert.strictEqual(srv.validateWriteRequest(ws, '../outside.md', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'notes/../../outside.md', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, path.join(ws, '..', 'abs.md'), 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, '/etc/hosts.md', 'x', false).ok, false);
+  });
+
+  test('knowledge mode enforces the supported file types; code mode does not', () => {
+    assert.strictEqual(srv.validateWriteRequest(ws, 'notes/a.md', 'x', false).ok, true);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'data.yaml', 'x', false).ok, true);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'data.json', 'x', false).ok, true);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'plain.txt', 'x', false).ok, true);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'script.ps1', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'tool.js', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'tool.js', 'x', true).ok, true, 'code mode allows code files');
+  });
+
+  test('rejects oversized content and empty paths', () => {
+    const big = 'x'.repeat(1024 * 1024 + 1);
+    assert.strictEqual(srv.validateWriteRequest(ws, 'big.md', big, false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, '', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, '   ', 'x', false).ok, false);
+  });
+
+  test('rejects writes into the managed .claude and .rundock directories', () => {
+    assert.strictEqual(srv.validateWriteRequest(ws, '.claude/agents/evil.md', 'x', false).ok, false);
+    assert.strictEqual(srv.validateWriteRequest(ws, '.rundock/state.json', 'x', false).ok, false);
+  });
+});

--- a/test/unit/codex-write-requests.test.js
+++ b/test/unit/codex-write-requests.test.js
@@ -58,6 +58,37 @@ describe('parseWriteMarkers', () => {
   });
 });
 
+describe('hasWindowsSandboxConfig', () => {
+  // Presence-only scan of the Codex config for a [windows] sandbox
+  // declaration. When present, the CLI grants a real workspace-write policy
+  // (in-process patch writes, workspace-bounded), so the write-marker
+  // fallback stands down. Verified live: an unconfigured CLI silently
+  // downgrades to read-only; a configured one writes directly.
+  const withConfig = (content) => ({
+    readFileSync: () => content,
+    homedir: () => '/tmp/fake-home',
+    env: {},
+  });
+
+  test('true when [windows] declares a sandbox', () => {
+    assert.strictEqual(codex.hasWindowsSandboxConfig(withConfig('[windows]\nsandbox = "unelevated"\n')), true);
+    assert.strictEqual(codex.hasWindowsSandboxConfig(withConfig('# comment\n\n[windows]\nsandbox = "elevated"\n\n[projects.x]\ntrust_level = "trusted"\n')), true);
+  });
+
+  test('false when [windows] exists without a sandbox key', () => {
+    assert.strictEqual(codex.hasWindowsSandboxConfig(withConfig('[windows]\nsandbox_private_desktop = false\n')), false);
+  });
+
+  test('false when a sandbox key lives under a different section', () => {
+    assert.strictEqual(codex.hasWindowsSandboxConfig(withConfig('[features]\nsandbox = "x"\n')), false);
+    assert.strictEqual(codex.hasWindowsSandboxConfig(withConfig('sandbox_mode = "workspace-write"\n')), false);
+  });
+
+  test('false when the config file is missing or unreadable', () => {
+    assert.strictEqual(codex.hasWindowsSandboxConfig({ readFileSync: () => { throw new Error('ENOENT'); }, homedir: () => '/x', env: {} }), false);
+  });
+});
+
 describe('validateWriteRequest', () => {
   const ws = makeWorkspace({ claudeMd: '# x' });
 

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -419,3 +419,46 @@ describe('findDirectReportMatch', () => {
     assert.strictEqual(srv.findDirectReportMatch('chief-of-staff', { subagent_type: 'no-such-agent', prompt: 'ask Penn' }), null);
   });
 });
+
+describe('agent runtime field', () => {
+  test('runtime: codex is parsed onto the agent; model stays unset unless frontmatter sets one', () => {
+    useWorkspace({ agents: {
+      'researcher': agentFile({ name: 'researcher', type: 'specialist', order: 2, runtime: 'codex' }),
+    } });
+    srv.invalidateAgentCache();
+    const a = srv.discoverAgents().find(x => x.id === 'researcher');
+    assert.strictEqual(a.runtime, 'codex');
+    // Codex applies its own default model; the Claude default must not leak in.
+    assert.strictEqual(a.model, null);
+  });
+
+  test('runtime: codex with an explicit model keeps that model', () => {
+    useWorkspace({ agents: {
+      'researcher': agentFile({ name: 'researcher', type: 'specialist', order: 2, runtime: 'codex', model: 'gpt-5.3-codex' }),
+    } });
+    srv.invalidateAgentCache();
+    const a = srv.discoverAgents().find(x => x.id === 'researcher');
+    assert.strictEqual(a.runtime, 'codex');
+    assert.strictEqual(a.model, 'gpt-5.3-codex');
+  });
+
+  test('absent runtime means claude: existing agent files see no behaviour change', () => {
+    useWorkspace({ agents: {
+      'writer': agentFile({ name: 'writer', type: 'specialist', order: 2 }),
+    } });
+    srv.invalidateAgentCache();
+    const a = srv.discoverAgents().find(x => x.id === 'writer');
+    assert.strictEqual(a.runtime, 'claude');
+    assert.strictEqual(a.model, 'sonnet');
+  });
+
+  test('unknown runtime values fall back to claude (a typo never strands an agent)', () => {
+    useWorkspace({ agents: {
+      'writer': agentFile({ name: 'writer', type: 'specialist', order: 2, runtime: 'gemini' }),
+    } });
+    srv.invalidateAgentCache();
+    const a = srv.discoverAgents().find(x => x.id === 'writer');
+    assert.strictEqual(a.runtime, 'claude');
+    assert.strictEqual(a.model, 'sonnet');
+  });
+});

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -420,6 +420,45 @@ describe('findDirectReportMatch', () => {
   });
 });
 
+describe('findOffRosterWorkspaceMatch', () => {
+  // The impersonation gap: an Agent tool call explicitly naming a workspace
+  // agent OUTSIDE the caller's direct reports used to fall through silently,
+  // and Claude Code spawned a generic subagent wearing that agent's name.
+  // For runtime: codex agents this silently bypassed the runtime choice.
+  test('explicit subagent_type naming an off-roster workspace agent matches', () => {
+    useWorkspace({ agents: standardTeam() });
+    // Des reports to chief-of-staff, not to Penn.
+    const byName = srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'lead-designer', prompt: 'design this' });
+    assert.strictEqual(byName.id, 'lead-designer');
+    const byDisplay = srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'Des', prompt: 'design this' });
+    assert.strictEqual(byDisplay.id, 'lead-designer');
+  });
+
+  test('direct reports are not claimed (the interception path owns them)', () => {
+    useWorkspace({ agents: standardTeam() });
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('chief-of-staff', { subagent_type: 'content-lead', prompt: 'x' }), null);
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'content-analyst', prompt: 'x' }), null);
+  });
+
+  test('built-in and unknown subagent types pass through untouched', () => {
+    useWorkspace({ agents: standardTeam() });
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'general-purpose', prompt: 'search files' }), null);
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'Explore', prompt: 'x' }), null);
+  });
+
+  test('prompt-only mentions of off-roster agents never match (explicit path only)', () => {
+    useWorkspace({ agents: standardTeam() });
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { prompt: 'Review what Des produced last week' }), null);
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'general-purpose', prompt: 'Review what lead-designer produced' }), null);
+  });
+
+  test('the caller itself never matches', () => {
+    useWorkspace({ agents: standardTeam() });
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'content-lead', prompt: 'x' }), null);
+    assert.strictEqual(srv.findOffRosterWorkspaceMatch('content-lead', { subagent_type: 'Penn', prompt: 'x' }), null);
+  });
+});
+
 describe('agent runtime field', () => {
   test('runtime: codex is parsed onto the agent; model stays unset unless frontmatter sets one', () => {
     useWorkspace({ agents: {

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -333,6 +333,30 @@ describe('rosters and system prompt', () => {
     assert.ok(plain.includes('<!-- RUNDOCK:RETURN -->'));
   });
 
+  test('buildSystemPrompt: self-description is runtime-neutral (a Codex agent must not say "powered by Claude Code")', () => {
+    // Live finding: the base rules described Rundock as "powered by Claude
+    // Code" and a Codex agent said it verbatim. The identity line now names
+    // both runtimes and no agent claims a single one.
+    useWorkspace({ agents: standardTeam() });
+    const prompt = srv.buildSystemPrompt(srv.discoverAgents().find(a => a.id === 'content-lead'));
+    assert.ok(!prompt.includes('powered by Claude Code'), 'single-runtime claim removed');
+    assert.ok(prompt.includes('Claude Code') && prompt.includes('Codex'), 'both runtimes named');
+  });
+
+  test('buildSystemPrompt: injects the concrete review-annotation handle instead of a derivation rule', () => {
+    // Live finding: "by: <your agent name, lowercase>" parsed differently on
+    // GPT-5 (it wrote its ROLE). The concrete handle is now injected.
+    useWorkspace({ agents: standardTeam() });
+    const agents = srv.discoverAgents();
+    const penn = srv.buildSystemPrompt(agents.find(a => a.id === 'content-lead'));
+    assert.ok(penn.includes('Your review-annotation handle is: penn'), 'concrete handle stated');
+    assert.ok(penn.includes('by: penn'), 'metadata example uses the concrete handle');
+    assert.ok(!penn.includes('<your agent name'), 'derivation placeholder removed');
+    // displayName lowercased is the handle convention Claude agents settled on
+    const des = srv.buildSystemPrompt(agents.find(a => a.id === 'lead-designer'));
+    assert.ok(des.includes('Your review-annotation handle is: des'));
+  });
+
   test('buildSystemPrompt: knowledge mode text by default, code mode when state says so', () => {
     const dir = useWorkspace({ agents: standardTeam() });
     const agents = srv.discoverAgents();


### PR DESCRIPTION
Adds a second agent runtime: agents can run on the Codex CLI (ChatGPT plans) alongside Claude Code. Per-turn exec spawns with thread resume, orchestrator delegation to Codex specialists, runtime status surfacing, keepalive heartbeats for long turns, and hardened spawn/cancel/failure paths (two adversarial review rounds baked into the branch history).

Rebased onto current main (universal search + File View + Node 22); combined suite 504 green locally. This PR exists to run the CI gate and hold review artifacts before merge; final gate is live testing on Mac and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)