### PR TITLE
Organise conversations with Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Added
 
+- **Organise conversations with Lists:** right-click any conversation to add it to a named list (or create one on the spot); lists appear as pills beside All and Unread and filter the sidebar with the usual pinned-first ordering. A conversation can belong to several lists, lists survive reloads and workspace switches, and deleting a list (right-click its pill) never deletes conversations: they simply leave the grouping.
 - **First-run setup adapts to the runtimes you have:** the wizard now detects both Claude Code and Codex. A Codex user is told plainly why Claude Code is still needed (it runs your team's orchestrator and Doc, the setup guide) instead of receiving a bare install instruction, and once Claude Code is signed in, a machine with the Codex CLI gets an optional third step to sign in to Codex so specialists can run on a ChatGPT plan, skippable and available later from Settings. Machines without Codex see the setup flow exactly as before.
 
 ### Changed

--- a/public/app.js
+++ b/public/app.js
@@ -27,7 +27,7 @@
 const sunIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>`;
 const moonIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
 
-let ws=null, agents=[], conversations=[], activeConversation=null, currentView='home', currentFilePath=null, skills=[], skillsLoaded=false, currentWorkspacePath=null, workspaceAnalysis=null, workspaceIsEmpty=false, workspaceMode='knowledge', setupComplete=true, conversationsLoaded=false, activeSidebarPill='all';
+let ws=null, agents=[], conversations=[], activeConversation=null, currentView='home', currentFilePath=null, skills=[], skillsLoaded=false, currentWorkspacePath=null, workspaceAnalysis=null, workspaceIsEmpty=false, workspaceMode='knowledge', setupComplete=true, conversationsLoaded=false, activeSidebarPill='all', convoLists=[];
 let runtimeStatus = null; // { defaultRuntime, claude: {installed, authenticated, version}, codex: {...} }
 const agentLastActivity = {}; // { agentId: { time: Date, label: string } }
 // Per-conversation state: { convoId: { isProcessing, currentStreamingMsg, latestText } }
@@ -276,6 +276,23 @@ function handle(d) {
     case 'agents': agents=d.agents; renderAgentList(); renderOrgChart(); renderRoutinesSidebar(); renderConvoList(); break;
     case 'skills': skills=d.skills; skillsLoaded=true; renderSkills(); if(palettePendingSkill){const s=palettePendingSkill;palettePendingSkill=null;selectSkill(s);} break;
     case 'conversations': handlePersistedConversations(d.conversations, d.lastActiveConversationId); break;
+    case 'lists': {
+      const prevIds = new Set(convoLists.map(l => l.id));
+      convoLists = d.lists || [];
+      // Create-and-add flow: a list created from a conversation's context menu
+      // adds that conversation to it once the server confirms creation.
+      if (pendingListAdd) {
+        const created = convoLists.filter(l => !prevIds.has(l.id));
+        if (created.length === 1) toggleConvoListMembership(pendingListAdd, created[0].id);
+        pendingListAdd = null;
+      }
+      renderListPills();
+      // If the active pill's list was deleted, fall back to All (via
+      // setSidebarPill so the fixed pills' active classes update too).
+      if (RundockConvoList.isListPill(activeSidebarPill) && !convoLists.some(l => 'list:' + l.id === activeSidebarPill)) setSidebarPill('all');
+      else renderConvoList();
+      break;
+    }
     case 'system':
       // Track active process per conversation to ignore stale events
       if(d.subtype==='process_started' && convoId && d._processId) {
@@ -1317,6 +1334,7 @@ function persistConversation(convo) {
       status: convo.status,
       pinned: convo.pinned || false,
       pinnedAt: convo.pinnedAt || null,
+      listIds: convo.listIds || [],
       createdAt: convo.createdAt || new Date().toISOString()
     }
   }));
@@ -1345,6 +1363,7 @@ function handlePersistedConversations(persisted, persistedLastActiveId) {
       sessionIds: entry.sessionIds || [],
       pinned: entry.pinned || false,
       pinnedAt: entry.pinnedAt || null,
+      listIds: entry.listIds || [],
       createdAt: entry.createdAt,
       lastActiveAt: entry.lastActiveAt,
       lastAgentId: entry.lastAgentId || null,
@@ -1704,12 +1723,120 @@ function convoBorderClass(c) {
 }
 
 // Switch the active sidebar pill filter and re-render. Reset to 'all' on
-// workspace switch via onWorkspaceReady.
+// workspace switch via onWorkspaceReady. Pills are 'all', 'unread', or
+// 'list:<id>' (user-created lists render as pills after Unread).
 function setSidebarPill(pill) {
   activeSidebarPill = pill;
   ['all','unread'].forEach(p => {
     document.getElementById('pill-' + p)?.classList.toggle('active', p === pill);
   });
+  document.querySelectorAll('#sidebar-pills .pill-list').forEach(el => {
+    el.classList.toggle('active', el.dataset.pill === pill);
+  });
+  renderConvoList();
+}
+
+// Render the user-created list pills after the fixed All | Unread pair.
+// Right-click a list pill to delete the list (conversations are never
+// deleted with it; they just leave the grouping).
+function renderListPills() {
+  const wrap = document.getElementById('sidebar-pills');
+  if (!wrap) return;
+  wrap.querySelectorAll('.pill-list').forEach(el => el.remove());
+  for (const l of convoLists) {
+    const btn = document.createElement('button');
+    btn.className = 'pill pill-list' + ('list:' + l.id === activeSidebarPill ? ' active' : '');
+    btn.dataset.pill = 'list:' + l.id;
+    btn.textContent = l.name;
+    btn.onclick = () => setSidebarPill('list:' + l.id);
+    btn.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      openConvoMenu(e, [{ label: `Delete list "${l.name}"`, action: () => ws.send(JSON.stringify({ type: 'delete_list', id: l.id })) }]);
+    });
+    wrap.appendChild(btn);
+  }
+}
+
+// Minimal shared context menu (positioned card, closes on any click or Esc).
+// Items: [{ label, action, checked? }] plus an optional inline input row via
+// { input: true, placeholder, onSubmit }.
+function openConvoMenu(evt, items) {
+  closeConvoMenu();
+  const menu = document.createElement('div');
+  menu.id = 'convo-context-menu';
+  menu.className = 'convo-menu';
+  for (const item of items) {
+    if (item.input) {
+      const row = document.createElement('div');
+      row.className = 'convo-menu-input';
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.placeholder = item.placeholder || '';
+      input.maxLength = 60;
+      input.onkeydown = (e) => {
+        e.stopPropagation();
+        if (e.key === 'Enter' && input.value.trim()) { item.onSubmit(input.value.trim()); closeConvoMenu(); }
+        if (e.key === 'Escape') closeConvoMenu();
+      };
+      input.onclick = (e) => e.stopPropagation();
+      row.appendChild(input);
+      menu.appendChild(row);
+    } else {
+      const row = document.createElement('button');
+      row.className = 'convo-menu-item';
+      row.innerHTML = `<span class="convo-menu-check">${item.checked ? '✓' : ''}</span>${esc(item.label)}`;
+      row.onclick = (e) => { e.stopPropagation(); item.action(); closeConvoMenu(); };
+      menu.appendChild(row);
+    }
+  }
+  document.body.appendChild(menu);
+  // Clamp to viewport.
+  const r = menu.getBoundingClientRect();
+  menu.style.left = Math.min(evt.clientX, window.innerWidth - r.width - 8) + 'px';
+  menu.style.top = Math.min(evt.clientY, window.innerHeight - r.height - 8) + 'px';
+  menu.querySelector('input')?.focus();
+  setTimeout(() => {
+    document.addEventListener('click', closeConvoMenu, { once: true });
+    document.addEventListener('keydown', convoMenuEsc);
+  }, 0);
+}
+function convoMenuEsc(e) { if (e.key === 'Escape') closeConvoMenu(); }
+function closeConvoMenu() {
+  document.getElementById('convo-context-menu')?.remove();
+  document.removeEventListener('keydown', convoMenuEsc);
+}
+
+// Right-click menu on a conversation row: toggle membership per list plus
+// create-and-add via the inline input. Membership is many-to-many.
+function openConvoListMenu(evt, convoId) {
+  evt.preventDefault();
+  evt.stopPropagation();
+  const convo = conversations.find(c => c.id === convoId);
+  if (!convo) return;
+  const items = convoLists.map(l => ({
+    label: l.name,
+    checked: Array.isArray(convo.listIds) && convo.listIds.includes(l.id),
+    action: () => toggleConvoListMembership(convoId, l.id),
+  }));
+  items.push({ input: true, placeholder: 'New list…', onSubmit: (name) => {
+    pendingListAdd = convoId;
+    ws.send(JSON.stringify({ type: 'create_list', name }));
+  }});
+  openConvoMenu(evt, items);
+}
+
+// When a list is created from a conversation's menu, add that conversation to
+// it as soon as the server confirms the list exists.
+let pendingListAdd = null;
+
+function toggleConvoListMembership(convoId, listId) {
+  const convo = conversations.find(c => c.id === convoId);
+  if (!convo) return;
+  if (!Array.isArray(convo.listIds)) convo.listIds = [];
+  convo.listIds = convo.listIds.includes(listId)
+    ? convo.listIds.filter(id => id !== listId)
+    : [...convo.listIds, listId];
+  persistConversation(convo);
   renderConvoList();
 }
 
@@ -1852,7 +1979,7 @@ function renderConvoItem(c, variant) {
     leftButton = `<button class="convo-delete" onclick="deleteConversation('${c.id}', event)" data-tooltip="Delete">${deleteSvg}</button>`;
   }
 
-  return `<div class="${classes.join(' ')}" ${styleAttr} onclick="openConversation('${c.id}')">
+  return `<div class="${classes.join(' ')}" ${styleAttr} onclick="openConversation('${c.id}')" oncontextmenu="openConvoListMenu(event, '${c.id}')">
     ${leftButton}
     ${titleSection}
     ${preview ? `<span class="convo-preview">${esc(preview)}</span>` : ''}
@@ -3478,6 +3605,7 @@ function onWorkspaceReady(dir, analysis, isEmpty, mode, scaffoldError, isSetupCo
   ws.send(JSON.stringify({ type: 'get_files' }));
   ws.send(JSON.stringify({ type: 'get_skills' }));
   ws.send(JSON.stringify({ type: 'get_conversations' }));
+  ws.send(JSON.stringify({ type: 'get_lists' }));
   ws.send(JSON.stringify({ type: 'get_runtime_status' }));
   skillsLoaded = false;
   currentSkillId = null;
@@ -3492,6 +3620,8 @@ function onWorkspaceReady(dir, analysis, isEmpty, mode, scaffoldError, isSetupCo
   conversations = [];
   conversationsLoaded = false;
   activeSidebarPill = 'all';
+  convoLists = [];
+  renderListPills();
   ['all','unread'].forEach(p => document.getElementById('pill-' + p)?.classList.toggle('active', p === 'all'));
   activeConversation = null;
   // Clear per-conversation client state that keys by convoId. Leftover entries

--- a/public/conversation-list.js
+++ b/public/conversation-list.js
@@ -27,15 +27,25 @@
     return ((b.pinned === true) - (a.pinned === true)) || compareTimeDesc(a, b);
   }
 
+  // List pills are encoded as 'list:<id>' so they travel through the same
+  // pill channel as 'all' and 'unread'. Membership lives on the conversation
+  // (listIds, many-to-many); a conversation with no listIds field is simply
+  // in no lists.
+  function isListPill(pill) { return typeof pill === 'string' && pill.startsWith('list:'); }
+  function listPillId(pill) { return isListPill(pill) ? pill.slice(5) : null; }
+  function inList(c, listId) { return Array.isArray(c.listIds) && c.listIds.includes(listId); }
+
   // Split and order the sidebar's data: the main list (non-archived,
-  // optionally filtered to unread, pinned grouped first) and the archived
-  // section (recency only). unreadIds is a Set-like with .has().
+  // optionally filtered to unread or to a list's members, pinned grouped
+  // first) and the archived section (recency only). unreadIds is a Set-like
+  // with .has().
   function partitionConversations(conversations, opts) {
     const pill = (opts && opts.pill) || 'all';
     const unreadIds = (opts && opts.unreadIds) || { has: () => false };
 
     let main = conversations.filter(c => c.status !== 'archived');
     if (pill === 'unread') main = main.filter(c => unreadIds.has(c.id));
+    if (isListPill(pill)) main = main.filter(c => inList(c, listPillId(pill)));
     main.sort(pinnedFirst);
 
     const archived = conversations
@@ -50,5 +60,5 @@
   // stays 'current' so users can still unpin it.
   function itemVariant(c) { return (c.persisted && !c.pinned) ? 'previous' : 'current'; }
 
-  return { sortKeyTime, compareTimeDesc, pinnedFirst, partitionConversations, itemVariant };
+  return { sortKeyTime, compareTimeDesc, pinnedFirst, partitionConversations, itemVariant, isListPill, listPillId, inList };
 }));

--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,18 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
 .pill:hover { border-color: var(--text-2); color: var(--text-1); }
 .pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .pill.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+.sidebar-pills { flex-wrap: wrap; }
+.pill-list { max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Context menu for conversation lists (row right-click: membership;
+   list-pill right-click: delete). Positioned card, closes on click or Esc. */
+.convo-menu { position: fixed; z-index: 1000; min-width: 180px; max-width: 260px; background: var(--bg-2, var(--bg-1)); border: 1px solid var(--border); border-radius: 8px; padding: 4px; box-shadow: 0 8px 24px rgba(0,0,0,0.35); }
+.convo-menu-item { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; padding: 7px 10px; border: none; background: transparent; color: var(--text-1); font-size: var(--caption); font-family: inherit; border-radius: 5px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.convo-menu-item:hover { background: var(--bg-3, rgba(128,128,128,0.12)); }
+.convo-menu-check { width: 14px; flex-shrink: 0; color: var(--accent); }
+.convo-menu-input { padding: 4px; }
+.convo-menu-input input { width: 100%; box-sizing: border-box; padding: 6px 8px; border: 1px solid var(--border); border-radius: 5px; background: transparent; color: var(--text-1); font-size: var(--caption); font-family: inherit; }
+.convo-menu-input input:focus { outline: 1px solid var(--accent); }
 
 /* Archive sidebar action (replaces delete on persisted, not-yet-archived items).
    Mirrors .convo-delete shape; hover uses a neutral bright text colour rather

--- a/server.js
+++ b/server.js
@@ -249,6 +249,37 @@ function writeConversations(list) {
   fs.writeFileSync(path.join(dir, 'conversations.json'), JSON.stringify(list, null, 2));
 }
 
+// Conversation lists (user-named, many-to-many groupings shown as sidebar
+// pills). The registry lives in .rundock/lists.json; membership lives on each
+// conversation entry (listIds) so it rides the existing conversation
+// persistence. Deleting a list removes the registry entry and strips the id
+// from every conversation, never touching the conversations themselves.
+function readLists() {
+  try {
+    const list = JSON.parse(fs.readFileSync(path.join(rundockDir(), 'lists.json'), 'utf-8'));
+    return Array.isArray(list) ? list.filter(l => l && typeof l.id === 'string' && typeof l.name === 'string') : [];
+  } catch (e) { return []; }
+}
+
+function writeLists(lists) {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'lists.json'), JSON.stringify(lists, null, 2));
+}
+
+function deleteListEverywhere(listId) {
+  writeLists(readLists().filter(l => l.id !== listId));
+  const convos = readConversations();
+  let changed = false;
+  for (const c of convos) {
+    if (Array.isArray(c.listIds) && c.listIds.includes(listId)) {
+      c.listIds = c.listIds.filter(id => id !== listId);
+      changed = true;
+    }
+  }
+  if (changed) writeConversations(convos);
+}
+
 function readState() {
   try {
     const file = path.join(rundockDir(), 'state.json');
@@ -4114,12 +4145,38 @@ wss.on('connection', (ws) => {
           status: msg.conversation.status || 'active',
           pinned: msg.conversation.pinned || false,
           pinnedAt: msg.conversation.pinnedAt || null,
+          listIds: Array.isArray(msg.conversation.listIds) ? msg.conversation.listIds.filter(x => typeof x === 'string') : [],
           createdAt: msg.conversation.createdAt || new Date().toISOString(),
           lastActiveAt: new Date().toISOString()
         };
         if (idx >= 0) { convos[idx] = entry; } else { convos.unshift(entry); }
         // Cap at 100 conversations
         writeConversations(convos.slice(0, 100));
+      }
+
+      // ── CONVERSATION LISTS: named many-to-many sidebar groupings ──
+      if (msg.type === 'get_lists') {
+        if (!WORKSPACE) return;
+        ws.send(JSON.stringify({ type: 'lists', lists: readLists() }));
+      }
+
+      if (msg.type === 'create_list') {
+        if (!WORKSPACE) return;
+        const name = typeof msg.name === 'string' ? msg.name.trim().slice(0, 60) : '';
+        if (!name) return;
+        const lists = readLists();
+        // Same name twice is a no-op rather than a duplicate pill.
+        if (!lists.some(l => l.name.toLowerCase() === name.toLowerCase())) {
+          lists.push({ id: 'list-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6), name, createdAt: new Date().toISOString() });
+          writeLists(lists);
+        }
+        ws.send(JSON.stringify({ type: 'lists', lists }));
+      }
+
+      if (msg.type === 'delete_list') {
+        if (!WORKSPACE || typeof msg.id !== 'string') return;
+        deleteListEverywhere(msg.id);
+        ws.send(JSON.stringify({ type: 'lists', lists: readLists() }));
       }
 
       // ── DELEGATION: orchestrator hands off to another agent in the same conversation ──
@@ -5994,6 +6051,7 @@ module.exports._internal = {
   readMcpServerNames, getFileTree, validateAgentSlug, isInsideWorkspace,
   // persistence
   readConversations, writeConversations, readState, writeState,
+  readLists, writeLists, deleteListEverywhere,
   loadTranscript, saveTranscript, appendTranscript, formatTranscript,
   transcriptDir, countSessionMessagesSync, countConversationMessages,
   parseSessionHistory, getSessionJsonlPath,

--- a/test/e2e/lists.spec.js
+++ b/test/e2e/lists.spec.js
@@ -1,0 +1,87 @@
+'use strict';
+// E2E: conversation Lists (named many-to-many sidebar groupings as pills).
+// Proves the card's user-observable criteria end to end against the real
+// server + browser: create a list from a conversation's context menu, the
+// pill filters with pinned-first ordering unchanged, membership is
+// many-to-many, state survives a reload, and deleting a list never deletes
+// conversations.
+const { test, expect } = require('@playwright/test');
+
+async function boot(page) {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+}
+
+async function openConversationsView(page) {
+  await page.locator('.nav-item[data-nav="conversations"]').click();
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+}
+
+function convoRow(page, title) {
+  return page.locator('.convo-item', { hasText: title });
+}
+
+test('lists: create from the context menu, filter via the pill, survive reload, delete safely', async ({ page }) => {
+  await boot(page);
+  await openConversationsView(page);
+
+  // Create "Client work" from the pinned conversation's context menu.
+  await convoRow(page, 'Board prep planning').first().click({ button: 'right' });
+  const menuInput = page.locator('.convo-menu-input input');
+  await expect(menuInput).toBeFocused();
+  await menuInput.fill('Client work');
+  await menuInput.press('Enter');
+
+  // The pill appears and the creating conversation is already a member.
+  const pill = page.locator('.pill-list', { hasText: 'Client work' });
+  await expect(pill).toBeVisible();
+  await pill.click();
+  await expect(page.locator('.convo-item')).toHaveCount(1);
+  await expect(page.locator('.convo-item').first()).toContainText('Board prep planning');
+
+  // Add a second conversation from the All view; pinned-first ordering holds
+  // inside the list (Board prep is pinned, so it stays first even though the
+  // other conversation is more recent).
+  await page.locator('#pill-all').click();
+  const second = page.locator('.convo-item:not(:has-text("Board prep planning"))').first();
+  const secondTitle = await second.locator('.convo-title').textContent();
+  await second.click({ button: 'right' });
+  await page.locator('.convo-menu-item', { hasText: 'Client work' }).click();
+  await pill.click();
+  await expect(page.locator('.convo-item')).toHaveCount(2);
+  await expect(page.locator('.convo-item').first()).toContainText('Board prep planning');
+
+  // Many-to-many: the same conversation joins a second list.
+  await convoRow(page, 'Board prep planning').first().click({ button: 'right' });
+  const input2 = page.locator('.convo-menu-input input');
+  await input2.fill('Research');
+  await input2.press('Enter');
+  await expect(page.locator('.pill-list', { hasText: 'Research' })).toBeVisible();
+
+  // Reload: lists, membership, and the pills all survive.
+  await page.reload();
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await openConversationsView(page);
+  await expect(page.locator('.pill-list', { hasText: 'Client work' })).toBeVisible();
+  await expect(page.locator('.pill-list', { hasText: 'Research' })).toBeVisible();
+  await page.locator('.pill-list', { hasText: 'Client work' }).click();
+  await expect(page.locator('.convo-item')).toHaveCount(2);
+
+  // Membership toggle removes without deleting: check the row still exists
+  // under All after removal from the list.
+  await convoRow(page, secondTitle).first().click({ button: 'right' });
+  await page.locator('.convo-menu-item', { hasText: 'Client work' }).click();
+  await expect(page.locator('.convo-item')).toHaveCount(1);
+
+  // Delete the list from the pill's context menu while it is the active
+  // filter: the pill disappears, the view falls back to All, and no
+  // conversations were deleted.
+  await page.locator('#pill-all').click();
+  const allCount = await page.locator('.convo-item').count();
+  await page.locator('.pill-list', { hasText: 'Client work' }).click();
+  await page.locator('.pill-list', { hasText: 'Client work' }).click({ button: 'right' });
+  await page.locator('.convo-menu-item', { hasText: 'Delete list' }).click();
+  await expect(page.locator('.pill-list', { hasText: 'Client work' })).toHaveCount(0);
+  await expect(page.locator('#pill-all')).toHaveClass(/active/);
+  await expect(page.locator('.convo-item')).toHaveCount(allCount);
+});

--- a/test/unit/conversation-list.test.js
+++ b/test/unit/conversation-list.test.js
@@ -77,3 +77,55 @@ describe('itemVariant', () => {
     assert.strictEqual(M.itemVariant(convo('c', { persisted: true, pinned: true })), 'current');
   });
 });
+
+describe('list pills (conversation Lists card)', () => {
+  const listData = [
+    convo('in-work', { listIds: ['l1'], lastActiveAt: '2026-07-10T00:00:00Z' }),
+    convo('in-both', { listIds: ['l1', 'l2'], lastActiveAt: '2026-07-12T00:00:00Z' }),
+    convo('pinned-in-work', { pinned: true, listIds: ['l1'], lastActiveAt: '2026-07-01T00:00:00Z' }),
+    convo('no-lists', { lastActiveAt: '2026-07-16T00:00:00Z' }),
+    convo('legacy-no-field', {}),
+    convo('archived-in-work', { status: 'archived', listIds: ['l1'] }),
+  ];
+
+  test('isListPill / listPillId round the encoding', () => {
+    assert.strictEqual(M.isListPill('list:abc'), true);
+    assert.strictEqual(M.isListPill('all'), false);
+    assert.strictEqual(M.isListPill('unread'), false);
+    assert.strictEqual(M.listPillId('list:abc'), 'abc');
+    assert.strictEqual(M.listPillId('all'), null);
+  });
+
+  test('a list pill filters main to that list, pinned-first ordering unchanged', () => {
+    const { main } = M.partitionConversations(listData, { pill: 'list:l1' });
+    assert.deepStrictEqual(main.map(c => c.id), ['pinned-in-work', 'in-both', 'in-work']);
+  });
+
+  test('many-to-many: a conversation in two lists appears under both pills', () => {
+    const l1 = M.partitionConversations(listData, { pill: 'list:l1' }).main.map(c => c.id);
+    const l2 = M.partitionConversations(listData, { pill: 'list:l2' }).main.map(c => c.id);
+    assert.ok(l1.includes('in-both') && l2.includes('in-both'));
+  });
+
+  test('archived conversations stay in the archived section even when in the list', () => {
+    const { main, archived } = M.partitionConversations(listData, { pill: 'list:l1' });
+    assert.ok(!main.some(c => c.id === 'archived-in-work'));
+    assert.ok(archived.some(c => c.id === 'archived-in-work'));
+  });
+
+  test('conversations without a listIds field are tolerated (legacy entries)', () => {
+    const { main } = M.partitionConversations(listData, { pill: 'list:l1' });
+    assert.ok(!main.some(c => c.id === 'legacy-no-field'));
+    assert.strictEqual(M.inList({ id: 'x' }, 'l1'), false);
+  });
+
+  test('unknown list id yields an empty main list, not an error', () => {
+    const { main } = M.partitionConversations(listData, { pill: 'list:nope' });
+    assert.deepStrictEqual(main, []);
+  });
+
+  test('the all pill ignores list membership entirely', () => {
+    const { main } = M.partitionConversations(listData, { pill: 'all' });
+    assert.strictEqual(main.length, 5);
+  });
+});

--- a/test/unit/conversation-lists-store.test.js
+++ b/test/unit/conversation-lists-store.test.js
@@ -1,0 +1,82 @@
+'use strict';
+// Server-side store for conversation Lists: .rundock/lists.json registry plus
+// listIds membership on conversation entries. Pins the card's safety property:
+// deleting a list strips membership everywhere but never touches the
+// conversations themselves.
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { _internal: srv } = require('../../server.js');
+
+let tmpDir, prevWorkspace;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-lists-'));
+  prevWorkspace = srv.getWorkspace();
+  srv.setWorkspace(tmpDir);
+});
+afterEach(() => {
+  srv.setWorkspace(prevWorkspace);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('lists registry (.rundock/lists.json)', () => {
+  test('read/write round-trip', () => {
+    const lists = [{ id: 'l1', name: 'Client work', createdAt: '2026-07-17T00:00:00.000Z' }];
+    srv.writeLists(lists);
+    assert.deepStrictEqual(srv.readLists(), lists);
+  });
+
+  test('missing file reads as empty', () => {
+    assert.deepStrictEqual(srv.readLists(), []);
+  });
+
+  test('corrupted or non-array files read as empty; malformed entries are dropped', () => {
+    fs.mkdirSync(path.join(tmpDir, '.rundock'), { recursive: true });
+    const file = path.join(tmpDir, '.rundock', 'lists.json');
+    fs.writeFileSync(file, 'nope {{{');
+    assert.deepStrictEqual(srv.readLists(), []);
+    fs.writeFileSync(file, JSON.stringify({ not: 'an array' }));
+    assert.deepStrictEqual(srv.readLists(), []);
+    fs.writeFileSync(file, JSON.stringify([{ id: 'ok', name: 'Fine' }, { id: 42 }, null, { name: 'no id' }]));
+    assert.deepStrictEqual(srv.readLists().map(l => l.id), ['ok']);
+  });
+});
+
+describe('deleteListEverywhere (the card\'s safety property)', () => {
+  test('removes the registry entry and strips membership; conversations survive untouched', () => {
+    srv.writeLists([
+      { id: 'l1', name: 'Client work', createdAt: 'x' },
+      { id: 'l2', name: 'Research', createdAt: 'x' },
+    ]);
+    srv.writeConversations([
+      { id: 'c1', title: 'One', status: 'active', listIds: ['l1', 'l2'], pinned: true },
+      { id: 'c2', title: 'Two', status: 'active', listIds: ['l1'] },
+      { id: 'c3', title: 'Three', status: 'archived', listIds: ['l2'] },
+      { id: 'c4', title: 'Legacy', status: 'active' },
+    ]);
+
+    srv.deleteListEverywhere('l1');
+
+    assert.deepStrictEqual(srv.readLists().map(l => l.id), ['l2']);
+    const convos = srv.readConversations();
+    // Every conversation still exists with its other fields intact.
+    assert.deepStrictEqual(convos.map(c => c.id), ['c1', 'c2', 'c3', 'c4']);
+    assert.strictEqual(convos.find(c => c.id === 'c1').pinned, true);
+    // l1 stripped everywhere; l2 memberships untouched.
+    assert.deepStrictEqual(convos.find(c => c.id === 'c1').listIds, ['l2']);
+    assert.deepStrictEqual(convos.find(c => c.id === 'c2').listIds, []);
+    assert.deepStrictEqual(convos.find(c => c.id === 'c3').listIds, ['l2']);
+    assert.strictEqual(convos.find(c => c.id === 'c4').listIds, undefined);
+  });
+
+  test('deleting an unknown list id is a safe no-op', () => {
+    srv.writeLists([{ id: 'l1', name: 'Keep', createdAt: 'x' }]);
+    srv.writeConversations([{ id: 'c1', title: 'One', status: 'active', listIds: ['l1'] }]);
+    srv.deleteListEverywhere('ghost');
+    assert.deepStrictEqual(srv.readLists().map(l => l.id), ['l1']);
+    assert.deepStrictEqual(srv.readConversations()[0].listIds, ['l1']);
+  });
+});


### PR DESCRIPTION
## Summary

- Named, many-to-many conversation groupings rendered as pills beside All and Unread
- Right-click a conversation row to toggle membership or create-and-add via an inline input; right-click a pill to delete the list
- Filtering runs through the tested `conversation-list.js` module (stage-2 pattern); pinned-first ordering unchanged under list filters
- Registry persists to `.rundock/lists.json`; membership rides conversation entries as `listIds` (survives reloads and workspace switches)
- Deleting a list strips membership everywhere and never deletes conversations (pinned by test)

## Acceptance criteria (all covered by the e2e journey + unit tests)

- [x] Create a list, name it, add any conversation from its context menu; several lists per conversation
- [x] Lists appear as pills beside All and Unread; selecting one filters with pinned-first ordering unchanged
- [x] Lists survive reload and workspace switches
- [x] Removing a list never deletes conversations

## Tests

Suite 647 → 659, e2e 11 → 12, `conversation-list.js` 100% lines, combined client coverage 30.9% → 35.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)