### PR TITLE
Kanban board view: render, drag, add, and byte-safe save

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3151,8 +3151,45 @@ function loadFileContent(path, content) {
   // lands as one registry entry + one surface function, no dispatch edits.
   loadViewersModule().then((viewers) => {
     if (currentFilePath !== path) return; // stale: another file opened while the module loaded
+    // A markdown file whose frontmatter carries the kanban-plugin key opens as
+    // a board (detection is content-based, so it cannot ride the path-keyed
+    // classify table); everything else dispatches by file kind.
+    if (viewers.classify(path) === 'markdown' && window.Kanban && window.Kanban.isBoardFile(content)) {
+      openBoardFile(path, content);
+      return;
+    }
     const surface = FILE_SURFACES[viewers.classify(path)] || openBinaryOrUnsupportedFile;
     surface(viewers, path, content);
+  });
+}
+
+// Board view: a writable registry view. Mounts the board into the editor pane
+// and wires its edits to the same guarded autosave the editor uses. Unlike the
+// read-only viewers, its getContentForSave is non-null (unless the board holds
+// content the grammar would drop, in which case saving is refused).
+let boardSaveTimer = null;
+function openBoardFile(path, content) {
+  destroyTiptapEditorIfActive();
+  document.getElementById('tiptap-editor-pane').classList.add('hidden');
+  document.getElementById('toggle-preview').classList.add('hidden');
+  document.getElementById('toggle-edit').classList.add('hidden');
+  document.getElementById('editor-textarea').classList.add('hidden');
+  const pane = document.getElementById('editor-content');
+  pane.classList.remove('hidden');
+  pane.className = 'editor-content';
+  import('./viewers/board-view.js').then((mod) => {
+    if (currentFilePath !== path) return; // stale
+    activeFileViewer = mod.mountBoardView({ paneElement: pane, path, content }, window.Kanban);
+    if (typeof activeFileViewer.setOnChange === 'function' && typeof activeFileViewer.getContentForSave === 'function') {
+      activeFileViewer.setOnChange(() => {
+        const md = activeFileViewer.getContentForSave();
+        if (md == null) return; // save refused (droppable content)
+        const status = document.getElementById('editor-status');
+        if (status) { status.textContent = 'Unsaved'; status.style.color = 'var(--attention)'; }
+        clearTimeout(boardSaveTimer);
+        boardSaveTimer = setTimeout(() => saveFileGuarded(path, md), 500);
+      });
+    }
   });
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -3131,6 +3131,7 @@ let editorMode='preview', rawFileContent='', fileFrontmatter='', fileBody='';
 function loadFileContent(path, content) {
   // Close any active find before swapping the editor content.
   if (currentFilePath !== path) closeFindBar();
+  flushBoardSave(); // never drop a board's last edit when switching files
   destroyActiveFileViewer();
   hideExternalEditConflict();
   currentFilePath = path;
@@ -3168,6 +3169,18 @@ function loadFileContent(path, content) {
 // read-only viewers, its getContentForSave is non-null (unless the board holds
 // content the grammar would drop, in which case saving is refused).
 let boardSaveTimer = null;
+let boardPendingSave = null; // { path, md } — the latest debounced board write
+// Flush a pending board save immediately. Called before opening any file so a
+// board's last edit is never dropped when switching away inside the debounce
+// window (the pending save carries its own path, so it writes the right file).
+function flushBoardSave() {
+  if (boardSaveTimer) { clearTimeout(boardSaveTimer); boardSaveTimer = null; }
+  if (boardPendingSave) {
+    const p = boardPendingSave;
+    boardPendingSave = null;
+    saveFileGuarded(p.path, p.md);
+  }
+}
 function openBoardFile(path, content) {
   destroyTiptapEditorIfActive();
   document.getElementById('tiptap-editor-pane').classList.add('hidden');
@@ -3186,8 +3199,9 @@ function openBoardFile(path, content) {
         if (md == null) return; // save refused (droppable content)
         const status = document.getElementById('editor-status');
         if (status) { status.textContent = 'Unsaved'; status.style.color = 'var(--attention)'; }
+        boardPendingSave = { path, md };
         clearTimeout(boardSaveTimer);
-        boardSaveTimer = setTimeout(() => saveFileGuarded(path, md), 500);
+        boardSaveTimer = setTimeout(flushBoardSave, 500);
       });
     }
   });

--- a/public/index.html
+++ b/public/index.html
@@ -986,6 +986,8 @@ mark.find-match.current,
   </div>
 </div>
 
