### PR TITLE
Persist routine state; fire past-due routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 - **Fresh installs no longer print security warnings:** the packaged Electron runtime moved from 35 to 42, clearing the cluster of published advisories that `npm audit` reported against every contributor install. No user-visible behaviour change; the full suite, browser tests, and a locally built packaged app were verified on the new runtime.
 
+### Fixed
+
+- **Scheduled routines fire reliably and never twice:** routine run state now persists in the workspace's `.rundock/` folder, so quitting and reopening Rundock after a routine has run can no longer fire it again the same day. The due-check itself is also fixed: a routine whose scheduled time has passed without running today now fires on the next scheduler tick (previously the timing comparison was so strict that scheduled routines effectively never fired on their own). A run interrupted by a quit shows as "interrupted" rather than appearing to still be running.
+
 ## 0.10.0: Search, Review & Codex (2026-07-14)
 
 One palette searches everything you have, files agents produce can be reviewed where they live, and any specialist can run on your ChatGPT plan alongside your Claude agents. The biggest release since launch: universal search, an in-editor review loop, and a second runtime.

--- a/server.js
+++ b/server.js
@@ -491,9 +491,47 @@ function discoverWorkspaces() {
   return candidates;
 }
 
-// ===== ROUTINE STATE (in-memory) =====
+// ===== ROUTINE STATE =====
+// In-memory view of routine run state, persisted to .rundock/routine-state.json
+// so a server restart cannot re-fire a routine that already ran in its window
+// (the desktop quit-and-reopen pattern). The file is workspace-scoped like the
+// other .rundock stores; loadRoutineState() runs at startup and on every
+// workspace switch.
 
 const routineState = {}; // { routineKey: { lastRun, status, duration } }
+
+function loadRoutineState() {
+  for (const key of Object.keys(routineState)) delete routineState[key];
+  try {
+    const file = path.join(rundockDir(), 'routine-state.json');
+    const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    for (const [key, state] of Object.entries(saved)) {
+      if (!state || typeof state.lastRun !== 'string') continue;
+      // A run that was 'running' when the server died never finished; surface
+      // that honestly. lastRun stays, so the run still suppresses a re-fire
+      // (the work was started; firing it again is the bug this file prevents).
+      if (state.status === 'running') state.status = 'interrupted';
+      routineState[key] = state;
+    }
+  } catch (e) { /* missing or unreadable file: start empty */ }
+}
+
+function saveRoutineState() {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'routine-state.json'), JSON.stringify(routineState, null, 2));
+}
+
+function recordRoutineRun(key, state) {
+  routineState[key] = state;
+  try {
+    saveRoutineState();
+  } catch (e) {
+    // Persistence is protection for the NEXT process; this one already has
+    // the in-memory state. An unwritable .rundock must not kill the scheduler.
+    console.error('[Scheduler] Failed to persist routine state:', e && e.message ? e.message : e);
+  }
+}
 
 // ===== AGENT HELPERS =====
 
