### PR TITLE
First-run onboarding detects both runtimes and sets users up honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 **Name:** TBD
 
+### Added
+
+- **First-run setup adapts to the runtimes you have:** the wizard now detects both Claude Code and Codex. A Codex user is told plainly why Claude Code is still needed (it runs your team's orchestrator and Doc, the setup guide) instead of receiving a bare install instruction, and once Claude Code is signed in, a machine with the Codex CLI gets an optional third step to sign in to Codex so specialists can run on a ChatGPT plan, skippable and available later from Settings. Machines without Codex see the setup flow exactly as before.
+
 ### Changed
 
 - **Fresh installs no longer print security warnings:** the packaged Electron runtime moved from 35 to 42, clearing the cluster of published advisories that `npm audit` reported against every contributor install. No user-visible behaviour change; the full suite, browser tests, and a locally built packaged app were verified on the new runtime.

--- a/electron/main.js
+++ b/electron/main.js
@@ -123,6 +123,50 @@ function isClaudeAuthenticated() {
   }
 }
 
+// Codex detection for the wizard. Reuses the server-side detector in codex.js
+// (packaged with the app) rather than porting it: binary resolution is
+// .cmd-shim aware on Windows, auth detection is the PRESENCE of auth.json
+// under $CODEX_HOME or ~/.codex, contents never read. Detection must never
+// break the wizard's Claude path, so failures collapse to "not installed".
+function detectCodexForWizard() {
+  try {
+    const { detectCodex } = require('../codex.js');
+    const d = detectCodex();
+    return { installed: !!d.installed, authenticated: !!d.authenticated };
+  } catch {
+    return { installed: false, authenticated: false };
+  }
+}
+
+// Launch Codex's sign-in (`codex login`) in a visible terminal, mirroring
+// launchClaudeSignIn below. Best-effort (never throws); the wizard keeps
+// polling auth.json presence and advances automatically once sign-in lands.
+function launchCodexSignIn() {
+  let bin = null;
+  try { bin = require('../codex.js').resolveCodexBin(); } catch { /* fall through */ }
+  if (!bin) return { ok: false, error: 'Codex was not found.' };
+  const { spawn } = require('child_process');
+  try {
+    if (process.platform === 'win32') {
+      spawn(`start "Sign in to Codex" cmd /k ""${bin}" login"`, {
+        shell: true, detached: true, stdio: 'ignore',
+      }).unref();
+    } else if (process.platform === 'darwin') {
+      // Terminal.app opens files, not commands with arguments, so the login
+      // command travels via a tiny generated .command script.
+      const os = require('os');
+      const script = path.join(os.tmpdir(), 'rundock-codex-login.command');
+      fs.writeFileSync(script, `#!/bin/bash\n"${bin}" login\n`, { mode: 0o755 });
+      spawn('open', ['-a', 'Terminal', script], { detached: true, stdio: 'ignore' }).unref();
+    } else {
+      spawn('x-terminal-emulator', ['-e', `${bin} login`], { detached: true, stdio: 'ignore' }).unref();
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err && err.message ? err.message : String(err) };
+  }
+}
+
 // Launch Claude Code's interactive sign-in in a visible terminal, so the user
 // can complete the browser OAuth without opening a terminal or knowing any
 // commands themselves. The wizard keeps polling and advances automatically once
