### PR TITLE
Harden bash permission classifier, plus flaky-test and comment fixes

### DIFF
--- a/public/permissions.js
+++ b/public/permissions.js
@@ -35,23 +35,37 @@
   function bashBin(cmd) { return cmd.split(/\s+/)[0].replace(/^.*\//, ''); }
 
   // Risk of a shell command, judged across EVERY segment of a compound command
-  // (split on &&, ||, ;, |, &), not just the first token. This stops a
-  // read-only prefix from smuggling a destructive command past the gate
+  // (split on &&, ||, ;, |, &, and newlines), not just the first token. This
+  // stops a read-only prefix from smuggling a destructive command past the gate
   // ("ls && rm x" is high, not low) and stops a harmless leading cd from
   // forcing an all-read-only chain to look risky ("cd dir && ls" is low, so
-  // ordinary exploration is not carded). A destructive flag or a
-  // download-piped-to-a-shell anywhere in the command is high regardless of
-  // segmenting. Naive splitting can over-flag an operator inside a quoted
-  // string, which only ever errs toward showing a card (safe for a gate).
+  // ordinary exploration is not carded). A destructive flag, a
+  // download-piped-to-a-shell, or a find that runs/deletes anywhere in the
+  // command is high regardless of segmenting. Structure the segmenter cannot
+  // see into (command/process substitution, backticks) never earns the low
+  // auto-allow verdict, so a destructive command hidden inside it still cards.
+  // Naive splitting can over-flag an operator inside a quoted string, which
+  // only ever errs toward showing a card (safe for a gate).
   function classifyBashRisk(cmd) {
     if (!cmd) return 'low';
     if (/--force|--hard|-rf\b/.test(cmd)) return 'high';
     if (/git\s+(push|reset|clean|checkout\s+\.)/.test(cmd)) return 'high';
     if (/\b(curl|wget)\b[\s\S]*\|\s*(sh|bash|zsh|dash)\b/.test(cmd)) return 'high';
+    // find is read-only until it runs a command or deletes: -exec/-execdir/-ok
+    // spawn an arbitrary command per match and -delete removes files, so a bare
+    // find leading segment must not shield these.
+    if (/\bfind\b[\s\S]*-(exec(dir)?|delete|ok(dir)?)\b/.test(cmd)) return 'high';
     const DESTRUCTIVE = /^(rm|sudo|chmod|chown|kill|mkfs|dd)/;
     const READ_ONLY = /^(ls|cat|head|tail|echo|pwd|whoami|which|grep|rg|find|wc|sort|uniq|diff|file|stat|date|env|printenv|node\s+-e|python3?\s+-c)/;
     const NEUTRAL = /^(cd|pushd|popd|true)(\s|$)/;
-    const segments = cmd.split(/\s*(?:&&|\|\||[;|&])\s*/).map(function (s) { return s.trim(); }).filter(Boolean);
+    // Command/process substitution and backticks run an inner command the
+    // segmenter cannot see (`ls $(rm x)`), so their presence disqualifies the
+    // low (auto-allow) verdict: the command falls to at least a card.
+    const HIDES_SUBCOMMAND = /\$\(|`|<\(|>\(/;
+    // Split on newlines as well as shell operators: bash runs each newline as a
+    // separate command, so a read-only first line must not shield a destructive
+    // one below it.
+    const segments = cmd.split(/\s*(?:&&|\|\||[;|&\n\r])\s*/).map(function (s) { return s.trim(); }).filter(Boolean);
     var anyHigh = false, allSafe = true;
     for (var i = 0; i < segments.length; i++) {
       var seg = segments[i];
@@ -60,7 +74,7 @@
       else allSafe = false;
     }
     if (anyHigh) return 'high';
-    if (allSafe) return 'low';
+    if (allSafe && !HIDES_SUBCOMMAND.test(cmd)) return 'low';
     return 'medium';
   }
 

--- a/public/viewers/registry.js
+++ b/public/viewers/registry.js
@@ -58,9 +58,16 @@ const CSP_META = `<meta http-equiv="Content-Security-Policy" content="${ARTIFACT
 // the implied head and commits the policy before any element is processed.
 // A leading <!doctype> is preserved (the meta goes right after it, still
 // ahead of every element, avoiding quirks mode).
-// A <meta http-equiv="refresh"> can navigate the sandboxed frame to an
-// external URL and issue an outbound request; CSP has no directive that
-// governs navigation, so the no-phone-home guarantee needs this. The attribute
+// A <meta http-equiv="refresh"> can navigate a frame to an external URL and
+// issue an outbound request, and CSP has no directive that governs navigation.
+// The primary control against this is the sandbox posture: a frame with
+// allow-same-origin but NO allow-scripts does not honour meta refresh at all
+// (verified in Chromium), so the no-phone-home guarantee holds even if a
+// refresh tag survives. This strip is defense-in-depth on top of that: it also
+// removes the tag from the source so a future sandbox change cannot silently
+// reopen the vector. It is best-effort (see the two-pass note below) precisely
+// because the sandbox, not the regex, is what the guarantee rests on. The
+// attribute
 // tokenizer ((?:[^>"']|"[^"]*"|'[^']*')*) skips over quoted attribute values,
 // so a `>` hidden inside a quoted attribute cannot end the tag early and slip
 // the meta through. The CSP meta this module injects uses

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -105,6 +105,13 @@ test('Cmd+F is a no-op on read-only binary viewers', async ({ page }) => {
   await boot(page);
   for (const name of ['chart.png', 'report.pdf']) {
     await openFromTree(page, name);
+    // Wait for the binary viewer to finish mounting before probing. The tree
+    // click returns before loadFileContent swaps surfaces, so a premature
+    // Cmd+F reads the previous surface's find backend and the probe flakes.
+    const surface = name.endsWith('.png')
+      ? page.locator('.viewer-image-wrap img')
+      : page.locator('iframe.viewer-frame');
+    await expect(surface).toBeVisible();
     await page.keyboard.press('ControlOrMeta+f');
     // No find bar opens: there is nothing searchable in an image or PDF viewer.
     await expect(page.locator('#find-bar')).toBeHidden();

--- a/test/unit/permissions.test.js
+++ b/test/unit/permissions.test.js
@@ -50,6 +50,44 @@ describe('classifyRisk Bash', () => {
     // A non-read-only step after cd is medium (carded), never auto-approved.
     assert.strictEqual(risk('cd x && npm install'), 'medium', 'cd then npm');
   });
+
+  test('a destructive command hidden in command/process substitution never auto-allows', () => {
+    // The segmenter splits on shell operators only, so a read-only outer
+    // command can hide a destructive inner one. Substitution disqualifies the
+    // low (auto-allow) verdict, so these all card instead of running silently.
+    for (const cmd of [
+      'ls $(rm ~/.ssh/id_rsa)',
+      'ls `rm secret`',
+      'echo $(sudo reboot)',
+      'cat file $(rm -r foo)',
+      'echo hi > $(rm foo)',
+      'diff <(rm a) <(cat b)',
+    ]) {
+      assert.notStrictEqual(risk(cmd), 'low', cmd);
+      assert.strictEqual(P.decidePermission(risk(cmd), 'Bash:ls', new Set()).action, 'card', cmd);
+    }
+  });
+
+  test('a newline separates commands, so a leading read must not shield a destructive line', () => {
+    assert.strictEqual(risk('ls\nrm ~/important'), 'high', 'read then rm on next line');
+    assert.strictEqual(risk('echo hi\nsudo reboot'), 'high', 'read then sudo on next line');
+    // An all-read-only multi-line block stays low: no false card.
+    assert.strictEqual(risk('ls\ncat README.md'), 'low', 'read then read');
+  });
+
+  test('find that runs or deletes is high despite find being read-only', () => {
+    for (const cmd of [
+      'find . -exec rm {} +',
+      'find . -exec rm {} \\;',
+      'find . -delete',
+      'find /tmp -execdir rm {} +',
+      'find . -ok rm {} \\;',
+    ]) {
+      assert.strictEqual(risk(cmd), 'high', cmd);
+    }
+    // Plain find with no run/delete action stays low.
+    assert.strictEqual(risk('find . -name "*.md"'), 'low', 'plain find');
+  });
 });
 
 // ── classifyRisk: PowerShell ────────────────────────────────────────────────


### PR DESCRIPTION
Post-review hardening ahead of the 0.11.0 tag. Three atomic commits.

## 1. Harden bash risk classifier (security)

The permission classifier auto-allowed several genuinely destructive commands as low risk, because it split compound commands only on shell operators (`&&`, `||`, `;`, `|`, `&`) and treated `find` as read-only. A read-only outer command could hide a destructive inner one that never reached a permission card:

| command | before | after |
|---|---|---|
| `find . -exec rm {} +` | low (auto-allow) | high, card |
| `ls $(rm ~/.ssh/id_rsa)` | low | medium, card |
| `` ls `rm secret` `` | low | medium, card |
| `ls\nrm ~/important` | low | high, card |

Three fail-safe additions, all keeping ordinary read-only commands low:
- `find` with `-exec`/`-execdir`/`-delete`/`-ok` is high (it runs or deletes).
- Command/process substitution and backticks disqualify the low verdict, so a hidden inner command falls to at least a card.
- Newlines split segments too, so a read-only first line cannot shield a destructive one below it.

Legitimate read-only commands (`ls`, `cd x && ls`, `grep ... | sort | uniq`, plain `find`) stay low, so no new false cards. Three tests added, one per vector, asserting `decidePermission` cards them.

## 2. Fix flaky Cmd+F no-op E2E test

The test read the find backend immediately after clicking a file row, before the viewer swap completed, failing about one run in three. It now waits for the image or PDF viewer to be visible before probing. Green 5 of 5 in isolation after the change.

## 3. Correct meta-refresh comment

The comment claimed the meta-refresh strip upheld the no phone-home guarantee. A frame with `allow-same-origin` and no `allow-scripts` does not honour meta refresh at all (verified in Chromium), so the sandbox is the primary control and the strip is defense-in-depth. Comment only, no behaviour change.

## Verification

- Full unit and integration suite green locally: 999 pass, 0 fail (+3 new).
- Full E2E suite green locally: 72 pass.
- `npm run check:refs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)