+<!-- Kanban parser/serializer (UMD): sets window.Kanban for the board view. -->
+<script src="/kanban.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/public/kanban.js
+++ b/public/kanban.js
@@ -1,0 +1,508 @@
+/**
+ * kanban.js — parser/serializer for Obsidian Kanban plugin board files.
+ *
+ * Byte-compatibility target: obsidian-kanban v2.0.51. Every rule here was
+ * extracted from the plugin's compiled main.js (functions W_/LB/U_/PB/vk on
+ * the serialize side; R_/B_/gf/IB/AB and helpers Dg/Eg/qk/Cd/Sg/co/OB on the
+ * parse side), so the minified names are cited to keep each rule re-verifiable
+ * against the bundle.
+ *
+ * No dependencies. Works in Node and the browser (UMD-style export at bottom).
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.Kanban = factory();
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // The plugin serializes continuation-line indentation from the Obsidian
+  // workspace's "useTab" setting (default true), which this build assumes.
+  const INDENT = '\t'; // Cd: '\n' -> '\n\t' when useTab, '\n    ' otherwise
+
+  // ---------------------------------------------------------------------
+  // Parse
+  // ---------------------------------------------------------------------
+
+  /**
+   * Parse a board file into { frontmatter, lanes, archive, settings, dropped }.
+   * - frontmatter: ordered [key, rawValueString] pairs (verbatim lines)
+   * - lanes: [{ title, maxItems, shouldMarkItemsComplete, items }]
+   * - archive: items
+   * - settings: parsed settings JSON object (key order preserved)
+   * - dropped: lines the plugin would silently drop on save (we surface them)
+   * Item: { checkChar, checked, titleRaw, blockId }
+   */
+  // A brand-new board, byte-exact to the plugin's basicFrontmatter
+  // (src/parsers/common.ts): frontmatter only. No lanes and NO settings
+  // block: that appears on the first save, because parse hoists
+  // kanban-plugin into settings (mirrored below).
+  function newBoardContent() {
+    return ['---', '', 'kanban-plugin: board', '', '---', '', ''].join('\n');
+  }
+
+  // Board detection, mirroring hasFrontmatterKeyRaw: any file whose
+  // frontmatter carries the kanban-plugin key opens as a board.
+  function isBoardFile(text) {
+    try { return readFrontmatter(String(text)).keys.some(([k]) => k === 'kanban-plugin'); }
+    catch (e) { return false; }
+  }
+
+  function parse(text) {
+    const src = String(text);
+    const fm = readFrontmatter(src); // { keys: [[k, v]], end: index-after-closing-delimiter }
+    const settings = readSettingsBlock(src); // { json, start } or null
+
+    // Body = between frontmatter and the settings block marker line.
+    let bodyEnd = src.length;
+    if (settings) bodyEnd = settings.start;
+    const body = src.slice(fm.end, bodyEnd);
+    const lines = body.split('\n');
+
+    const lanes = [];
+    const archive = [];
+    const dropped = [];
+    let lane = null; // current lane object
+    let item = null; // current item: { checkChar, lines: [] }
+    let pendingBreak = false; // saw a thematic break (potential archive marker)
+    let inArchive = false;
+
+    const flushItem = () => {
+      if (!item) return;
+      const parsed = finishItem(item);
+      (inArchive ? archive : lane.items).push(parsed);
+      item = null;
+    };
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Heading at column 0 (any level; plugin normalises to '## ' on save)
+      const h = line.match(/^(#{1,6}) (.*)$/);
+      if (h) {
+        flushItem();
+        const rawTitle = h[2];
+        if (pendingBreak && stripMd(rawTitle) === 'Archive') {
+          inArchive = true;
+          lane = null;
+          pendingBreak = false;
+          continue;
+        }
+        pendingBreak = false;
+        inArchive = false;
+        const { title, maxItems } = parseLaneTitle(rawTitle);
+        lane = { title, maxItems, shouldMarkItemsComplete: false, items: [] };
+        lanes.push(lane);
+        continue;
+      }
+
+      // Thematic break at column 0 (potential archive marker; plugin drops it
+      // and re-synthesises '***' before '## Archive' on save)
+      if (/^ {0,3}(\*{3,}|-{3,}|_{3,})\s*$/.test(line)) {
+        flushItem();
+        pendingBreak = true;
+        continue;
+      }
+
+      // New top-level list item at column 0
+      const li = line.match(/^- \[(.)\] (.*)$/) || line.match(/^- \[(.)\]$/);
+      if (li && (lane || inArchive)) {
+        flushItem();
+        pendingBreak = false;
+        item = { checkChar: li[1], lines: [li[2] || ''] };
+        continue;
+      }
+      // Bare list item without checkbox: plugin parses it as an unchecked task
+      // and rewrites it as '- [ ] ...' on save (churn).
+      const bare = line.match(/^- (.*)$/);
+      if (bare && (lane || inArchive) && !item) {
+        pendingBreak = false;
+        item = { checkChar: ' ', lines: [bare[1]] };
+        continue;
+      }
+
+      // Continuation of the current item: indented content, blank lines
+      // between indented content, or lazy continuation.
+      if (item) {
+        if (line === '' ) {
+          // Blank line: belongs to the item only if more indented content follows
+          // before the next structural line. Look ahead.
+          let j = i + 1;
+          while (j < lines.length && lines[j] === '') j++;
+          if (j < lines.length && /^(\t| {2,})/.test(lines[j])) {
+            item.lines.push('');
+            continue;
+          }
+          flushItem();
+          pendingBreak = false;
+          continue;
+        }
+        if (/^(\t| {2,})/.test(line) || /^\S/.test(line) === false) {
+          item.lines.push(line);
+          continue;
+        }
+        // Lazy continuation (non-blank, column 0, not structural): CommonMark
+        // attaches it to the item's paragraph; the plugin's mdast parse does too.
+        if (!h && !li && !bare) {
+          item.lines.push(line);
+          continue;
+        }
+      }
+
+      if (line === '') { continue; }
+
+      // The '**Complete**' marker paragraph inside a lane
+      if (lane && stripMd(line) === 'Complete') {
+        lane.shouldMarkItemsComplete = true;
+        continue;
+      }
+
+      // Anything else at top level: the plugin drops it on save.
+      dropped.push({ line: i, text: line });
+      pendingBreak = false;
+    }
+    flushItem();
+
+    // Mirror the plugin's R_ key routing: kanban-plugin is hoisted from the
+    // frontmatter into the settings object on EVERY parse ('basic' migrates
+    // to 'board'), which is why even a fresh board gains its settings block
+    // on the first save. Existing blocks keep their key order (assignment of
+    // an existing key preserves position); a missing block starts as
+    // {"kanban-plugin": ...} exactly like the plugin's first save.
+    const fmKeys = fm.keys.map(([k, v]) => (k === 'kanban-plugin' && v === 'basic') ? [k, 'board'] : [k, v]);
+    let settingsObj = settings ? settings.json : null;
+    const kp = fmKeys.find(([k]) => k === 'kanban-plugin');
+    if (kp) {
+      if (!settingsObj) settingsObj = {};
+      settingsObj['kanban-plugin'] = kp[1];
+    }
+
+    return {
+      frontmatter: fmKeys,
+      lanes,
+      archive,
+      settings: settingsObj,
+      settingsRaw: settings ? settings.raw : null,
+      dropped,
+    };
+  }
+
+  function readFrontmatter(src) {
+    // Plugin's IB: file must start with '---'; find the closing '---'.
+    if (!src.startsWith('---')) throw new Error('Error parsing frontmatter');
+    const m = src.slice(3).match(/\n---/);
+    if (!m) throw new Error('Error parsing frontmatter: no closing delimiter');
+    const inner = src.slice(3, 3 + m.index);
+    let end = 3 + m.index + 4; // after '\n---'
+    // consume the rest of the delimiter line + one trailing newline
+    while (end < src.length && src[end] !== '\n') end++;
+    if (src[end] === '\n') end++;
+    const keys = [];
+    for (const line of inner.split('\n')) {
+      const t = line.trim();
+      if (!t) continue;
+      const kv = t.match(/^([^:]+):\s*(.*)$/);
+      if (kv) keys.push([kv[1].trim(), kv[2].trim()]);
+    }
+    return { keys, end };
+  }
+
+  function readSettingsBlock(src) {
+    // Plugin's AB: scan from EOF for the last fenced code block, JSON.parse it.
+    // Serialized form: '\n\n%% kanban:settings\n```\n{json}\n```\n%%' at EOF.
+    const marker = src.lastIndexOf('%% kanban:settings');
+    if (marker < 0) return null;
+    const fenceOpen = src.indexOf('```', marker);
+    if (fenceOpen < 0) return null;
+    const jsonStart = src.indexOf('\n', fenceOpen) + 1;
+    const fenceClose = src.indexOf('```', jsonStart);
+    if (fenceClose < 0) return null;
+    const raw = src.slice(jsonStart, fenceClose).trim();
+    let json = null;
+    try { json = JSON.parse(raw); } catch (e) { /* invalid settings JSON */ }
+    // start = beginning of the blank padding before the marker line
+    let start = marker;
+    while (start > 0 && (src[start - 1] === '\n' || src[start - 1] === '\r')) start--;
+    return { json, raw, start };
+  }
+
+  function finishItem(item) {
+    // Mirror of gf: titleRaw = qk(Eg(Dg(sourceSlice)))
+    let raw = item.lines.join('\n');
+    // Dg: <br> -> \n happens on lane titles; on items the plugin operates on
+    // the source slice directly. Trim (Dg/Eg both trim).
+    raw = raw.trim();
+    // Eg: dedent exactly one level: '\n' + (4 spaces | tab) -> '\n'
+    raw = raw.replace(/(?:\r\n|\n)(?: {4}|\t)/g, '\n');
+    // qk: strip ' ^blockid' from first line
+    let blockId;
+    const nl = raw.indexOf('\n');
+    const first = nl < 0 ? raw : raw.slice(0, nl);
+    const bid = first.match(/\s+\^([a-zA-Z0-9-]+)$/);
+    if (bid) {
+      blockId = bid[1];
+      const stripped = first.replace(/\s+\^([a-zA-Z0-9-]+)$/, '');
+      raw = nl < 0 ? stripped : stripped + raw.slice(nl);
+    }
+    return {
+      checkChar: item.checkChar === ' ' ? ' ' : item.checkChar,
+      checked: item.checkChar !== ' ',
+      titleRaw: raw,
+      blockId,
+    };
+  }
+
+  function parseLaneTitle(raw) {
+    // co: <br> -> \n + trim (Dg), then 'Title (N)' -> maxItems
+    const t = raw.replace(/<br>/g, '\n').trim();
+    const m = t.match(/^(.*?)\s*\((\d+)\)$/);
+    if (m) return { title: m[1], maxItems: Number(m[2]) };
+    return { title: t, maxItems: 0 };
+  }
+
+  function stripMd(s) {
+    // crude equivalent of the plugin's _s(node) text extraction for the
+    // 'Complete' / 'Archive' comparisons: strip emphasis markers + trim
+    return s.replace(/[*_`]/g, '').trim();
+  }
+
+  // ---------------------------------------------------------------------
+  // Serialize (byte-exact mirror of W_/LB/U_/PB/vk)
+  // ---------------------------------------------------------------------
+
+  function serialize(board) {
+    let out = ['---', '', stringifyFrontmatter(board.frontmatter), '---', '', ''].join('\n');
+    for (const lane of board.lanes) out += serializeLane(lane);
+    out += serializeArchive(board.archive || []);
+    out += serializeSettings(board.settings);
+    return out;
+  }
+
+  function stringifyFrontmatter(keys) {
+    // Obsidian's stringifyYaml for flat scalar values: 'key: value\n' per key.
+    return keys.map(([k, v]) => `${k}: ${v}`).join('\n') + '\n';
+  }
+
+  function serializeLane(lane) {
+    // LB
+    const t = [];
+    const title = cd(lane.title, lane.maxItems);
+    t.push(`## ${title.trim().replace(/(?:\r\n|\n)/g, '<br>')}`); // jk
+    t.push('');
+    if (lane.shouldMarkItemsComplete) t.push('**Complete**');
+    for (const it of lane.items) t.push(serializeItem(it));
+    t.push('');
+    t.push('');
+    t.push('');
+    return t.join('\n');
+  }
+
+  function cd(title, maxItems) {
+    return maxItems ? `${title} (${maxItems})` : title;
+  }
+
+  function serializeItem(it) {
+    // U_ + Cd + Sg
+    let content = it.titleRaw.trim().replace(/(?:\r\n|\n)/g, '\n' + INDENT); // Cd
+    if (it.blockId) {
+      const lines = content.split('\n');
+      lines[0] += ' ^' + it.blockId;
+      content = lines.join('\n');
+    }
+    return `- [${it.checkChar}] ${content}`;
+  }
+
+  function serializeArchive(items) {
+    // PB: only when non-empty
+    if (!items.length) return '';
+    const t = ['***', '', '## Archive', ''];
+    for (const it of items) t.push(serializeItem(it));
+    return t.join('\n');
+  }
+
+  function serializeSettings(settings) {
+    // vk: file ends '%%' with NO trailing newline
+    if (!settings) return '';
+    return ['', '', '%% kanban:settings', '```', JSON.stringify(settings), '```', '%%'].join('\n');
+  }
+
+  // ---------------------------------------------------------------------
+  // Board operations (what the board UI needs)
+  // ---------------------------------------------------------------------
+
+  /** Move an item between/within lanes. Indexes are pre-removal positions. */
+  function moveItem(board, fromLane, fromIndex, toLane, toIndex) {
+    const src = board.lanes[fromLane];
+    const dst = board.lanes[toLane];
+    if (!src || !dst) throw new Error('bad lane index');
+    const [it] = src.items.splice(fromIndex, 1);
+    if (!it) throw new Error('bad item index');
+    dst.items.splice(toIndex, 0, it);
+    return board;
+  }
+
+  function addItem(board, laneIndex, titleRaw) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) throw new Error('bad lane index');
+    lane.items.push({ checkChar: ' ', checked: false, titleRaw: String(titleRaw).trim(), blockId: undefined });
+    return board;
+  }
+
+  /** Archive an item (plain variant: no archive-with-date settings in play). */
+  function archiveItem(board, laneIndex, itemIndex) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) throw new Error('bad lane index');
+    const [it] = lane.items.splice(itemIndex, 1);
+    if (!it) throw new Error('bad item index');
+    board.archive.push(it); // archiveEntity uses $push (end of archive)
+    return board;
+  }
+
+  /**
+   * Replace a card's raw markdown. Mirrors the plugin's updateItemContent:
+   * the text is stored verbatim (trimmed at serialize by Cd); checkChar and
+   * blockId are separate fields and survive the edit untouched.
+   */
+  function updateItem(board, laneIndex, itemIndex, titleRaw) {
+    const it = (board.lanes[laneIndex] || { items: [] }).items[itemIndex];
+    if (!it) throw new Error('bad item index');
+    it.titleRaw = String(titleRaw).trim();
+    return board;
+  }
+
+  /** Delete a card outright (the plugin's deleteEntity). */
+  function deleteItem(board, laneIndex, itemIndex) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) throw new Error('bad lane index');
+    const [it] = lane.items.splice(itemIndex, 1);
+    if (!it) throw new Error('bad item index');
+    return board;
+  }
+
+  /**
+   * Toggle a card's checkbox. v2.0.51 semantics without the Tasks plugin:
+   * flip between ' ' and 'x' in place; no move, no date stamp. A custom
+   * checked char (e.g. '-') unchecks to ' ' and re-checks as 'x'.
+   */
+  function toggleItem(board, laneIndex, itemIndex) {
+    const it = (board.lanes[laneIndex] || { items: [] }).items[itemIndex];
+    if (!it) throw new Error('bad item index');
+    it.checked = !it.checked;
+    it.checkChar = it.checked ? 'x' : ' ';
+    return board;
+  }
+
+  // ---------------------------------------------------------------------
+  // Lane operations (column parity with the Obsidian Kanban plugin)
+  // ---------------------------------------------------------------------
+  // THE syntax trap for every structural lane operation: 'list-collapse' in
+  // the settings JSON is POSITIONAL (one boolean per lane, lane order), so
+  // reorder/insert/delete must splice it in lockstep or collapse states
+  // silently attach to the wrong columns. The plugin's own boardModifiers
+  // do exactly this (insertLane splices false; deleteEntity/drag reorder).
+
+  function collapseArray(board) {
+    if (!board.settings) board.settings = { 'kanban-plugin': 'board' };
+    let lc = board.settings['list-collapse'];
+    if (!Array.isArray(lc)) lc = [];
+    // Pad to lane count with false (expanded). Both live boards carry
+    // full-length arrays, so this is byte-neutral on canonical files.
+    while (lc.length < board.lanes.length) lc.push(false);
+    if (lc.length > board.lanes.length) lc = lc.slice(0, board.lanes.length);
+    board.settings['list-collapse'] = lc;
+    return lc;
+  }
+
+  /** Reorder columns. Indexes are pre-removal positions. */
+  function moveLane(board, fromIndex, toIndex) {
+    const lc = collapseArray(board);
+    const [lane] = board.lanes.splice(fromIndex, 1);
+    if (!lane) throw new Error('bad lane index');
+    board.lanes.splice(toIndex, 0, lane);
+    const [flag] = lc.splice(fromIndex, 1);
+    lc.splice(toIndex, 0, flag);
+    return board;
+  }
+
+  /** Toggle a column's collapsed state (settings JSON only; body untouched). */
+  function toggleCollapse(board, laneIndex) {
+    const lc = collapseArray(board);
+    if (laneIndex < 0 || laneIndex >= lc.length) throw new Error('bad lane index');
+    lc[laneIndex] = !lc[laneIndex];
+    return board;
+  }
+
+  /**
+   * Rename a column ("Edit list"). rawTitle may carry the plugin's ' (N)'
+   * WIP-limit suffix and <br> newlines, exactly as the heading line stores it.
+   */
+  function renameLane(board, laneIndex, rawTitle) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) throw new Error('bad lane index');
+    const { title, maxItems } = parseLaneTitle(String(rawTitle));
+    if (!title) throw new Error('empty lane title');
+    lane.title = title;
+    lane.maxItems = maxItems;
+    return board;
+  }
+
+  /** Insert a new empty column at laneIndex (before/after = caller's index). */
+  function insertLane(board, laneIndex, title) {
+    const lc = collapseArray(board);
+    const { title: t, maxItems } = parseLaneTitle(String(title || 'New list'));
+    board.lanes.splice(laneIndex, 0, { title: t || 'New list', maxItems, shouldMarkItemsComplete: false, items: [] });
+    lc.splice(laneIndex, 0, false); // plugin's insertLane splices false
+    return board;
+  }
+
+  /**
+   * "Archive cards": empty the lane into the archive. The plugin's
+   * archiveLaneItems $unshifts, so the lane's cards land at the FRONT of the
+   * archive in their existing order (single-card archive appends instead).
+   */
+  function archiveLaneCards(board, laneIndex) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) throw new Error('bad lane index');
+    board.archive = lane.items.concat(board.archive);
+    lane.items = [];
+    return board;
+  }
+
+  /** "Archive list": archive its cards, then remove the column. */
+  function archiveLane(board, laneIndex) {
+    archiveLaneCards(board, laneIndex);
+    return deleteLane(board, laneIndex);
+  }
+
+  /** "Delete list": remove the column and its cards outright. */
+  function deleteLane(board, laneIndex) {
+    const lc = collapseArray(board);
+    const [lane] = board.lanes.splice(laneIndex, 1);
+    if (!lane) throw new Error('bad lane index');
+    lc.splice(laneIndex, 1);
+    return board;
+  }
+
+  /**
+   * Sort a lane's cards in place. by = 'text' (display text, natural
+   * case-insensitive) or 'tags' (first #tag alphabetically, untagged last).
+   * Byte-safe by construction (any permutation of card blocks is valid);
+   * ORDER parity with the plugin's comparator is approximate, noted in the
+   * format spec.
+   */
+  function sortLane(board, laneIndex, by) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) throw new Error('bad lane index');
+    const text = (it) => it.titleRaw.replace(/[*_`#\[\]]/g, '').trim().toLowerCase();
+    const firstTag = (it) => {
+      const m = it.titleRaw.match(/(?:^|\s)#([\w/][\w/-]*)/);
+      return m ? m[1].toLowerCase() : '￿'; // untagged sorts last
+    };
+    if (by === 'tags') lane.items.sort((a, b) => firstTag(a).localeCompare(firstTag(b)) || text(a).localeCompare(text(b)));
+    else lane.items.sort((a, b) => text(a).localeCompare(text(b), undefined, { numeric: true }));
+    return board;
+  }
+
+  return { parse, serialize, moveItem, addItem, archiveItem, updateItem, deleteItem, toggleItem,
+    moveLane, toggleCollapse, renameLane, insertLane, archiveLaneCards, archiveLane, deleteLane, sortLane,
+    newBoardContent, isBoardFile };
+});

--- a/public/kanban.js
+++ b/public/kanban.js
@@ -176,8 +176,14 @@
       settingsObj['kanban-plugin'] = kp[1];
     }
 
+    // Verbatim frontmatter body, with the legacy value migrated in place (the
+    // only edit the plugin makes besides js-yaml reformatting, which we do not
+    // replicate so nothing is lost).
+    const frontmatterBody = fm.body.replace(/^(\s*kanban-plugin:\s*)basic(\s*)$/m, '$1board$2');
+
     return {
       frontmatter: fmKeys,
+      frontmatterBody,
       lanes,
       archive,
       settings: settingsObj,
@@ -203,7 +209,13 @@
       const kv = t.match(/^([^:]+):\s*(.*)$/);
       if (kv) keys.push([kv[1].trim(), kv[2].trim()]);
     }
-    return { keys, end };
+    // Capture the YAML body verbatim (framing blank lines stripped; internal
+    // structure kept), so block-style YAML (multi-line tag/alias lists, nested
+    // maps, comments) survives on save. A flat key/value re-emit would silently
+    // destroy it. The plugin's canonical delimiter/blank template is re-applied
+    // on serialize, so a canonical board stays byte-identical.
+    const body = inner.replace(/^\n+/, '').replace(/\s+$/, '') + '\n';
+    return { keys, end, body };
   }
 
   function readSettingsBlock(src) {
@@ -270,7 +282,11 @@
   // ---------------------------------------------------------------------
 
   function serialize(board) {
-    let out = ['---', '', stringifyFrontmatter(board.frontmatter), '---', '', ''].join('\n');
+    // Re-emit the verbatim YAML body (preserving block-style YAML) inside the
+    // plugin's canonical delimiter/blank template. A board built without going
+    // through parse (no frontmatterBody) falls back to the flat key/value emit.
+    const fmInner = board.frontmatterBody != null ? board.frontmatterBody : stringifyFrontmatter(board.frontmatter);
+    let out = ['---', '', fmInner, '---', '', ''].join('\n');
     for (const lane of board.lanes) out += serializeLane(lane);
     out += serializeArchive(board.archive || []);
     out += serializeSettings(board.settings);

--- a/public/viewers/board-markdown.js
+++ b/public/viewers/board-markdown.js
@@ -1,0 +1,65 @@
+// Inline markdown rendering for kanban card text. Cards display styled markdown
+// (bold, italic, strikethrough, inline code, links, wikilinks) rather than raw
+// syntax. Card text is untrusted (user- or agent-authored), so the input is
+// HTML-escaped FIRST and every transform operates on the escaped string; only
+// the tags this module emits are ever introduced. A link URL is rendered only
+// when its scheme is safe (http/https/mailto), so a javascript: or data: URL
+// can never become an href.
+
+// A NUL sentinel that HTML-escaped text can never contain, used as a
+// collision-proof placeholder delimiter for extracted inline code (a plain
+// digit token would clash with numbers that appear in card text).
+var SENT = String.fromCharCode(0);
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function safeUrl(url) {
+  // url is already HTML-escaped; test the scheme on a decoded copy.
+  var decoded = url.replace(/&amp;/g, '&');
+  return /^(https?:|mailto:)/i.test(decoded.trim());
+}
+
+// Render one line of already-escaped text with inline markdown. Inline code is
+// extracted to placeholders first so its contents are never re-parsed as
+// emphasis, then restored last.
+function renderInline(escaped) {
+  var codes = [];
+  var s = escaped.replace(/`([^`]+)`/g, function (_, c) {
+    codes.push(c);
+    return SENT + (codes.length - 1) + SENT;
+  });
+
+  // Links [text](url) before emphasis so bracketed text is not eaten.
+  s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, function (m, text, url) {
+    return safeUrl(url) ? '<a href="' + url + '" target="_blank" rel="noreferrer noopener">' + text + '</a>' : m;
+  });
+
+  // Wikilinks [[target]] or [[target|alias]] render as links (navigation wired
+  // by the host later); display the alias when present.
+  s = s.replace(/\[\[([^\[\]\|]+?)(?:\|([^\[\]\|]+?))?\]\]/g, function (m, target, alias) {
+    return '<a class="board-wikilink" data-target="' + target.trim() + '">' + (alias || target).trim() + '</a>';
+  });
+
+  s = s.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+  s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  s = s.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+  s = s.replace(/(^|[^*])\*([^*\s][^*]*?)\*/g, '$1<em>$2</em>');
+  s = s.replace(/(^|[^_\w])_([^_\s][^_]*?)_(?![\w])/g, '$1<em>$2</em>');
+
+  return s.replace(new RegExp(SENT + '(\\d+)' + SENT, 'g'), function (_, i) {
+    return '<code>' + codes[Number(i)] + '</code>';
+  });
+}
+
+// Render a card's raw title text (possibly multi-line) to display HTML.
+export function renderCardHtml(raw) {
+  var lines = String(raw == null ? '' : raw).split('\n');
+  return lines.map(function (line) { return renderInline(escapeHtml(line)); }).join('<br>');
+}

--- a/public/viewers/board-markdown.js
+++ b/public/viewers/board-markdown.js
@@ -60,6 +60,8 @@ function renderInline(escaped) {
 
 // Render a card's raw title text (possibly multi-line) to display HTML.
 export function renderCardHtml(raw) {
-  var lines = String(raw == null ? '' : raw).split('\n');
+  // Strip any NUL from the input so real card text can never collide with the
+  // inline-code placeholder sentinel (SENT).
+  var lines = String(raw == null ? '' : raw).replace(/\x00/g, '').split('\n');
   return lines.map(function (line) { return renderInline(escapeHtml(line)); }).join('<br>');
 }

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -379,6 +379,8 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     menu.className = 'board-lane-popup';
     const items = [
       ['Rename list', () => renameLaneInline(anchor.closest('.board-lane-head'), anchor.closest('.board-lane-head').querySelector('.board-lane-title'), laneIndex)],
+      ...(laneIndex > 0 ? [['Move list left', () => { Kanban.moveLane(board, laneIndex, laneIndex - 1); onChange(); render(); }]] : []),
+      ...(laneIndex < board.lanes.length - 1 ? [['Move list right', () => { Kanban.moveLane(board, laneIndex, laneIndex + 1); onChange(); render(); }]] : []),
       ['Insert list before', () => { Kanban.insertLane(board, laneIndex, 'New list'); onChange(); render(); }],
       ['Insert list after', () => { Kanban.insertLane(board, laneIndex + 1, 'New list'); onChange(); render(); }],
       ['Sort by card text', () => { Kanban.sortLane(board, laneIndex, 'text'); onChange(); render(); }],

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -30,9 +30,17 @@ function ensureStyles(doc) {
     .board-lane-title { font-size: var(--body); font-weight: 600; color: var(--text-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .board-lane-count { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; margin-left: auto; }
     .board-lane-body { flex: 1; overflow-y: auto; padding: 8px; display: flex; flex-direction: column; gap: 8px; min-height: 8px; }
-    .board-card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; font-size: var(--body); color: var(--text-1); line-height: 1.5; cursor: grab; }
+    .board-card { position: relative; background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; font-size: var(--body); color: var(--text-1); line-height: 1.5; cursor: grab; }
     .board-card:hover { border-color: var(--text-2); }
     .board-card.dragging { opacity: 0.4; }
+    .board-card-controls { position: absolute; top: 6px; right: 6px; display: none; gap: 2px; }
+    .board-card:hover .board-card-controls { display: flex; }
+    .board-card-ctl { display: flex; align-items: center; justify-content: center; width: 22px; height: 22px; border-radius: 6px; color: var(--text-2); background: var(--surface); }
+    .board-card-ctl:hover { color: var(--danger, #E85A5A); background: var(--elevated); }
+    .board-card-edit { width: 100%; resize: none; background: var(--elevated); border: 1px solid var(--accent); border-radius: 6px; color: var(--text-1); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; line-height: 1.5; padding: 8px 10px; outline: none; }
+    .board-undo-toast { position: absolute; left: 50%; bottom: 16px; transform: translateX(-50%); z-index: 8; display: flex; align-items: center; gap: 12px; padding: 8px 12px 8px 16px; border-radius: 8px; background: var(--card); border: 1px solid var(--border); box-shadow: 0 4px 16px rgba(0,0,0,0.25); font-size: var(--body); color: var(--text-1); }
+    .board-undo-btn { color: var(--accent); font-weight: 600; padding: 4px 8px; border-radius: 6px; }
+    .board-undo-btn:hover { background: var(--accent-glow); }
     .board-card-row { display: flex; gap: 8px; align-items: flex-start; }
     .board-card-check { flex: 0 0 auto; margin-top: 2px; width: 15px; height: 15px; cursor: pointer; accent-color: var(--accent); }
     .board-card-text { flex: 1; min-width: 0; overflow-wrap: anywhere; }
@@ -56,6 +64,27 @@ function ensureStyles(doc) {
     .board-dropped-warn { margin: 8px 20px; padding: 10px 14px; border-radius: 8px; background: rgba(232,168,76,0.12); border: 1px solid rgba(232,168,76,0.35); color: var(--text-1); font-size: var(--caption); }
   `;
   doc.head.appendChild(style);
+}
+
+// Lucide-style inline SVG from a list of path `d` strings (24 viewBox, 1.8
+// stroke, round caps) — never a unicode glyph.
+function iconSvg(doc, paths) {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = doc.createElementNS(NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.8');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const d of paths) {
+    const p = doc.createElementNS(NS, 'path');
+    p.setAttribute('d', d);
+    svg.appendChild(p);
+  }
+  return svg;
 }
 
 // icon: a small lucide-style plus, inline SVG (24 viewBox, stroke 1.8)
@@ -194,8 +223,26 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     const text = doc.createElement('div');
     text.className = 'board-card-text' + (item.checked ? ' checked' : '');
     text.innerHTML = renderCardHtml(item.titleRaw);
+    // Click the card text to edit in place (a click on a wikilink does not
+    // edit; navigation is wired separately).
+    text.addEventListener('click', (e) => {
+      if (e.target.closest && e.target.closest('a.board-wikilink')) return;
+      enterCardEdit(card, laneIndex, itemIndex);
+    });
     row.appendChild(check);
     row.appendChild(text);
+
+    const controls = doc.createElement('div');
+    controls.className = 'board-card-controls';
+    const del = doc.createElement('button');
+    del.type = 'button';
+    del.className = 'board-card-ctl';
+    del.title = 'Delete card';
+    del.appendChild(iconSvg(doc, ['M3 6h18', 'M8 6V4h8v2', 'M19 6l-1 14H6L5 6', 'M10 11v6', 'M14 11v6']));
+    del.addEventListener('click', (e) => { e.stopPropagation(); deleteCardWithUndo(laneIndex, itemIndex); });
+    controls.appendChild(del);
+    card.appendChild(controls);
+
     card.appendChild(row);
 
     card.addEventListener('dragstart', (e) => {
@@ -226,6 +273,79 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     drag = null;
     onChange();
     render();
+  }
+
+  // In-place card edit. The card's raw markdown opens in a textarea; Enter
+  // saves, Shift+Enter inserts a newline, Esc cancels, click-away saves. No
+  // hint text. The edited text feeds titleRaw straight through the byte-exact
+  // serializer.
+  function enterCardEdit(card, laneIndex, itemIndex) {
+    if (card.querySelector('textarea.board-card-edit')) return;
+    const item = board.lanes[laneIndex] && board.lanes[laneIndex].items[itemIndex];
+    if (!item) return;
+    const row = card.querySelector('.board-card-row');
+    const ta = doc.createElement('textarea');
+    ta.className = 'board-card-edit';
+    ta.value = item.titleRaw;
+    row.replaceWith(ta);
+    card.draggable = false;
+    ta.focus();
+    ta.setSelectionRange(ta.value.length, ta.value.length);
+    const grow = () => { ta.style.height = 'auto'; ta.style.height = ta.scrollHeight + 'px'; };
+    grow();
+    ta.addEventListener('input', grow);
+    let done = false;
+    const finish = (commit) => {
+      if (done) return;
+      done = true;
+      if (commit && ta.value.trim() !== item.titleRaw.trim()) {
+        Kanban.updateItem(board, laneIndex, itemIndex, ta.value);
+        onChange();
+      }
+      render();
+    };
+    ta.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); finish(true); }
+      else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+    });
+    ta.addEventListener('blur', () => finish(true)); // click-away saves
+  }
+
+  function deleteCardWithUndo(laneIndex, itemIndex) {
+    const lane = board.lanes[laneIndex];
+    if (!lane) return;
+    const removed = lane.items[itemIndex];
+    Kanban.deleteItem(board, laneIndex, itemIndex);
+    onChange();
+    render();
+    showUndoToast('Card deleted', () => {
+      // Restore into the same position (clamped, in case the lane shrank).
+      const l = board.lanes[laneIndex];
+      if (!l) return;
+      l.items.splice(Math.min(itemIndex, l.items.length), 0, removed);
+      onChange();
+      render();
+    });
+  }
+
+  let undoTimer = null;
+  function showUndoToast(label, undoFn) {
+    const existing = paneElement.querySelector('.board-undo-toast');
+    if (existing) existing.remove();
+    clearTimeout(undoTimer);
+    const toast = doc.createElement('div');
+    toast.className = 'board-undo-toast';
+    const msg = doc.createElement('span');
+    msg.textContent = label;
+    const btn = doc.createElement('button');
+    btn.type = 'button';
+    btn.className = 'board-undo-btn';
+    btn.textContent = 'Undo';
+    btn.addEventListener('click', () => { clearTimeout(undoTimer); toast.remove(); undoFn(); });
+    toast.appendChild(msg);
+    toast.appendChild(btn);
+    paneElement.appendChild(toast);
+    undoTimer = setTimeout(() => toast.remove(), 6000);
   }
 
   function addComposer(laneIndex) {

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -29,6 +29,13 @@ function ensureStyles(doc) {
     .board-lane-head { display: flex; align-items: center; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); }
     .board-lane-title { font-size: var(--body); font-weight: 600; color: var(--text-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .board-lane-count { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; margin-left: auto; }
+    .board-lane-menu-btn { display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 6px; color: var(--text-2); }
+    .board-lane-menu-btn:hover { color: var(--text-1); background: var(--elevated); }
+    .board-lane-rename { flex: 1; min-width: 0; background: var(--elevated); border: 1px solid var(--accent); border-radius: 6px; color: var(--text-1); font-size: var(--body); font-weight: 600; padding: 3px 8px; outline: none; }
+    .board-lane-popup { position: absolute; z-index: 10; min-width: 180px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.25); display: flex; flex-direction: column; }
+    .board-lane-popup-item { text-align: left; padding: 7px 10px; border-radius: 6px; color: var(--text-1); font-size: var(--body); }
+    .board-lane-popup-item:hover { background: var(--elevated); }
+    .board-lane-popup-item.danger:hover { color: var(--danger, #E85A5A); }
     .board-lane-body { flex: 1; overflow-y: auto; padding: 8px; display: flex; flex-direction: column; gap: 8px; min-height: 8px; }
     .board-card { position: relative; background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; font-size: var(--body); color: var(--text-1); line-height: 1.5; cursor: grab; }
     .board-card:hover { border-color: var(--text-2); }
@@ -148,8 +155,17 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     const count = doc.createElement('span');
     count.className = 'board-lane-count';
     count.textContent = String(lane.items.length);
+    const menuBtn = doc.createElement('button');
+    menuBtn.type = 'button';
+    menuBtn.className = 'board-lane-menu-btn';
+    menuBtn.title = 'List actions';
+    menuBtn.appendChild(iconSvg(doc, ['M12 5.5a.6.6 0 100-1.2.6.6 0 000 1.2', 'M12 12.6a.6.6 0 100-1.2.6.6 0 000 1.2', 'M12 19.7a.6.6 0 100-1.2.6.6 0 000 1.2']));
+    menuBtn.addEventListener('click', (e) => { e.stopPropagation(); openLaneMenu(menuBtn, laneIndex); });
     head.appendChild(title);
     head.appendChild(count);
+    head.appendChild(menuBtn);
+    // Double-click the title to rename in place.
+    title.addEventListener('dblclick', () => renameLaneInline(head, title, laneIndex));
     el.appendChild(head);
 
     const body = doc.createElement('div');
@@ -311,21 +327,90 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     ta.addEventListener('blur', () => finish(true)); // click-away saves
   }
 
-  function deleteCardWithUndo(laneIndex, itemIndex) {
+  // Lane (three-dot) menu: every column operation the serializer supports.
+  // Destructive ones (archive, delete) run through withUndo.
+  let openMenu = null;
+  function closeLaneMenu() { if (openMenu) { openMenu.remove(); openMenu = null; doc.removeEventListener('click', closeLaneMenu); } }
+
+  function openLaneMenu(anchor, laneIndex) {
+    closeLaneMenu();
     const lane = board.lanes[laneIndex];
     if (!lane) return;
-    const removed = lane.items[itemIndex];
-    Kanban.deleteItem(board, laneIndex, itemIndex);
+    const menu = doc.createElement('div');
+    menu.className = 'board-lane-popup';
+    const items = [
+      ['Rename list', () => renameLaneInline(anchor.closest('.board-lane-head'), anchor.closest('.board-lane-head').querySelector('.board-lane-title'), laneIndex)],
+      ['Insert list before', () => { Kanban.insertLane(board, laneIndex, 'New list'); onChange(); render(); }],
+      ['Insert list after', () => { Kanban.insertLane(board, laneIndex + 1, 'New list'); onChange(); render(); }],
+      ['Sort by card text', () => { Kanban.sortLane(board, laneIndex, 'text'); onChange(); render(); }],
+      ['Sort by tags', () => { Kanban.sortLane(board, laneIndex, 'tags'); onChange(); render(); }],
+      ['Archive all cards', () => withUndo('Cards archived', () => Kanban.archiveLaneCards(board, laneIndex))],
+      ['Archive list', () => withUndo('List archived', () => Kanban.archiveLane(board, laneIndex))],
+      ['Delete list', () => withUndo('List deleted', () => Kanban.deleteLane(board, laneIndex))],
+    ];
+    for (const [label, fn] of items) {
+      const row = doc.createElement('button');
+      row.type = 'button';
+      row.className = 'board-lane-popup-item' + (/^(Archive|Delete)/.test(label) ? ' danger' : '');
+      row.textContent = label;
+      row.addEventListener('click', (e) => { e.stopPropagation(); closeLaneMenu(); fn(); });
+      menu.appendChild(row);
+    }
+    const r = anchor.getBoundingClientRect();
+    const host = paneElement.getBoundingClientRect();
+    menu.style.top = (r.bottom - host.top + 4) + 'px';
+    menu.style.left = Math.max(4, r.right - host.left - 180) + 'px';
+    paneElement.appendChild(menu);
+    openMenu = menu;
+    // Close on the next document click (this click is still propagating, so
+    // defer the listener registration by a tick).
+    setTimeout(() => doc.addEventListener('click', closeLaneMenu), 0);
+  }
+
+  function renameLaneInline(head, titleEl, laneIndex) {
+    closeLaneMenu();
+    const lane = board.lanes[laneIndex];
+    if (!lane || head.querySelector('input.board-lane-rename')) return;
+    const input = doc.createElement('input');
+    input.className = 'board-lane-rename';
+    input.value = lane.maxItems ? `${lane.title} (${lane.maxItems})` : lane.title;
+    titleEl.replaceWith(input);
+    input.focus();
+    input.select();
+    let done = false;
+    const finish = (commit) => {
+      if (done) return;
+      done = true;
+      const v = input.value.trim();
+      if (commit && v) { try { Kanban.renameLane(board, laneIndex, v); onChange(); } catch (e) {} }
+      render();
+    };
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+      else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
+    });
+    input.addEventListener('blur', () => finish(true));
+  }
+
+  // Run a destructive mutation with a single-level, in-session undo. Undo
+  // restores a full snapshot of the board taken before the mutation, so it is
+  // correct for card and lane operations alike (the closure's board is
+  // reassigned; getContentForSave serializes whatever board currently is).
+  function withUndo(label, mutate) {
+    const snapshot = Kanban.serialize(board);
+    mutate();
     onChange();
     render();
-    showUndoToast('Card deleted', () => {
-      // Restore into the same position (clamped, in case the lane shrank).
-      const l = board.lanes[laneIndex];
-      if (!l) return;
-      l.items.splice(Math.min(itemIndex, l.items.length), 0, removed);
+    showUndoToast(label, () => {
+      board = Kanban.parse(snapshot);
       onChange();
       render();
     });
+  }
+
+  function deleteCardWithUndo(laneIndex, itemIndex) {
+    if (!board.lanes[laneIndex] || !board.lanes[laneIndex].items[itemIndex]) return;
+    withUndo('Card deleted', () => Kanban.deleteItem(board, laneIndex, itemIndex));
   }
 
   let undoTimer = null;
@@ -404,6 +489,8 @@ export function mountBoardView({ paneElement, content }, Kanban) {
       : () => Kanban.serialize(board),
     setOnChange(cb) { onChange = typeof cb === 'function' ? cb : (() => {}); },
     destroy() {
+      closeLaneMenu();
+      clearTimeout(undoTimer);
       paneElement.classList.remove('viewer-host', 'board-host');
       paneElement.innerHTML = '';
     },

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -132,8 +132,15 @@ export function mountBoardView({ paneElement, content }, Kanban) {
   paneElement.appendChild(scroll);
 
   function render() {
+    // Any board change dismisses a pending undo (withUndo re-shows its toast
+    // AFTER this render), so an Undo can only ever revert the immediately
+    // preceding destructive op, never silently discard later edits.
+    const staleToast = paneElement.querySelector('.board-undo-toast');
+    if (staleToast) staleToast.remove();
     scroll.innerHTML = '';
     board.lanes.forEach((lane, laneIndex) => scroll.appendChild(renderLane(lane, laneIndex)));
+    const oldWarn = paneElement.querySelector('.board-dropped-warn');
+    if (oldWarn) oldWarn.remove(); // never stack banners across renders
     if (board.dropped && board.dropped.length) {
       const warn = doc.createElement('div');
       warn.className = 'board-dropped-warn';

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -1,0 +1,291 @@
+// Kanban board view: renders a markdown board file (frontmatter carries the
+// kanban-plugin key) as columns of cards, and serializes every edit back to
+// byte-compatible markdown through kanban.js. The board view owns no state that
+// is not in the file: the parsed model IS the state, and getContentForSave
+// re-serializes it.
+//
+// Mount contract (shared with the other registry viewers):
+//   mount({ paneElement, path, content }) -> { getContentForSave, destroy }
+// getContentForSave is non-null: the board participates in autosave/Cmd+S like
+// the editor, and the external-edit guard protects concurrent disk changes.
+//
+// This first increment: render (rich card text), drag between columns, add
+// card, checkbox toggle. Lane menus, in-place card editing, collapse, and undo
+// build on this model in follow-ups.
+
+import { renderCardHtml } from './board-markdown.js';
+
+let stylesInjected = false;
+function ensureStyles(doc) {
+  if (stylesInjected) return;
+  stylesInjected = true;
+  const style = doc.createElement('style');
+  style.dataset.rundockBoard = '';
+  style.textContent = `
+    .board-host { padding: 0 !important; display: flex; flex-direction: column; overflow: hidden; }
+    .board-scroll { flex: 1; display: flex; gap: 16px; align-items: flex-start; padding: 20px; overflow-x: auto; overflow-y: hidden; }
+    .board-lane { flex: 0 0 300px; max-height: 100%; display: flex; flex-direction: column; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    .board-lane.drop-target { border-color: var(--accent); }
+    .board-lane-head { display: flex; align-items: center; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); }
+    .board-lane-title { font-size: var(--body); font-weight: 600; color: var(--text-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .board-lane-count { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; margin-left: auto; }
+    .board-lane-body { flex: 1; overflow-y: auto; padding: 8px; display: flex; flex-direction: column; gap: 8px; min-height: 8px; }
+    .board-card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 10px 12px; font-size: var(--body); color: var(--text-1); line-height: 1.5; cursor: grab; }
+    .board-card:hover { border-color: var(--text-2); }
+    .board-card.dragging { opacity: 0.4; }
+    .board-card-row { display: flex; gap: 8px; align-items: flex-start; }
+    .board-card-check { flex: 0 0 auto; margin-top: 2px; width: 15px; height: 15px; cursor: pointer; accent-color: var(--accent); }
+    .board-card-text { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+    .board-card-text.checked { color: var(--text-2); text-decoration: line-through; }
+    .board-card-text a { color: var(--accent); text-decoration: none; }
+    .board-card-text a:hover { text-decoration: underline; }
+    .board-card-text code { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 12px; background: var(--elevated); padding: 1px 4px; border-radius: 4px; }
+    .board-card-drop { height: 2px; margin: -5px 0; border-radius: 2px; background: transparent; }
+    .board-card-drop.active { background: var(--accent); }
+    /* Add-card composer: the standing small-input grammar (field is the input,
+       accent border on focus, circular submit inside, faded when empty). */
+    .board-add { margin: 8px; position: relative; }
+    .board-add-field { width: 100%; display: flex; align-items: flex-start; background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 8px 36px 8px 10px; transition: border-color 0.15s ease; }
+    .board-add-field:focus-within { border-color: var(--accent); }
+    .board-add textarea { flex: 1; resize: none; border: none; background: transparent; color: var(--text-1); font-family: inherit; font-size: var(--body); line-height: 1.5; outline: none; max-height: 160px; }
+    .board-add textarea::placeholder { color: var(--text-2); }
+    .board-add-submit { position: absolute; right: 8px; bottom: 8px; width: 24px; height: 24px; border-radius: 100px; display: flex; align-items: center; justify-content: center; background: var(--border); color: var(--text-2); opacity: 0.6; transition: background 0.15s ease, opacity 0.15s ease; }
+    .board-add-field:focus-within .board-add-submit.ready, .board-add-submit.ready { background: var(--accent); color: #fff; opacity: 1; box-shadow: 0 2px 8px rgba(232,122,90,0.30); }
+    .board-add-open { margin: 4px 8px 8px; padding: 8px 10px; border-radius: 8px; color: var(--text-2); font-size: var(--body); text-align: left; }
+    .board-add-open:hover { background: var(--elevated); color: var(--text-1); }
+    .board-dropped-warn { margin: 8px 20px; padding: 10px 14px; border-radius: 8px; background: rgba(232,168,76,0.12); border: 1px solid rgba(232,168,76,0.35); color: var(--text-1); font-size: var(--caption); }
+  `;
+  doc.head.appendChild(style);
+}
+
+// icon: a small lucide-style plus, inline SVG (24 viewBox, stroke 1.8)
+function plusIcon(doc) {
+  const NS = 'http://www.w3.org/2000/svg';
+  const svg = doc.createElementNS(NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('width', '14');
+  svg.setAttribute('height', '14');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '1.8');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  for (const d of ['M12 5v14', 'M5 12h14']) {
+    const p = doc.createElementNS(NS, 'path');
+    p.setAttribute('d', d);
+    svg.appendChild(p);
+  }
+  return svg;
+}
+
+export function mountBoardView({ paneElement, content }, Kanban) {
+  const doc = paneElement.ownerDocument;
+  ensureStyles(doc);
+  paneElement.innerHTML = '';
+  paneElement.classList.add('viewer-host', 'board-host');
+
+  let board = Kanban.parse(String(content == null ? '' : content));
+
+  // Drag state: {fromLane, fromIndex}. Re-renders are deferred past dragend so
+  // macOS does not play the ~400ms snap-back ghost.
+  let drag = null;
+  let onChange = () => {};
+
+  const scroll = doc.createElement('div');
+  scroll.className = 'board-scroll';
+  paneElement.appendChild(scroll);
+
+  function render() {
+    scroll.innerHTML = '';
+    board.lanes.forEach((lane, laneIndex) => scroll.appendChild(renderLane(lane, laneIndex)));
+    if (board.dropped && board.dropped.length) {
+      const warn = doc.createElement('div');
+      warn.className = 'board-dropped-warn';
+      warn.textContent = `This board contains ${board.dropped.length} line(s) that the board grammar cannot represent. They are preserved on screen but editing here could drop them, so saving is disabled until they are removed in the source.`;
+      paneElement.insertBefore(warn, scroll);
+    }
+  }
+
+  function renderLane(lane, laneIndex) {
+    const el = doc.createElement('div');
+    el.className = 'board-lane';
+    el.dataset.lane = String(laneIndex);
+
+    const head = doc.createElement('div');
+    head.className = 'board-lane-head';
+    const title = doc.createElement('span');
+    title.className = 'board-lane-title';
+    title.textContent = lane.title + (lane.maxItems ? ` (${lane.maxItems})` : '');
+    const count = doc.createElement('span');
+    count.className = 'board-lane-count';
+    count.textContent = String(lane.items.length);
+    head.appendChild(title);
+    head.appendChild(count);
+    el.appendChild(head);
+
+    const body = doc.createElement('div');
+    body.className = 'board-lane-body';
+    lane.items.forEach((item, itemIndex) => {
+      body.appendChild(dropZone(laneIndex, itemIndex));
+      body.appendChild(renderCard(item, laneIndex, itemIndex));
+    });
+    body.appendChild(dropZone(laneIndex, lane.items.length));
+    el.appendChild(body);
+
+    el.appendChild(addComposer(laneIndex));
+
+    // Lane is a drop target for the whole column (drops append to the end when
+    // not over a specific card gap).
+    el.addEventListener('dragover', (e) => {
+      if (!drag) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      el.classList.add('drop-target');
+    });
+    el.addEventListener('dragleave', (e) => {
+      if (!el.contains(e.relatedTarget)) el.classList.remove('drop-target');
+    });
+    el.addEventListener('drop', (e) => {
+      if (!drag) return;
+      e.preventDefault();
+      el.classList.remove('drop-target');
+      commitMove(laneIndex, lane.items.length);
+    });
+    return el;
+  }
+
+  function dropZone(laneIndex, itemIndex) {
+    const z = doc.createElement('div');
+    z.className = 'board-card-drop';
+    z.addEventListener('dragover', (e) => {
+      if (!drag) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.dataTransfer.dropEffect = 'move';
+      z.classList.add('active');
+    });
+    z.addEventListener('dragleave', () => z.classList.remove('active'));
+    z.addEventListener('drop', (e) => {
+      if (!drag) return;
+      e.preventDefault();
+      e.stopPropagation();
+      z.classList.remove('active');
+      commitMove(laneIndex, itemIndex);
+    });
+    return z;
+  }
+
+  function renderCard(item, laneIndex, itemIndex) {
+    const card = doc.createElement('div');
+    card.className = 'board-card';
+    card.draggable = true;
+
+    const row = doc.createElement('div');
+    row.className = 'board-card-row';
+    const check = doc.createElement('input');
+    check.type = 'checkbox';
+    check.className = 'board-card-check';
+    check.checked = item.checked;
+    check.addEventListener('change', () => {
+      Kanban.toggleItem(board, laneIndex, itemIndex);
+      onChange();
+      render();
+    });
+    const text = doc.createElement('div');
+    text.className = 'board-card-text' + (item.checked ? ' checked' : '');
+    text.innerHTML = renderCardHtml(item.titleRaw);
+    row.appendChild(check);
+    row.appendChild(text);
+    card.appendChild(row);
+
+    card.addEventListener('dragstart', (e) => {
+      drag = { fromLane: laneIndex, fromIndex: itemIndex };
+      card.classList.add('dragging');
+      e.dataTransfer.effectAllowed = 'move';
+      try { e.dataTransfer.setData('text/plain', ''); } catch (err) {}
+    });
+    card.addEventListener('dragend', () => {
+      card.classList.remove('dragging');
+      drag = null;
+      // Defer the re-render one frame past dragend so the drop animation
+      // settles (avoids the snap-back ghost).
+      requestAnimationFrame(() => render());
+    });
+    return card;
+  }
+
+  // Move the dragged card to (toLane, toIndex), correcting the target index for
+  // the removal when moving within the same lane below the source.
+  function commitMove(toLane, toIndex) {
+    if (!drag) return;
+    const { fromLane, fromIndex } = drag;
+    let target = toIndex;
+    if (fromLane === toLane && fromIndex < toIndex) target -= 1;
+    if (fromLane === toLane && target === fromIndex) { drag = null; return; }
+    Kanban.moveItem(board, fromLane, fromIndex, toLane, target);
+    drag = null;
+    onChange();
+    render();
+  }
+
+  function addComposer(laneIndex) {
+    const wrap = doc.createElement('div');
+    const openBtn = doc.createElement('button');
+    openBtn.type = 'button';
+    openBtn.className = 'board-add-open';
+    openBtn.textContent = '+ Add a card';
+    wrap.appendChild(openBtn);
+
+    openBtn.addEventListener('click', () => {
+      wrap.innerHTML = '';
+      const field = doc.createElement('div');
+      field.className = 'board-add-field';
+      const ta = doc.createElement('textarea');
+      ta.rows = 1;
+      ta.placeholder = 'Card text';
+      const submit = doc.createElement('button');
+      submit.type = 'button';
+      submit.className = 'board-add-submit';
+      submit.appendChild(plusIcon(doc));
+      field.appendChild(ta);
+      field.appendChild(submit);
+      wrap.className = 'board-add';
+      wrap.appendChild(field);
+      ta.focus();
+      const sync = () => {
+        submit.classList.toggle('ready', ta.value.trim().length > 0);
+        ta.style.height = 'auto';
+        ta.style.height = Math.min(ta.scrollHeight, 160) + 'px';
+      };
+      ta.addEventListener('input', sync);
+      const commit = () => {
+        const v = ta.value.trim();
+        if (v) { Kanban.addItem(board, laneIndex, v); onChange(); }
+        render();
+      };
+      ta.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); commit(); }
+        else if (e.key === 'Escape') { e.preventDefault(); render(); }
+      });
+      submit.addEventListener('mousedown', (e) => { e.preventDefault(); commit(); });
+      ta.addEventListener('blur', () => { if (!ta.value.trim()) render(); });
+    });
+    return wrap;
+  }
+
+  render();
+
+  return {
+    // A board carrying droppable content refuses to save (protect, never
+    // replicate the plugin's silent destruction): a null save opts out of
+    // autosave for this open, exactly like a read-only viewer.
+    getContentForSave: (board.dropped && board.dropped.length)
+      ? null
+      : () => Kanban.serialize(board),
+    setOnChange(cb) { onChange = typeof cb === 'function' ? cb : (() => {}); },
+    destroy() {
+      paneElement.classList.remove('viewer-host', 'board-host');
+      paneElement.innerHTML = '';
+    },
+  };
+}

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -27,6 +27,13 @@ function ensureStyles(doc) {
     .board-lane { flex: 0 0 300px; max-height: 100%; display: flex; flex-direction: column; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
     .board-lane.drop-target { border-color: var(--accent); }
     .board-lane-head { display: flex; align-items: center; gap: 8px; padding: 12px 14px; border-bottom: 1px solid var(--border); }
+    .board-lane-collapse { display: flex; align-items: center; justify-content: center; width: 22px; height: 22px; flex: 0 0 auto; border-radius: 6px; color: var(--text-2); }
+    .board-lane-collapse:hover { color: var(--text-1); background: var(--elevated); }
+    .board-lane.collapsed { flex: 0 0 42px; cursor: pointer; }
+    .board-lane.collapsed .board-lane-head { flex-direction: column; height: 100%; padding: 12px 8px; gap: 12px; border-bottom: none; align-items: center; }
+    .board-lane.collapsed .board-lane-title { writing-mode: vertical-rl; transform: rotate(180deg); white-space: nowrap; overflow: visible; }
+    .board-lane.collapsed .board-lane-count { margin-left: 0; }
+    .board-lane.collapsed .board-lane-menu-btn { display: none; }
     .board-lane-title { font-size: var(--body); font-weight: 600; color: var(--text-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .board-lane-count { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; margin-left: auto; }
     .board-lane-menu-btn { display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 6px; color: var(--text-2); }
@@ -149,13 +156,31 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     }
   }
 
+  function isCollapsed(laneIndex) {
+    const lc = board.settings && board.settings['list-collapse'];
+    return Array.isArray(lc) && lc[laneIndex] === true;
+  }
+
   function renderLane(lane, laneIndex) {
     const el = doc.createElement('div');
-    el.className = 'board-lane';
+    const collapsed = isCollapsed(laneIndex);
+    el.className = 'board-lane' + (collapsed ? ' collapsed' : '');
     el.dataset.lane = String(laneIndex);
 
     const head = doc.createElement('div');
     head.className = 'board-lane-head';
+    // Collapse/expand toggle (a chevron). Persists to list-collapse.
+    const collapseBtn = doc.createElement('button');
+    collapseBtn.type = 'button';
+    collapseBtn.className = 'board-lane-collapse';
+    collapseBtn.title = collapsed ? 'Expand list' : 'Collapse list';
+    collapseBtn.appendChild(iconSvg(doc, collapsed ? ['M9 6l6 6-6 6'] : ['M6 9l6 6 6-6']));
+    collapseBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      Kanban.toggleCollapse(board, laneIndex);
+      onChange();
+      render();
+    });
     const title = doc.createElement('span');
     title.className = 'board-lane-title';
     title.textContent = lane.title + (lane.maxItems ? ` (${lane.maxItems})` : '');
@@ -168,12 +193,19 @@ export function mountBoardView({ paneElement, content }, Kanban) {
     menuBtn.title = 'List actions';
     menuBtn.appendChild(iconSvg(doc, ['M12 5.5a.6.6 0 100-1.2.6.6 0 000 1.2', 'M12 12.6a.6.6 0 100-1.2.6.6 0 000 1.2', 'M12 19.7a.6.6 0 100-1.2.6.6 0 000 1.2']));
     menuBtn.addEventListener('click', (e) => { e.stopPropagation(); openLaneMenu(menuBtn, laneIndex); });
+    head.appendChild(collapseBtn);
     head.appendChild(title);
     head.appendChild(count);
     head.appendChild(menuBtn);
     // Double-click the title to rename in place.
     title.addEventListener('dblclick', () => renameLaneInline(head, title, laneIndex));
     el.appendChild(head);
+
+    // A collapsed lane is a narrow rail: just the head. Clicking it expands.
+    if (collapsed) {
+      el.addEventListener('click', () => { Kanban.toggleCollapse(board, laneIndex); onChange(); render(); });
+      return el;
+    }
 
     const body = doc.createElement('div');
     body.className = 'board-lane-body';

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -117,6 +117,10 @@ function buildFixture() {
   // preserve it verbatim rather than flattening it away.
   fs.writeFileSync(path.join(workspace, 'tagged-board.md'),
     "---\n\nkanban-plugin: board\ntitle: Tagged board\ntags:\n  - project\n  - kanban\n\n---\n\n## To do\n\n- [ ] first card\n- [ ] second card\n\n\n## Done\n\n- [ ] shipped\n\n\n\n\n%% kanban:settings\n```\n{\"kanban-plugin\":\"board\",\"list-collapse\":[false,false]}\n```\n%%");
+  // A dedicated board for the column-reorder test (isolated so other board
+  // tests cannot shift its lane order).
+  fs.writeFileSync(path.join(workspace, 'reorder-board.md'),
+    "---\n\nkanban-plugin: board\n\n---\n\n## Alpha\n\n- [ ] a1\n\n\n## Beta\n\n- [ ] b1\n\n\n## Gamma\n\n- [ ] g1\n\n\n\n\n%% kanban:settings\n```\n{\"kanban-plugin\":\"board\",\"list-collapse\":[false,false,false]}\n```\n%%");
   fs.writeFileSync(path.join(workspace, 'chart.png'), buildPng());
   fs.writeFileSync(path.join(workspace, 'report.pdf'), Buffer.from(
     '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -113,6 +113,10 @@ function buildFixture() {
   // to prove the board registry view renders columns and round-trips bytes.
   fs.writeFileSync(path.join(workspace, 'board.md'),
     "---\n\nkanban-plugin: board\n\n---\n\n## To do\n\n- [ ] Draft the outline\n- [ ] **Review** the brief\n\n\n## Doing\n\n- [ ] Wire the [[Board]] view\n\n\n## Done\n\n- [ ] Ship it\n\n\n\n\n%% kanban:settings\n```\n{\"kanban-plugin\":\"board\",\"list-collapse\":[false,false,false]}\n```\n%%");
+  // A board with block-style frontmatter (a multi-line tag list): a save must
+  // preserve it verbatim rather than flattening it away.
+  fs.writeFileSync(path.join(workspace, 'tagged-board.md'),
+    "---\n\nkanban-plugin: board\ntitle: Tagged board\ntags:\n  - project\n  - kanban\n\n---\n\n## To do\n\n- [ ] first card\n- [ ] second card\n\n\n## Done\n\n- [ ] shipped\n\n\n\n\n%% kanban:settings\n```\n{\"kanban-plugin\":\"board\",\"list-collapse\":[false,false]}\n```\n%%");
   fs.writeFileSync(path.join(workspace, 'chart.png'), buildPng());
   fs.writeFileSync(path.join(workspace, 'report.pdf'), Buffer.from(
     '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -109,6 +109,10 @@ function buildFixture() {
     '<p>A third needle sits far below for the scroll.</p>',
     '</body></html>',
   ].join('\n'));
+  // A canonical Kanban board (frontmatter carries the kanban-plugin key), used
+  // to prove the board registry view renders columns and round-trips bytes.
+  fs.writeFileSync(path.join(workspace, 'board.md'),
+    "---\n\nkanban-plugin: board\n\n---\n\n## To do\n\n- [ ] Draft the outline\n- [ ] **Review** the brief\n\n\n## Doing\n\n- [ ] Wire the [[Board]] view\n\n\n## Done\n\n- [ ] Ship it\n\n\n\n\n%% kanban:settings\n```\n{\"kanban-plugin\":\"board\",\"list-collapse\":[false,false,false]}\n```\n%%");
   fs.writeFileSync(path.join(workspace, 'chart.png'), buildPng());
   fs.writeFileSync(path.join(workspace, 'report.pdf'), Buffer.from(
     '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -542,6 +542,41 @@ test('opening a board changes zero bytes; adding a card persists canonical markd
   expect(saved.endsWith('%%')).toBe(true); // no trailing newline: still canonical
 });
 
+test('a board card edits in place and persists byte-honest markdown', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'board.md');
+  await expect(page.locator('.board-lane')).toHaveCount(3);
+  const card = page.locator('.board-card-text', { hasText: 'Draft the outline' });
+  await card.click();
+  const editor = page.locator('textarea.board-card-edit');
+  await expect(editor).toBeVisible();
+  await editor.fill('Draft the **full** outline');
+  await editor.press('Enter'); // Enter saves
+  await expect(page.locator('.board-card-text strong', { hasText: 'full' })).toBeVisible();
+  // Only that card's line changed; the file stays canonical.
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=board.md')).text()))
+    .toContain('- [ ] Draft the **full** outline');
+  const saved = await (await page.request.get('/api/file?path=board.md')).text();
+  expect(saved.endsWith('%%')).toBe(true);
+});
+
+test('deleting a board card is undoable in-session', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'board.md');
+  const target = page.locator('.board-card', { hasText: 'Ship it' });
+  await target.hover();
+  await target.locator('.board-card-ctl').click();
+  await expect(page.locator('.board-card', { hasText: 'Ship it' })).toHaveCount(0);
+  // Persisted removal...
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=board.md')).text()))
+    .not.toContain('Ship it');
+  // ...but recoverable via the undo toast.
+  await page.locator('.board-undo-btn').click();
+  await expect(page.locator('.board-card', { hasText: 'Ship it' })).toHaveCount(1);
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=board.md')).text()))
+    .toContain('- [ ] Ship it');
+});
+
 test('markdown files still open in the rich editor after the registry shim', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'Roadmap-2026.md');

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -577,6 +577,33 @@ test('deleting a board card is undoable in-session', async ({ page }) => {
     .toContain('- [ ] Ship it');
 });
 
+test('the lane menu renames, inserts, and deletes lists with undo', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'board.md');
+  await expect(page.locator('.board-lane')).toHaveCount(3);
+
+  // Rename the first lane via the menu.
+  await page.locator('.board-lane').first().locator('.board-lane-menu-btn').click();
+  await page.locator('.board-lane-popup-item', { hasText: 'Rename list' }).click();
+  const rename = page.locator('input.board-lane-rename');
+  await expect(rename).toBeVisible();
+  await rename.fill('Icebox');
+  await rename.press('Enter');
+  await expect(page.locator('.board-lane-title', { hasText: 'Icebox' })).toBeVisible();
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=board.md')).text()))
+    .toContain('## Icebox');
+
+  // Insert a list after the first, then delete it with undo.
+  await page.locator('.board-lane').first().locator('.board-lane-menu-btn').click();
+  await page.locator('.board-lane-popup-item', { hasText: 'Insert list after' }).click();
+  await expect(page.locator('.board-lane')).toHaveCount(4);
+  await page.locator('.board-lane').nth(1).locator('.board-lane-menu-btn').click();
+  await page.locator('.board-lane-popup-item', { hasText: 'Delete list' }).click();
+  await expect(page.locator('.board-lane')).toHaveCount(3);
+  await page.locator('.board-undo-btn').click();
+  await expect(page.locator('.board-lane')).toHaveCount(4);
+});
+
 test('markdown files still open in the rich editor after the registry shim', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'Roadmap-2026.md');

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -577,6 +577,34 @@ test('deleting a board card is undoable in-session', async ({ page }) => {
     .toContain('- [ ] Ship it');
 });
 
+test('a later edit dismisses the undo, so undo never discards interim work', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'board.md');
+  // Delete a card: the undo toast appears.
+  const target = page.locator('.board-card', { hasText: 'Ship it' });
+  await target.hover();
+  await target.locator('.board-card-ctl').click();
+  await expect(page.locator('.board-undo-toast')).toBeVisible();
+  // Make an unrelated edit (on a card no other test mutates): the stale undo
+  // is dismissed, so it can never revert this edit away.
+  await page.locator('.board-card-text', { hasText: 'Wire the' }).click();
+  const editor = page.locator('textarea.board-card-edit');
+  await editor.fill('Wire the whole board');
+  await editor.press('Enter');
+  await expect(page.locator('.board-undo-toast')).toHaveCount(0);
+  await expect(page.locator('.board-card-text', { hasText: 'Wire the whole board' })).toBeVisible();
+});
+
+test('block-style frontmatter on a board survives a save', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'tagged-board.md');
+  await expect(page.locator('.board-lane')).toHaveCount(2);
+  // Toggle a checkbox (forces a save) and confirm the block tag list is intact.
+  await page.locator('.board-card-check').first().check();
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=tagged-board.md')).text()))
+    .toContain('tags:\n  - project\n  - kanban');
+});
+
 test('the lane menu renames, inserts, and deletes lists with undo', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'board.md');

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -505,6 +505,43 @@ test('in-view find covers the frontmatter properties panel', async ({ page }) =>
   await expect(page.locator('#tiptap-properties mark.find-match')).toHaveText('Briefing');
 });
 
+test('a kanban board file opens as a column board and renders rich cards', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'board.md');
+  // Detected as a board (not the markdown editor) by its frontmatter key.
+  await expect(page.locator('.board-lane')).toHaveCount(3);
+  await expect(page.locator('#tiptap-editor-pane')).toBeHidden();
+  const lanes = page.locator('.board-lane-title');
+  await expect(lanes.nth(0)).toHaveText('To do');
+  await expect(lanes.nth(1)).toHaveText('Doing');
+  await expect(lanes.nth(2)).toHaveText('Done');
+  // Cards render styled markdown, not raw syntax.
+  await expect(page.locator('.board-card-text strong', { hasText: 'Review' })).toBeVisible();
+  await expect(page.locator('.board-card-text a.board-wikilink', { hasText: 'Board' })).toBeVisible();
+  await page.screenshot({ path: `${SHOTS}/board-view.png` });
+});
+
+test('opening a board changes zero bytes; adding a card persists canonical markdown', async ({ page }) => {
+  await boot(page);
+  const before = await (await page.request.get('/api/file?path=board.md')).text();
+  await openFromTree(page, 'board.md');
+  await expect(page.locator('.board-lane')).toHaveCount(3);
+  // Merely opening a board must not rewrite it.
+  const afterOpen = await (await page.request.get('/api/file?path=board.md')).text();
+  expect(afterOpen).toBe(before);
+  // Add a card to the first lane through the composer.
+  await page.locator('.board-lane').first().locator('.board-add-open').click();
+  await page.locator('.board-lane').first().locator('.board-add textarea').fill('A brand new card');
+  await page.locator('.board-lane').first().locator('.board-add textarea').press('Enter');
+  await expect(page.locator('.board-card-text', { hasText: 'A brand new card' })).toBeVisible();
+  // The new card persists as a canonical markdown line in the To do lane.
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=board.md')).text()))
+    .toContain('- [ ] A brand new card');
+  const saved = await (await page.request.get('/api/file?path=board.md')).text();
+  expect(saved).toContain('## To do\n\n- [ ] Draft the outline\n- [ ] **Review** the brief\n- [ ] A brand new card');
+  expect(saved.endsWith('%%')).toBe(true); // no trailing newline: still canonical
+});
+
 test('markdown files still open in the rich editor after the registry shim', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'Roadmap-2026.md');

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -605,6 +605,21 @@ test('block-style frontmatter on a board survives a save', async ({ page }) => {
     .toContain('tags:\n  - project\n  - kanban');
 });
 