@@ -180,31 +224,42 @@ function showWizard() {
 
     wizard.loadFile(path.join(__dirname, 'wizard.html'));
 
-    // Wizard polls for Claude Code via IPC
-    ipcMain.handle('wizard-check-claude', () => {
-      const bin = findClaude();
-      if (!bin) return { status: 'not-installed' };
-      // Claude is installed: make sure its directory is on the user's PATH so
-      // they can simply type `claude` in a new terminal to sign in.
-      ensureClaudeOnUserPath(path.dirname(bin));
-      if (!isClaudeAuthenticated()) return { status: 'not-authenticated' };
-      return { status: 'ready' };
+    // Wizard polls for both runtimes via IPC. The Claude checks are unchanged;
+    // Codex detection rides alongside so the wizard can adapt honestly to what
+    // the user has (a Codex user is told why Claude Code is still needed, and
+    // can sign in to Codex as an optional final step).
+    ipcMain.handle('wizard-check-runtimes', () => {
+      const claude = (() => {
+        const bin = findClaude();
+        if (!bin) return { status: 'not-installed' };
+        // Claude is installed: make sure its directory is on the user's PATH so
+        // they can simply type `claude` in a new terminal to sign in.
+        ensureClaudeOnUserPath(path.dirname(bin));
+        if (!isClaudeAuthenticated()) return { status: 'not-authenticated' };
+        return { status: 'ready' };
+      })();
+      return { claude, codex: detectCodexForWizard() };
     });
 
     // Launch Claude's browser sign-in for the user (no terminal needed).
     ipcMain.handle('wizard-signin-claude', () => launchClaudeSignIn());
 
+    // Launch Codex's terminal sign-in (optional wizard step).
+    ipcMain.handle('wizard-signin-codex', () => launchCodexSignIn());
+
     ipcMain.handle('wizard-done', () => {
-      ipcMain.removeHandler('wizard-check-claude');
+      ipcMain.removeHandler('wizard-check-runtimes');
       ipcMain.removeHandler('wizard-signin-claude');
+      ipcMain.removeHandler('wizard-signin-codex');
       ipcMain.removeHandler('wizard-done');
       wizard.close();
       resolve();
     });
 
     wizard.on('closed', () => {
-      ipcMain.removeHandler('wizard-check-claude');
+      ipcMain.removeHandler('wizard-check-runtimes');
       ipcMain.removeHandler('wizard-signin-claude');
+      ipcMain.removeHandler('wizard-signin-codex');
       ipcMain.removeHandler('wizard-done');
       resolve();
     });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -10,9 +10,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // App version for display
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
 
-  // Wizard-specific (only used during first-run)
-  checkClaude: () => ipcRenderer.invoke('wizard-check-claude'),
+  // Wizard-specific (only used during first-run). checkRuntimes detects both
+  // CLIs (Claude Code and Codex) so the wizard can adapt to what the user has.
+  checkRuntimes: () => ipcRenderer.invoke('wizard-check-runtimes'),
   signInClaude: () => ipcRenderer.invoke('wizard-signin-claude'),
+  signInCodex: () => ipcRenderer.invoke('wizard-signin-codex'),
   wizardDone: () => ipcRenderer.invoke('wizard-done'),
 
   // Listen for update notifications from main process

--- a/electron/wizard.html
+++ b/electron/wizard.html
@@ -130,7 +130,7 @@
 </head>
 <body>
   <h1>Rundock Setup</h1>
-  <p class="subtitle">Rundock needs Claude Code to power your agent team.</p>
+  <p class="subtitle" id="subtitle">Rundock needs Claude Code to power your agent team.</p>
 
   <div class="status">
     <div class="step" id="step-install">
@@ -147,10 +147,21 @@
         <div class="hint" id="auth-hint">Click <strong>Sign in to Claude</strong> below. A terminal opens to complete the sign-in.</div>
       </div>
     </div>
+    <!-- Rendered only when the Codex CLI is detected on this machine; Claude-only
+         machines see the wizard exactly as before. -->
+    <div class="step" id="step-codex" style="display:none">
+      <div class="step-icon pending" id="icon-codex">3</div>
+      <div class="step-text">
+        <div>Sign in to Codex</div>
+        <div class="hint" id="codex-hint">Optional. Specialists can run on your ChatGPT plan via the official Codex CLI.</div>
+      </div>
+    </div>
   </div>
 
   <button class="btn" id="btn-signin" style="display:none" onclick="signIn()">Sign in to Claude</button>
+  <button class="btn" id="btn-codex-signin" style="display:none" onclick="signInCodex()">Sign in to Codex</button>
   <button class="btn" id="btn-check" onclick="checkNow()">Check again</button>
+  <button class="btn-secondary" id="btn-codex-skip" style="display:none" onclick="skipCodex()">Skip for now</button>
   <button class="btn-secondary" id="btn-skip" onclick="skipAndQuit()">Quit</button>
 
   <script>
@@ -183,15 +194,65 @@
       }
     }
 
+    // The user can defer Codex sign-in; guidance stays available in Settings.
+    let codexSkipped = false;
+
+    // Copy rule (0.10.0 docs sweep): a ChatGPT plan is always an addition for
+    // specialists, never an alternative to Claude Code, and a Codex user is
+    // never told to install Claude Code without being told why it is needed.
+    const BASE_SUBTITLE = 'Rundock needs Claude Code to power your agent team.';
+    const CODEX_SUBTITLE = 'Your specialists can run on your ChatGPT plan via the official Codex CLI. '
+      + "Rundock still needs Claude Code: it runs your team's orchestrator and Doc, your setup guide.";
+
+    function renderCodexStep(codex, claudeReady) {
+      const step = document.getElementById('step-codex');
+      const hint = document.getElementById('codex-hint');
+      const codexSigninBtn = document.getElementById('btn-codex-signin');
+      const codexSkipBtn = document.getElementById('btn-codex-skip');
+      step.style.display = codex.installed ? 'flex' : 'none';
+      codexSigninBtn.style.display = 'none';
+      codexSkipBtn.style.display = 'none';
+      if (!codex.installed) return { pendingCodex: false };
+      if (codex.authenticated) {
+        updateStep('codex', 'done');
+        hint.textContent = 'Signed in. Specialists can run on your ChatGPT plan.';
+        return { pendingCodex: false };
+      }
+      if (codexSkipped) {
+        updateStep('codex', 'pending');
+        hint.textContent = 'Skipped. You can sign in any time from Settings.';
+        return { pendingCodex: false };
+      }
+      if (!claudeReady) {
+        updateStep('codex', 'pending');
+        return { pendingCodex: false };
+      }
+      // Claude is ready and Codex is installed but not signed in: offer the
+      // optional sign-in step now.
+      updateStep('codex', 'active');
+      hint.textContent = 'Optional. A terminal opens to run codex login with your ChatGPT account.';
+      codexSigninBtn.style.display = 'inline-block';
+      codexSkipBtn.style.display = 'inline-block';
+      return { pendingCodex: true };
+    }
+
     async function checkStatus() {
-      const result = await window.electronAPI.checkClaude();
+      const runtimes = await window.electronAPI.checkRuntimes();
+      const result = runtimes.claude;
+      const codex = runtimes.codex || { installed: false, authenticated: false };
 
       const signinBtn = document.getElementById('btn-signin');
       const checkBtn = document.getElementById('btn-check');
 
+      // A Codex user waiting on the Claude steps is told why Claude Code is
+      // still required rather than being handed a bare install instruction.
+      document.getElementById('subtitle').textContent =
+        (codex.installed && result.status !== 'ready') ? CODEX_SUBTITLE : BASE_SUBTITLE;
+
       if (result.status === 'not-installed') {
         updateStep('install', 'active');
         updateStep('auth', 'pending');
+        renderCodexStep(codex, false);
         // Install step: Check again is the primary action.
         signinBtn.style.display = 'none';
         checkBtn.style.display = 'inline-block';
@@ -201,6 +262,7 @@
       if (result.status === 'not-authenticated') {
         updateStep('install', 'done');
         updateStep('auth', 'active');
+        renderCodexStep(codex, false);
         // Sign-in step: the Sign in button replaces Check again (single action).
         signinBtn.style.display = 'inline-block';
         checkBtn.style.display = 'none';
@@ -211,6 +273,14 @@
         updateStep('install', 'done');
         updateStep('auth', 'done');
         signinBtn.style.display = 'none';
+        const { pendingCodex } = renderCodexStep(codex, true);
+        if (pendingCodex) {
+          // The optional Codex step holds the wizard open; Sign in to Codex
+          // and Skip for now are the actions.
+          checkBtn.style.display = 'none';
+          document.getElementById('btn-skip').style.display = 'none';
+          return false;
+        }
         checkBtn.style.display = 'inline-block';
         checkBtn.textContent = 'Continue';
         checkBtn.onclick = () => window.electronAPI.wizardDone();
@@ -242,6 +312,33 @@
           ? ('Could not start sign-in: ' + res.error)
           : 'Could not start sign-in. Please try again.';
       }
+    }
+
+    async function signInCodex() {
+      const btn = document.getElementById('btn-codex-signin');
+      btn.disabled = true;
+      btn.textContent = 'Opening sign-in...';
+      const res = await window.electronAPI.signInCodex();
+      const hint = document.getElementById('codex-hint');
+      if (res && res.ok) {
+        btn.textContent = 'Waiting for sign-in...';
+        if (hint) hint.textContent =
+          'A terminal opened with codex login. Sign in with your ChatGPT account; '
+          + 'this screen continues automatically once you finish.';
+        // Poll so the wizard advances the moment auth.json appears.
+        if (!polling) polling = setInterval(checkStatus, 3000);
+      } else {
+        btn.disabled = false;
+        btn.textContent = 'Sign in to Codex';
+        if (hint) hint.textContent = (res && res.error)
+          ? ('Could not start sign-in: ' + res.error)
+          : 'Could not start sign-in. Please try again.';
+      }
+    }
+
+    function skipCodex() {
+      codexSkipped = true;
+      checkStatus();
     }
 
     async function checkNow() {


### PR DESCRIPTION
## Summary

- The wizard's `checkClaude` IPC becomes `checkRuntimes`: Codex detection rides alongside the unchanged Claude checks, reusing `codex.js` `detectCodex()` from the Electron main process (presence-only, `.cmd`-shim aware). Claude-only machines see the wizard exactly as before
- A machine with Codex but no Claude Code is told why Claude Code is still step one (it runs the team's orchestrator and Doc) while the ChatGPT plan powers specialists via the official Codex CLI
- Once Claude Code is ready, a machine with the Codex CLI installed but not signed in gets an optional third step: Sign in to Codex opens a terminal running `codex login` and the wizard polls `auth.json` presence every 3s; Skip for now defers to the Settings Runtimes card
- Copy follows the 0.10.0 discipline: a ChatGPT plan adds specialists and is never presented as an alternative to Claude Code

## Verification

- All six wizard states driven in a browser against a stubbed `electronAPI` (baseline byte-identical for Claude-only, explanation state, optional step active, skip, already-signed-in, continue wiring)
- Full suite green on the rebased branch (Electron 42)
- Local packaged launch: pending, will report before merge (this change adds a runtime require of `codex.js` from the Electron main process, the packaging class that broke the first 0.10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)