### PR TITLE
Lists menus and pills follow the design system

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1751,7 +1751,7 @@ function renderListPills() {
     btn.onclick = () => setSidebarPill('list:' + l.id);
     btn.addEventListener('contextmenu', (e) => {
       e.preventDefault();
-      openConvoMenu(e, [{ label: `Delete list "${l.name}"`, action: () => ws.send(JSON.stringify({ type: 'delete_list', id: l.id })) }]);
+      openConvoMenu(e, [{ label: `Delete list "${l.name}"`, action: () => ws.send(JSON.stringify({ type: 'delete_list', id: l.id })) }], btn);
     });
     wrap.appendChild(btn);
   }
@@ -1759,12 +1759,15 @@ function renderListPills() {
 
 // Minimal shared context menu (positioned card, closes on any click or Esc).
 // Items: [{ label, action, checked? }] plus an optional inline input row via
-// { input: true, placeholder, onSubmit }.
-function openConvoMenu(evt, items) {
+// { input: true, placeholder, onSubmit }. Positioning: at the pointer for
+// row context menus, or anchored below an element (dropdown-style) when
+// anchorEl is passed, so the menu never covers its own trigger.
+function openConvoMenu(evt, items, anchorEl) {
   closeConvoMenu();
   const menu = document.createElement('div');
   menu.id = 'convo-context-menu';
   menu.className = 'convo-menu';
+  menu.style.visibility = 'hidden';
   for (const item of items) {
     if (item.input) {
       const row = document.createElement('div');
@@ -1790,10 +1793,23 @@ function openConvoMenu(evt, items) {
     }
   }
   document.body.appendChild(menu);
-  // Clamp to viewport.
+  // Position (clamped to the viewport), then reveal: anchored menus sit
+  // below their trigger's left edge with a 4px gap; pointer menus open at
+  // the cursor.
   const r = menu.getBoundingClientRect();
-  menu.style.left = Math.min(evt.clientX, window.innerWidth - r.width - 8) + 'px';
-  menu.style.top = Math.min(evt.clientY, window.innerHeight - r.height - 8) + 'px';
+  let x, y;
+  if (anchorEl) {
+    const a = anchorEl.getBoundingClientRect();
+    x = a.left;
+    y = a.bottom + 4;
+    if (y + r.height > window.innerHeight - 8) y = Math.max(8, a.top - r.height - 4); // flip above if no room
+  } else {
+    x = evt.clientX;
+    y = evt.clientY;
+  }
+  menu.style.left = Math.min(x, window.innerWidth - r.width - 8) + 'px';
+  menu.style.top = Math.min(y, window.innerHeight - r.height - 8) + 'px';
+  menu.style.visibility = '';
   menu.querySelector('input')?.focus();
   setTimeout(() => {
     document.addEventListener('click', closeConvoMenu, { once: true });

--- a/public/index.html
+++ b/public/index.html
@@ -113,17 +113,24 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
 .pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .pill.active { background: var(--accent); border-color: var(--accent); color: #fff; }
 .sidebar-pills { flex-wrap: wrap; }
+/* User-created list pills read as chips with substance: an --elevated fill
+   (one surface step up from the sidebar) distinguishes them from the fixed
+   All/Unread filters while the active state keeps the shared accent fill. */
+.pill-list:not(.active) { background: var(--elevated); }
 .pill-list { max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* Context menu for conversation lists (row right-click: membership;
-   list-pill right-click: delete). Positioned card, closes on click or Esc. */
-.convo-menu { position: fixed; z-index: 1000; min-width: 180px; max-width: 260px; background: var(--bg-2, var(--bg-1)); border: 1px solid var(--border); border-radius: 8px; padding: 4px; box-shadow: 0 8px 24px rgba(0,0,0,0.35); }
-.convo-menu-item { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; padding: 7px 10px; border: none; background: transparent; color: var(--text-1); font-size: var(--caption); font-family: inherit; border-radius: 5px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.convo-menu-item:hover { background: var(--bg-3, rgba(128,128,128,0.12)); }
+   list-pill right-click: delete, anchored below the pill). Floating-control
+   grammar from the design system: opaque --elevated surface, 1px --border,
+   shadow-3, 10px radius, tooltip-style backdrop blur. Closes on click or Esc. */
+.convo-menu { position: fixed; z-index: 1000; min-width: 180px; max-width: 260px; background: var(--elevated); border: 1px solid var(--border); border-radius: 10px; padding: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); }
+.convo-menu-item { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; padding: 7px 10px; border: none; background: transparent; color: var(--text-1); font-size: var(--caption); font-weight: 500; font-family: inherit; border-radius: 6px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.convo-menu-item:hover { background: var(--card); }
 .convo-menu-check { width: 14px; flex-shrink: 0; color: var(--accent); }
 .convo-menu-input { padding: 4px; }
-.convo-menu-input input { width: 100%; box-sizing: border-box; padding: 6px 8px; border: 1px solid var(--border); border-radius: 5px; background: transparent; color: var(--text-1); font-size: var(--caption); font-family: inherit; }
-.convo-menu-input input:focus { outline: 1px solid var(--accent); }
+.convo-menu-input input { width: 100%; box-sizing: border-box; padding: 6px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text-1); font-size: var(--caption); font-family: inherit; }
+.convo-menu-input input::placeholder { color: var(--text-2); }
+.convo-menu-input input:focus { border-color: var(--accent); outline: none; }
 
 /* Archive sidebar action (replaces delete on persisted, not-yet-archived items).
    Mirrors .convo-delete shape; hover uses a neutral bright text colour rather


### PR DESCRIPTION
## Summary

Design-review feedback on #19: the context menu used invented CSS tokens (`--bg-2`/`--bg-1`) that don't exist in Rundock's token set, so it rendered fully transparent, and the pill's delete menu opened on top of its own trigger.

- Menu: opaque `--elevated` + `--border` + shadow-3 + 10px radius + tooltip-style backdrop blur (the shipped floating-control grammar)
- Items: `--card` hover, 6px radius, weight 500; input gets a `--surface` inset fill with accent focus border
- Inactive list pills gain an `--elevated` fill so they read as chips with substance
- Pill delete menu anchors below the pill (flips above when out of room); row menus stay at the pointer

Verified in a driven browser (both menus opaque and readable, anchoring correct). Suite 659 green, e2e 12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)