+test('a column collapses to a rail and the state persists to the board file', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'tagged-board.md');
+  const firstLane = page.locator('.board-lane').first();
+  await expect(firstLane).not.toHaveClass(/collapsed/);
+  await firstLane.locator('.board-lane-collapse').click();
+  await expect(firstLane).toHaveClass(/collapsed/);
+  // Persisted into list-collapse (first lane true).
+  await expect.poll(async () => (await (await page.request.get('/api/file?path=tagged-board.md')).text()))
+    .toContain('"list-collapse":[true,false]');
+  // Clicking the collapsed rail expands it again.
+  await firstLane.click();
+  await expect(page.locator('.board-lane').first()).not.toHaveClass(/collapsed/);
+});
+
 test('the lane menu renames, inserts, and deletes lists with undo', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'board.md');

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -647,6 +647,23 @@ test('the lane menu renames, inserts, and deletes lists with undo', async ({ pag
   await expect(page.locator('.board-lane')).toHaveCount(4);
 });
 
+test('the lane menu moves a column right, reordering it in the file', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'reorder-board.md');
+  const titles = () => page.locator('.board-lane-title');
+  const first = (await titles().nth(0).textContent()) || '';
+  const second = (await titles().nth(1).textContent()) || '';
+  await page.locator('.board-lane').first().locator('.board-lane-menu-btn').click();
+  await page.locator('.board-lane-popup-item', { hasText: 'Move list right' }).click();
+  // Order swapped in the UI and in the file heading order.
+  await expect(titles().nth(0)).toHaveText(second);
+  await expect(titles().nth(1)).toHaveText(first);
+  await expect.poll(async () => {
+    const md = await (await page.request.get('/api/file?path=reorder-board.md')).text();
+    return md.indexOf('## ' + second) < md.indexOf('## ' + first);
+  }).toBe(true);
+});
+
 test('markdown files still open in the rich editor after the registry shim', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'Roadmap-2026.md');