@@ -1220,15 +1258,20 @@ function getNextRun(schedule, lastRunISO) {
   // Parse "every day at HH:MM"
   const dailyMatch = s.match(/every day at (\d{2}):(\d{2})/);
   if (dailyMatch) {
-    const target = new Date(now);
-    target.setHours(parseInt(dailyMatch[1]), parseInt(dailyMatch[2]), 0, 0);
-    // If already past today, next is tomorrow
-    if (now > target) target.setDate(target.getDate() + 1);
-    // Don't re-run if already ran today
+    // Don't re-run if already ran today. This suppression (fed by the
+    // persisted routine state) is the ONLY thing standing between a due
+    // routine and a duplicate fire, which is why it is checked first.
     if (lastRunISO) {
       const lastRun = new Date(lastRunISO);
       if (lastRun.toDateString() === now.toDateString() && lastRun.getHours() >= parseInt(dailyMatch[1])) return null;
     }
+    const target = new Date(now);
+    target.setHours(parseInt(dailyMatch[1]), parseInt(dailyMatch[2]), 0, 0);
+    // A target already past today stays TODAY: the scheduler's `now >= nextRun`
+    // check fires it on the next tick (same-day catch-up). The previous code
+    // rolled it to tomorrow, which meant the fire condition was only
+    // satisfiable in the single millisecond HH:MM:00.000 - routines whose
+    // tick did not land exactly on that instant never fired at all.
     return target;
   }
 
@@ -1238,17 +1281,19 @@ function getNextRun(schedule, lastRunISO) {
     const days = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
     const targetDay = days[weeklyMatch[1]];
     if (targetDay === undefined) return null;
-    const target = new Date(now);
-    target.setHours(parseInt(weeklyMatch[2]), parseInt(weeklyMatch[3]), 0, 0);
-    const daysUntil = (targetDay - now.getDay() + 7) % 7;
-    if (daysUntil === 0 && now > target) target.setDate(target.getDate() + 7);
-    else target.setDate(target.getDate() + daysUntil);
-    // Don't re-run if already ran this week
+    // Suppression first, same reasoning as the daily branch.
     if (lastRunISO) {
       const lastRun = new Date(lastRunISO);
       const daysSinceLastRun = (now - lastRun) / (1000 * 60 * 60 * 24);
       if (daysSinceLastRun < 1 && lastRun.getDay() === targetDay) return null;
     }
+    const target = new Date(now);
+    target.setHours(parseInt(weeklyMatch[2]), parseInt(weeklyMatch[3]), 0, 0);
+    const daysUntil = (targetDay - now.getDay() + 7) % 7;
+    target.setDate(target.getDate() + daysUntil);
+    // On the target weekday a past-due target stays TODAY so the scheduler
+    // fires it (same-day catch-up); the suppression above prevents re-fires.
+    // See the daily branch for why the old roll-forward meant never firing.
     return target;
   }
 
@@ -1257,7 +1302,9 @@ function getNextRun(schedule, lastRunISO) {
 
 function executeRoutine(agent, routine, key) {
   const startTime = Date.now();
-  routineState[key] = { lastRun: new Date().toISOString(), status: 'running', duration: null };
+  // Persisted immediately: if the server dies mid-run, the restarted process
+  // still knows the run started and will not fire it again in the same window.
+  recordRoutineRun(key, { lastRun: new Date().toISOString(), status: 'running', duration: null });
 
   // Notify connected clients
   broadcastRoutineUpdate();
@@ -1294,11 +1341,11 @@ function executeRoutine(agent, routine, key) {
 
   proc.on('close', (code) => {
     const duration = Math.round((Date.now() - startTime) / 1000);
-    routineState[key] = {
+    recordRoutineRun(key, {
       lastRun: new Date().toISOString(),
       status: code === 0 ? 'completed' : 'failed',
       duration
-    };
+    });
     console.log(`[Scheduler] Routine "${routine.name}" ${code === 0 ? 'completed' : 'failed'} (${duration}s)`);
     broadcastRoutineUpdate();
   });
@@ -3784,6 +3831,7 @@ wss.on('connection', (ws) => {
           // serve the previous workspace's cached file/skill lists.
           searchEngineFailedWorkspace = null;
           invalidateAgentCache();
+          loadRoutineState();
           saveRecentWorkspace(dir);
           // Clean up orphaned processes from previous sessions in this workspace
           cleanOrphanedProcesses();
@@ -3868,6 +3916,7 @@ wss.on('connection', (ws) => {
             // Kill all running processes when creating/switching workspace
             killAllChildren();
             WORKSPACE = dir;
+            loadRoutineState();
             saveRecentWorkspace(dir);
 
             // New workspace is always empty: scaffold defaults
@@ -5872,6 +5921,7 @@ function startServer(options = {}) {
         WORKSPACE = null;
       }
       if (WORKSPACE) {
+        loadRoutineState();
         saveRecentWorkspace(WORKSPACE);
         try { scaffoldWorkspace(WORKSPACE); } catch (e) { console.warn('Scaffold warning:', e.message); }
         const agents = discoverAgents();
@@ -5909,6 +5959,7 @@ module.exports._internal = {
   getWorkspace() { return WORKSPACE; },
   // scheduler
   getNextRun, executeRoutine, routineState,
+  loadRoutineState, saveRoutineState, recordRoutineRun,
   // agent + skill discovery / parsing
   discoverAgents, invalidateAgentCache, discoverSkills, parseSkillFile,
   parseAgentFrontmatter, extractFrontmatterText, parseCapabilities,

--- a/test/unit/scheduler.test.js
+++ b/test/unit/scheduler.test.js
@@ -31,10 +31,16 @@ describe('getNextRun: daily grammar', () => {
     assert.deepStrictEqual(next, new Date(2026, 6, 1, 14, 0, 0));
   });
 
-  test('after the target time: next run is tomorrow', () => {
+  test('after the target time with no run today: due NOW (same-day catch-up)', () => {
+    // Deliberate flip (routine-state card): the old behaviour rolled a
+    // past-due target to tomorrow BEFORE the scheduler compared now >= nextRun,
+    // which made the fire condition unsatisfiable except in the single
+    // millisecond HH:MM:00.000. A past-due, not-yet-run daily target now stays
+    // today so the next tick fires it.
     atTime(WED_1030);
     const next = srv.getNextRun('every day at 09:00', null);
-    assert.deepStrictEqual(next, new Date(2026, 6, 2, 9, 0, 0));
+    assert.deepStrictEqual(next, new Date(2026, 6, 1, 9, 0, 0));
+    assert.ok(new Date() >= next, 'scheduler fire condition (now >= nextRun) is satisfied');
   });
 
   test('exactly at the target time: now > target is false, so next run is today (due immediately)', () => {
@@ -49,13 +55,14 @@ describe('getNextRun: daily grammar', () => {
     assert.strictEqual(srv.getNextRun('every day at 14:00', lastRun), null);
   });
 
-  test('ran yesterday: due today', () => {
+  test('ran yesterday: due today (fires on the next tick)', () => {
     atTime(new Date(2026, 6, 1, 14, 30, 0));
     const lastRun = new Date(2026, 5, 30, 14, 1, 0).toISOString();
     const next = srv.getNextRun('every day at 14:00', lastRun);
-    // Past today's target with no run today yet -> target rolls to tomorrow,
-    // but the scheduler's `now >= nextRun` check makes it fire then.
-    assert.deepStrictEqual(next, new Date(2026, 6, 2, 14, 0, 0));
+    // Deliberate flip (routine-state card): yesterday's run does not suppress
+    // today; the past-due target stays today so the scheduler actually fires.
+    assert.deepStrictEqual(next, new Date(2026, 6, 1, 14, 0, 0));
+    assert.ok(new Date() >= next, 'scheduler fire condition (now >= nextRun) is satisfied');
   });
 
   test('pinned as-is: lastRun earlier today but BEFORE the scheduled hour does not suppress (getHours comparison)', () => {
@@ -97,10 +104,12 @@ describe('getNextRun: weekly grammar', () => {
     assert.deepStrictEqual(next, new Date(2026, 6, 6, 8, 0, 0));
   });
 
-  test('same weekday, time already past: next week', () => {
+  test('same weekday, time already past, no run today: due NOW (same-day catch-up)', () => {
+    // Deliberate flip (routine-state card): see the daily catch-up test.
     atTime(WED_1030);
     const next = srv.getNextRun('every wednesday at 09:00', null);
-    assert.deepStrictEqual(next, new Date(2026, 6, 8, 9, 0, 0));
+    assert.deepStrictEqual(next, new Date(2026, 6, 1, 9, 0, 0));
+    assert.ok(new Date() >= next, 'scheduler fire condition (now >= nextRun) is satisfied');
   });
 
   test('same weekday, time still ahead: today', () => {
@@ -164,5 +173,128 @@ describe('getNextRun: silent-null inputs (pinned as-is)', () => {
     atTime(WED_1030);
     const next = srv.getNextRun('every day at 25:99', null);
     assert.deepStrictEqual(next, new Date(2026, 6, 2, 2, 39, 0));
+  });
+});
+
+describe('routine state persistence (.rundock/routine-state.json)', () => {
+  const fs = require('node:fs');
+  const os = require('node:os');
+  const path = require('node:path');
+  let tmpDir, prevWorkspace;
+
+  function setupTmpWorkspace() {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-routine-state-'));
+    prevWorkspace = srv.getWorkspace();
+    srv.setWorkspace(tmpDir);
+  }
+  function teardownTmpWorkspace() {
+    srv.setWorkspace(prevWorkspace);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+  function stateFile() { return path.join(tmpDir, '.rundock', 'routine-state.json'); }
+
+  test('recordRoutineRun persists to disk; loadRoutineState restores after a simulated restart', () => {
+    setupTmpWorkspace();
+    try {
+      const state = { lastRun: new Date(2026, 6, 1, 14, 5, 0).toISOString(), status: 'completed', duration: 12 };
+      srv.recordRoutineRun('cos:morning-briefing', state);
+      assert.ok(fs.existsSync(stateFile()), 'state file written');
+
+      // Simulated restart: in-memory state gone, disk state remains.
+      delete srv.routineState['cos:morning-briefing'];
+      assert.strictEqual(srv.routineState['cos:morning-briefing'], undefined);
+
+      srv.loadRoutineState();
+      assert.deepStrictEqual(srv.routineState['cos:morning-briefing'], state);
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('THE CARD SCENARIO: routine ran, server restarted in the same window -> not due again', () => {
+    setupTmpWorkspace();
+    try {
+      // 14:05 - the daily 14:00 routine runs and its state is persisted.
+      srv.recordRoutineRun('cos:morning-briefing', { lastRun: new Date(2026, 6, 1, 14, 5, 0).toISOString(), status: 'completed', duration: 12 });
+
+      // 14:30 - the user quit and reopened Rundock (restart inside the window).
+      atTime(new Date(2026, 6, 1, 14, 30, 0));
+      for (const key of Object.keys(srv.routineState)) delete srv.routineState[key];
+      srv.loadRoutineState();
+
+      // The scheduler's exact due-check inputs: suppressed, no double-fire.
+      const next = srv.getNextRun('every day at 14:00', srv.routineState['cos:morning-briefing']?.lastRun);
+      assert.strictEqual(next, null, 'routine must not be due again after restart');
+
+      // Control: WITHOUT persistence (pre-fix behaviour) the same routine IS
+      // due again - proving the state file is what closes the hole.
+      const nextWithoutPersistence = srv.getNextRun('every day at 14:00', undefined);
+      assert.notStrictEqual(nextWithoutPersistence, null);
+      assert.ok(new Date() >= nextWithoutPersistence, 'without persisted state the routine would double-fire');
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('a run left in status running (server died mid-run) loads as interrupted and still suppresses', () => {
+    setupTmpWorkspace();
+    try {
+      srv.recordRoutineRun('cos:morning-briefing', { lastRun: new Date(2026, 6, 1, 14, 5, 0).toISOString(), status: 'running', duration: null });
+      for (const key of Object.keys(srv.routineState)) delete srv.routineState[key];
+      srv.loadRoutineState();
+      assert.strictEqual(srv.routineState['cos:morning-briefing'].status, 'interrupted');
+
+      atTime(new Date(2026, 6, 1, 14, 30, 0));
+      assert.strictEqual(srv.getNextRun('every day at 14:00', srv.routineState['cos:morning-briefing'].lastRun), null);
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('missing state file: loadRoutineState starts empty without throwing', () => {
+    setupTmpWorkspace();
+    try {
+      srv.loadRoutineState();
+      assert.deepStrictEqual(srv.routineState, {});
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('corrupted state file: loadRoutineState starts empty without throwing', () => {
+    setupTmpWorkspace();
+    try {
+      fs.mkdirSync(path.join(tmpDir, '.rundock'), { recursive: true });
+      fs.writeFileSync(stateFile(), 'not json {{{');
+      srv.loadRoutineState();
+      assert.deepStrictEqual(srv.routineState, {});
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('entries without a string lastRun are dropped on load (defensive against hand edits)', () => {
+    setupTmpWorkspace();
+    try {
+      fs.mkdirSync(path.join(tmpDir, '.rundock'), { recursive: true });
+      fs.writeFileSync(stateFile(), JSON.stringify({
+        'good:routine': { lastRun: '2026-07-01T14:05:00.000Z', status: 'completed', duration: 3 },
+        'bad:routine': { status: 'completed' },
+        'worse:routine': null
+      }));
+      srv.loadRoutineState();
+      assert.ok(srv.routineState['good:routine']);
+      assert.strictEqual(srv.routineState['bad:routine'], undefined);
+      assert.strictEqual(srv.routineState['worse:routine'], undefined);
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('loadRoutineState replaces prior workspace state (workspace switch does not leak)', () => {
+    setupTmpWorkspace();
+    try {
+      srv.routineState['stale:from-other-workspace'] = { lastRun: '2026-07-01T00:00:00.000Z', status: 'completed', duration: 1 };
+      srv.loadRoutineState(); // tmp workspace has no state file
+      assert.strictEqual(srv.routineState['stale:from-other-workspace'], undefined);
+    } finally { teardownTmpWorkspace(); }
+  });
+
+  test('recordRoutineRun survives an unwritable .rundock (scheduler must not die)', () => {
+    setupTmpWorkspace();
+    try {
+      fs.writeFileSync(path.join(tmpDir, '.rundock'), 'a file, not a directory'); // mkdir will fail
+      assert.doesNotThrow(() => srv.recordRoutineRun('cos:x', { lastRun: new Date().toISOString(), status: 'completed', duration: 1 }));
+      assert.ok(srv.routineState['cos:x'], 'in-memory state still recorded');
+      delete srv.routineState['cos:x'];
+    } finally { teardownTmpWorkspace(); }
   });
 });


### PR DESCRIPTION
## Summary

- Routine run state persists to `.rundock/routine-state.json` (workspace-scoped, loaded at startup and on workspace switch), so a desktop quit-and-reopen after a routine has fired can no longer fire it again in the same window
- Fixes the underlying due-check defect the card's scenario exposed: `getNextRun` rolled past-due targets forward BEFORE the scheduler's `now >= nextRun` comparison, making the fire condition satisfiable only in the exact millisecond HH:MM:00.000 (verified by simulating 24h of scheduler ticks: zero fires at any realistic tick offset). Past-due-today targets now stay today (same-day catch-up), with the already-ran suppression checked first
- A run left as `running` by a dead server loads as `interrupted` and still suppresses a re-fire
- Persistence failures degrade gracefully (unwritable `.rundock` never kills the scheduler)

## Tests

- 3 characterization pins deliberately flipped (the roll-forward removal), each flagged in-file
- 8 new tests: the restart scenario end to end with a no-persistence control, interrupted-run handling, corrupted/missing/invalid state files, workspace-switch isolation, unwritable `.rundock`
- Suite 569 → 577, e2e 11/11 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)