### PR TITLE
Files view: keep the open file across view switches, reveal it in the tree

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3073,7 +3073,25 @@ function switchNav(nav) {
   closeFindBar();
   setNavState(nav);
   if(nav==='settings') { showView('settings'); showSettingsSection('workspace'); }
-  else if(nav==='files') { editorReturnView = 'editor'; if(currentFilePath && document.querySelector('.file-item.active')) { showView('editor'); } else { currentFilePath = null; destroyTiptapEditorIfActive(); document.getElementById('editor-header').classList.add('hidden'); document.getElementById('editor-content').classList.add('hidden'); document.getElementById('editor-textarea').classList.add('hidden'); document.getElementById('tiptap-editor-pane').classList.add('hidden'); document.getElementById('editor-empty').classList.remove('hidden'); showView('editor'); } }
+  else if(nav==='files') {
+    editorReturnView = 'editor';
+    if (currentFilePath) {
+      // A file is open: keep it open across the view switch (its editor/viewer
+      // is still mounted, just hidden) and re-reveal it in the tree.
+      showView('editor');
+      highlightFileInSidebar(currentFilePath);
+      updateEditorBackButton();
+    } else {
+      // Nothing open: show the empty state.
+      destroyTiptapEditorIfActive();
+      document.getElementById('editor-header').classList.add('hidden');
+      document.getElementById('editor-content').classList.add('hidden');
+      document.getElementById('editor-textarea').classList.add('hidden');
+      document.getElementById('tiptap-editor-pane').classList.add('hidden');
+      document.getElementById('editor-empty').classList.remove('hidden');
+      showView('editor');
+    }
+  }
   else if(nav==='skills') { showView('skills'); if(!skillsLoaded) { ws.send(JSON.stringify({type:'get_skills'})); } else if(skills.length && !currentSkillId) { selectSkill(skills[0].id); } }
   else if(nav==='conversations') { if(activeConversation) { showView('chat'); if(unreadConvos.delete(activeConversation.id)) { updateUnreadBadge(); renderConvoList(); } } else { const target = pickDefaultConversation(); if(target) { openConversation(target.id); } else { newConversation(); } } }
   else if(nav==='team') { showView('home'); renderOrgChart(); }
@@ -3143,6 +3161,7 @@ function loadFileContent(path, content) {
   document.getElementById('editor-status').textContent = '';
   document.getElementById('editor-header').classList.remove('hidden');
   document.getElementById('editor-empty').classList.add('hidden');
+  updateEditorBackButton();
 
   // The file-type registry decides the surface for EVERY path (the FV2
   // swap: the old per-type if-chain is gone). markdown -> Tiptap editor,
@@ -3356,11 +3375,22 @@ function openWikilink(name) {
 
 function highlightFileInSidebar(filePath) {
   document.querySelectorAll('.file-item').forEach(x => x.classList.remove('active'));
-  document.querySelectorAll('.file-item').forEach(fi => {
-    if (fi.dataset.path === filePath) {
-      fi.classList.add('active');
+  const target = Array.from(document.querySelectorAll('.file-item')).find(fi => fi.dataset.path === filePath);
+  if (!target) return;
+  target.classList.add('active');
+  // Reveal it: expand every collapsed ancestor folder so the highlighted file
+  // is actually visible, then scroll it into view within the sidebar.
+  let node = target.parentElement;
+  while (node && node !== document.body) {
+    if (node.classList && node.classList.contains('file-children') && node.classList.contains('collapsed')) {
+      node.classList.remove('collapsed');
+      const folder = node.previousElementSibling;
+      const ic = folder && folder.classList.contains('folder-item') ? folder.querySelector('.folder-icon') : null;
+      if (ic) ic.innerHTML = '&#x25BC;';
     }
-  });
+    node = node.parentElement;
+  }
+  if (target.scrollIntoView) target.scrollIntoView({ block: 'nearest' });
 }
 
 function findFileInTree(items, searchName) {
@@ -3389,6 +3419,17 @@ function findFileInTree(items, searchName) {
 let editorReturnView = 'editor';
 let fileHistory = [];
 
+// The editor back control is only useful when "back" leads somewhere: to the
+// view a file was opened from (Skills, Agents) or to the previous file in a
+// wikilink chain. Opened straight from the file tree with no history, "back"
+// would only blank the pane, which reads as losing your place, so it is hidden.
+function updateEditorBackButton() {
+  const btn = document.getElementById('editor-back');
+  if (!btn) return;
+  const useful = editorReturnView !== 'editor' || fileHistory.length > 0;
+  btn.style.display = useful ? '' : 'none';
+}
+
 function openSkillFile(filePath) {
   editorReturnView = 'skills';
   fileHistory = [];
@@ -3409,9 +3450,11 @@ function editorGoBack() {
     const prev = fileHistory.pop();
     ws.send(JSON.stringify({ type: 'read_file', path: prev }));
     highlightFileInSidebar(prev);
+    updateEditorBackButton();
     return;
   }
-  // Otherwise stay in files view: clear file content, show empty state
+  // No useful back target: this branch is now unreachable from the UI (the
+  // control hides itself in that state), but keep the safe fallback.
   currentFilePath = null;
   destroyTiptapEditorIfActive();
   document.getElementById('editor-header').classList.add('hidden');

--- a/public/index.html
+++ b/public/index.html
@@ -941,7 +941,7 @@ mark.find-match.current,
     <!-- Editor -->
     <div id="view-editor" class="hidden view-panel">
       <div class="editor-header hidden" id="editor-header">
-        <a class="chat-back" onclick="editorGoBack()"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></a>
+        <a class="chat-back" id="editor-back" onclick="editorGoBack()"><svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg></a>
         <span class="editor-filename" id="editor-filename"></span>
         <span class="editor-status" id="editor-status"></span>
         <button class="editor-toggle active" id="toggle-preview" onclick="setEditorMode('preview')">Preview</button>

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -664,6 +664,39 @@ test('the lane menu moves a column right, reordering it in the file', async ({ p
   }).toBe(true);
 });
 
+test('an open file persists across a view switch and is revealed in the tree', async ({ page }) => {
+  await boot(page);
+  await openFilesView(page);
+  // Open a nested file, then collapse its folder.
+  await page.locator('.folder-item', { hasText: 'notes' }).click();
+  await page.locator('.file-item', { hasText: 'pricing-strategy' }).click();
+  await expect(page.locator('#tiptap-editor-pane')).toBeVisible();
+  await page.locator('.folder-item', { hasText: 'notes' }).click(); // collapse
+  // Leave Files for another view, then return.
+  await page.locator('.nav-item[data-nav="team"]').click();
+  await page.locator('.nav-item[data-nav="files"]').click();
+  // The file is still open (not the empty state)...
+  await expect(page.locator('#editor-empty')).toBeHidden();
+  await expect(page.locator('#tiptap-editor-pane')).toBeVisible();
+  // ...and revealed: its folder is expanded again and the row is active.
+  await expect(page.locator('.file-item.active', { hasText: 'pricing-strategy' })).toBeVisible();
+});
+
+test('the editor back control hides when a file is opened straight from the tree', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'proposal.html');
+  await expect(page.locator('#editor-back')).toBeHidden();
+});
+
+test('the editor back control shows when a file was opened from another view', async ({ page }) => {
+  await boot(page);
+  await openFromTree(page, 'proposal.html');
+  await expect(page.locator('#editor-back')).toBeHidden();
+  // Opening from Skills sets a return view, so back becomes useful and appears.
+  await page.evaluate(() => openSkillFile('CLAUDE.md'));
+  await expect(page.locator('#editor-back')).toBeVisible();
+});
+
 test('markdown files still open in the rich editor after the registry shim', async ({ page }) => {
   await boot(page);
   await openFromTree(page, 'Roadmap-2026.md');


### PR DESCRIPTION
Three Files-view quality-of-life improvements.

- **The open file persists across view switches.** Leaving Files for Skills, Team, or a search and coming back no longer resets you to a blank pane: the file stays open. Return now keys on whether a file is open rather than a fragile sidebar-class check.
- **The open file is revealed in the tree.** On return (and any programmatic reveal) its parent folders expand and the row scrolls into view and highlights, so you can always see where the file lives.
- **The back control only appears when back leads somewhere.** Opened from Skills/Agents or partway through a wikilink chain, it returns you there. Opened straight from the file tree with no history it is hidden, since back would only blank the pane (which read as losing your place).

Three end-to-end journeys cover persistence + reveal and both back-control states. Unit 918, e2e 38 -> 41, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)