--- a/test/fixtures/kanban/backlog.md
+++ b/test/fixtures/kanban/backlog.md
@@ -1,0 +1,762 @@
+---
+
+kanban-plugin: board
+
+---
+
+## Guidance
+
+- [ ] **What goes on the backlog**
+	  A backlog item describes a specific piece of work that could help deliver a roadmap card. It is tactical: you know the problem, you have a proposed approach, and you can write acceptance criteria that tell you when it's done.
+	  Every Ready / In Progress / Done item must link up to exactly one roadmap card. Inbox items can sit unlinked while being triaged.
+- [ ] **Card title format**
+	  Imperative verb, specific scope.
+	  Good: "Gate onboarding orchestrator default behind [WORKSPACE_ANALYSIS] block"
+	  Good: "Port rundock-guide mode-gating fix to scaffold"
+	  Bad: "Fix Doc" (too vague)
+	  Bad: "Specialists need valid parents" (that's a roadmap card)
+- [ ] **Problem statement: pick the format that fits**
+	  **Format A (user story):** use for user-facing work where user and value are the point.
+	  `As a [user type], I want [capability], so that [outcome].`
+	  **Format B (problem statement):** use for platform, infra, or internal work where "as a user" is fiction.
+	  `[Current broken state]. [User-visible consequence]. [Why it matters now.]`
+	  Don't force-fit. Pick whichever makes the problem clearer.
+- [ ] **Card body (required and optional fields)**
+	  Required:
+	  • **Problem:** Format A or Format B above
+	  • **Acceptance criteria:** checklist of observable conditions, not opinions
+	  • **Tags:** must include a `#type/...` tag (see Tagging scheme)
+	  • **Parent:** wikilink to the [[Rundock-Roadmap]] card this item ladders up to. Required for `#type/feature`, optional for `#type/bug`, `#type/hygiene`, `#type/ops` (see Parent rule)
+	  Optional:
+	  • **Approach:** one paragraph on how you plan to solve it
+	  • **Files touched:** rough list, not exhaustive
+	  • **Dependencies:** other backlog items or external blockers
+	  • **Out of scope:** what you're explicitly NOT doing in this item
+	  • **Notes:** technical context, commit hashes, transcript links
+- [ ] **Columns (workflow states)**
+	  **Inbox:** captured, not yet refined. May lack a parent roadmap card. One-liners are fine here.
+	  **Ready:** fully specced against the Definition of Ready below. Parent roadmap card linked. Could be picked up today. Top of column = next to pull.
+	  **In Progress:** actively being worked. Ideally no more than one or two items at a time.
+	  **Done:** work complete, committed to main, awaiting release. Items live here between merge and `npm run release`.
+	  **Shipped:** in a tagged release users can download. Items move here from Done when the release ships. Kept for 30 days, then archived to `04_Archive/`.
+- [ ] **Definition of Ready (INVEST, Bill Wake)**
+	  Before moving an item from Inbox to Ready, it must be:
+	  • **Independent:** can be shipped without waiting on another backlog item, or the dependency is explicit
+	  • **Negotiable:** the approach isn't locked. You could ship a smaller or different version and still address the problem
+	  • **Valuable:** feature work links to a roadmap card so the value is traceable; maintenance work (bug, hygiene, ops) has a clear problem statement and user-visible impact
+	  • **Estimable:** you can t-shirt-size it (xs / s / m / l / xl). If you can't, it needs more shaping
+	  • **Small:** fits in a single work session ideally, one week maximum. Larger means split it
+	  • **Testable:** has acceptance criteria that are observable, not opinions
+- [ ] **Backlog Health Review (DEEP, Roman Pichler)**
+	  Run this monthly. The backlog as a whole should be:
+	  • **Detailed appropriately:** items near the top of Ready are fully specced. Items in Inbox can be one-liners. Don't over-spec what you might never build
+	  • **Emergent:** items change as you learn. Rewriting is normal. Delete items that no longer matter
+	  • **Estimated:** every item in Ready has a size tag
+	  • **Prioritised:** Ready column is ordered top-to-bottom by pull order
+	  Without this review, the backlog rots into an unreadable dumping ground.
+- [ ] **Tagging scheme**
+	  `#type/...` **(required)** feature, bug, hygiene, ops. Governs whether a parent roadmap card is required (see Parent rule).
+	  `#area/...` platform, scaffold, docs, release, onboarding (matches roadmap)
+	  `#size/...` xs, s, m, l, xl (t-shirt, not story points)
+	  `#priority/...` p1, p2, p3
+	  `#status/blocked` optional flag beyond column (use sparingly)
+- [ ] **Parent rule**
+	  Every `#type/feature` item in Ready / In Progress / Done must link to exactly one roadmap card via `[[Rundock-Roadmap]]` wikilink. `#type/bug`, `#type/hygiene`, and `#type/ops` items can stand alone without a parent: maintenance work flows through the backlog without needing strategic framing. Inbox items can be unlinked regardless of type.
+	  If a feature item has no viable parent, either archive it or promote its underlying idea to a new roadmap card first. If a string of related bug fixes or hygiene items reveals a pattern worth tracking strategically, that's a signal to create a roadmap card and retro-link the existing items to it.
+- [ ] **Example card (Format B, no parent, copy and adapt)**
+	  **Preserve blank line after Unreleased heading promotion**
+	  **Problem:** When `promoteUnreleasedChangelog` in `scripts/release.js` promotes `## Unreleased` to a versioned heading, the Name line is stripped but the trailing blank line is consumed with it, leaving the new heading adjacent to the body paragraph with no blank line between them. 0.8.4 shipped with a manual post-hoc fix. Every release cut requires the same manual touch-up until this is corrected.
+	  **Approach:** Adjust the regex in `promoteUnreleasedChangelog` to preserve one blank line between the new heading and the body. Self-contained, roughly 5 lines.
+	  **Acceptance criteria:**
+	  - [ ] Running the release script produces changelog output with exactly one blank line between the new versioned heading and the body paragraph
+	  - [ ] No manual edit required post-release
+	  **Files touched:** `scripts/release.js`
+	  #type/bug #area/release #size/xs #priority/p2
+- [ ] **Example card (Format A, with parent, copy and adapt)**
+	  **Show a completion toast when an agent is saved**
+	  **Parent:** [[Rundock-Roadmap#specialists-land-on-the-org-chart-with-a-valid-parent]]
+	  **Problem:** As a Rundock user creating a new agent, I want a visible confirmation when the save completes, so that I know the action succeeded without having to refresh the sidebar.
+	  **Acceptance criteria:**
+	  - [ ] A toast appears within 500ms of a successful SAVE_AGENT marker
+	  - [ ] The toast includes the new agent's display name
+	  - [ ] No toast appears on SAVE_AGENT failure (error surfaces in chat instead)
+	  #type/feature #area/platform #size/s #priority/p2
+
+
+## Inbox
+
+- [ ] **Requests: transfer the Edition surface into Rundock (GATED: Liam deems the Edition experiment ready)**
+	  **Problem:** The self-improving-team mechanism needs a workspace-level approval surface: one inbox where loop and agent proposals arrive, carry attributed human verdicts, and land in an append-only decision ledger. This exists and is live-proven as Edition (standalone, outside the repo; the RA1 eval's steer-approvals and rejection rendered as an auditable Decided trail with zero UI-owned state). Rundock's spend-governance positioning card is gated on this feature existing in-product.
+	  **Approach (the transfer is pre-engineered; see the CC1 spec's build-reality note):** reimplement `lib/host-adapter.js` against Rundock's server (`.rundock/` stores, Files-viewer links, session links); mount Edition's client and API routes as a Rundock view; `lib/store.js`, `lib/ledger.js`, and the Edition client transfer untouched; the masthead shell and personal-OS queue registry retire; on completion the Edition repo decommissions (ledgers, staging contracts, and the spec carry everything that compounded).
+	  **Contract alignment (binding):** the verdict/handback payload aligns with the one interaction language used by the file-level review loop (shipped 0.10.0) and the FV2 batch-verdict surface, so file, batch, and workspace approvals share one primitive.
+	  **Dependencies:** HARD: Liam's validated-in-use readiness verdict on Edition: BAR SET 2026-07-16: Edition runs as the daily driver through end of July; if it holds up (decisions keep flowing, the inbox is not abandoned), the gate opens 2026-08-01. Also: the dispatcher extraction with ledger-ready attributed events (quiet-cycle phase 2); the FV2 file-type registry (mount point). Sequence after both.
+	  **Tags:** #type/feature #area/platform #size/l #priority/p2
+	  **Notes:** Carded 2026-07-16 by Dev from Liam's integration question. Spec of record: CC1-Command-Centre-Spec (Personal-OS specs) including the transfer/decommission terms; positioning card "Integrate spend-governance positioning" (this backlog) is gated on THIS card shipping and being validated in use.
+- [ ] **Codex-only workspaces: run a full team without Claude Code installed**
+	  **Problem:** Rundock requires Claude Code even for users who only have a ChatGPT plan: the orchestrator and Doc are enforced onto the Claude runtime (by design: Codex exec has no Agent tool, so a Codex orchestrator cannot route), and onboarding assumes Claude Code. A ChatGPT-only user cannot run Rundock at all today, which caps the addressable audience of the two-runtime story.
+	  **Approach (to be shaped after the app-server protocol card lands):** the protocol integration gives Codex processes real tool round-trips, which removes the technical barrier to Codex orchestration. Then: lift the orchestrator/platform runtime enforcement behind a capability check (orchestration allowed on any runtime that supports tool round-trips), give Doc a runtime-appropriate spawn path, make first-run onboarding runtime-aware (detect what is installed; guide Codex-only users through codex login instead of the Claude wizard), and sweep the Claude-Code assumptions out of scaffolds/base rules conditionally.
+	  **Test-coverage pairing (Liam, 2026-07-14):** delivering this is the moment to level up coverage of the surface it touches: orchestration/delegation paths per runtime, onboarding flows, and runtime detection E2E. Coordinate with the client test coverage stages 2-3 cards so the new paths land tested rather than retrofitted.
+	  **Acceptance criteria (draft):**
+	  - [ ] A machine with Codex signed in and NO Claude Code runs onboarding, creates a team, converses, and delegates end to end
+	  - [ ] Runtime enforcement replaced by a capability model with tests per agent type x runtime
+	  - [ ] Mixed workspaces unchanged; Claude-only workspaces unchanged
+	  - [ ] New orchestration-per-runtime surface covered by unit + E2E tests at the levels the coverage cards define
+	  **Dependencies:** [[Rundock-Backlog#Ready|Integrate Codex via the app-server protocol]] (hard); client test coverage stages 2-3 (coordination).
+	  **Tags:** #type/feature #area/platform #size/l #priority/p2
+	  **Notes:** Requested by Liam 2026-07-14 after the orchestrator-runtime enforcement landed (c5c2567). Deliberately Inbox until the protocol card ships: the design space (can Doc be Codex? which onboarding flow?) is not shapeable before that. NOT a duplicate of the Ready onboarding story: that one onboards honestly WITHIN the Claude-orchestrator constraint; this card removes the constraint (boundary recorded on both cards 2026-07-16).
+- [ ] **Address open review comments with one click (Done-Reviewing gate)**
+	  **Problem:** As a user who has left comments on a reviewed file, I want one action that hands the open comments to an agent to address and resolve, so that closing out a review does not require composing a chat message. NOTE (2026-07-16, Liam + Dev correction): the substantive loop is ALREADY SHIPPED: suggestion verdicts apply to the document immediately with the markup removed, and agents act on comments today via a plain chat ask (live-proven on both runtimes with zero integration code). This card is the remaining convenience affordance only, plus recording who applied what.
+	  **Acceptance criteria:**
+	  - [ ] A reviewed file with open comments offers one action that sends it to an agent; the agent addresses the comments, resolves the threads, and the who-decided/who-applied trail is recorded
+	  **Tags:** #type/feature #area/editor #size/s #priority/p3
+	  **Notes:** The deferred Done-Reviewing gate from the review loop's initial ship. Deliberately Inbox: the manual loop works well; pull this when review volume makes the chat ask feel like friction.
+- [ ] **Distinguish auto-approved low-risk commands from a silently absent permission hook**
+	  **Problem:** The client auto-approves low-risk read-only commands with no card (by design), but from the user's seat that is indistinguishable from a broken hook failing open: command runs, nothing shown. This exact ambiguity cost a diagnostic detour during Windows testing (2026-07-14): a genuinely dead hook looked "fixed" because commands ran.
+	  **Approach (negotiable):** a subtle "auto-approved: read-only" annotation on the tool chip/activity summary for hook-approved low-risk commands, so the healthy path is visibly different from the broken one.
+	  **Tags:** #type/ux #size/xs
+	  **Notes:** Captured 2026-07-14 (Dev, from the Windows permission-hook investigation).
+- [ ] **Permission card copy robustness: heading fallback for shell keywords, purpose line, auto-allow bare date**
+	  **Problem:** (1) The permission-card heading parser takes the command's first token, so compound commands and shell keywords produce nonsense headings ("Run for" for a for-loop, observed 2026-07-13 when an agent looped `date`). (2) Bare read-only `date`/`Get-Date` variants could arguably auto-allow like other low-risk reads; agents mint timestamps constantly for review annotations.
+	  **Approach:** heading falls back to a generic "Run shell command" + one-line purpose (from the tool description field when present); extend the low-risk list with bare date variants after checking the classifier's anchoring.
+	  **Tags:** #type/ux #size/xs
+	  **Notes:** Both flagged during FV1 round 8 (2026-07-13); re-confirmed worth doing during the Windows pass.
+- [ ] **File the Codex CLI sandbox-subcommand issue upstream (rewritten)**
+	  **Problem:** `codex sandbox windows --full-auto -- <cmd>` mis-parses its arguments (tries to execute the literal word "windows"; `CreateProcessAsUserW failed: 2`), which produced a false "ARM64 sandbox broken" diagnosis during Windows testing. The sandbox itself works; the diagnostic subcommand is what fails. A silent-downgrade warning for `codex exec --sandbox workspace-write` on unconfigured Windows is worth requesting in the same issue.
+	  **Approach:** rewrite [[Codex-Windows-ARM-Sandbox-Issue-Draft]] around the subcommand repro (drop the broken-sandbox framing), Liam files from his account.
+	  **Tags:** #type/ops #size/xs
+	  **Notes:** Captured 2026-07-14 (Dev).
+- [ ] **Make Skill view selection unambiguous when the same slug exists in both skill roots**
+	  **Problem:** `discoverSkills` (server.js:4303-4306) scans both `System/Playbooks/<slug>/PLAYBOOK.md` and `.claude/skills/<slug>/SKILL.md`, and both records get `id = dir.name`. `selectSkill(id)` (public/app.js) does `skills.find(x => x.id === id)`, so when a slug exists in both roots the sidebar shows two identical entries and clicking EITHER selects the first record (the Playbooks-sourced one). The `.claude/skills` copy is unviewable until the duplicate is removed. Observed 2026-07-08 during the PS1 playbook-to-skill pilot (`writing-critique` present in both roots mid-migration).
+	  **Approach (negotiable):** key skill records by `source + slug` (e.g. `id = sourceLabel + '/' + slug`), and/or render a source badge on duplicate names so the two entries are distinguishable.
+	  **Acceptance criteria:** with the same slug in both roots, the sidebar entries are visually distinguishable and each opens its own record (verified by differing body content); no regression for single-source skills.
+	  **Tags:** #type/bug #size/xs
+	  **Notes:** Found by Dev during PS1 (see `Liam-Agent-Workspace/01_Projects/Fable-Testing-July-2026/PS1-Playbook-To-Skill-Migration-Completion.md`). Low urgency: the migration protocol keeps duplicate windows short, and the state disappears entirely once the playbook folder retires post-migration.
+- [ ] **Integrate spend-governance positioning into site, docs, and deck materials (GATED: Requests/self-improving-teams feature set built and validated in use)**
+	  **Parent:** [[Rundock-Roadmap#the-team-improves-itself-with-the-operators-approval]] (this card is that epic's success signal made public)
+	  **Problem:** Rundock's marketing surfaces do not yet carry its strongest differentiator against the always-on/autonomous class (OpenClaw, Hermes): deterministic-free sensing plus approval-gated execution means every token spent traces to an attributed human decision. Liam endorsed this positioning 2026-07-07; it must not ship as words before the feature ships as fact.
+	  **Approach:** When the gate clears, update rundock.ai (positioning sections, compare pages), docs.rundock.ai, and the standing deck/one-pager sources with the line "your team improves for free and spends only when you say so", grounded in the shipped ledger and tier mechanics. Sources: [[CC1-Command-Centre-Spec]] Addenda 7 to 9 and the RS1 positioning note (`Self-Improving-Teams-Positioning-Note.md`) once RS1 has run.
+	  **Acceptance criteria:** site, docs, and deck sources updated with consistent language; claims match shipped behaviour exactly; compare-page contrasts cite verifiable mechanics.
+	  **Tags:** #type/ops
+	  **Notes:** Captured 2026-07-07 during the CC1 design sessions (Dev). Deliberately not actioned now.
+- [ ] **Coverage-areas tool uses anchor-based ranges, not hardcoded line numbers**
+	  **Problem:** `test/tools/coverage-areas.js` maps coverage to functional areas using hardcoded `server.js` line ranges. Any change that shifts line numbers (as the 0.9.2 bug-fix work did) makes the per-area figures misreport; the overall and delegation-engine numbers stay reliable, the other rows drift.
+	  **Approach:** Resolve each area's line range by matching function signatures / anchor comments at runtime instead of fixed line numbers, so the per-area report stays correct as the file changes.
+	  **Notes:** Surfaced 2026-07-03 during the 0.9.2 test-suite work.
+	  #type/hygiene #area/dx #size/s #priority/p3
+	  **Problem:** Doc's scaffolding currently creates a default orchestrator named Ted, role Team Lead (order 0). The Lean Agent Team lead magnet and Liam's own Personal OS both use a Chief of Staff named Cos. Shipping a different default orchestrator across the ecosystem is inconsistent, and "Chief of Staff" is the stronger, more aspirational framing for the principal-and-team model. Aligning Doc's default to Cos / Chief of Staff makes the ecosystem consistent and spreads the "Cos = AI chief of staff" coinage.
+	  **Acceptance criteria:**
+	- [ ] Decision recorded: keep Ted / Team Lead, or switch the scaffold default orchestrator to Cos / Chief of Staff
+	- [ ] If switching: Doc scaffolds the default orchestrator as name `chief-of-staff`, displayName `Cos`, role `Chief of Staff`, type `orchestrator`, order 0
+	- [ ] The displayName naming convention (name contains the role acronym or a key part of the role) is documented if adopted
+	  **Notes:** Raised 2026-06-02 from the Lean Agent Team lead magnet work (uses Cos / Cleo / Bea). See [[01_Projects/Lean-Agent-Team/build-plan.md]]. Parent to assign at refinement (onboarding / scaffold).
+	  #type/feature #area/scaffold #size/xs #priority/p3
+- [ ] **Add project folders to the conversation sidebar for grouping related conversations**
+	  **Parent:** [[Rundock-Roadmap#users-organise-conversations-into-themed-projects]]
+	  **Problem:** As a Rundock user working on multiple distinct themes at once (a client, a product, a research area), I want to group related conversations into named folders in the sidebar so that conversations on the same theme live together rather than being interleaved chronologically with unrelated work. Raised by beta user James Compton 2026-04-24: "Rundock could benefit from project folders which consists of chats that can be with different agents, so the project is a theme".
+	  **Approach:** Minimal v1 modelled on the existing collapsible "Previous" section pattern. Sidebar gains user-created named folders rendered at the top, above the Pinned section (per Des's ordering model in [[Sidebar-Ordering-Findings]], Projects sit above Pinned). Each folder is independently collapsible. A conversation belongs to at most one folder — when moved into a folder it leaves the Active / Pinned / Done flat list entirely and appears only inside the folder. Folder creation and conversation-move both flow through a right-click context menu on the conversation row ("Move to folder → [existing folders] / New folder…"). Folder rename and delete flow through a right-click menu on the folder header. Folder-delete only works when the folder is empty; non-empty deletes surface a message asking the user to move conversations out first. Folder state (name, ordered member list, collapsed/expanded) persists to the existing `.rundock/` workspace metadata so it survives reloads and workspace switches.
+	  **Acceptance criteria:**
+	  - [ ] A user can create a named folder via the conversation-row context menu ("Move to folder → New folder…")
+	  - [ ] Created folders render at the top of the sidebar, above the Pinned section, each as an independently collapsible section matching the visual pattern of the existing "Previous" section
+	  - [ ] A conversation moved into a folder leaves the Active / Pinned / Done flat list and appears only inside the folder
+	  - [ ] A conversation belongs to at most one folder at any time
+	  - [ ] A user can rename a folder via the folder-header context menu
+	  - [ ] A user can delete a folder via the folder-header context menu, but only when the folder is empty; non-empty deletes surface a message asking the user to move conversations out first
+	  - [ ] A user can move a conversation out of a folder via the conversation-row context menu ("Move to folder → None" or equivalent); the conversation returns to the Active list
+	  - [ ] Folder membership, names, order, and collapsed/expanded state persist to `.rundock/` workspace metadata and survive a page reload and a workspace switch
+	  - [ ] Folders containing a conversation with an active agent or an unread message surface an indicator on the collapsed folder header (dot for unread, pulsing indicator for active) so the user sees that something needs attention without expanding
+	  - [ ] Empty folders (zero conversations) render with a subtle empty state rather than disappearing from the sidebar
+	  - [ ] No regression to the Pinned / Active / Done ordering model from the sidebar-ordering card — folders sit above, ordering within Active / Pinned / Done applies only to conversations not inside any folder
+	  **Files touched:** `public/app.js` (sidebar render, context menus, folder state), `server.js` (folder CRUD endpoints, `.rundock/` metadata persistence, folder-aware conversation enrichment on workspace load). Possibly a new small module for folder data management if the folder state grows complex enough to warrant it.
+	  **Out of scope:** Multi-folder membership (a conversation in two or more folders). Nested folders. Drag-and-drop conversation moves — context menu only for v1; drag-drop can be added later if users ask. Project-level context, brief, or settings injected into agents inside the folder. Project-scoped agents. Sharing a folder between workspaces or users. Any agent-level awareness of the folder structure — folders are purely a UI grouping construct.
+	  **Dependencies:** Works alongside [[Rundock-Backlog#rework-sidebar-ordering-so-pinned-active-and-unread-conversations-surface-predictably]]. If the sidebar ordering card ships first, project folders are layered on top of the three-section model with no rework. If this card ships first, the sidebar ordering card operates on the set of conversations not inside any folder. Either order works; no hard blocker either way.
+	  **Notes:** Raised 2026-04-24 by beta user James Compton. Scoped with Liam 2026-04-24: single-folder membership, context menu interaction (not drag-drop), folders sit above Pinned, deletes require empty first, no project-level context or settings. These are deliberate v1 simplifications — richer behaviours (multi-membership, project briefs, drag-drop) can land as future cards if demand emerges.
+	  #type/feature #area/platform #size/m #priority/p2
+- [ ] **Fix agent and skill instructions being clipped in the profile instructions view**
+	  **Problem:** The instructions panel on agent and skill profile pages cuts off content mid-sentence. The underlying `.md` files are complete and unmodified. The bug is a rendering or parsing issue in the UI: special characters in the instructions (likely square brackets, markdown constructs, or code fences) cause the renderer to stop early. Observed live during the Lucas Simonian beta session (2026-04-30): Scout's instructions displayed "Core Ideas Ke" and nothing after. Confirmed by Liam on the call: "It's cut off at a certain point. My hunch is there's a square bracket or something. It's not showing in this view but it should still be there in the file."
+	  **Acceptance criteria:**
+	  - [ ] Agent and skill instructions render in full in the profile view regardless of whether the content contains square brackets, markdown code fences, wikilinks, or other special characters
+	  - [ ] No truncation occurs on any instruction file present in the Lucas Simonian workspace or the Rundock scaffold defaults
+	  - [ ] If content genuinely exceeds a display limit, a clear "Show more" affordance is present rather than a silent hard cut
+	  **Files touched:** `public/app.js` (instructions rendering path in `showProfile` or equivalent profile render function).
+	  **Notes:** Surfaced during Lucas Simonian beta session, 2026-04-30. See [[03_Resources/Granola/Notes/2026-04-30 - 30 Min Meeting (Lucas Simonian __ Liam Darmody)]] for session context. Transcript timestamp approx. 14:56.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [ ] **Gate scaffold folder creation behind a workspace emptiness check**
+	  **Problem:** When a user opens an existing workspace that already has a folder structure, Doc's onboarding flow proposes (or executes) adding the default Rundock folder scaffold. This should only happen for empty directories or brand-new workspaces. Observed live during the Lucas Simonian beta session (2026-04-30): Lucas opened his existing well-organised Obsidian vault. Doc identified the structure correctly but then proposed adding folders to it anyway. Liam's reaction on the call: "I can see there's an issue here with Doc who's now identified your workspace and given you some folders to get started with. But in your case you've already got a good file structure." Users with existing vaults should not have scaffold folders imposed on them.
+	  **Acceptance criteria:**
+	  - [ ] Scaffold folder creation is skipped when the target workspace already contains a non-trivial folder structure (at minimum, more than a `.claude/` directory or one or two files)
+	  - [ ] Doc's onboarding conversation in an existing workspace does not propose adding default Rundock folders unless the workspace is effectively empty
+	  - [ ] New and empty workspaces continue to receive the full scaffold as today
+	  - [ ] The workspace analysis step correctly distinguishes empty/new from pre-existing structured workspaces before surfacing scaffold suggestions
+	  **Files touched:** `server.js` (workspace analysis and scaffold trigger logic), `scaffold/rundock-guide.md` (onboarding instructions that govern when Doc proposes folder creation).
+	  **Notes:** Surfaced during Lucas Simonian beta session, 2026-04-30. See [[03_Resources/Granola/Notes/2026-04-30 - 30 Min Meeting (Lucas Simonian __ Liam Darmody)]] for session context. Transcript timestamp approx. 14:00. Related: the existing `isEmpty` and `scaffoldError` fields on the `workspace_ready` payload (see Bundle workspace-open card) suggest server-side emptiness detection already exists in some form. Check whether `isEmpty` can gate the scaffold proposal directly.
+	  #type/bug #area/scaffold #size/s #priority/p2
+- [ ] **Bundle workspace-open into a single workspace_ready server push**
+	  **Problem:** When the server replies to `set_workspace` (or surfaces an existing workspace via the initial `workspaces` message), the client immediately fires four sequential WebSocket round-trips: `get_agents`, `get_files`, `get_skills`, `get_conversations` (`public/app.js:3056-3059`). The server already knows everything required to compute these payloads at the moment it sets the workspace. The round-trip pattern adds avoidable latency to every workspace open, and the slowest reply (`get_conversations`, which now reads JSONLs across delegated agents to compute `messageCount` since 0.8.8) gates when the conversations sidebar can render. The picker-sequencing fix removes the visible artefact but not the underlying load time.
+	  **Approach:** Server: in the `set_workspace` handler (and the initial workspace bootstrap path that emits `workspaces` with a `current` value) enumerate agents, files, skills, and conversations in parallel server-side, then push a single `workspace_ready` message containing all four payloads alongside the existing `analysis`, `workspaceMode`, `isEmpty`, `scaffoldError`, and `setupComplete` fields. Client: route the bundled payload through the existing `handleAgents`, `handleFiles`, `handleSkills`, and `handlePersistedConversations` functions without changing their contracts. Drop the four `ws.send` calls in `onWorkspaceReady`. Keep the standalone `get_*` message handlers in place: they remain in use by skills lazy-load, file refresh after save, and other non-workspace-open paths.
+	  **Acceptance criteria:**
+	  - [ ] Selecting a workspace produces exactly one server-to-client message carrying agents, files, skills, conversations, analysis, workspaceMode, isEmpty, scaffoldError, and setupComplete (verifiable in the browser DevTools network pane)
+	  - [ ] After the bundled message arrives, the client renders the team, conversations sidebar, skills (when the panel is first opened), and files tree with no further server round-trips during the workspace-open sequence
+	  - [ ] Time from `set_workspace` send to first conversation row painted in the sidebar is measurably lower than the four-round-trip baseline; record before/after timings in the change summary
+	  - [ ] First-launch flow (server has a workspace from env var or last-selection) uses the same single-push payload — no separate code path
+	  - [ ] Reconnecting to the same workspace preserves in-memory conversations and the active view (the `isSameWorkspace` branch in `onWorkspaceReady` works with the bundled payload)
+	  - [ ] Standalone `get_agents`, `get_files`, `get_skills`, `get_conversations` messages still work for any non-workspace-open code path that depends on them
+	  - [ ] Empty / new workspace flow (Path C, setup conversation) still routes correctly with the bundled payload
+	  - [ ] No regression to scaffold writes, workspace mode auto-detection, or active-process reconciliation on workspace open
+	  **Files touched:** `server.js` (`set_workspace` handler, workspace bootstrap path that builds the initial `workspaces` message, likely a shared `buildWorkspaceReadyPayload` helper). `public/app.js` (`onWorkspaceReady` drops the four `ws.send` calls; message dispatcher routes `workspace_ready` through the existing handlers).
+	  **Out of scope:** Optimising the `messageCount` enrichment itself — if profiling shows it dominates the bundled-payload assembly time, file a separate card. Reworking the agents/skills/files parsing or persistence model. Partial / streamed payloads (do not ship "agents now, conversations later"; this card delivers the full bundle in one push).
+	  **Dependencies:** No hard blocker, but only delivers user-visible benefit once [[Rundock-Backlog#hide-the-workspace-picker-immediately-on-selection-so-it-doesnt-linger-as-the-workspace-loads]] has shipped — without that, the visible picker hang masks any latency improvement here.
+	  **Notes:** Surfaced 2026-04-30 alongside the picker-sequencing investigation. The four-round-trip pattern dates back to when workspace switching was first added and was never revisited; the `messageCount` enrichment in 0.8.8 made the conversations reply slower and put the cost on the user-visible critical path. Sits in Inbox (not Ready) because the picker fix should land first; specced now so it can be pulled the moment the picker fix ships and we measure the residual delay.
+	  #type/hygiene #area/platform #size/m #priority/p3
+- [ ] **Users upload images into agent conversations**
+	  **Problem:** As a Rundock user working with an agent on visual context (design review, debugging a screenshot, reading a whiteboard photo, explaining an error dialog), I want to paste, drop, or pick an image into the chat input and have the agent receive and reason about it, so that I do not have to describe the image in text or switch tools to work with visual content. First raised by a beta user 2026-04-19.
+	  **Approach:** Two stages with a spike gate.
+	  *Stage 0 — Input-channel spike (½ day):* Confirm which Claude Code input channel actually carries images. Try two options in a throwaway sandbox: (a) write the image to a temp file under the conversation's workspace and reference its path inside the existing stream-json `content` text (e.g. `[image: /path/to/foo.png]`) and let the CLI read from disk; (b) extend the stream-json stdin payload with proper multimodal content blocks (`{ type: 'image', source: { type: 'base64', media_type: ..., data: ... } }`) and see if the CLI accepts them. Deliverable: one working "agent describes an uploaded image" round-trip, plus a one-paragraph note on which channel to use for Stage 1.
+	  *Stage 1 — Implementation (~3 days):* Frontend gets file-picker button, paste handler, and drag-drop on the chat input. Attached images show as thumbnail previews in the input area with a remove button before send. Message object gains an optional `attachments: [{ type: 'image', dataUrl, filename, mime, bytes }]` field. Server accepts attachments in the `chat` WebSocket payload and routes them to Claude Code via the channel chosen in Stage 0. User bubble renders the image in chat. Sidebar-preview strippers handle messages whose text content is only an image by falling back to a sensible placeholder (e.g. `[image]`).
+	  **Acceptance criteria:**
+	  - [ ] Stage 0 spike output documented: the chosen input channel plus one working round-trip where an agent correctly answers "what do you see" for an uploaded image
+	  - [ ] User can attach an image via (a) file-picker button, (b) paste into the chat textarea, (c) drag-drop onto the chat input
+	  - [ ] Attached image renders as a thumbnail preview in the input area before send, with a remove button that clears it
+	  - [ ] On send, the image renders in the user's message bubble
+	  - [ ] The agent receives the image and can reason about it, for both the orchestrator and specialists, with no per-agent wiring
+	  - [ ] The image and its message survive a page reload and re-opening the conversation from the sidebar (persistence round-trip)
+	  - [ ] Sidebar preview for a conversation whose last message is an image renders a sensible text fallback rather than empty or broken content
+	  - [ ] Non-image file drops (PDF, txt, etc.) are rejected with a clear inline message — not silently accepted
+	  - [ ] No regression to text-only conversations: a normal text message still dispatches with no attachment plumbing in the payload
+	  **Files touched:** `server.js` (WebSocket `chat` handler, stream-json stdin payload construction, possible temp-file write), `public/app.js` (chat input UI, paste/drop handlers, attachment state, message rendering, sidebar-preview strippers), `public/index.html` (file input element, thumbnail preview container in the chat-input block), conversation persistence path (attachment serialisation).
+	  **Out of scope:** Video upload. Non-image file upload (PDFs, docs) — separate future card. Image generation by agents (different outcome entirely). Automatic image compression / resizing (revisit if large images cause perf issues). Multi-image drag-drop in a single message (start with one attachment per message; add multi later if users ask).
+	  **Dependencies / notes:** Not yet linked to a roadmap card. Features in Ready must link up per the Parent rule, so before this moves out of Inbox, either (1) a new roadmap outcome like *"Users share rich content with agents in conversation"* gets created and this card links to it, or (2) this stays in Inbox. Claude Code is multimodal at the model level (Opus / Sonnet / Haiku are all multimodal) so the capability exists; the open question is the stream-json CLI input shape, which Stage 0 answers. If the spike shows neither channel works cleanly, resize this card or split it further.
+	  #type/feature #area/platform #size/m #priority/p2
+- [ ] **Device Sync two-machine spike**
+	  **Parent:** [[Rundock-Roadmap#teams-use-rundock-together]]
+	  **Problem:** As a Rundock user exploring multi-device and multi-user workflows, I want a time-boxed experiment that proves or disproves whether Device Sync via a user-owned sync service is a viable path to multi-user Rundock, so that we know whether to invest in the full architecture or retire the card before building anything.
+	  **Approach:** Pick one sync layer (Dropbox is fastest to set up; git is cleanest for conflict handling). Build the minimum assembly engine needed: a script that reads an `Agents/`, `Skills/`, `Knowledge/` directory structure and produces a working `.claude/` directory. Set up a shared sync folder containing this structure on two machines. Run two scenarios: (1) one person edits different files on different machines and reloads; (2) two people edit the same agent file within a few minutes of each other. Observe conflict behaviour, secrets handling, and live session state. Capture findings in a spike report.
+	  **Acceptance criteria:**
+	  - [ ] Assembly engine stub exists and successfully rebuilds `.claude/` from source directories on both machines
+	  - [ ] Scenario 1 (non-conflicting edits) produces the expected result on both machines with no manual intervention
+	  - [ ] Scenario 2 (concurrent same-file edits) is executed and the outcome documented (conflict file, silent overwrite, git merge conflict, whatever happens)
+	  - [ ] Spike report written covering: concurrent-edit behaviour, secrets strategy (shared vs per-machine), whether session JSONL files can sync safely or must stay local, recommended next step (promote to full build, retry with a different sync layer, retire the card)
+	  - [ ] Timeboxed to one work session. If the assembly engine alone takes longer, stop and document why.
+	  **Out of scope:** Production-quality assembly engine. Multi-user access control. Team routines. Anything that isn't "does this architecture survive first contact with two machines and two people".
+	  **Notes:** Gate for promoting [[Rundock-Roadmap#teams-use-rundock-together]] from Later to Next. If findings are positive, the full Device Sync backlog gets written. If findings are negative, the card retires and teams fall under [[Rundock-Roadmap#interactive-remote-access-to-rundock-from-anywhere]]. Sits in Inbox (not Ready) because the parent card is in Later and the spike is not yet pulled.
+	  #type/feature #area/platform #size/s #priority/p3
+- [ ] **Add routing coverage audit to surface unroutable skills and stale triggers**
+	  **Problem:** As a Rundock operator maintaining a workspace over time, I want a tool that parses `CLAUDE.md` and the orchestrator agent file for delegation rules and surfaces problems (unroutable skills, triggerless agents, stale triggers, references to agents that no longer exist), so that I can catch routing drift before it causes silent failures in specialist handoff.
+	  **Approach:** Parse `CLAUDE.md` and the orchestrator agent file for the delegation table and any trigger mappings. Cross-reference against the actual `Agents/` and `Skills/` directories. Surface: (1) skills with no trigger in the delegation table, (2) agents with no trigger, (3) triggers pointing at agents or skills that don't exist, (4) duplicate triggers. Output: a report. Not an interactive UI: a command or vault-lint-style report is enough.
+	  **Acceptance criteria:**
+	  - [ ] Audit runs against a workspace and produces a report listing the four problem categories
+	  - [ ] Report has zero false positives against a clean workspace
+	  - [ ] Audit handles both `CLAUDE.md` and direct agent-file inspection
+	  - [ ] Runnable as a command (vault-lint pattern acceptable)
+	  **Notes:** Spec: [[Workspace-Audit-v2]]. Demoted from old Roadmap Later column 2026-04-15: this is developer tooling, not a strategic outcome, so it stands alone as a `#type/ops` item rather than ladder under a roadmap card. Sits in Inbox rather than Ready because it's not currently the next thing to pull.
+	  #type/ops #area/platform #size/m #priority/p3
+- [ ] **Routines-as-compute end-to-end spike**
+	  **Parent:** [[Rundock-Roadmap#rundock-runs-scheduled-work-while-im-away]]
+	  **Problem:** As a Rundock user exploring always-on automations, I want a time-boxed experiment that proves or disproves whether Claude Code Routines can credibly back a "scheduled Rundock automation" feature, so that we know whether to invest in the Routines-backed architecture or fall back to a server-based scheduler.
+	  **Approach:** Pick one Rundock workspace. Create a shadow GitHub repo containing `CLAUDE.md`, `.claude/skills/`, `.claude/agents/`, and the relevant context files (ICP, voice profile, rules). Manually create a single daily-briefing routine on claude.ai pointed at this repo. Fire it once via the `/fire` API trigger to validate the auth token flow. Schedule it daily for seven days. Choose one result-delivery path (Slack via MCP connector, shadow repo commit, or session URL check) and confirm results arrive for all seven days. Document real daily run caps, setup friction, and any research-preview gotchas encountered.
+	  **Acceptance criteria:**
+	  - [ ] Shadow repo exists and contains enough workspace context for the routine to behave as if it were running inside Rundock
+	  - [ ] `/fire` endpoint triggers the routine and returns a valid `session_id` / `session_url`
+	  - [ ] The routine fires on schedule for seven consecutive days, producing usable output each day
+	  - [ ] Results reach an observable channel without manual intervention each day
+	  - [ ] Real daily run cap is documented for the account tier used (Pro / Max / Team)
+	  - [ ] Spike report written covering: setup friction story (end-to-end time and steps), run cap findings, result-delivery path chosen and why, observed failure modes, recommended next step (promote to full build, retry with different result-delivery path, retire the card)
+	  **Out of scope:** Automated routine creation (the research confirms no API exists). Programmatic output capture. Multi-user routine management. Anything that isn't "prove one routine runs reliably for a week against real workspace context".
+	  **Notes:** Gate for promoting [[Rundock-Roadmap#rundock-runs-scheduled-work-while-im-away]] from Later to Next. References [[Routines-as-Cloud-Compute]] research. If findings are positive, the full Routines-backed automation backlog gets written. If research-preview risk or run caps prove prohibitive, the scheduled-work case falls under [[Rundock-Roadmap#interactive-remote-access-to-rundock-from-anywhere]]. Sits in Inbox (not Ready) because the parent card is in Later and the spike is not yet pulled.
+	  #type/feature #area/platform #size/m #priority/p3
+- [ ] **Capture routine output to a recoverable per-run log or conversation**
+	  **Problem:** `executeRoutine` at `server.js:894` spawns Claude Code with stdout and stderr piped but nothing reads them. The model's response, tool calls, and tool results are never captured into a Rundock conversation, transcript, or file. Only `lastRun`, `status`, and `duration` are recorded. Routines that write files via Bash or update external systems via MCP are fine because the side effects live in those tools. Routines that ask the agent to "summarise the week" produce output nobody can recover, even though the run completed successfully.
+	  **Approach:** Two options. (a) Write stdout to a per-run log file under `.rundock/routine-logs/` keyed by routine slug and timestamp. (b) Auto-create a Rundock conversation under the agent for each run, with the model output rendered as the agent's reply. Option (b) is the better UX (output appears in the same UI as ad-hoc conversations) but more complex; pick during spec.
+	  **Acceptance criteria:** Dev to write before moving to Ready. Anchors: model output from a routine run is recoverable by the user after the run completes; output is attributed to the agent that ran the routine; the user can find a routine's output without inspecting server logs.
+	  **Files touched:** `server.js` (executeRoutine and surrounding scheduler functions), possibly conversation persistence path, possibly `public/app.js` if surfaced in UI.
+	  **Notes:** Surfaced in the ROUTINES.md audit, 2026-04-29.
+	  #type/bug #area/platform #size/s #priority/p2
+- [ ] **Add cron expression support to schedule parser plus validate unrecognised formats**
+	  **Problem:** `parseRoutines` at `server.js:785` accepts any string as the schedule. `getNextRun` at `server.js:851` only recognises `every day at HH:MM` and `every <weekday> at HH:MM` with strict lowercase weekday and zero-padded time. Cron expressions like `0 5 * * *`, hours without leading zero like `every day at 9:00`, and weekday shorthand like `every weekday at 18:00` all parse fine and silently never fire. No warning, no log line. Users have no way to know a routine is dead. Anthropic's Claude Code Routines support cron natively, so users moving between tools hit two different mental models.
+	  **Approach:** Two parts. (a) Validate at parse time. If the schedule string does not match a recognised format, log a warning and surface the routine in the UI as "schedule not understood" so the user can fix it. (b) Extend `getNextRun` to accept cron expressions in standard 5-field format. Use a battle-tested library (cron-parser or node-cron). Preserve existing human-readable strings unchanged.
+	  **Acceptance criteria:** Dev to write before moving to Ready. Anchors: cron-format schedules parse and fire correctly; existing human-readable strings continue to work; unrecognised formats produce a warning and surface as misconfigured in UI; ROUTINES.md updated to reflect cron support.
+	  **Files touched:** `server.js` (parseRoutines, getNextRun), possibly `public/app.js` (UI for misconfigured routines), `02_Areas/Rundock/Specs/Rundock-ROUTINES.md`.
+	  **Notes:** Surfaced in the ROUTINES.md audit, 2026-04-29. Aligning with Anthropic's schedule mental model reduces user friction across tools.
+	  #type/bug #area/platform #size/m #priority/p3
+- [ ] **Add per-routine HTTP webhook trigger with bearer-token auth**
+	  **Problem:** Anthropic's Claude Code Routines provide a per-routine bearer-token endpoint that accepts a freeform `text` body for run-specific context. External systems (alerting tools, monitoring, CI pipelines, Slack, Granola) can fire a saved prompt with live data merged in. Rundock has no equivalent: routine prompts are static once saved. Routines can react to timers but not to events. This means Rundock cannot be the home for any automation that needs to respond to external triggers.
+	  **Approach:** Add a local HTTP endpoint per routine, addressed by routine slug. POST with a `text` body merges the body into the routine prompt at fire time (template substitution or similar). Authentication via a per-routine bearer token, generated at routine creation, surfaced in the UI for the user to copy and use externally. Rotation supported.
+	  **Acceptance criteria:** Dev to write before moving to Ready. Anchors: each routine has a unique HTTP endpoint visible in the UI; POST with `text` body fires the routine with body merged into prompt; bearer-token auth prevents unauthorised triggers; failed auth returns a clean error; the user can rotate the token if compromised.
+	  **Files touched:** `server.js` (HTTP endpoint, routine fire path, auth), `public/app.js` (UI for endpoint URL and token rotation), routine state schema (token storage).
+	  **Notes:** Surfaced in the ROUTINES.md audit, 2026-04-29. Loosely models Anthropic Routines `/fire` endpoint pattern. Differentiator: this fires in the user's local agent team with full workspace context, where Anthropic's fires in their managed environment with repo-bound context. Genuinely complementary, not redundant.
+	  **Dependencies / notes:** No roadmap parent yet. Per the parent rule, before this moves out of Inbox either a new roadmap card like "Routines react to events, not just timers" gets created and this card links to it, or this stays in Inbox. Worth promoting to a roadmap card if the feature value is confirmed.
+	  #type/feature #area/platform #size/m #priority/p3
+- [ ] **Audit agent files for inline-array skills: declarations that parse to empty**
+	  **Problem:** `parseSkills` at `server.js:816` only matches the YAML block form for the `skills:` array. The inline flow-style array `skills: [a, b]` parses to an empty array. Agents that declare skills inline appear to Rundock to have no skills, even though the file looks correct to the human author. There is no warning at load time. Existing agent files in the rundock repo, in the rundock-managed workspace, and in any reference workspaces may contain inline declarations that have been silently empty.
+	  **Approach:** Two parts. (a) Audit existing agent files in the workspace at `.claude/agents/*.md` and in the rundock repo. Convert any inline-array `skills:` declarations to block form. (b) Optionally extend `parseSkills` to handle inline arrays, OR add a parse-time warning when inline form is detected so future authors get told.
+	  **Acceptance criteria:** Dev to write before moving to Ready. Anchors: every agent file in the rundock-managed workspace and the rundock repo uses block-form `skills:`; either inline form is supported, or a warning fires on parse when inline form is detected; agents created via Doc do not produce inline form.
+	  **Files touched:** `server.js` (parseSkills); various agent files in the workspace and rundock repo.
+	  **Notes:** Surfaced in the SKILLS.md audit, 2026-04-29.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [ ] **Decide and document per-skill allowed-tools direction**
+	  **Problem:** The skill frontmatter parser at `server.js:3638` reads only `name` and `description` from skill files. Other fields (`allowed-tools`, `model`, etc.) are ignored, even though Claude Code's broader skill format documents them. SKILLS.md currently documents the current behaviour as final. The roadmap question: should Rundock parse and forward `allowed-tools` per skill so a skill can restrict its own tool surface, or is the workspace-mode-only model the intended design? Open.
+	  **Approach:** Decision first, implementation second. Two paths. (a) Commit to the current "all tooling at agent level" model. Update SKILLS.md to mark this as deliberate design rather than a parser limitation. (b) Extend the parser to read `allowed-tools` (and possibly `model`) per skill. Forward to Claude Code at spawn. Document the new behaviour in SKILLS.md and ARCHITECTURE.md. Trade-off: (a) is simpler, keeps the workspace-mode model intact; (b) gives skill authors finer control and aligns with Claude Code's documented skill format.
+	  **Acceptance criteria:** Decision recorded in an ADR or directly in SKILLS.md. If (b), parser extended, agent spawn args updated to forward, and docs reflect new behaviour (both source `SKILLS.md` and the public `docs.rundock.ai/reference/skill-file-format` page). If (a), SKILLS.md explicitly notes the current behaviour is intentional design and the public skill-file-format page is updated to match.
+	  **Files touched:** `02_Areas/Rundock/Specs/Rundock-SKILLS.md` (always); `02_Areas/Rundock/Docs/reference/skill-file-format.md` (vault source; always, must mirror the SKILLS.md decision); `~/Documents/Projects/rundock-docs/reference/skill-file-format.mdx` (production renderer-target; always, promoted from the vault source); `server.js` (parseSkillFrontmatter and spawn args, only if option b); potentially `02_Areas/Rundock/Specs/Rundock-ARCHITECTURE.md` and a CONTRIBUTING note or ADR.
+	  **Notes:** Surfaced in the SKILLS.md audit, 2026-04-29. The decision affects how SKILLS.md reads (resigned acceptance vs deliberate design). Public docs path added 2026-05-04: any change to the source-of-truth SKILLS.md must propagate to the public `skill-file-format` reference page so docs.rundock.ai stays accurate.
+	  #type/ops #area/platform #size/s #priority/p3
+- [ ] **View and edit Excalidraw files in the file viewer (Obsidian Excalidraw plugin parity)**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a Rundock user who keeps diagrams and sketches as Excalidraw files in my workspace, I want to open, view, and edit `.excalidraw` files directly in Rundock with an experience similar to the Obsidian Excalidraw plugin, so that I can work with my drawings natively instead of switching to Obsidian or excalidraw.com. Today, `.excalidraw` files have zero handling: they fall through to the legacy text path and display as raw JSON.
+	  **Approach:** Add a new branch to the file-type routing in `loadFileContent()` for the `.excalidraw` extension that mounts an embedded Excalidraw canvas instead of the text editor. Excalidraw files are JSON documents (`{ type: "excalidraw", version, elements, appState, files }`); the official `@excalidraw/excalidraw` component reads and writes exactly this shape, so the canvas loads the parsed JSON and serialises edits back to the same format on save. This is a contained, self-isolated viewer/editor that shares nothing with Tiptap. Note: `@excalidraw/excalidraw` is a React component, which is net-new for a vanilla-JS frontend; a spike must confirm how to mount it (scoped React island in a container, or the lighter-weight standalone export/render path) without pulling a build step into the project. The Obsidian Excalidraw plugin is the UX target: open to a live editable canvas, full draw tools, edits persist back to the `.excalidraw` file in a format Obsidian's plugin also reads.
+	  **Acceptance criteria:**
+	  - [ ] Opening a `.excalidraw` file renders an interactive Excalidraw canvas showing the existing drawing, not raw JSON
+	  - [ ] The user can edit the drawing (add, move, delete, restyle elements) using standard Excalidraw tools
+	  - [ ] Edits persist back to the `.excalidraw` file as valid Excalidraw JSON that the Obsidian Excalidraw plugin and excalidraw.com both open without corruption (round-trip safe)
+	  - [ ] A new or empty `.excalidraw` file opens to a usable blank canvas
+	  - [ ] The Excalidraw surface is isolated from the rest of the app and does not regress markdown (Tiptap), HTML, or other non-markdown file handling
+	  - [ ] Spike output documents the React-mounting decision (how `@excalidraw/excalidraw` is loaded into the vanilla-JS frontend without a build step) before full implementation
+	  **Files touched:** `public/app.js` (`loadFileContent` routing branch, Excalidraw mount/unmount lifecycle, save serialisation), `public/index.html` (canvas container), a new Excalidraw viewer module, `public/vendor/` (Excalidraw bundle), possibly `server.js` if `.excalidraw` needs different read/write normalisation than plain text.
+	  **Notes:** Research 2026-06-05 (Dev). **Tiptap question, confirmed: this does NOT use the Tiptap rich markdown editor.** There are zero references to Excalidraw, canvas, or drawing formats anywhere in the codebase today, and `.excalidraw` files currently get no special handling. Tiptap is a markdown editor (`.md` / `.mdx` only, `html: false`) and cannot host a drawing canvas; this needs a fully separate embedded viewer/editor added as a new branch in the `loadFileContent()` if-chain (no file-type registry exists). The format target is Excalidraw JSON (`.excalidraw`); the UX target is the Obsidian Excalidraw plugin's live-canvas editing experience. Larger and higher-risk than the HTML card because of the React-component-in-vanilla-JS mounting question and the canvas/save lifecycle: recommend a time-boxed spike on the mount approach before committing to full build. Size and exact scope to be confirmed at shaping.
+	  #type/feature #area/platform #size/l #priority/p3
+
+
+## Ready
+
+- [ ] **Audit Obsidian markdown syntax parity in the rich editor and card the gaps**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a user who edits the same vault in Rundock and Obsidian interchangeably, I want to know that every Obsidian syntax construct either renders correctly in Rundock or at minimum survives a save untouched, so that using Rundock never degrades my files or hides my content. Callouts and frontmatter wikilinks were found as live gaps by daily friction; the rest of the surface (embeds `![[...]]`, highlights `==text==`, comments `%%...%%`, block references `^id`, tags, footnotes, task lists, maths, mermaid, strikethrough) has never been systematically checked.
+	  **Acceptance criteria:**
+	  - [ ] A parity matrix covering every construct in Obsidian's syntax reference (https://obsidian.md/help/syntax and https://studio-obsidian.com/obsidian-markdown-guide/) with three verdicts per construct: renders correctly / renders wrong / unsupported-but-round-trips
+	  - [ ] Round-trip safety verified BY TEST for every construct, including unsupported ones: opening and saving a file using any construct changes zero bytes (a rendering gap is acceptable; corruption never is)
+	  - [ ] Each renders-wrong gap becomes a prioritised backlog story, ordered by real vault usage, with Liam choosing the order
+	  **Approach:** build the matrix as a fixture corpus in the editor round-trip harness (one file per construct family), so the audit's artefact IS the regression suite.
+	  **Tags:** #type/hygiene #area/editor #size/s #priority/p2
+	  **Notes:** Raised by Liam 2026-07-16 while hardening the Kanban interchangeability requirement; generalises the callouts card's origin story into a systematic sweep.
+- [ ] **Render Obsidian callouts and make frontmatter wikilinks clickable in the editor**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a user whose vault files use Obsidian callouts and frontmatter wikilinks (my daily briefing is built from them), I want them to render in Rundock the way they do in Obsidian, so that I can read and work with my own files without switching apps.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] A file with `> [!note]`, a collapsible `> [!abstract]+`, and a nested `> > [!warning]-` shows titled admonition boxes with working expand/collapse, and no literal `[!type]` or `+`/`-` characters
+	  - [ ] The live morning briefing renders with its labelled sections intact, matching Obsidian
+	  - [ ] A `related:` frontmatter list of wikilinks is clickable and navigates to the resolved files; unresolvable links look visibly dead rather than erroring
+	  - [ ] Byte-for-byte round-trip holds: opening and saving a callout-heavy file changes nothing
+	  **Approach:** two independent tasks (callout parser; frontmatter link resolution), built directly against the editor round-trip harness. Prior shaping in the 2026-07-15 card notes.
+	  #type/feature #area/editor #size/m #priority/p2
+- [ ] Test new KANBAN board card
+	- [ ] Overall client line coverage at least doubles from the 30.9% baseline and the ratchet (never goes down) is recorded
+	  #type/hygiene #area/platform #size/m #priority/p1
+- [ ] **Organise conversations with Lists so related work stays together**
+	  **Parent:** [[Rundock-Roadmap#users-organise-conversations-into-themed-projects]]
+	  **Problem:** As a user running many conversations across agents, I want to group them into named lists shown as sidebar pills (the way WhatsApp organises chats), so that work on one theme stays together instead of interleaving chronologically with everything else.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] I can create a list, name it, and add any conversation to it from the conversation's context menu; a conversation can belong to several lists
+	  - [ ] Lists appear as pills beside All and Unread; selecting one filters the sidebar to its conversations, pinned-first ordering unchanged
+	  - [ ] Lists survive reload and workspace switches
+	  - [ ] Removing a list never deletes conversations
+	  **Approach:** list/filter logic lands as a stage-2-style tested module. Shaping decision vs the project-folders Inbox card recorded here: Lists is the first iteration; folders decision follows usage.
+	  **Dependencies:** ideally after the client extraction lands (module pattern); not blocked by it.
+	  #type/feature #area/platform #size/m #priority/p2
+- [ ] **First-run onboarding detects both runtimes and sets users up honestly**
+	  **Parent:** [[Rundock-Roadmap#users-run-their-team-on-whichever-ai-subscription-they-already-have]]
+	  **Problem:** As a new user arriving with a ChatGPT plan (with or without a Claude subscription), I want first-run to detect what I have and guide me through what I need (set up Codex for my specialists; explain plainly that the orchestrator needs Claude Code today), so that the "works with your ChatGPT subscription" promise survives my first ten minutes.
+	  **Boundary (2026-07-16):** this story works WITHIN today's architecture: Claude Code remains required for the orchestrator and this flow says so honestly. Removing that requirement entirely is the separate, gated "Codex-only workspaces" card (Inbox), which depends on the Codex protocol story above. First iteration vs endgame; not duplicates.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] First-run detects installed runtimes and adapts: a Codex-signed-in machine is not told to install Claude Code as step one with no explanation of why
+	  - [ ] A ChatGPT-plan user finishes first-run with Codex set up for specialists and a truthful, specific statement of what Claude Code is still needed for, without leaving the app for documentation
+	  - [ ] Settings and onboarding tell one consistent runtime story
+	  **Approach:** shaped in [[R6.2-Codex-First-Onboarding-Handoff]]. CURRENCY NOTE (2026-07-16): that handoff predates 0.10.0; the executing session reconciles it against shipped reality first (runtime status detection, the Windows sandbox guidance, the enforced Claude-only orchestrator, the two-runtime base rules) and records deltas in its run notes. Copy honesty rules from the 0.10.0 docs sweep apply (never claim wizard support that does not exist).
+	  #type/feature #area/onboarding #size/m #priority/p2
+- [ ] **Edit frontmatter properties in the panel without touching raw YAML**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a user viewing a file's properties panel, I want to edit values there (text, lists, wikilinks, dates), so that updating metadata does not require switching to raw markdown or to Obsidian.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] Text, list, and wikilink property values are editable in the panel and persist correctly to the file's YAML
+	  - [ ] Invalid edits cannot corrupt the frontmatter (the file still parses; body editing unaffected)
+	  - [ ] Byte-honest saves: editing one property changes only that property
+	  #type/feature #area/editor #size/m #priority/p2
+- [ ] **Warn before overwriting a file that changed outside Rundock**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a user who edits the same vault in Rundock and Obsidian (the interchangeable workflow the Kanban story makes binding), I want Rundock to notice when a file changed on disk since it was opened and ask before overwriting, so that auto-save can never silently destroy edits I made elsewhere.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] Editing a file in Obsidian while it is open in Rundock, then typing in Rundock, produces a visible choice (reload theirs / keep mine) instead of a silent overwrite
+	  - [ ] Agent edits to open files surface the same way
+	  - [ ] No prompt when nothing external changed (zero false positives in normal use)
+	  #type/feature #area/editor #size/m #priority/p2
+- [ ] **Review agent-produced HTML files with inline comments agents can act on**
+	  **Parent:** [[Rundock-Roadmap#the-team-improves-itself-with-the-operators-approval]]
+	  **Problem:** As a user whose agents produce HTML deliverables (proposals, slides, designs), I want to view them faithfully in Rundock and leave comments anchored to what I see, so that an agent can execute my feedback without me switching apps or describing locations by hand.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] An HTML file in the workspace renders faithfully (sandboxed) instead of showing source
+	  - [ ] I can leave a comment anchored to a passage; the comment is stored openly (file-native or sidecar) and an agent can read it, act on it, and resolve it
+	  - [ ] Verdict/handback payloads use the same shape as the shipped file-level review loop, so one interaction language spans inline, batch, and (later) inbox review
+	  **Approach:** design-complete: [[FV2-Design]] (file-type registry + sandboxed viewer; registry seam already in code), [[Review-And-Feedback-Loop-Spec]] phases 1-2, batch-verdict surface per the proven c1 pattern. Roughdraft is the live prototype: mine it, don't rebuild it.
+	  **Dependencies:** none hard; registry swap lands after the client extraction merges.
+	  #type/feature #area/editor #size/l #priority/p2
+- [ ] **Open images and PDFs in Rundock, including from wikilinks in conversations**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a user whose workspace contains images and PDFs (agent-generated or dropped in via Finder), I want clicking them, in the file tree or as a wikilink in a conversation, to show the actual image or document, so that I never have to leave Rundock to look at my own files.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] Clicking an image in the file tree shows the image; clicking a PDF shows a readable document view
+	  - [ ] Clicking a wikilink to an image or PDF in a CONVERSATION opens it the same way (agents reference their outputs by wikilink; those links must not be dead ends)
+	  - [ ] Unsupported binary types degrade gracefully (clear "cannot preview" state, never raw bytes)
+	  - [ ] No upload mechanism in scope: the workspace is a local folder; Finder is the upload mechanism
+	  **Approach:** file-type registry views (the registry ships with the HTML-review card above); wikilink resolution already exists for markdown targets and extends to these types.
+	  **Dependencies:** the file-type registry (HTML-review card). Same lane; same delivery plan.
+	  **Tags:** #type/feature #area/editor #size/m #priority/p2
+- [ ] **Persist routine state so restarts cannot double-fire scheduled work**
+	  **Problem:** Routine last-run state lives in memory, so a restart after a routine has fired can fire it again (duplicate morning briefings observed). The common exposure is the DESKTOP quit-and-reopen pattern, not long-running servers: any user who reopens Rundock later the same day is in the window. Deprioritised 2026-07-16 (Liam): the routine-using population is small today; grows with the scheduled-work roadmap outcome.
+	  **Acceptance criteria:**
+	  - [ ] A routine that ran, followed by a restart inside the same window, does not run again (pinned by test)
+	  - [ ] State survives in `.rundock/` alongside other workspace state
+	  #type/bug #area/platform #size/s #priority/p2
+- [ ] **Manage markdown Kanban boards inside Rundock (Obsidian Kanban parity)**
+	  **Parent:** [[Rundock-Roadmap#users-edit-knowledge-inline-without-switching-to-obsidian]]
+	  **Problem:** As a user who runs backlogs and roadmaps as Obsidian Kanban boards (this backlog is one), I want Rundock to render and edit them as real boards, so that managing my work does not require Obsidian.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] A `kanban-plugin: board` markdown file opens as a column board; cards drag between columns; edits persist to markdown
+	  - [ ] BINDING (Liam, 2026-07-16): full format interchangeability with the Obsidian Kanban plugin: the exact same structure and syntax, so one board file is edited in Rundock and Obsidian alternately with neither app breaking the other's features (checkboxes, card metadata, archive section, settings block)
+	  - [ ] The BACKLOG FILE ITSELF round-trips: open in Rundock, move a card, open in Obsidian, move a card back, nothing broken and no formatting churn in the diff
+	  **Approach (two-step, deliberate):** (1) reverse-engineer the plugin's format as research: the docs (https://publish.obsidian.md/kanban/Obsidian+Kanban+Plugin) and the source (https://github.com/obsidian-community/obsidian-kanban), covering the frontmatter settings block, column/card syntax, archive handling, and any metadata the plugin round-trips; then a standalone local prototype against a COPY of this backlog file answers the drag/persistence questions, validated by alternating edits between the prototype and Obsidian; (2) the Rundock build lands as a registry view AFTER the HTML-review card ships the file-type registry (building it earlier means building it twice).
+	  **Dependencies:** the file-type registry (HTML-review card above). Deliberately last in this column.
+	  #type/feature #area/platform #size/l #priority/p3
+
+
+## Test Before
+
+- [ ] **Queue a follow-up that races an in-flight handoff instead of losing it**
+	  **Problem:** A message sent in the moment an agent handoff is completing can be written to a dying process and lost, or clear a committed handback. Rare, but when it happens the user's message silently vanishes: the worst failure mode a chat product has.
+	  **Acceptance criteria:**
+	  - [ ] A message sent during any kill/handback window is delivered to the restored process and answered, never dropped (pinned by an integration test that fires the race deliberately)
+	  **Approach:** small state machine in the kill-window path; folds into the dispatcher extraction above (same layer, same motion).
+	  #type/bug #area/platform #size/s #priority/p2
+- [ ] **Extract the conversation state machine as the WS dispatcher, with contract fixtures shared with the server**
+	  **Spec:** [[Client-Test-Coverage-Spec]] (stage 3 of 3) · **Delivery plan:** [[R10-Rundock-Quiet-Cycle-Handoff]] phase 2 (one paired effort with the protocol story above)
+	  **Problem:** The client's multi-agent orchestration experience (who is working, who joined, who resumed, which events are stale, which turns are silent) is a several-hundred-line untested switch. It is the layer users watch when they "watch delegation happen", and the layer this month's client bugs lived in. A server/client divergence in the delegation protocol is currently only catchable by a human noticing the UI misbehave.
+	  **Acceptance criteria:**
+	  - [ ] The per-conversation state machine is a reducer ((state, message) -> state + effects) unit-tested per message family, including the full delegation sequences (join, stale-done suppression, silent park, resume)
+	  - [ ] The server's stub-runtime delegation sequences run as table-driven CLIENT tests from one shared fixture corpus: a protocol divergence is a failing test
+	  - [ ] Dispatcher events carry enough to attribute and log a decision (the enabler for [[Rundock-Roadmap#the-team-improves-itself-with-the-operators-approval]])
+	  - [ ] Zero behaviour change per commit (full suite + e2e green)
+	  - [ ] Folded hygiene (was a separate Inbox card): the 'info' system subtype's session-clearing side effect is audited and side-effect-free senders move to 'notice'; designed-path done-suppression logs stop logging at warn level; notice pills render wikilinks as links
+	  #type/hygiene #area/platform #size/l #priority/p1
+- [ ] **New card (with added text) + more added text**
+	*New italic text here*
+	And standard text here
+
+
+## In Progress
+
+- [ ] **Upgrade Electron from 39 to 42 to clear the dependency-security audit cluster**
+	  **Problem:** `npm audit` reports a cluster of advisories rooted in the packaged Electron version. Users are not directly exposed today, but every fresh contributor install prints security warnings, and the gap widens with each Electron release. Deferred from the 0.10.0 train ("wrong moment for a runtime bump"); the quiet cycle is the right moment.
+	  **Acceptance criteria:**
+	  - [ ] `npm audit` reports zero advisories from the Electron cluster
+	  - [ ] Full suite + e2e green; a locally built packaged app launches and stays alive (the 0.10.0 packaging lesson: this change class breaks packaging silently)
+	  - [ ] Auto-update from a 0.10.0 install to a build on the new Electron works
+	  #type/hygiene #area/release #size/s #priority/p1
+
+
+## Test after
+
+- [ ] **Extract the client's decision logic into unit-tested modules (palette, conversation list, markers, permissions)**
+	  **Spec:** [[Client-Test-Coverage-Spec]] (stage 2 of 3) · **Delivery plan:** [[R10-Rundock-Quiet-Cycle-Handoff]] phase 1
+	  **Problem:** app.js is 4,401 lines at 30.9% test coverage, and it holds logic users feel directly: this is where the vanishing-short-reply bug and the stale focus ring shipped from. It also holds the permission/risk classification the trust page's claims rest on, unfindable by anyone accepting the licence's "audit it" invitation. New client logic lands untestable by default until this is done.
+	  **Acceptance criteria:**
+	  - [ ] Palette, conversation-list, marker-scanning, and permission/risk logic live in ES modules unit-tested at 90%+ lines, with zero behaviour change (full suite + e2e green before and after every extraction commit)
+	  - [ ] The permissions module is findable by name and documents the auto-allow policy it implements
+	  - [ ] Overall client line coverage at least doubles from the 30.9% baseline and the ratchet (never goes down) is recorded
+	  #type/hygiene #area/platform #size/m #priority/p1
+
+
+## Done
+
+- [ ] **Codex agents stream, approve, and cancel like Claude agents on every platform**
+	  **Parent:** [[Rundock-Roadmap#users-run-their-team-on-whichever-ai-subscription-they-already-have]]
+	  **Problem:** As a user running specialists on my ChatGPT plan, I want their replies to stream live, every command and file write to ask my permission individually where no sandbox protects me, and cancel to stop them instantly, so that a Codex teammate is as trustworthy and responsive as a Claude one.
+	  **Acceptance criteria (user-observable):**
+	  - [ ] A Codex agent's reply renders progressively as it is produced, not all at once at the end of the turn
+	  - [ ] On Windows without the native sandbox, a Codex agent running a shell command or writing a file produces a permission card for THAT action; deny stops it, approve runs it
+	  - [ ] Pressing stop on a streaming Codex turn halts output within a second and the conversation accepts the next message normally
+	  - [ ] A Codex conversation resumed after a Rundock restart retains its context
+	  - [ ] The write-request card flow shipped in 0.10.0 no longer exists as a separate mechanism (its behaviour is subsumed by per-action approvals)
+	  **Approach:** integrate via Codex's app-server protocol; design record [[Codex-Windows-Writes-F-vs-E]] ("Option E"); delivery plan [[R10-Rundock-Quiet-Cycle-Handoff]] phase 2, including the runtime adapter contract that makes a third runtime additive.
+	  **Dependencies:** the client decision-logic extraction above (same message layer; sequence, don't overlap). Windows live pass requires Liam's VM.
+	  #type/feature #area/platform #size/l #priority/p1
+
+
+## Shipped
+
+- [x] **Update repo README, About, site, and docs for Codex availability** — SHIPPED in 0.10.0 (2026-07-14)
+	  All surfaces on the two-runtime story with one canonical description ("Works with your Claude or ChatGPT subscription"): GitHub About (Liam), README (runtimes section, Node 22 correction, per-runtime security section), CHANGELOG Codex narrative, package.json, Doc's scaffold descriptions, docs.rundock.ai/concepts/runtimes CREATED (the in-app 404 target) + installation/how-rundock-works/trust pages, site metas + JSON-LD + llms.txt + body copy (index, download; trust tile now "Two runtimes"). Copy discipline: ChatGPT is always "add a plan for specialists", never an alternative (the orchestrator requires Claude Code); compare page deliberately left Claude-scoped; testimonial quotes untouched. e2e spec vault-path comment removed. Repo commits 46965f3/5328e62/022ff33, docs 60e3cf8, site a9dd4fe/91c2060.
+	  #type/ops
+- [x] **Stop unlabelled code blocks mis-highlighting as VB.NET in the conversations UI** — SHIPPED in 0.10.0 (2026-07-14) (shipped to main in 1e0a373)
+	  Option B as approved, all four slices in one pass: decision logic extracted to code-language.js (pure UMD, unit-tested in Node against the real vendored hljs build); explicit hints unchanged; plaintext/text/plain first-class (escaped, labelled "text"); unlabelled blocks auto-detect over a curated subset (markdown in, vbnet out) gated on relevance >= 5, tuned by measurement (prose 2, plain lists/logs 4, real content 6-9). Regression suite pins the upstream vbnet misdetection so removing the gate fails loudly. 10 new tests; suite 556 → 566. Remaining manual AC (eyeball the original two blocks in the live app) lands with Liam's next session on the release build.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Index Codex-runtime conversations for content search** — SHIPPED in 0.10.0 (2026-07-14) (shipped to main in 30d006a)
+	  Codex thread files resolve via the rollout filename convention (one file per thread; resumes append, verified against real sessions, so byte-offset reconcile applies unchanged). Extractor indexes user + assistant text and excludes developer instructions, environment_context blocks, and Rundock's injected identity prompt. Mixed conversations index both runtimes under one conversation id. All acceptance criteria met; live-verified against the real demo workspace (28 messages, real phrases findable, injected prompts absent). Suite 551 → 556.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Codex runtime: run agents on the Codex CLI** — SHIPPED in 0.10.0 (2026-07-14) (merged to main in 73b4d14, PR #13)
+	  Agents with `runtime: codex` run on the official Codex CLI under a ChatGPT plan: direct chat with thread resume, cross-runtime delegation (Claude orchestrator → Codex specialist, transactional handback), review annotations with correct attribution, quota/auth/model failures classified into guidance cards, runtime status detection in Settings (presence-only evidence), off-roster impersonation guard, Windows write support (direct sandboxed writes with `[windows] sandbox` configured; validated write-request markers behind permission cards without it, never silent read-only). Live-tested end to end on Mac (7 checkpoints) and Windows ARM (9 checkpoints); suite 253 → 549 across the release train. Run of record: `01_Projects/Fable-Testing-July-2026/FV1-Run-Notes.md` rounds 15-23.
+	  #type/feature #area/platform #size/xl #priority/p1
+- [x] **Make the left sidebar width adjustable (drag-resize, persisted)** — SHIPPED in 0.10.0 (2026-07-14; merged 2026-07-13) (shipped to main in d6a2ad0)
+	  Drag handle on the sidebar's inner edge, clamped 200-480px, width persisted locally, one width shared by team/conversations/skills/files views, default unchanged. Reuses the review panel's resize interaction grammar. Built on post-merge main as planned. All acceptance criteria verified by measurement (default 280, drag accuracy, both clamps, persistence across reload, cross-view width).
+	  #type/feature #area/platform #size/s #priority/p2
+- [x] **Render markdown tables in the Tiptap rich markdown editor** — SHIPPED in 0.10.0 (2026-07-14; merged 2026-07-13) (shipped to main in 280080a)
+	  GFM tables render and edit in the rich editor with STRICT source-preserving serialization: unedited tables round-trip byte-for-byte (padding, alignment markers, column spacing), an edited cell changes only its own bytes, undo restores the source exactly, and blockquote/list-nested and ragged rows hold. Cell editing inline; add/remove rows supported (canonical style for new rows). Wide tables scroll in place. Fixed three pre-existing save-drift bugs found by the byte-for-byte bar (frontmatter blank line, 10+-item ordered-list padding, POSIX trailing newline).
+	  #type/feature #area/platform #size/s #priority/p2
+- [x] **Native inline markdown review in the Rundock editor** — SHIPPED in 0.10.0 (2026-07-14; merged 2026-07-13) (shipped to main in 280080a; superseded the prototype-first phasing per Liam 2026-07-12: wire format and UX were live-proven in Roughdraft + c1-review.html, so it went straight to a production build)
+	  Roughdraft-style review native in the editor: five CriticMarkup constructs as atoms on the free Tiptap core, YAML endmatter for attribution/threading, review sidebar with Accept/Reject verdicts, reply/resolve, both authoring directions, workspace identity ("Me"/agent roster/Unattributed), orphan-highlight handling, and byte-exact round-trips. The Suggest-mode open question resolved from real usage: suggestions are agent-authored; humans comment (full-width Comment action). Reference semantics: ids are invisible plumbing, display numbers positional, cross-party references quote text. Done-Reviewing gate deferred with the agent-apply decision. Design decisions of record in [[Review-And-Feedback-Loop-Spec]] ("Phase 2 as built").
+	  #type/feature #area/editor #size/l #priority/p3
+- [x] **SPIKE: CriticMarkup / Pandiff rendering in the Tiptap editor** — SHIPPED in 0.10.0 (2026-07-14; merged 2026-07-13) (superseded by the production build shipped in 280080a, per Liam's 2026-07-12 decision to skip the throwaway phase)
+	  All acceptance questions answered in-flight and folded into [[Review-And-Feedback-Loop-Spec]]: custom atoms (not marks — escaping would drift bytes), YAML-endmatter serializer with byte-exact round-trip, resolve lifecycle + overlapping/orphan handling, Tiptap Pro rejection confirmed unnecessary. Pandiff untouched; still the reference for the future agent-apply "propose edits" direction.
+	  #type/research #area/editor #size/s #priority/p2
+- [ ] **Add Playwright E2E smoke suite with client coverage measurement**
+	**Spec:** [[Client-Test-Coverage-Spec]] (stage 1 of 3)
+	**Problem:** `public/app.js` (4,130 lines, the entire user-facing layer) has zero automated regression protection. During SR1, two user-facing bugs shipped through the 338-test suite because both lived in the browser layer the suite cannot observe: the anchor flash replayed on every view switch (CSS animations restart on `display:none` cycles), and the nav rail desynced from the destination when navigating from search. Manual driven verification caught them once; nothing re-checks on later changes.
+	**Approach:** Playwright (devDependency only) driving the real server + browser, ~10 tests: the two escaped bugs as named invariant tests, plus palette golden paths. Browser-side V8 coverage (`page.coverage`) converted to lcov and merged with the Node runner's report so `app.js` gets a tracked coverage number and baseline. CI job lands non-blocking for a two-week soak, then flips to gating releases. Architecture decisions frozen in the spec (incl. why jsdom was rejected).
+	**Files touched:** new `test/e2e/` directory, `package.json` (devDependency + scripts), CI workflow, `.gitignore` (Playwright artefacts)
+	**Acceptance criteria:**
+	- [ ] Named regression test: a search-anchored message flashes once and does not re-flash when navigating away and back
+	- [ ] Named regression test: opening each result type (conversation, file, agent, skill) from each origin view (conversations, files, skills, team) lands with nav icon, sidebar, and main view in agreement (the full matrix)
+	- [ ] Golden paths covered: palette opens via nav icon and Cmd+K, grouped results render with highlights, Enter navigates, Esc closes and restores focus
+	- [ ] Deliberately reverting the anchor-flash fix or the setNavState fix makes the corresponding named test fail (proof the net catches exactly what escaped)
+	- [ ] `public/app.js` appears in the merged coverage report with a recorded baseline
+	- [ ] E2E job runs in CI non-blocking; a dated follow-up note records when to flip it to gating (two weeks after landing, if flake-free)
+	- [ ] Suite runs deterministically against a seeded temp workspace (no dependence on a real vault or live model)
+	**Dependencies:** none (resequenced by Liam 2026-07-12: built directly on the `universal-search` branch, which merges to `main` ahead of the Codex branch). Stage 1 must land before stages 2-3 (it is their behaviour-preservation safety net).
+	**Out of scope:** any refactor of `app.js` (stages 2-3); expanding E2E beyond ~10 tests to chase coverage (depth belongs to unit tests on extracted modules).
+	**Release note:** ships in the SAME release as universal search. Test-only, zero product-code risk, and it protects exactly the features in that release (Liam, 2026-07-12).
+	**Tags:** #type/hygiene #area/platform #size/m #priority/p1
+	**Notes:** Specced by Dev 2026-07-12 from the SR1 production-readiness review. Coverage context: server.js 84.6%, search.js 98.5%, app.js 0%. DONE (Dev, 2026-07-13): merged to main in 47067b4. 10 E2E tests, all acceptance criteria met incl. both revert-proofs. Client coverage baseline: public/app.js 31.3% lines (1,293/4,130). CI e2e job green on first run (non-blocking soak until 2026-07-27).
+- [x] **Windows support** *(shipped 0.9.0)*
+	  Rundock now runs on Windows: native NSIS installer (Desktop + Start Menu shortcuts) + portable `.exe`, built x64 via the activated `windows-latest` CI job. First-run wizard works on Windows: platform-aware menu (File/Edit/View/Help), `darwin`-only `titleBarStyle`, fixed window sizing, Windows install command (PowerShell/WinGet), and a one-click **"Sign in to Claude"** button that launches the OAuth flow (no terminal needed; lands on Mac too). Rundock adds Claude's `.local\bin` to the user PATH on first-run (Anthropic's installer doesn't). Wizard now also gates on auth (no more silent 401). **The hard part — permissions on Windows:** the hook needs a runtime (packaged users have no `node`) so it runs via Rundock's bundled runtime; it must cover the **PowerShell tool** (Windows shell tool, not Bash); and the launcher must be invoked with PowerShell's `&` call operator (Claude runs hooks via PowerShell, which treats a bare quoted path as a string). All three landed → permission cards work on Windows. Validated end-to-end in Parallels (install → wizard → sign-in → permission cards → MCP connectors). rundock.ai/download now offers a Windows installer with a SmartScreen note. Reused @DMCK96's titleBarStyle/menu/win-config ideas (credit logged). **Remaining:** 2-3 real **x64** beta testers (VM is ARM); code signing deferred (SmartScreen click-through documented).
+	  #type/feature #area/release #size/m #priority/p2
+- [x] **CI release pipeline + universal Mac build** *(shipped 0.8.14)*
+	  Moved releases off Liam's laptop to a tag-triggered GitHub Actions workflow (`.github/workflows/release.yml`) that builds, signs, notarises, and publishes a draft release; Apple credentials moved from `.env` to 6 GitHub Secrets (see [[CI-Release-Setup]]). `release.js` collapsed to bump-and-tag (`890834e`). The Mac build is now a **universal** DMG (one download for Apple Silicon + Intel, no architecture to choose) — `ffab87c`, validated in CI (universal binary contains x86_64 + arm64, notarised). New **rundock.ai/download** page with a smart OS-detected download button + "Other platforms" link and a Windows "Coming soon" row; all site footers routed through `/download`. Absorbed the retired Intel x64 card. `windows-latest`/`ubuntu-latest` jobs are scaffolded for their platform cards. Failure recovery is now re-run-the-tag (no `main` revert). Pipeline proven by cutting 0.8.14 itself through it.
+	  #type/ops #area/release #size/m #priority/p2
+- [x] **Show a recovery card when the Claude Code sign-in expires (401)** *(shipped 0.8.13)*
+	  When a Claude Code session expired, Rundock forwarded the raw 401 `authentication_error` blob, which looked like a crash (5+ users got stuck). It now detects the case and shows a recovery card with reconnect steps + a copy button, plus a Troubleshooting > Authentication docs page. `3379f3f` (+ docs `16da2ef`).
+	  #type/feature #area/platform #size/s #priority/p1
+- [x] **MCP read/write permissions across all sources (B-unified)** *(shipped 0.8.13)*
+	  Knowledge mode now auto-approves read-style MCP calls and shows a permission card for writes/destructive actions, uniformly across workspace `.mcp.json`, user-global servers, and Claude.ai connectors. MCP removed from `--allowed-tools` and routed through the permission hook (read/destructive classification, server-side). Code mode unchanged. Subsumes the v2.1.166 fix. `f5d6518`.
+	  #type/feature #area/platform #size/m #priority/p2
+- [x] **Syntax highlighting and copy button for chat code blocks** *(shipped 0.8.13)*
+	  Chat code blocks render with highlight.js syntax highlighting (vendored locally, works offline) and a copy button, with the theme following the app's light/dark setting. Isolated and hardened from external PRs #6/#7 + #10/#11 (escaped label, clipboard fallback, auto-detect cap); @dougseven credited as co-author. `01186ee`.
+	  #type/feature #area/platform #size/m #priority/p2
+- [x] **Update positioning copy to "visual workspace for your AI agent team"** *(shipped 0.8.13)*
+	  Updated the two remaining "visual interface" surfaces in the repo (README opening line + scaffold product description). `04d1a1c`.
+	  #type/hygiene #area/scaffold #size/xs #priority/p2
+- [x] **Replace blanket mcp__* allow rule with per-server scopes for Claude Code v2.1.166+** *(shipped 0.8.12)*
+	  Claude Code v2.1.166 tightened `--allowed-tools` validation and rejected the blanket `mcp__*` allow rule, erroring before every response and dropping MCP tools to per-invocation prompts. Fixed with a per-spawn allow-list builder that reads `WORKSPACE/.mcp.json` and expands registered servers into `mcp__<server>__*` scopes, a shared `readMcpServerNames()` reader (replacing a duplicate parser), and server-name validation against injection. Shipped as `af6eb27`. Correct diagnosis credited to @dougseven (#8 / #9). Validated by an 8/8 logic suite, a live in-app test, and a clean-clone + signed-build gate.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Render agent profile capabilities (Reads from / Writes to) consistently** *(shipped 0.8.12)*
+	  The capabilities card rendered Writes to as a single comma-joined line while Reads from listed each entry separately, and reads entries were unescaped. Both sections now list each entry on its own line, HTML-escaped, with the split preserving entries that contain commas inside parentheses (e.g. subreddit lists), padded list items, and a null-safe display name. Shipped as `c29e3b7` (contribution from @dougseven, PR #3) plus follow-up `c363f87`. PR #3 and issue #4 closed with credit.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **Replace the file editor with a Tiptap rich markdown editor** *(shipped 0.8.11)*
+	  Markdown files now open in a Tiptap-based WYSIWYG editor that formats text as you type, replacing the previous Preview/Edit toggle. Custom Wikilink (inline atom) and Callout (block atom) nodes preserve Obsidian-flavoured syntax through markdown-it plugins registered via tiptap-markdown's `parse.setup` hook; the SoftHardBreak extension overrides the GFM hard-break serialiser to plain `\n` so round-trips are byte-for-byte. Frontmatter renders in a read-only properties panel above the editor (editable in a follow-up). Floating toolbar on selection covers bold, italic, code, link, h1, h2, h3. External links open on plain click with `target=_blank`; the link prompt normalises bare domains to `https://`. Non-markdown files fall through to the legacy preview/edit pane unchanged. Bundle infrastructure under `public/vendor/`; editor module under `public/editor/`.
+	  #type/feature #area/platform #size/l #priority/p1
+- [x] **Add Cmd+F find within the active conversation and file view** *(shipped 0.8.11)*
+	  In-view find for the active panel. Press Cmd+F (Ctrl+F on Windows and Linux) to search the current conversation, an open markdown file, or a non-markdown file preview. Three search backends share a single find-bar UI: text-node DOM walks with `<mark class="find-match">` wrapping via the Range API for the conversation messages and the legacy preview, and a ProseMirror decoration plugin for the markdown editor that never modifies the document. The bar shows position as you go (e.g. *3 of 12*), navigates via Enter / Shift+Enter with wrap-around, and clears cleanly on Esc or any navigation to a different view. Resolves the long-standing gap that browser-native Cmd+F was broken in the Electron window and only ever matched currently-rendered DOM in browser tabs.
+	  #type/hygiene #area/platform #size/m #priority/p2
+- [x] **Conversation sidebar: session continuity on reopen and stronger selected-row contrast** *(shipped 0.8.11)*
+	  Two conversation-sidebar polish items shipped together. (1) Reopening Rundock now lands on the conversation last opened in that workspace, falling back to the most-recently-active non-archived conversation when the last-opened is missing or archived. The default-load priority chain replaced three pinned-first patterns in `handlePersistedConversations`, the post-delete handler, and the nav-to-conversations fallback with a shared `pickDefaultConversation` helper. (2) Selected conversation rows use a terracotta tint (`var(--accent-glow)`) instead of the same neutral elevated background as hover, with a slightly stronger tint on hover-while-selected so the active row stays identifiable when scanning. `lastActiveConversationId` persists per workspace via `.rundock/state.json`.
+	  #type/hygiene #area/platform #size/s #priority/p2
+- [x] **Restore agent message content lost in get_session_history merge** *(shipped 0.8.11)*
+	  Old agent messages no longer render as blank bubbles on reload. The merge in `get_session_history` was pairing real agent transcript entries with whitespace-only JSONL entries via a permissive substring match, producing empty bubbles where the original responses should have appeared. The fix filters whitespace entries from the jsonl pool, prevents them at the `parseSessionHistory` source, raises the slice limit on reopen from 50 to 200, and raises the per-conversation transcript soft cap from 100 to 1000 (forward-protective only; existing already-dropped middle history stays dropped).
+	  #type/bug #area/platform #size/m #priority/p1
+- [x] **Fix Windows Claude detection so npm-installed claude.cmd is recognised** *(shipped 0.8.11)*
+	  Windows users who installed Claude Code via npm previously hit a first-run wizard error saying Claude was not installed, even though the `.cmd` shim was on PATH. `findClaude` now uses `where.exe` on Windows (parsing multi-line output and preferring `.exe` over `.cmd`) and returns the absolute path. `spawnClaude` uses a new `resolveClaudeBin` helper so the standalone server path doesn't depend on the Electron entry point. `ensurePath` uses `path.delimiter` and adds `%USERPROFILE%\.local\bin`, `%LOCALAPPDATA%\Microsoft\WinGet\Links`, and `%APPDATA%\npm` to PATH on Windows.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Document Rundock's data, privacy, and security story in the public docs** *(shipped 2026-05-26, docs only)*
+	  New top-level Trust section added to the docs navigation, with a Data, privacy, and security page covering where files live, what gets transmitted, training defaults, retention and Zero Data Retention, and the BYOK relationship between users and Anthropic. Designed to be forwardable to a buyer's IT, legal, or compliance lead during evaluation. All Anthropic claims linked to primary sources: Commercial Terms, the commercial data retention policy (30-day default), the Claude Code ZDR docs (available via Commercial-organisation API keys or Claude Enterprise), and the training privacy article. The page also surfaces the limit that ZDR does not extend to third-party MCP servers an agent connects to from the workspace. Surfaced during sales coaching session 2026-05-15 while assessing fit for boutique law firms as an outbound niche; the same page unblocks the regulated sub-segments of consulting and search.
+	  #type/hygiene #area/docs #size/s #priority/p1
+- [x] **Replace Pinned/Active/Done sidebar sections with filter pills and a left-border state system** *(shipped 0.8.10)*
+	  The 0.8.9 three-section model (Pinned, Active with working/unread/idle tiers, Done) created a double-clustering problem at higher conversation volumes: a pinned unread conversation appeared in both the Pinned section and the unread tier of Active. Replaced with a flat list filtered by three pills (All, Unread, Pinned), a left-border state system on each row (green for working or unread, orange for pinned-idle, no border otherwise), and WhatsApp-style recency labels right-aligned in the meta row. Scope expanded during implementation to include the Done to Archive UI rename, a Mark Done sidebar action replacing the soft-delete on non-archived items, a custom CSS tooltip layer with immediate hover-show and simplified copy (Pin / Unpin / Archive / Delete), search results that narrow by the active pill, and a fix for the click-on-archived auto-unarchive bug surfaced during testing. Triggered by James Compton feedback.
+	  #type/feature #area/platform #size/s #priority/p2
+- [x] **Migrate persisted conversation status from 'done' to 'archived'** *(shipped 0.8.10)*
+	  The UI rename of Done to Archive originally left the data model at `status: 'done'` for backwards compatibility, creating an internal mismatch (`isArchivedSet = convo.status === 'done'`) that future readers would have had to context-switch on. Server-side migration in `readConversations()` rewrites `status: 'done'` to `status: 'archived'` on first workspace open, logs a single line, and snapshots the pre-migration file to `.rundock/conversations.json.pre-archive-backup` for manual recovery. Idempotent and failure-safe. Verified on rundock-sandbox-testing (29 conversations, 2 migrated) and Liam-Agent-Workspace (100 conversations, 2 migrated) before release; zero data loss, every non-status field byte-identical to backup.
+	  #type/hygiene #area/platform #size/xs #priority/p1
+- [x] **Defer the conversation empty state until conversations have loaded** *(shipped 0.8.10)*
+	  Opening a workspace used to flash the "No conversations yet" sidebar text and the "Start a conversation" main-panel empty state for a few hundred milliseconds before the get_conversations reply arrived. Pre-0.8.9 the gap was masked by the workspace picker staying visible; 0.8.9's picker-hides-immediately fix exposed it. Added a `conversationsLoaded` boolean to the client state (false on workspace open, true at the top of `handlePersistedConversations`); the sidebar's "No conversations yet" line gates on it, and `onWorkspaceReady` now hides the workspace picker view directly instead of calling `showView('convo-empty')` so the main panel stays blank until handlePersistedConversations picks the right destination.
+	  #type/bug #area/platform #size/xs #priority/p1
+- [x] **Vertically centre the sidebar search clear button** *(shipped 0.8.10)*
+	  The clear (×) button rendered 5px below the search input's vertical centre across conversations, skills, and files. `.sidebar-search-wrap` declares `padding: 0 8px 10px` (10px bottom padding, no top padding), so the wrap is 10px taller than the input and the wrap's vertical centre sits 5px below the input's centre. Shifted the clear button up by 5px via `top: calc(50% - 5px)` on `.sidebar-search-clear`; the existing `translateY(-50%)` continues to pull the button up by half its own height. Single property change on the button, no change to the wrap (an earlier attempt that moved the wrap's padding-bottom to margin-bottom broke the visual framing of the search section).
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **Rework sidebar ordering so pinned, active, and unread conversations surface predictably** *(shipped 0.8.9)*
+	  Three-section model in `renderConvoList`. Section A (Pinned) sorts by `lastActiveAt` desc. Section B (Active) uses a three-tier compound sort: working agents first, unread second, idle last, each tier by `lastActiveAt` desc. Section C (Done) collapses at the bottom and shows an unread dot when any done conversation has unread messages. Idle Active items older than seven days fold under a collapsible "Older" section. The Active/Done badge in the chat header reveals "Mark Done" / "Mark Active" on hover. Working-to-idle animation deferred to 0.9.0 after the View Transitions API approach produced visible ghosting.
+	  #type/hygiene #area/platform #size/s #priority/p2
+- [x] **Hide the workspace picker immediately on selection so it doesn't linger as the workspace loads** *(shipped 0.8.9)*
+	  `onWorkspaceReady` calls `showView('convo-empty')` at the end of the different-workspace branch so the picker hides within one frame of the `set_workspace` reply. The reconnect-to-same-workspace branch is untouched, preserving the active view and in-memory conversation list.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **Teach every agent the basics about Rundock, with Doc holding the full reference** *(shipped 0.8.9)*
+	  Two-tier fix. Tier 1 prepends a short identity line to the base system prompt every agent receives: states what Rundock is, gives the docs URL, and routes deeper meta questions to Doc or the docs. Tier 2 rewrites the body of `## What you know` in `scaffold/rundock-guide.md` into "### About Rundock" (what it is, the licence summary, and creator credit with three canonical surfaces) and "### Workspaces" (the existing definition preserved). Follow-up refinement tightens the Tier 1 wording so specialists answer the basic identity question directly rather than routing it.
+	  #type/hygiene #area/platform #size/s #priority/p3
+- [x] **Add error handlers on every spawned Claude Code child process** *(shipped 0.8.9)*
+	  A baseline `'error'` listener now attaches inside the `spawnClaude` wrapper so every spawn callsite is covered safely. Five chat callsites also pass an `onError` callback that surfaces a `system/info` message in the conversation with distinct copy per error code (`ENOENT`, `EACCES`, fallback), dedupes consecutive identical errors per conversation within a 30-second window, and gates close handlers via a new `entry.spawnFailed` flag so error and close paths never double-fire. Follow-up commit emits a `subtype: 'done'` from the error handler so the conversation's "thinking" indicator clears after a spawn failure.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Harden Doc fallback so a broken scaffold file does not produce duplicate agents** *(shipped 0.8.9)*
+	  The built-in `rundock-guide` fallback in `server.js` now checks for the file's existence, not only for an agent with `type: 'platform'`. A second clause `!agents.find(a => a.id === 'rundock-guide')` skips the injection when a file-parsed Doc exists with broken frontmatter, so the agents list never contains two `rundock-guide` entries with the same id.
+	  #type/bug #area/platform #size/xs #priority/p3
+- [x] **Fix CRLF line-ending bug that breaks agent and skill frontmatter parsing on Windows** *(shipped 0.8.9)*
+	  Two-layer fix. `.gitattributes` at the repo root forces LF endings on every text file across all platforms. A new `readNormalisedFile(path)` helper in `server.js` strips `\r\n` to `\n` before frontmatter parsing, routed through seven read sites (agent files, skill `defPath` reads, CLAUDE.md instructions, and the `read_file` endpoint that serves content to the client). Mac smoke test passed by hand-CRLF'ing a test agent and re-opening the workspace; Windows verification by beta users still pending per the spec's deferred Task 9.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Ship a one-command Windows from-source bootstrap so non-developer Windows users can get into Rundock without a real terminal session** *(shipped 0.8.9)*
+	  `scripts/install-windows-source.ps1` runs end-to-end via `irm ... | iex`: detects/installs Node 20+ and Git via `winget`, prompts to install Claude Code via Anthropic's official installer, clones to `%USERPROFILE%\Rundock`, runs `npm install`, and creates a Desktop shortcut and Start Menu entry pointing at a generated `launch-rundock.ps1` launcher. README gains a "Run on Windows (interim)" subsection naming the retirement trigger explicitly. CI smoke test on `windows-latest` covers deps detection, clone, install, shortcuts, and idempotency. Four interactive criteria (Claude consent prompt, double-click launch, beta onboarding call, Parallels rehearsal) deferred pending real-world testing.
+	  #type/hygiene #area/release #size/s #priority/p1
+- [x] **Tidy the repo root: relocate reference docs into `docs/` and add SECURITY.md** *(shipped 0.8.9)*
+	  `AGENTS.md`, `ROUTINES.md`, and `SKILLS.md` moved into `docs/` via `git mv` so history follows. `ARCHITECTURE.md` stays at root per the matklad single-architecture-doc convention. Cross-links in `README.md` and `ARCHITECTURE.md` updated. New `SECURITY.md` at root covers reporting channel, response window, and scope.
+	  #type/hygiene #area/docs #size/s #priority/p3
+- [x] **Swap README hero image to the launch site app screenshot** *(shipped 0.8.9)*
+	  `README.md` now references `docs/rundock-app-hero.png` (a real screenshot of the running app, mirroring the launch site at rundock.ai) instead of the org-chart-only render. Old `docs/rundock-agent-team-org-chart.png` removed.
+	  #type/hygiene #area/docs #size/xs #priority/p3
+- [x] **Add subtle personal-reference hyperlinks to the README** *(shipped 0.8.9)*
+	  Two natural-text hyperlinks. A single short credit line "Built by [Liam Darmody](https://www.linkedin.com/in/liamdarmody/)." sits beneath the opening paragraph as the canonical creator mention. The "Built from real use" principle now opens with "I run my own business" hyperlinked to https://liamdarmody.com. No URLs appear as visible link text.
+	  #type/hygiene #area/docs #size/xs #priority/p3
+- [x] **Ship Mintlify docs site at docs.rundock.ai**
+	  Public docs site live at https://docs.rundock.ai. New `liamdarmody/rundock-docs` repo holds 17 MDX pages across Get Started / Concepts / Guides / Reference plus `docs.json` config, deployed via Mintlify Hobby tier. The original plan was a `rundock.ai/docs` subfolder via Netlify `_redirects` proxy; the proxy approach proved unworkable so a subdomain deploy was the operational fix, with the SEO trade-off accepted. Shipped 2026-05-04, separate from any tagged app release.
+	  #type/ops #area/docs #size/s #priority/p1
+- [x] **Preserve line breaks in sent messages end-to-end** *(shipped 0.8.8)*
+	  Multi-paragraph messages composed with Shift+Enter or pasted text now survive end-to-end through the send pipeline (textarea → WebSocket → transcript → stdin → render) instead of being flattened. Fix was a single CSS rule: `white-space: pre-wrap` on `.msg-user .msg-bubble`. The pipeline was already preserving newlines; the visible regression was HTML rendering collapsing them under default `white-space: normal`.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Persist orchestrator handoff text to transcript on intercepted delegation** *(shipped 0.8.8)*
+	  RETURN-path interception now persists the orchestrator's handoff text correctly. Two changes in `server.js`: send the orchestrator's `done` event AFTER `handleDelegation` returns so `agent_switch` reaches the client while `currentStreamingMsg` is still set; on RETURN-path interception, always append a transcript entry — a `routing`-typed entry with `buildToolSummary(toolCalls)` content when `responseText` is empty. New optional `type` field on `appendTranscript`. Client renderer skips routing entries from chat bubbles.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Relocate Existing Conversations section below instructions on agent profile page** *(shipped 0.8.8)*
+	  Pure DOM reorder in `showProfile()`: the existing-conversations block now renders at the bottom of agent profiles, after the configuration sections (Capabilities, Skills, Routines, Connectors, Model, Instructions). Existing `if(existing.length)` hide-when-empty guard preserved.
+	  #type/hygiene #area/platform #size/xs #priority/p2
+- [x] **Fix chat message timestamps showing the same time for every message** *(shipped 0.8.8)*
+	  Every message in a conversation rendered with the same timestamp on rehydrate (e.g. all 19:51 if the conversation was reopened at 19:51). Root cause was hybrid: `addAgentMsg` computed `Date.now()` at render-time so replayed messages all got the re-open time, and `convo.messages` had no timestamp field. Fix sources timestamps from Claude Code JSONL on rehydrate, stamps live messages at push, and threads the timestamp through `addAgentMsg`. Legacy entries with no JSONL match render no time span (sensible fallback rather than wrong-for-all).
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Deploy Rundock launch site and repo docs to production**
+	  Production deploy of the Rundock launch site and repo documentation. Marketing site at rundock.ai (Marketing-Site-Launch.html lifted into `rundock-site/index.html`, 11 image assets moved to repo root). Repo docs at github.com/liamdarmody/rundock root: README.md (overwritten), plus ARCHITECTURE.md, AGENTS.md, SKILLS.md, ROUTINES.md (all new). Followed by post-deploy polish across nine commits: testimonial quote-mark cleanup, mobile horizontal-overflow fix on iOS Safari, hero glow CLS fix via aspect-ratio, og:image swap to a purpose-built typographic asset, and the directory consistency port (Liquid Glass + sticky nav + 3-column footer + shared.css extraction). Shipped via direct push to `rundock-site` main and `rundock` main 2026-04-29 — no app version (site deploys via Netlify on push).
+	  #type/ops #area/release #size/m #priority/p1
+- [x] **Give orchestrator visibility into specialist output on handback** *(shipped 0.8.7)*
+	  Specialist output injected into orchestrator resume prompt via `sanitizeSpecialistOutput`. Silent-park leakage suppressed with `<silent>` sentinel, server-side `isSilentParkResponse` filter, and client-side no-op filter. Delegation dividers persisted as explicit markers in `convo.messages` for navigate-away survival.
+	  #type/bug #area/platform #size/m #priority/p2
+- [x] **Show skill instructions and description for skills created without frontmatter** *(shipped 0.8.5)*
+	  Skills without YAML frontmatter now display full content as instructions. Doc scaffold includes frontmatter template and audit guidance.
+	  #type/bug #area/scaffold #size/xs #priority/p2
+- [x] **Fix rehydrate rendering: ghost bubbles, message ordering, and false-positive drops** *(shipped 0.8.5)*
+	  Transcript-authoritative merge eliminates ghost bubbles and ordering mismatches after page refresh on delegation conversations. Pre-0.8.3 attribution damage accepted as-is.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Reconcile stale `activeAgentId` pointers on conversation load** *(shipped 0.8.5)*
+	  Pre-0.8.3 delegations left `activeAgentId` stuck on delegatee. Reconciliation runs once on load, persists corrected pointer.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Invalidate skill "Used By" list when SAVE_AGENT modifies an agent's skills frontmatter** *(shipped 0.8.5)*
+	  "Used By" list updates immediately after SAVE_AGENT. SAVE_SKILL no longer auto-navigates away from conversation.
+	  #type/bug #area/platform #size/xs #priority/p3
+- [x] **Include agent identity in `process_started` events sent to frontend** *(shipped 0.8.5)*
+	  Agent slug included in `process_started` payload. Frontend logs show actual agent name instead of `agent=?`.
+	  #type/hygiene #area/platform #size/xs #priority/p2
+- [x] **Add narrow auto-resume gate after COMPLETE marker** *(shipped 0.8.5)*
+	  Orchestrator left idle after specialist COMPLETE on sub-delegate path. No silent re-delegation.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Clear orchestrator working indicator on delegation handoff** *(shipped 0.8.5)*
+	  Emits `done` event for orchestrator before specialist's `process_started` at SIGKILL interception site.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **Page refresh re-invokes orchestrator on completed conversation** *(shipped 0.8.5)*
+	  Parked orchestrator process marked idle so client skips it on reconnect.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Suppress "Cos resumed" badge when orchestrator is parked silently after COMPLETE** *(shipped 0.8.5)*
+	  COMPLETE-path rendering no longer emits spurious "[Agent] resumed" badge.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **SAVE_AGENT marker parser truncates agent files containing markdown code fences** *(shipped 0.8.5)*
+	  Parser extracts content between HTML comment markers, treating inner code fences as content. SAVE_SKILL uses same fix.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Require explicit execution signal before emitting SAVE/DELETE markers in `rundock-guide`** *(shipped 0.8.5)*
+	  Doc now proposes before executing. Multi-turn proposal flows supported. Emits COMPLETE not RETURN. SAVE_SKILL emission working.
+	  #type/bug #area/scaffold #size/s #priority/p1
+- [x] **Add delegation loop circuit breaker and RETURN-path auto-pause** *(shipped 0.8.5)*
+	  Auto-pauses after 3 consecutive agent events without user input. Counter resets on each user message.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Orchestrator must only reference agents on the runtime roster and not claim parallel delegation** *(shipped 0.8.5)*
+	  Scaffold orchestrator prompt constrains delegation to runtime roster and states delegation is sequential.
+	  #type/bug #area/scaffold #size/xs #priority/p1
+- [x] **Support `skills:` frontmatter field for explicit skill-to-agent assignment** *(shipped 0.8.5)*
+	  Frontmatter `skills:` field takes precedence over body-text scan. Both methods coexist, duplicates suppressed.
+	  #type/feature #area/platform #size/s #priority/p1
+- [x] **Prevent orchestrator re-delegation to the specialist that just returned** *(shipped 0.8.5)*
+	  Scaffold prompt instruction plus code-level guard with clear error message on edge cases.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **Harden orchestrator error messaging on tool failure** *(shipped 0.8.5)*
+	  Error strings describe what happened factually. No loaded words that invite the model to infer platform rules.
+	  #type/bug #area/platform #size/s #priority/p1
+- [x] **Neutralise canned permission hook timeout message** *(shipped 0.8.5)*
+	  Hook failure messages describe observed failure without inferring user intent. No "user" in fallback text.
+	  #type/bug #area/platform #size/xs #priority/p2
+- [x] **Filter stale entries from recent workspaces list and derive names from path** *(shipped 0.8.5)*
+	  Deleted directories filtered from picker, names derived from current path, scaffold guards against recreating deleted directories.
+	  #type/hygiene #area/platform #size/xs #priority/p2
+- [x] **Unify Conversations sidebar footer chrome with adjacent panels** *(shipped 0.8.5)*
+	  Fixed footer with separator aligned to chat input border-top. Full-width button, SVG icon, subtle hover treatment.
+	  #type/hygiene #area/platform #size/xs #priority/p2
+- [x] **Deterministic tag placement in release script** *(shipped 0.8.5)*
+	  `gh release create` receives `--target <sha>` pointing at the version-bump commit.
+	  #type/bug #area/release #size/xs #priority/p2
+- [x] **Auto-commit and push version bump before tagging** *(shipped 0.8.5)*
+	  Release script commits, pushes, and runs pre-flight checks (clean tree, on main, remote reachable) before tagging.
+	  #type/bug #area/release #size/xs #priority/p2
+- [x] **Preserve blank line after Unreleased heading promotion** *(shipped 0.8.5)*
+	  Fixed `\s*` to `[ \t]*` in `promoteUnreleasedChangelog` regex.
+	  #type/bug #area/release #size/xs #priority/p2
+- [x] **Port rundock-guide mode-gating fix to scaffold** *(shipped 0.8.5)*
+	  Onboarding default orchestrator rule gated behind `[WORKSPACE_ANALYSIS]` check. "Existing workspace mode" section with six concrete rules added.
+	  #type/bug #area/scaffold #size/s #priority/p1
+- [x] **Resume delegate's prior session on re-delegation instead of spawning fresh**
+	  **Shipped:** Re-delegations to a specialist already in the conversation now pass `--resume <prior-session-id>` to the spawn path. The specialist retains tool results, reasoning, and working state from earlier turns; only the new delegation brief is sent, not a full transcript replay. Platform delegates continue to cold-spawn under the transactional one-shot pattern. Session-id bookkeeping is unchanged: the CLI extends the existing JSONL in place, so the frontend's dedup check handles it with no schema changes.
+	  **Shipped in:** 0.8.6 (2026-04-17)
+	  **Notes:** Reproduced on conversation `1776378506613` with four accumulated content-lead sessions before the fix. Commit `1c16bf1`.
+	  #type/bug #area/platform #size/m #priority/p2
+- [x] **Render sidebar agent and preview from last agent message, not reconciled `activeAgentId`**
+	  **Shipped:** Server now enriches each persisted conversation on workspace load with `lastAgentId` and `lastMessagePreview` derived from the final agent message in the transcript. Sidebar renders the last speaker's avatar and name for idle conversations, the currently-active agent during live delegation, and a clean plain-text preview of the last message. Preview pipeline strips tool-call markers, paired RUNDOCK marker blocks (including the YAML payload between them), markdown formatting, and HTML comments so the sidebar reads as human-readable prose regardless of what the transcript contains.
+	  **Shipped in:** 0.8.6 (2026-04-17)
+	  **Notes:** Commits `1c16bf1` (server enrichment + base render), `c35d414` (frontend hydration), `4f6d1bf` (tool-marker strip), `7c491f1` (markdown strip), `4f7222d` (paired RUNDOCK marker block strip). Originally surfaced in 0.8.5 after cut; too late for that release.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Align chat input label with actual message recipient when a conversation has a live process**
+	  **Shipped:** Server's `active_processes` WebSocket message now includes idle-but-alive processes with `idle: true`. Client sets `activeAgentId` and `activeProcessId` for both processing and idle entries, and the history-load reconciliation now gates on `activeProcessId` instead of `isProcessing`. Chat input placeholder, header avatar/name, and actual message routing all point at the same agent after a page reload — idle-but-alive specialists are preserved through the reload instead of being overwritten by the default orchestrator attribution.
+	  **Shipped in:** 0.8.6 (2026-04-17)
+	  **Notes:** Commits `369a162` (initial client fix keyed on `isProcessing` — too narrow) and `ff445ea` (server surfaces idle processes + client handles them). Surfaced in sandbox testing: input said "Message Ted..." while messages routed to Nina.
+	  #type/bug #area/platform #size/s #priority/p2
+- [x] **Render orchestrator handoff text and "agent joined" divider on intercepted delegations**
+	  **Shipped:** On intercepted delegations (orchestrator uses the Agent tool, server SIGKILLs mid-stream, emits `agent_switch`), the `agent_switch` handler now captures `outgoingAgentId` before reassigning `activeAgentId`, strips RUNDOCK markers from accumulated streaming text, promotes the streaming DOM node to a permanent message, and pushes the cleaned text to `convo.messages` under the outgoing agent's id. Orchestrator's brief handoff text and the "[specialist] joined" divider now render in the correct order during live delegation, matching post-reload history view.
+	  **Shipped in:** 0.8.6 (2026-04-17)
+	  **Notes:** Pre-existing bug; caught during 0.8.6 testing on sandbox conversation `1776425281982`. Commit `98baef8`.
+	  #type/bug #area/platform #size/m #priority/p2
+- [x] **Ship delegation hygiene and permission reliability bundle**
+	  **Shipped:** Delegation pipeline split into RETURN (out-of-scope) vs COMPLETE (pipeline finished) markers so orchestrators stop re-delegating after clean completion and stop silent-resume narrating filler. Routing prompt gagged against user-facing chatter, delegation briefs tagged so rehydrate drops them, specialists no longer narrate briefs in chat. Permission hook bundled into packaged builds (scripts directory marked `asarUnpack`, Electron-aware path resolution) with stale-entry auto-repair on workspace open: every packaged-build user since the hook architecture shipped had a silently broken permission system, and 0.8.3 auto-heals their stale settings on first launch. UI fixes: outgoing-agent working indicator clears on handoff, chat-status header resets on workspace switch, nav rail unread indicators reset on workspace switch, late responses no longer dirty unread on the wrong workspace.
+	  **Shipped in:** 0.8.3 (2026-04-13)
+	  **Notes:** Migrated from [[2026-04-16-Rundock-Roadmap#delegation-hygiene-and-permission-reliability]] 2026-04-15. Reclassified from [[Rundock-Roadmap]] Shipped as a tactical multi-fix delivery bundle with no strategic outcome parent. Recorded here for historical delivery tracking.
+	  #type/ops #area/platform #size/l #priority/p1
+- [x] **Redesign Skills UI to sidebar and detail page pattern**
+	  **Shipped:** Skills UI moved to a sidebar + detail page layout. Addressed user testing feedback on skills panel confusion.
+	  **Shipped in:** 0.8.0 (2026-04-09)
+	  **Notes:** Mock: `mocks/skills-redesign.html`. Migrated from [[2026-04-16-Rundock-Roadmap#skills-ui-redesign]] 2026-04-15. Reclassified from [[Rundock-Roadmap]] Shipped as a tactical UI change without a strategic outcome parent.
+	  #type/ops #area/platform #size/m #priority/p2
+- [x] **Ship stability pass bundle**
+	  **Shipped:** Five scoped reliability items: MCP routing, `--bare` flag, reconnection, crash cleanup, audit v2. Routing coverage descoped at the time and later added to this backlog as a standalone audit item.
+	  **Shipped in:** 0.8.0 (2026-04-09)
+	  **Notes:** Spec: [[Workspace-Audit-v2]]. Migrated from [[2026-04-16-Rundock-Roadmap#stability-pass]] 2026-04-15. Reclassified from [[Rundock-Roadmap]] Shipped as a tactical multi-fix delivery bundle with no strategic outcome parent.
+	  #type/ops #area/platform #size/l #priority/p1
+- [x] **Ship code signing and auto-update**
+	  **Shipped:** Enrolled in Apple Developer Program. Signed `.dmg`, notarisation, auto-update via GitHub Releases.
+	  **Shipped in:** 0.8.0 (2026-04-09)
+	  **Notes:** Migrated from [[2026-04-16-Rundock-Roadmap#code-signing-and-auto-update]] 2026-04-15. Reclassified from [[Rundock-Roadmap]] Shipped as a release-infrastructure bundle with no strategic outcome parent.
+	  #type/ops #area/platform #size/m #priority/p1
+- [x] **Prepare Rundock for open source release**
+	  **Shipped:** LICENSE, CONTRIBUTING.md, issue templates, README, commit history review. Demo GIF deferred.
+	  **Shipped in:** 0.8.0 (2026-04-09)
+	  **Notes:** Migrated from [[2026-04-16-Rundock-Roadmap#open-source-prep]] 2026-04-15. Reclassified from [[Rundock-Roadmap]] Shipped as a release-prep bundle with no strategic outcome parent.
+	  #type/ops #area/platform #size/m #priority/p2
+
+
+***
+
+## Archive
+
+- [ ] **Release pipeline launches the packaged app before signing**
+	  **Problem:** The first 0.10.0 build died on launch (a module missing from the packaging manifest) and no gate had ever launched the packaged app: tests drive the source tree and the pipeline built without running. The contents gate added in the incident checks presence, not behaviour; a human launch is on the runbook but manual steps get skipped under pressure (that is how the incident happened).
+	  **Acceptance criteria:**
+	  - [ ] The release pipeline boots the built app on the macOS runner after packing and fails the build if the process exits within a grace window
+	  - [ ] Verified by deliberately breaking the manifest on a branch: the pipeline catches it
+	  #type/hygiene #area/release #size/s #priority/p2
+- [ ] Adding a new card as part of the test
+
+%% kanban:settings
+```
+{"kanban-plugin":"board","list-collapse":[true,false,false,false,true,false,false,false],"mark-cards-in-list-as-complete":["Done","Shipped"]}
+```
+%%

--- a/test/fixtures/kanban/edge-cases.md
+++ b/test/fixtures/kanban/edge-cases.md
@@ -1,0 +1,39 @@
+---
+
+kanban-plugin: board
+
+---
+
+## Doing (3)
+
+**Complete**
+- [ ] **Multi-paragraph card**
+	  First paragraph continues here.
+	
+	  Second paragraph after a blank line.
+- [ ] **Card with code block**
+	  ```js
+	  const x = 1;
+	  ```
+	  After the fence. #type/ops
+- [x] **Checked card with block id** ^abc-123
+	- [ ] nested unchecked
+	- [x] nested checked
+- [-] **Custom checkChar card** cancelled style
+
+
+## Two<br>Lines
+
+
+
+***
+
+## Archive
+
+- [x] **Archived card** done long ago #area/platform
+
+%% kanban:settings
+```
+{"kanban-plugin":"board","list-collapse":[false,true]}
+```
+%%

--- a/test/fixtures/kanban/roadmap.md
+++ b/test/fixtures/kanban/roadmap.md
@@ -1,0 +1,176 @@
+---
+
+kanban-plugin: board
+
+---
+
+## Guidance
+
+- [ ] **What goes on the roadmap**
+	  A roadmap card describes a problem we've committed to solving or an outcome we're working toward. It is strategic, not tactical. One paragraph maximum.
+	  Rule of thumb: if you can write acceptance criteria for it, it belongs on the backlog, not here. A roadmap card is answered by one or more backlog items, not by a single commit.
+- [ ] **Card title format**
+	  Outcome or problem statement, not feature name.
+	  Good: "Specialists land on the org chart with a valid parent"
+	  Good: "Releases are safe to cut unattended"
+	  Bad: "Add reportsTo validation" (that's a backlog item)
+	  Bad: "SAVE_AGENT marker rework" (that's implementation detail)
+- [ ] **Card body (required and optional fields)**
+	  Required:
+	  • **Why now:** one sentence on the trigger or evidence
+	  • **Target outcome:** what changes in the world, observable if possible
+	  • Column placement (Now / Next / Later)
+	  Optional:
+	  • **Success signal:** how we'll know it worked, one metric or observable behaviour
+	  • **Linked backlog:** wikilinks to [[Rundock-Backlog]] items that ladder up to this card
+	  • **Tags**
+- [ ] **What does NOT go on the roadmap**
+	  No acceptance criteria, file paths, function names, effort estimates, commit hashes, or implementation notes. If you catch yourself writing any of those, the thought belongs on the backlog.
+- [ ] **Columns (certainty gradient, not timeline)**
+	  **Shipped:** delivered. Kept for 30 days, then archived to `04_Archive/`. Leftmost active column: completed items exit left.
+	  **Now:** actively being worked or next up. High certainty. Has at least one backlog item in progress or Ready.
+	  **Next:** committed to pursuing after Now clears. Medium certainty. May not yet have backlog items.
+	  **Later:** on the radar, not yet committed. Low certainty. Rationale captured, details deliberately vague.
+- [ ] **Tagging scheme**
+	  `#area/...` platform, scaffold, docs, release, onboarding
+	  `#horizon/...` now, next, later (mirrors column, useful for search)
+	  `#confidence/...` high, medium, low
+	  `#theme/...` optional grouping (e.g. `#theme/hygiene`, `#theme/dx`)
+- [ ] **Linking to the backlog**
+	  One roadmap card resolves to one or more backlog items. Use Obsidian wikilinks in the "Linked backlog" field: `[[Rundock-Backlog#card-slug]]`. Every `#type/feature` backlog item in Ready / In Progress / Done must link up to exactly one roadmap card. `#type/bug`, `#type/hygiene`, and `#type/ops` items can stand alone without a parent (see the Backlog.md Parent rule for details). Inbox items can be unlinked regardless of type.
+- [ ] **Cards in Now must have linked backlog items**
+	  A roadmap card with zero linked backlog items is either in Later (intentional, per DEEP "Detailed appropriately": items further out in the pull order stay high-level) or in Next awaiting activation. **Cards in Now with zero items in Ready or In Progress are a bug in the pull queue.** When a card moves from Next to Now, the same action creates at least one backlog item under it. A card should not sit in Now without linked work for more than one work session: if it does, either the backlog items were not written (fix the queue) or the card is not actually ready to pull (move it back to Next).
+- [ ] **Example card (copy and adapt)**
+	  **Specialists land on the org chart with a valid parent**
+	  **Why now:** Doc assigned `reportsTo: team-lead` to a specialist in a workspace where the orchestrator slug is `chief-of-staff`, so the specialist was invisible in the org chart (0.8.3 incident).
+	  **Target outcome:** Every specialist created in an existing workspace has a `reportsTo` value that resolves to a real agent in that workspace.
+	  **Success signal:** Zero orphaned specialists reported over a 30-day window after 0.8.5.
+	  **Linked backlog:** [[Rundock-Backlog#port-rundock-guide-mode-gating-fix-to-scaffold]]
+	  #area/platform #horizon/now #confidence/high
+
+
+## Shipped
+
+- [x] **Changes to Rundock's core can't regress silently**
+	  **Shipped:** 0.9.2 (2026-07-03)
+	  Rundock's delegation and orchestration engine, previously changed blind, is now covered by an automated test suite with a harness that reproduces the full multi-agent delegation lifecycle without a live model. The suite runs on every change and must pass before any release build is produced, so a regression in the core engine is caught before it reaches users rather than in the field. The same release fixed a batch of reliability and hardening defects in that engine that were surfaced while the net was being built: more dependable specialist hand-offs, safer conversation history, immediate visibility of newly created agents, and a tighter workspace file boundary.
+	  **Success signal:** A regression in the covered engine surfaces as a failed check on its change before merge, not as a user-visible bug in a shipped build.
+	  #area/release #horizon/shipped #theme/dx
+- [x] **Rundock is downloadable on every platform users run**
+	  **Shipped:** Windows 0.9.0 (2026-06-26), Intel Mac 0.8.14 (2026-06-25)
+	  A user on macOS Apple Silicon, macOS Intel, or Windows can download a native installer from the website and run Rundock without a terminal session; installing Claude Code is the only command-line step. The download page distinguishes the platform builds so users pick the right one. The Windows build is unsigned for now, so SmartScreen shows a one-time "More info → Run anyway" prompt, explained on the page. SmartScreen-clean signing (Azure Trusted Signing) is a demand-gated refinement now carried on the backlog, pulled when Windows conversions justify it rather than on a calendar.
+	  #area/release #horizon/shipped
+- [ ] <!-- Shipped 0.8.0–0.8.4 (April 2026) archived per the 30-day retention rule → [[2026-07-03-Rundock-Roadmap-Shipped-Archive]] -->
+
+
+## Now
+
+- [ ] **Users run their team on whichever AI subscription they already have**
+	  **Why now:** 0.10.0 shipped the Codex runtime and every public surface (site, README, About) now claims "works with your Claude or ChatGPT subscription". The shipped integration is honest but first-generation: Codex replies arrive at end-of-turn rather than streaming, there are no per-action approvals (Windows file writes use a card-based workaround; shell commands can't be individually approved anywhere), and a ChatGPT-only subscriber still cannot onboard at all because the wizard installs Claude Code only. The positioning is ahead of the product; this outcome closes the gap.
+	  **Target outcome:** A specialist on the Codex runtime is indistinguishable in capability and trustworthiness from a Claude one on every platform: replies stream live, every side effect can be individually approved, cancel is instant, and conversations survive restarts. A user whose only subscription is a ChatGPT plan can install Rundock, complete first-run, and operate a working team.
+	  **Success signal:** A ChatGPT-plan user goes from download to a completed delegation without ever being told to buy a Claude subscription; Codex conversations are visually indistinguishable from Claude ones in responsiveness and approval behaviour.
+	  **Linked backlog:** [[Rundock-Backlog#codex-agents-stream-approve-and-cancel-like-claude-agents-on-every-platform]] (Ready), [[Rundock-Backlog#first-run-onboarding-works-for-chatgpt-only-users]] (Ready), [[Rundock-Backlog#codex-only-workspaces-run-a-full-team-without-claude-code-installed]] (Inbox, gated)
+	  #area/platform #horizon/now #confidence/high
+
+- [ ] **Users organise conversations into themed projects**
+	  **Why now:** Beta user James Compton asked for it 2026-04-24: "Rundock could benefit from project folders which consists of chats that can be with different agents, so the project is a theme". The workflow is already latent: users run multiple conversations with different agents on the same client, product, or research area, and they get interleaved chronologically with unrelated work. First iteration is cheap because no agent-level or server-level machinery is required — just a UI grouping layer above the existing sidebar.
+	  **Target outcome:** A Rundock user can group conversations into named, collapsible folders in the sidebar so related work on the same theme lives together rather than being interleaved chronologically with everything else. Folders persist across page reloads and workspace switches, and survive the existing Pinned / Active / Done ordering behaviour.
+	  **Success signal:** Within one month of shipping, at least one user actively uses project folders — self-reported until workspace-health observability lands, observable in usage afterwards. Secondary: James reports the feature addresses his original ask.
+	  **Linked backlog:** [[Rundock-Backlog#organise-conversations-with-lists-so-related-work-stays-together]] (Ready, first iteration), [[Rundock-Backlog#add-project-folders-to-the-conversation-sidebar-for-grouping-related-conversations]] (Inbox, shaping decision pending vs Lists)
+	  #area/platform #horizon/now #confidence/high
+
+- [ ] **Users edit knowledge inline without switching to Obsidian**
+	  **Why now:** Raw textarea editing is the last workflow that forces users out of Rundock into Obsidian. With 0.8.5 shipping the correctness platform (orchestrator auto-resume gate, `rundock-guide` propose-first rule, release-pipeline hygiene) and the Tiptap validation prototype proving all five round-trip tests pass, the editor is the next strategic move. Spec is finalised at revision 2.2 with three user-facing phases.
+	  **Target outcome:** Every agent and knowledge file in the Rundock workspace can be edited inline via a rich WYSIWYG editor with auto-save, with full round-trip fidelity to Obsidian-flavour markdown syntax (wikilinks, callouts, frontmatter, bold, headings, lists, code blocks). No external editor switch required for any task that previously needed Obsidian.
+	  **Success signal:** Open any knowledge file, click into the body, edit, reload the workspace, edits persist exactly as typed. Frontmatter renders as a structured panel and cannot be accidentally broken by body editing. Auto-save fires within 2 seconds of typing pause.
+	  **Spec:** [[Tiptap-Editor-Implementation]], [[Editor-and-Collaboration-Decision]]
+	  **Linked backlog:** editor shipped through 0.10.0 (rich editing, tables, inline review). Current: [[Rundock-Backlog#render-obsidian-callouts-and-make-frontmatter-wikilinks-clickable-in-the-editor]] (Ready), [[Rundock-Backlog#edit-frontmatter-properties-in-the-panel-without-touching-raw-yaml]] (Ready), [[Rundock-Backlog#warn-before-overwriting-a-file-that-changed-outside-rundock]] (Ready), [[Rundock-Backlog#manage-markdown-kanban-boards-inside-rundock-obsidian-kanban-parity]] (Ready, registry-gated), [[Rundock-Backlog#open-images-and-pdfs-in-rundock-including-from-wikilinks-in-conversations]] (Ready, registry-gated)
+	  #area/platform #horizon/now #confidence/high
+
+
+
+## Next
+
+- [ ] **The team improves itself, with the operator's approval**
+	  **Why now:** The three pieces exist separately and are each proven: the file-level review loop shipped in 0.10.0 (inline comments and suggestions with attributed accept/reject, live-proven on both runtimes), the batch-verdict pattern is live-proven in content review (itemised verdicts with a machine-readable handback), and the workspace-level approval inbox with an append-only attributed decision ledger is live-proven in the Edition experiment (external; transfer path pre-engineered). What does not exist is the connected loop: agents propose, the operator decides in one consistent interaction language at any zoom level (a passage, a batch, an inbox), agents apply, and every decision is attributed and auditable. This is also the gate on the spend-governance positioning ("every token traces to an attributed human decision").
+	  **Target outcome:** An agent proposal, wherever it appears (inline in a file, in a batch review, in the approvals inbox), carries the same verdict affordances and produces the same machine-readable, attributed decision record; accepted proposals are applied by agents without manual editing; the operator can audit any decision after the fact.
+	  **Success signal:** One full loop completes in product: an agent proposes an improvement, the operator approves it, an agent applies it, and the decision trail shows who decided what and when. The spend-governance positioning card ungates.
+	  **Linked backlog:** [[Rundock-Backlog#address-open-review-comments-with-one-click-done-reviewing-gate]] (Inbox: the substantive loop shipped in 0.10.0; this is the remaining one-click affordance), [[Rundock-Backlog#review-agent-produced-html-files-with-inline-comments-agents-can-act-on]] (Ready), [[Rundock-Backlog#requests-transfer-the-edition-surface-into-rundock-gated-liam-deems-the-edition-experiment-ready]] (Inbox, gated)
+	  #area/platform #horizon/next #confidence/medium
+
+
+## Later
+
+- [ ] **Teams use Rundock together**
+	  **Why now:** Split out of the old "second user as always-on cloud service" card 2026-04-15. A team sharing a sync service they already own (Dropbox, Google Drive, git) is a leaner path to multi-user Rundock than provisioning a central server. Architecture is unproven but cheap to test, and avoids both infrastructure spend and access-control design.
+	  **Target outcome:** Two or more people use a shared Rundock workspace from their own machines. Changes to agents, skills, and knowledge are visible to each other via the sync service the team already owns. Access control piggybacks on that service's existing permissions. Zero infrastructure cost to Rundock.
+	  **Success signal:** A second person opens a shared workspace, makes a change, and the first person sees it on next launch without manual export or re-scaffold. No conflict files in normal-use traffic over a one-week window.
+	  **Lean candidate:** Device Sync. Local state separation into `~/.rundock/` (credentials, sessions, memory). Assembly engine scans `Agents/`, `Skills/`, `Knowledge/` directories and rebuilds `.claude/` on launch. Sync layer is whatever the team already uses.
+	  **Documented fallback candidates:** Rank-ordered if the Device Sync spike retires. (1) Real-Time Collaboration via Yjs + Hocuspocus on Tiptap (AI agents as CRDT peers) if concurrent-edit conflicts prove unworkable on the sync-service approach: see [[Real-Time-Collaboration-Research]]. (2) Full-cloud team workspaces (shared conversations, centralised access control) if the outcome needs live multi-user state that neither Device Sync nor RTC-on-local-files can deliver: this route merges back into `Interactive remote access to Rundock from anywhere` since it requires the same infrastructure.
+	  **Absorbed:** Old Later cards 2026-04-15: Device Sync (now the lean candidate above), Team Workspace Structure (`rundock.yaml` / CLAUDE.md merge / collision-handling work, which becomes backlog items under this card when the spike passes), Team Workspaces (full-cloud fallback above), Real-Time Collaboration (RTC fallback above).
+	  **Spec:** None yet. The old Device Sync Later card carries the original architectural sketch.
+	  **Linked backlog:** [[Rundock-Backlog]] contains the Device Sync two-machine spike as the first and only item. Beyond the spike, backlog items are created when the spike validates the approach and the card moves up. Per DEEP "Detailed appropriately".
+	  **Dependencies:** Gated on the Device Sync spike. If concurrent-edit conflicts, secrets handling, or live session state prove unworkable, this card retires and teams fall under `Interactive remote access to Rundock from anywhere` instead.
+	  #area/platform #horizon/later #confidence/medium
+- [ ] **Rundock runs scheduled work while I'm away**
+	  **Why now:** Split out of the old "second user as always-on cloud service" card 2026-04-15. Anthropic's Claude Code Routines (see [[Routines-as-Cloud-Compute]] research, 2026-04-15) can credibly back the scheduled-automation half of the original cloud plan at zero infrastructure cost: routines run on Anthropic's compute, billed to the user's Pro/Max, with workspace context carried by a shadow GitHub repo. Materially cheaper than Hetzner and ships faster. The pre-baby window rewards the lean path.
+	  **Target outcome:** A Rundock user sets up a scheduled automation (daily briefing, weekly review, alert triage) that runs on its own schedule without Rundock having to be open on any machine, without Rundock provisioning compute, and without the user keeping their machine awake. Results flow back via an observable channel (MCP connector, shadow repo commit, or session URL).
+	  **Success signal:** A daily briefing routine fires on schedule for seven consecutive days, producing usable output each time, without Rundock running anywhere during the fire window.
+	  **Lean candidate:** Routines-as-compute. Shadow GitHub repo per workspace carries `CLAUDE.md`, `.claude/skills/`, `.claude/agents/`, and context files. Rundock provides a setup wizard and fires routines via the `/fire` API trigger. Scheduling uses Anthropic's built-in scheduler.
+	  **Absorbed:** Old "Always-On Workspace" Later card 2026-04-15. That card's outcome ("persistent agent connections, background processing, webhook triggers") is this card's outcome, now delivered via Routines-as-compute rather than a Rundock-managed server.
+	  **Spec:** [[Routines-as-Cloud-Compute]] (research, not yet a committed spec).
+	  **Linked backlog:** [[Rundock-Backlog]] contains the Routines end-to-end spike as the first and only item. Beyond the spike, backlog items are created when the spike validates the approach and the card moves up.
+	  **Dependencies:** Gated on the Routines spike. Risks named in the research: research-preview status, unknown daily run caps, manual routine creation friction, no output-capture API. If any of these prove prohibitive, this card retires and scheduled work falls under `Interactive remote access to Rundock from anywhere`.
+	  #area/platform #horizon/later #confidence/medium
+- [ ] **Interactive remote access to Rundock from anywhere**
+	  **Why now:** Split out of the old "second user as always-on cloud service" card 2026-04-15. Neither Device Sync (lean candidate for teams) nor Routines-as-compute (lean candidate for scheduled work) can deliver live interactive conversations with agents from a device that isn't running Rundock locally. The "phone away from my desk" use case survives both leaner alternatives and is the only remaining case where a Hetzner-shaped server is required. Parked as low-confidence until the other two cards prove the gap is real.
+	  **Target outcome:** A user holds a live, interactive conversation with their Rundock agent team from a device that isn't running Rundock locally, with orchestrator routing, specialist delegation, and file access working end-to-end.
+	  **Success signal:** To be developed if and when this card advances. Not worth defining until the gap is visible in practice.
+	  **Absorbed:** Old Later cards 2026-04-15: Browser Cloud Access (`workspace-name.rundock.cloud`, login page, same app served remotely), Full Auth and User Accounts (signup, login, session management), Mobile-Responsive UI (phone/tablet browser access), Cloud Security Hardening (WORKSPACE refactor, safePath, TOCTOU spawn lock). All four describe parts of the infrastructure this card would need if it ever advances. They become backlog items if and when that happens.
+	  **Spec:** [[Cloud-MVP-Spec]], [[Cloud-Security-Spec]], [[Electron-Cloud-Spec]], [[Cloud-Architecture-Decisions]]. These become the reference implementation only if this card moves up.
+	  **Linked backlog:** None. No items until the other two cards ship or retire and the demand for interactive cloud is validated in practice.
+	  **Dependencies:** Do not start until `Teams use Rundock together` and `Rundock runs scheduled work while I'm away` have both landed or both retired. If both leaner paths succeed and no one asks for interactive cloud over six months, archive this card.
+	  #area/platform #horizon/later #confidence/low
+- [ ] **Operators can tell whether their agent team is healthy**
+	  **Why now:** Merged out of the old Organisation Health System + Usage Analytics Dashboard Later cards 2026-04-15. Today a Rundock operator has no visibility into whether their agents are being used, whether they're producing output that gets accepted, or whether the team shape itself makes sense. Layer 1 (stability pass) shipped already. Layers 2-3 (usage dashboard, quality monitoring) are outcome-adjacent but not yet needed because Liam is still the only active operator.
+	  **Target outcome:** A Rundock operator can answer three questions from inside Rundock: (1) which agents am I using and how often, (2) which agents are producing output I accept vs reject, and (3) is my team shape (roster, routing, delegation chains) working.
+	  **Success signal:** After one month of daily use with the health system live, the operator can point to one concrete decision they made (retire an agent, reshape a routing rule, adjust a skill) based on what the health system surfaced.
+	  **Absorbed:** Old Later cards 2026-04-15: Organisation Health System (the parent idea), Usage Analytics Dashboard (layer 2 of org health per its own card body).
+	  **Linked backlog:** None yet. Per DEEP "Detailed appropriately". Backlog items created when this card moves from Later to Next.
+	  **Dependencies:** None. Independent of the teams/cloud stack. Pure observability work on the local workspace.
+	  #area/platform #horizon/later #confidence/medium
+- [ ] **Operators discover and install agents and skills built by others**
+	  **Why now:** Merged out of the old Marketplace + Playbook Portability Format Later cards 2026-04-15. Longest-horizon card on the roadmap. No work happens until three preconditions are met: (1) Rundock has users beyond Liam, (2) those users are building agents and skills worth sharing, and (3) distribution demand is observed rather than assumed.
+	  **Target outcome:** A Rundock operator browses a catalogue of agents and skills built by others, installs one with a single action, and uses it in their workspace without manual setup. The catalogue supports publish, install, and rate operations.
+	  **Success signal:** One non-Liam user publishes one agent or skill that one other non-Liam user installs and uses.
+	  **Absorbed:** Old Later cards 2026-04-15: Marketplace (the user-visible outcome), Playbook Portability Format (the technical substrate, which becomes the first backlog item under this card when it moves up).
+	  **Linked backlog:** None yet. First backlog item when this card moves up: a playbook portability format (distributable skills with dependency declaration and install-time resolution), because the catalogue needs something to catalogue.
+	  **Dependencies:** Blocked on Rundock having users beyond Liam. Gated behind `Teams use Rundock together` and `Interactive remote access to Rundock from anywhere` both producing real non-Liam users.
+	  #area/platform #horizon/later #confidence/low
+- [ ] **Complex multi-step delegations are observable and run in parallel**
+	  **Why now:** Merged out of the old Progress Tracking + Parallel Delegation Later cards 2026-04-15. Long-running delegations today are opaque (the operator can't see intermediate state) and serial (independent subtasks wait in line). Both limits bite when the delegation shape gets ambitious, which 0.8.x shipping the correctness platform is making more common.
+	  **Target outcome:** When a specialist runs a long multi-step task, the operator can see progress in real time via a visible plan-file state machine. When a specialist has independent subtasks, they run in parallel rather than in sequence, so the whole delegation finishes in roughly the time of the longest subtask rather than the sum of all subtasks.
+	  **Success signal:** A delegation with three independent subtasks completes in the time of the longest one, with all three visible in the UI as they progress. The operator can glance at the Rundock window and see what's being worked on without opening individual conversations.
+	  **Lean candidate:** Plan files as state machines (pattern from Dispatch). Workers update plan files; orchestrator reads for status. UI renders as progress bars. Parallel delegation uses one of: Claude Code Agent Teams, open-multi-agent, or a custom layer.
+	  **Absorbed:** Old Later cards 2026-04-15: Progress Tracking (file-based progress visibility), Parallel Delegation (multiple agents on independent subtasks).
+	  **Linked backlog:** None yet. Per DEEP "Detailed appropriately". Backlog items created when this card moves up.
+	  **Dependencies:** Builds on Delegation Context Tiers (shipped 0.8.2). Progress Tracking is a prerequisite for Parallel Delegation within this card.
+	  #area/platform #horizon/later #confidence/medium
+- [ ] **Agent output reaches the operator outside Rundock's UI**
+	  **Why now:** Split out of the old Notification Layer Later card 2026-04-15. Today, anything an agent produces is only visible inside the Rundock window. For scheduled work (see `Rundock runs scheduled work while I'm away`) and any other async agent activity, the operator has no way to be notified somewhere they actually are (phone, Slack, messaging app). Small card, isolated scope, but becomes more important once async activity grows.
+	  **Target outcome:** A Rundock operator receives agent output at a channel of their choice (Telegram, Discord, iMessage, Slack, email) when the agent decides the output warrants interrupting them. Rundock provides the plumbing; the agent decides what's worth pushing.
+	  **Success signal:** An agent finishes a scheduled task and the operator sees the result on their phone without opening Rundock.
+	  **Lean candidate:** Claude Code Channels for the outbound side. MCP connectors (Telegram, Discord, Slack) for the delivery side. Agent-level rules for what counts as notification-worthy.
+	  **Absorbed:** Old "Notification Layer" Later card 2026-04-15.
+	  **Linked backlog:** None yet. Per DEEP "Detailed appropriately".
+	  **Dependencies:** Most valuable once `Rundock runs scheduled work while I'm away` has landed. Not strictly blocked, though: an always-open Rundock conversation can still benefit from async notifications.
+	  #area/platform #horizon/later #confidence/low
+
+
+
+
+%% kanban:settings
+```
+{"kanban-plugin":"board","list-collapse":[true,true,false,false,false],"mark-cards-in-list-as-complete":["Shipped"]}
+```
+%%

--- a/test/unit/board-markdown.test.js
+++ b/test/unit/board-markdown.test.js
@@ -1,0 +1,60 @@
+'use strict';
+// Card display rendering: styled markdown with strict escaping. Card text is
+// untrusted, so the priority is that no input can inject markup or a dangerous
+// URL scheme.
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderCardHtml } from '../../public/viewers/board-markdown.js';
+
+describe('renderCardHtml', () => {
+  test('escapes HTML so card text cannot inject markup', () => {
+    const html = renderCardHtml('<img src=x onerror="alert(1)"> hi');
+    assert.ok(!html.includes('<img'), 'raw tag must be escaped to inert text');
+    assert.ok(html.includes('&lt;img'), 'angle brackets escaped');
+    assert.ok(!html.includes('onerror="'), 'the handler quotes are escaped, so it can never fire');
+  });
+
+  test('renders bold, italic, strikethrough, and inline code', () => {
+    assert.ok(renderCardHtml('**bold**').includes('<strong>bold</strong>'));
+    assert.ok(renderCardHtml('_it_').includes('<em>it</em>'));
+    assert.ok(renderCardHtml('~~gone~~').includes('<del>gone</del>'));
+    assert.ok(renderCardHtml('`x=1`').includes('<code>x=1</code>'));
+  });
+
+  test('inline code content is not re-parsed as emphasis', () => {
+    const html = renderCardHtml('`a*b*c`');
+    assert.ok(html.includes('<code>a*b*c</code>'), 'code stays literal');
+    assert.ok(!html.includes('<em>'), 'no emphasis inside code');
+  });
+
+  test('a number surrounded by spaces is not mistaken for a code placeholder', () => {
+    const html = renderCardHtml('step 3 of 5');
+    assert.ok(html.includes('step 3 of 5'), 'plain digits survive verbatim');
+    assert.ok(!html.includes('undefined'), 'no placeholder collision');
+  });
+
+  test('safe links render; javascript: and data: URLs do not become hrefs', () => {
+    assert.ok(renderCardHtml('[docs](https://example.com)').includes('<a href="https://example.com"'));
+    const bad = renderCardHtml('[x](javascript:alert(1))');
+    assert.ok(!bad.includes('href'), 'javascript: URL is not linked');
+    const data = renderCardHtml('[y](data:text/html,<script>1</script>)');
+    assert.ok(!data.includes('href'), 'data: URL is not linked');
+  });
+
+  test('wikilinks render as links, alias shown when present', () => {
+    const a = renderCardHtml('[[Some Note]]');
+    assert.ok(a.includes('class="board-wikilink"') && a.includes('data-target="Some Note"'));
+    assert.ok(a.includes('>Some Note</a>'));
+    const b = renderCardHtml('[[Some Note|Alias]]');
+    assert.ok(b.includes('data-target="Some Note"') && b.includes('>Alias</a>'));
+  });
+
+  test('a wikilink target with a quote cannot break out of the attribute', () => {
+    const html = renderCardHtml('[[x" onmouseover="pwn()]]');
+    assert.ok(!/onmouseover="pwn/.test(html), 'the injected handler is neutralised by escaping');
+  });
+
+  test('multi-line card text joins with line breaks', () => {
+    assert.ok(renderCardHtml('line one\nline two').includes('line one<br>line two'));
+  });
+});

--- a/test/unit/kanban.test.js
+++ b/test/unit/kanban.test.js
@@ -401,4 +401,28 @@ describe('board creation and detection lifecycle', () => {
   test('the hoist is byte-neutral on canonical boards', () => {
     assert.strictEqual(Kanban.serialize(Kanban.parse(backlog.once)), backlog.once);
   });
+
+  test('block-style frontmatter (multi-line lists, nested maps) survives a round-trip', () => {
+    // A flat key/value re-emit would destroy these; the body is preserved verbatim.
+    const src = '---\n\nkanban-plugin: board\ntitle: My board\ntags:\n  - project\n  - kanban\naliases:\n  - "[[Other]]"\n\n---\n\n## To do\n\n- [ ] a card\n\n\n\n\n%% kanban:settings\n```\n{"kanban-plugin":"board","list-collapse":[false]}\n```\n%%';
+    const board = Kanban.parse(src);
+    const out = Kanban.serialize(board);
+    // The tag/alias lists and every frontmatter line survive intact.
+    assert.ok(out.includes('tags:\n  - project\n  - kanban'), 'block tag list preserved');
+    assert.ok(out.includes('aliases:\n  - "[[Other]]"'), 'block alias list preserved');
+    assert.ok(out.includes('title: My board'), 'scalar preserved');
+    // And it is a fixed point (idempotent) with a card edit staying byte-honest.
+    assert.strictEqual(Kanban.serialize(Kanban.parse(out)), out, 'idempotent');
+    assert.strictEqual(board.dropped.length, 0, 'nothing reported dropped');
+    Kanban.toggleItem(board, 0, 0);
+    const toggled = Kanban.serialize(board);
+    assert.ok(toggled.includes('tags:\n  - project\n  - kanban'), 'tags still intact after a card edit');
+  });
+
+  test('a fresh board built via newBoardContent still emits the canonical first-save shape', () => {
+    const fresh = Kanban.parse(Kanban.newBoardContent());
+    Kanban.insertLane(fresh, 0, 'To do');
+    assert.strictEqual(Kanban.serialize(fresh),
+      '---\n\nkanban-plugin: board\n\n---\n\n## To do\n\n\n\n\n\n%% kanban:settings\n```\n{"kanban-plugin":"board","list-collapse":[false]}\n```\n%%');
+  });
 });

--- a/test/unit/kanban.test.js
+++ b/test/unit/kanban.test.js
@@ -1,0 +1,404 @@
+'use strict';
+// Byte-level parity tests for public/kanban.js, the Obsidian Kanban plugin
+// (v2.0.51) parser/serializer. The bar is byte interchangeability: a board
+// file edited in Rundock and Obsidian alternately must never churn. Every
+// move/CRUD/lane op is proven to change ONLY the bytes it should, by
+// constructing the expected output through pure text surgery on the canonical
+// form.
+//
+// Fixtures (test/fixtures/kanban/) are copies of real boards. Format rules were
+// reverse-engineered from the installed plugin's compiled bundle.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const Kanban = require('../../public/kanban.js');
+
+const FIX = path.join(__dirname, '..', 'fixtures', 'kanban');
+const read = (f) => fs.readFileSync(path.join(FIX, f), 'utf8');
+
+// Line diff sufficient for eyeballing failures and for the drift classifier.
+function lineDiff(a, b) {
+  const la = a.split('\n'), lb = b.split('\n');
+  const out = [];
+  let i = 0, j = 0;
+  while (i < la.length && j < lb.length) {
+    if (la[i] === lb[j]) { i++; j++; continue; }
+    let synced = false;
+    for (let k = 1; k <= 6 && !synced; k++) {
+      if (la[i + k] === lb[j]) { for (let x = 0; x < k; x++) out.push(`-${i + x + 1}: ${JSON.stringify(la[i + x])}`); i += k; synced = true; }
+      else if (la[i] === lb[j + k]) { for (let x = 0; x < k; x++) out.push(`+${j + x + 1}: ${JSON.stringify(lb[j + x])}`); j += k; synced = true; }
+    }
+    if (!synced) { out.push(`-${i + 1}: ${JSON.stringify(la[i])}`); out.push(`+${j + 1}: ${JSON.stringify(lb[j])}`); i++; j++; }
+    if (out.length > 60) { out.push('... (diff truncated)'); return out; }
+  }
+  for (; i < la.length; i++) out.push(`-${i + 1}: ${JSON.stringify(la[i])}`);
+  for (; j < lb.length; j++) out.push(`+${j + 1}: ${JSON.stringify(lb[j])}`);
+  return out;
+}
+
+/** Extract a card's text block (title line + all tab-continuation lines, incl. trailing \n). */
+function extractBlock(text, titleLinePrefix) {
+  const start = text.indexOf('\n' + titleLinePrefix) + 1;
+  if (start <= 0) throw new Error('card not found: ' + titleLinePrefix);
+  let end = text.indexOf('\n', start) + 1;
+  while (end < text.length && text[end] === '\t') end = text.indexOf('\n', end) + 1;
+  return { block: text.slice(start, end), start, end };
+}
+
+// Canonical form (a fixed point of parse->serialize) for each fixture, computed
+// once. Byte-surgery expectations are built against `.once`, so a hand-edit in
+// the raw fixture never destabilises the move/CRUD/lane tests.
+function canonical(file) {
+  const orig = read(file);
+  const board = Kanban.parse(orig);
+  const once = Kanban.serialize(board);
+  return { orig, board, once };
+}
+
+const backlog = canonical('backlog.md');
+const roadmap = canonical('roadmap.md');
+
+describe('round-trip idempotence and canonicalisation drift', () => {
+  for (const [label, fx] of [['backlog', backlog], ['roadmap', roadmap]]) {
+    test(`${label}: serialize is idempotent (canonical form is a fixed point)`, () => {
+      const twice = Kanban.serialize(Kanban.parse(fx.once));
+      assert.strictEqual(fx.once, twice, lineDiff(fx.once, twice).join('\n'));
+    });
+
+    test(`${label}: drift vs original is blank-line normalisation only (no content changes)`, () => {
+      const drift = lineDiff(fx.orig, fx.once);
+      const removed = drift.filter(d => d.startsWith('-')).map(d => JSON.parse(d.replace(/^-\d+: /, '')));
+      const added = drift.filter(d => d.startsWith('+')).map(d => JSON.parse(d.replace(/^\+\d+: /, '')));
+      const nonBlankRemoved = removed.filter(l => l.trim() !== '').sort().join(' ');
+      const nonBlankAdded = added.filter(l => l.trim() !== '').sort().join(' ');
+      assert.strictEqual(nonBlankRemoved, nonBlankAdded,
+        'non-blank line content changed:\n' + drift.slice(0, 30).join('\n'));
+    });
+
+    test(`${label}: zero dropped lines (plugin-canonical board carries nothing droppable)`, () => {
+      assert.strictEqual(fx.board.dropped.length, 0, JSON.stringify(fx.board.dropped.slice(0, 5)));
+    });
+  }
+});
+
+describe('move-card byte discipline (backlog)', () => {
+  const base = backlog.once;
+  const readyIdx = () => Kanban.parse(base).lanes.findIndex(l => l.title === 'Ready');
+  const firstTwoTitles = () => {
+    const b = Kanban.parse(base);
+    const r = b.lanes.findIndex(l => l.title === 'Ready');
+    return [0, 1].map(i => '- [' + b.lanes[r].items[i].checkChar + '] ' + b.lanes[r].items[i].titleRaw.split('\n')[0]);
+  };
+
+  test('reorder within Ready: bytes differ ONLY by the two swapped card blocks', () => {
+    const board = Kanban.parse(base);
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const [t0, t1] = firstTwoTitles();
+    const b0 = extractBlock(base, t0);
+    const b1 = extractBlock(base, t1);
+    const expected = base.slice(0, b0.start) + b1.block + b0.block + base.slice(b1.end);
+    Kanban.moveItem(board, ready, 0, ready, 1);
+    assert.strictEqual(Kanban.serialize(board), expected);
+  });
+
+  test('cross-lane move Inbox->Ready: bytes differ ONLY by the moved card block', () => {
+    const board = Kanban.parse(base);
+    const inbox = board.lanes.findIndex(l => l.title === 'Inbox');
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const [t0] = firstTwoTitles();
+    const ti = '- [' + board.lanes[inbox].items[0].checkChar + '] ' + board.lanes[inbox].items[0].titleRaw.split('\n')[0];
+    const bi = extractBlock(base, ti);
+    const withoutCard = base.slice(0, bi.start) + base.slice(bi.end);
+    const br0 = extractBlock(withoutCard, t0);
+    const expected = withoutCard.slice(0, br0.start) + bi.block + withoutCard.slice(br0.start);
+    Kanban.moveItem(board, inbox, 0, ready, 0);
+    assert.strictEqual(Kanban.serialize(board), expected);
+  });
+
+  test('move to In Progress and back restores canonical bytes exactly', () => {
+    const board = Kanban.parse(base);
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const inprog = board.lanes.findIndex(l => l.title === 'In Progress');
+    Kanban.moveItem(board, ready, 0, inprog, 0);
+    Kanban.moveItem(board, inprog, 0, ready, 0);
+    assert.strictEqual(Kanban.serialize(board), base);
+  });
+
+  test('move into empty lane: canonical spacing and idempotent under reparse', () => {
+    const board = Kanban.parse(base);
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const inprog = board.lanes.findIndex(l => l.title === 'In Progress');
+    const [t0] = firstTwoTitles();
+    const b0 = extractBlock(base, t0);
+    Kanban.moveItem(board, ready, 0, inprog, 0);
+    const out = Kanban.serialize(board);
+    assert.strictEqual(Kanban.serialize(Kanban.parse(out)), out, 'idempotent');
+    assert.ok(out.includes('## In Progress\n\n' + b0.block.split('\n')[0]), 'card under heading with canonical spacing');
+  });
+});
+
+describe('add + archive round-trip (backlog)', () => {
+  const base = backlog.once;
+
+  test('add card: diff is exactly one added line', () => {
+    const board = Kanban.parse(base);
+    Kanban.addItem(board, 0, 'in-app test card #type/ops');
+    const d1 = lineDiff(base, Kanban.serialize(board));
+    assert.ok(d1.length === 1 && d1[0].startsWith('+'), d1.join('\n'));
+  });
+
+  test('archive card: *** + ## Archive present, card is last archive entry, before settings', () => {
+    const board = Kanban.parse(base);
+    Kanban.addItem(board, 0, 'in-app test card #type/ops');
+    const withCard = Kanban.serialize(board);
+    const board2 = Kanban.parse(withCard);
+    Kanban.archiveItem(board2, 0, board2.lanes[0].items.length - 1);
+    const archived = Kanban.serialize(board2);
+    const parsedBack = Kanban.parse(archived);
+    assert.ok(archived.includes('***\n\n## Archive\n\n'), 'separator + heading');
+    assert.strictEqual(parsedBack.archive[parsedBack.archive.length - 1].titleRaw, 'in-app test card #type/ops');
+    const idxArchive = archived.indexOf('## Archive');
+    const idxSettings = archived.indexOf('%% kanban:settings');
+    assert.ok(idxArchive > 0 && idxArchive < idxSettings, 'archive sits before settings');
+  });
+});
+
+describe('edge inventory (edge-cases fixture)', () => {
+  const fx = read('edge-cases.md');
+  const b = Kanban.parse(fx);
+
+  test('fixture is byte-stable (canonical fixed point) with zero dropped lines', () => {
+    assert.strictEqual(Kanban.serialize(b), fx, lineDiff(fx, Kanban.serialize(b)).join('\n'));
+    assert.strictEqual(b.dropped.length, 0, JSON.stringify(b.dropped));
+  });
+
+  test('lane WIP limit "(3)" parses as maxItems; **Complete** marker parses', () => {
+    const doing = b.lanes[0];
+    assert.strictEqual(doing.title, 'Doing');
+    assert.strictEqual(doing.maxItems, 3);
+    assert.strictEqual(doing.shouldMarkItemsComplete, true);
+  });
+
+  test('multi-paragraph body: blank line round-trips through a tab-only line', () => {
+    assert.ok(b.lanes[0].items[0].titleRaw.includes('here.\n\n  Second paragraph'));
+  });
+
+  test('fenced code block inside a card is preserved in titleRaw', () => {
+    assert.ok(b.lanes[0].items[1].titleRaw.includes('```js\n  const x = 1;\n  ```'));
+  });
+
+  test('block id split from first line; checkChar preserved; nested checkboxes stay inside parent', () => {
+    const bid = b.lanes[0].items[2];
+    assert.strictEqual(bid.blockId, 'abc-123');
+    assert.strictEqual(bid.checkChar, 'x');
+    assert.ok(!bid.titleRaw.includes('^abc-123'));
+    assert.strictEqual(b.lanes[0].items.length, 4);
+    assert.ok(bid.titleRaw.includes('- [ ] nested unchecked'));
+  });
+
+  test('custom checkChar preserved; <br> lane title parses to newline; archive parsed', () => {
+    assert.strictEqual(b.lanes[0].items[3].checkChar, '-');
+    assert.strictEqual(b.lanes[1].title, 'Two\nLines');
+    assert.strictEqual(b.archive.length, 1);
+    assert.strictEqual(b.archive[0].checkChar, 'x');
+  });
+
+  test('hand-authored normalisations: ### -> ##, bare item gains checkbox, 2-space cont. gains a tab', () => {
+    const hand = ['---', '', 'kanban-plugin: board', '', '---', '', '',
+      '### Deep Heading', '', '- bare item no checkbox', '- [ ] two-space indent card', '  indented with two spaces only', '', '', ''].join('\n')
+      + ['', '', '%% kanban:settings', '```', '{"kanban-plugin":"board"}', '```', '%%'].join('\n');
+    const hout = Kanban.serialize(Kanban.parse(hand));
+    assert.ok(hout.includes('## Deep Heading') && !hout.includes('### Deep Heading'));
+    assert.ok(hout.includes('- [ ] bare item no checkbox'));
+    assert.ok(hout.includes('- [ ] two-space indent card\n\t  indented with two spaces only'));
+    assert.strictEqual(Kanban.serialize(Kanban.parse(hout)), hout, 'idempotent after one canonicalisation');
+  });
+});
+
+describe('update / delete / toggle byte discipline (backlog)', () => {
+  const base = backlog.once;
+  const readyFirstTitle = () => {
+    const b = Kanban.parse(base);
+    const r = b.lanes.findIndex(l => l.title === 'Ready');
+    const it = b.lanes[r].items[0];
+    return '- [' + it.checkChar + '] ' + it.titleRaw.split('\n')[0];
+  };
+
+  test('update: bytes differ ONLY by the edited card block (tab re-indent applied); idempotent', () => {
+    const board = Kanban.parse(base);
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const b0 = extractBlock(base, readyFirstTitle());
+    Kanban.updateItem(board, ready, 0, '**Edited card title**\n  New body line for the CRUD test.');
+    const after = Kanban.serialize(board);
+    const expected = base.slice(0, b0.start)
+      + '- [ ] **Edited card title**\n\t  New body line for the CRUD test.\n'
+      + base.slice(b0.end);
+    assert.strictEqual(after, expected, lineDiff(expected, after).slice(0, 10).join('\n'));
+    assert.strictEqual(Kanban.serialize(Kanban.parse(after)), after, 'idempotent');
+  });
+
+  test('delete: bytes differ ONLY by the removed card block', () => {
+    const board = Kanban.parse(base);
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const b0 = extractBlock(base, readyFirstTitle());
+    Kanban.deleteItem(board, ready, 0);
+    assert.strictEqual(Kanban.serialize(board), base.slice(0, b0.start) + base.slice(b0.end));
+  });
+
+  test('toggle: exactly the checkbox char changes; double-toggle restores canonical bytes', () => {
+    const board = Kanban.parse(base);
+    const ready = board.lanes.findIndex(l => l.title === 'Ready');
+    const b0 = extractBlock(base, readyFirstTitle());
+    Kanban.toggleItem(board, ready, 0);
+    assert.strictEqual(Kanban.serialize(board), base.slice(0, b0.start) + '- [x]' + base.slice(b0.start + 5));
+    Kanban.toggleItem(board, ready, 0);
+    assert.strictEqual(Kanban.serialize(board), base);
+  });
+
+  test('update preserves blockId and checkChar (fields live outside titleRaw)', () => {
+    const fx = Kanban.parse(read('edge-cases.md'));
+    const bidItem = fx.lanes[0].items[2];
+    Kanban.updateItem(fx, 0, 2, 'Edited body, id must survive');
+    assert.strictEqual(bidItem.blockId, 'abc-123');
+    assert.strictEqual(bidItem.checkChar, 'x');
+    assert.ok(Kanban.serialize(fx).includes('- [x] Edited body, id must survive ^abc-123'));
+  });
+});
+
+describe('lane operations (column parity byte discipline, backlog)', () => {
+  const base = backlog.once;
+
+  test('moveLane: lane order changes; list-collapse reorders in LOCKSTEP; reversible', () => {
+    const b1 = Kanban.parse(base);
+    const lcBefore = [...b1.settings['list-collapse']];
+    const titlesBefore = b1.lanes.map(l => l.title);
+    Kanban.moveLane(b1, 0, 2);
+    const out1 = Kanban.serialize(b1);
+    const b1b = Kanban.parse(out1);
+    assert.deepStrictEqual(b1b.lanes.map(l => l.title),
+      [titlesBefore[1], titlesBefore[2], titlesBefore[0], ...titlesBefore.slice(3)]);
+    assert.deepStrictEqual(b1b.settings['list-collapse'],
+      [lcBefore[1], lcBefore[2], lcBefore[0], ...lcBefore.slice(3)]);
+    assert.strictEqual(Kanban.serialize(Kanban.parse(out1)), out1, 'idempotent');
+    Kanban.moveLane(b1, 2, 0);
+    assert.strictEqual(Kanban.serialize(b1), base, 'reversible to canonical bytes');
+  });
+
+  test('toggleCollapse: diff is EXACTLY the settings JSON line; double-toggle restores', () => {
+    const b2 = Kanban.parse(base);
+    Kanban.toggleCollapse(b2, 1);
+    const d2 = lineDiff(base, Kanban.serialize(b2));
+    assert.ok(d2.length === 2 && d2.every(l => l.includes('list-collapse')), d2.join('\n'));
+    Kanban.toggleCollapse(b2, 1);
+    assert.strictEqual(Kanban.serialize(b2), base);
+  });
+
+  test('renameLane: one heading line changes; WIP suffix round-trips; reversible', () => {
+    const b3 = Kanban.parse(base);
+    const original = b3.lanes[3].maxItems ? `${b3.lanes[3].title} (${b3.lanes[3].maxItems})` : b3.lanes[3].title;
+    Kanban.renameLane(b3, 3, 'Doing (2)');
+    const d3 = lineDiff(base, Kanban.serialize(b3));
+    assert.ok(d3.length === 2 && d3.some(l => l.includes('## Doing (2)')), d3.join('\n'));
+    const b3b = Kanban.parse(Kanban.serialize(b3));
+    assert.strictEqual(b3b.lanes[3].title, 'Doing');
+    assert.strictEqual(b3b.lanes[3].maxItems, 2);
+    Kanban.renameLane(b3, 3, original);
+    assert.strictEqual(Kanban.serialize(b3), base);
+  });
+
+  test('insertLane: canonical empty-lane spacing; false spliced into list-collapse; deleteLane restores', () => {
+    const b4 = Kanban.parse(base);
+    const lc4 = [...b4.settings['list-collapse']];
+    Kanban.insertLane(b4, 2, 'Blocked');
+    const out4 = Kanban.serialize(b4);
+    assert.ok(out4.includes('## Blocked\n\n\n\n## '), 'empty-lane spacing');
+    assert.deepStrictEqual(b4.settings['list-collapse'], [...lc4.slice(0, 2), false, ...lc4.slice(2)]);
+    assert.strictEqual(Kanban.serialize(Kanban.parse(out4)), out4, 'idempotent');
+    Kanban.deleteLane(b4, 2);
+    assert.strictEqual(Kanban.serialize(b4), base, 'deleteLane restores, collapse spliced back');
+  });
+
+  test('archiveLaneCards: cards PREPEND in lane order; lane stays empty; idempotent', () => {
+    const b5 = Kanban.parse(base);
+    const ready5 = b5.lanes.findIndex(l => l.title === 'Ready');
+    const readyTitles = b5.lanes[ready5].items.map(i => i.titleRaw.split('\n')[0]);
+    const archBefore = b5.archive.map(i => i.titleRaw.split('\n')[0]);
+    Kanban.archiveLaneCards(b5, ready5);
+    assert.deepStrictEqual(b5.archive.map(i => i.titleRaw.split('\n')[0]), [...readyTitles, ...archBefore]);
+    assert.strictEqual(b5.lanes[ready5].items.length, 0);
+    assert.strictEqual(b5.lanes[ready5].title, 'Ready');
+    const out5 = Kanban.serialize(b5);
+    assert.strictEqual(Kanban.serialize(Kanban.parse(out5)), out5);
+  });
+
+  test('archiveLane removes lane but keeps cards; deleteLane removes both', () => {
+    const b6 = Kanban.parse(base);
+    const inboxCount = b6.lanes[1].items.length;
+    const archCount = b6.archive.length;
+    Kanban.archiveLane(b6, 1);
+    assert.ok(!b6.lanes.some(l => l.title === 'Inbox'));
+    assert.strictEqual(b6.archive.length, archCount + inboxCount);
+    const b7 = Kanban.parse(base);
+    Kanban.deleteLane(b7, 1);
+    assert.ok(!b7.lanes.some(l => l.title === 'Inbox'));
+    assert.strictEqual(b7.archive.length, archCount);
+    assert.strictEqual(Kanban.serialize(Kanban.parse(Kanban.serialize(b7))), Kanban.serialize(b7));
+  });
+
+  test('sortLane: pure permutation of card blocks; content set unchanged; byte-stable', () => {
+    const b8 = Kanban.parse(base);
+    const ready8 = b8.lanes.findIndex(l => l.title === 'Ready');
+    const before8 = [...b8.lanes[ready8].items.map(i => i.titleRaw)].sort();
+    Kanban.sortLane(b8, ready8, 'text');
+    const out8 = Kanban.serialize(b8);
+    const b8b = Kanban.parse(out8);
+    assert.deepStrictEqual([...b8b.lanes[ready8].items.map(i => i.titleRaw)].sort(), before8);
+    assert.strictEqual(Kanban.serialize(b8b), out8);
+    Kanban.sortLane(b8, ready8, 'tags');
+    assert.deepStrictEqual([...b8.lanes[ready8].items.map(i => i.titleRaw)].sort(), before8);
+    assert.strictEqual(Kanban.serialize(Kanban.parse(Kanban.serialize(b8))), Kanban.serialize(b8));
+  });
+});
+
+describe('board creation and detection lifecycle', () => {
+  test('newBoardContent is byte-exact to the plugin basicFrontmatter', () => {
+    assert.strictEqual(Kanban.newBoardContent(), '---\n\nkanban-plugin: board\n\n---\n\n');
+  });
+
+  test('isBoardFile mirrors hasFrontmatterKeyRaw', () => {
+    assert.strictEqual(Kanban.isBoardFile(Kanban.newBoardContent()), true);
+    assert.strictEqual(Kanban.isBoardFile(backlog.orig), true);
+    assert.strictEqual(Kanban.isBoardFile('---\ntitle: Note\n---\n\n# Hi\n'), false);
+    assert.strictEqual(Kanban.isBoardFile('# Just markdown\n'), false);
+  });
+
+  test('fresh board: zero lanes, settings hoisted from frontmatter', () => {
+    const fresh = Kanban.parse(Kanban.newBoardContent());
+    assert.strictEqual(fresh.lanes.length, 0);
+    assert.strictEqual(fresh.dropped.length, 0);
+    assert.deepStrictEqual(fresh.settings, { 'kanban-plugin': 'board' });
+  });
+
+  test('first save adds the settings block in the plugin first-save shape; idempotent', () => {
+    const fresh = Kanban.parse(Kanban.newBoardContent());
+    Kanban.insertLane(fresh, 0, 'To do');
+    const firstSave = Kanban.serialize(fresh);
+    assert.strictEqual(firstSave,
+      '---\n\nkanban-plugin: board\n\n---\n\n## To do\n\n\n\n\n\n%% kanban:settings\n```\n{"kanban-plugin":"board","list-collapse":[false]}\n```\n%%');
+    assert.strictEqual(Kanban.serialize(Kanban.parse(firstSave)), firstSave);
+  });
+
+  test('legacy kanban-plugin: basic migrates to board in both homes on save', () => {
+    const legacy = '---\n\nkanban-plugin: basic\n\n---\n\n## Old\n\n- [ ] card\n\n\n\n%% kanban:settings\n```\n{"kanban-plugin":"basic"}\n```\n%%';
+    const lOut = Kanban.serialize(Kanban.parse(legacy));
+    assert.ok(lOut.includes('kanban-plugin: board'));
+    assert.ok(lOut.includes('{"kanban-plugin":"board"}'));
+    assert.ok(!lOut.includes('basic'));
+  });
+
+  test('the hoist is byte-neutral on canonical boards', () => {
+    assert.strictEqual(Kanban.serialize(Kanban.parse(backlog.once)), backlog.once);
+  });
+});


### PR DESCRIPTION
The Kanban board registry view: a markdown file whose frontmatter carries the kanban-plugin key opens as a column board that reads and writes byte-compatible markdown (validated against the real 761-line board and canonical fixtures).

## Features
- Columns of cards with rich, safely-escaped card text (bold, italic, code, links, wikilinks).
- Drag cards between columns; add cards; toggle checkboxes.
- Edit a card in place (Enter saves, Shift+Enter newline, Esc cancels, click-away saves); delete a card; single-level undo for destructive actions.
- Lane three-dot menu: rename, move left/right, insert before/after, sort by text or tags, archive cards, archive list, delete list, with undo on the destructive ones.
- Collapse a column to a rail (persisted); reorder columns from the menu.
- Content-based detection and routing; the first writable registry view, saving through the guarded autosave (external-edit banner and Saved status included). A board carrying content the grammar cannot represent refuses to save rather than dropping lines.

## Quality
- Dependency-free parser/serializer with a byte-parity suite (round-trip idempotence, canonicalisation-drift discipline, move/CRUD/lane-op text-surgery expectations, the list-collapse lockstep splice, board-creation lifecycle).
- An independent adversarial review of the whole diff found and this PR fixes: a critical frontmatter data-loss bug (block-style YAML lists were flattened on save; now preserved verbatim), an undo that could discard interim edits, a debounce that could drop a board's last edit on file switch, stacked warning banners, and a placeholder-collision edge. Each fix has a regression test.

Unit 863 to 918, e2e 26 to 38, all green.

## Not in this PR (refinements, tracked)
Content-hash-addressed writes for concurrent-edit safety (the external-edit guard covers the common case); a second drag surface for column reorder (the menu ships the capability now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)