### PR TITLE
fix(agents): deny direct edits to global ~/.claude; stop truncating instructions

### DIFF
--- a/scripts/permission-hook.js
+++ b/scripts/permission-hook.js
@@ -15,6 +15,8 @@
  */
 
 const http = require('http');
+const os = require('os');
+const path = require('path');
 
 // MCP read/write classification. Read-style MCP tools auto-approve; writes,
 // destructive actions, and anything unrecognised get a permission card.
@@ -36,6 +38,29 @@ function isMcpReadTool(toolName) {
   return false;
 }
 
+// Deny a direct file edit to the GLOBAL Claude Code agent/skill config
+// (~/.claude/agents, ~/.claude/skills). Rundock never reads the global folder,
+// so such an edit would silently succeed somewhere invisible to the app: the
+// reported bug where an agent "updated" and nothing changed, surviving a
+// restart. Workspace .claude edits are deliberately NOT blocked (the workspace
+// is the agent's own domain, and those land in the file the app reads); the
+// SAVE_AGENT / SAVE_SKILL markers remain the way to get a live UI refresh.
+const CLAUDE_EDIT_TOOLS = new Set(['Write', 'Edit', 'MultiEdit', 'NotebookEdit']);
+function isProtectedClaudeEdit(toolName, toolInput) {
+  if (!CLAUDE_EDIT_TOOLS.has(toolName)) return false;
+  const ti = toolInput || {};
+  const target = ti.file_path || ti.notebook_path || ti.path;
+  if (typeof target !== 'string') return false;
+  const resolved = path.resolve(target);
+  const under = (root) => resolved === root || resolved.startsWith(root + path.sep);
+  return under(path.join(os.homedir(), '.claude', 'agents'))
+      || under(path.join(os.homedir(), '.claude', 'skills'));
+}
+
+module.exports = { isProtectedClaudeEdit, isMcpReadTool };
+
+if (require.main === module) main();
+function main() {
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
@@ -76,6 +101,26 @@ process.stdin.on('end', () => {
         hookEventName: 'PreToolUse',
         permissionDecision: 'allow',
         permissionDecisionReason: 'Auto-approved: MCP read'
+      }
+    }));
+    process.exit(0);
+  }
+
+  // Agents and skills are managed ONLY through the RUNDOCK:SAVE_AGENT /
+  // RUNDOCK:SAVE_SKILL markers, which write into THIS workspace's .claude folder
+  // and refresh the UI. Deterministically deny any direct file edit to a
+  // .claude/agents or .claude/skills path, in the workspace OR the global
+  // ~/.claude (Claude Code's native default). Without this, a direct edit
+  // silently succeeds in the wrong place: an edit to the global agents folder
+  // that Rundock never reads, leaving the user told "done" while the workspace
+  // file, and the profile panel, never changed. This is enforcement, not a
+  // prompt: the wrong path can no longer look like a success.
+  if (isProtectedClaudeEdit(data.tool_name, data.tool_input)) {
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: "This edits the global ~/.claude agent or skill config, which Rundock does not use. Manage this workspace's agents and skills through the RUNDOCK:SAVE_AGENT / RUNDOCK:SAVE_SKILL markers (which write into this workspace and refresh the app), or edit the workspace's own .claude file."
       }
     }));
     process.exit(0);
@@ -161,3 +206,4 @@ process.stdin.on('end', () => {
   req.write(payload);
   req.end();
 });
+}

--- a/server.js
+++ b/server.js
@@ -913,6 +913,10 @@ function detectCodexCached() {
 let _agentCache = null;
 let _agentCacheTime = 0;
 const AGENT_CACHE_TTL = 2000; // 2 seconds
+// Cap on the instructions shown in the profile panel. Generous so a real agent
+// file (or CLAUDE.md) is never silently cut off, which used to look like "my
+// edit vanished"; the panel scrolls, so the length is not a layout problem.
+const AGENT_INSTRUCTIONS_MAX = 20000;
 
 function invalidateAgentCache() { _agentCache = null; _agentCacheTime = 0; _skillCache = null; _skillCacheTime = 0; invalidateFileListCache(); }
 
@@ -976,7 +980,7 @@ function discoverAgents() {
 
         // If this is the default agent, merge instructions from CLAUDE.md
         if (isDefault && fs.existsSync(claudeMdPath)) {
-          instructions = readNormalisedFile(claudeMdPath).substring(0, 2000);
+          instructions = readNormalisedFile(claudeMdPath).substring(0, AGENT_INSTRUCTIONS_MAX);
         }
 
         const caps = parseCapabilities(fmText);
@@ -1028,7 +1032,7 @@ function discoverAgents() {
           model: ((meta.type !== 'orchestrator' && meta.type !== 'platform') && String(meta.runtime || '').toLowerCase() === 'codex') ? (meta.model || null) : (meta.model || DEFAULT_MODEL),
           order: orderNum,
           reportsTo: meta.reportsTo || null,
-          instructions: instructions.substring(0, 2000),
+          instructions: instructions.substring(0, AGENT_INSTRUCTIONS_MAX),
           isDefault,
           colour: meta.colour || colours[colourIdx % colours.length],
           icon: meta.icon || icons[colourIdx % icons.length],

--- a/test/unit/permission-agent-guard.test.js
+++ b/test/unit/permission-agent-guard.test.js
@@ -1,0 +1,53 @@
+'use strict';
+// The permission hook deterministically denies direct file edits to the GLOBAL
+// Claude Code agent/skill config (~/.claude/agents, ~/.claude/skills). Rundock
+// never reads the global folder, so such an edit would silently succeed
+// somewhere invisible to the app (the reported bug: an agent "updated" and
+// nothing changed, surviving a restart). Workspace .claude edits, reads, and
+// ordinary file edits are deliberately NOT blocked.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+
+const { isProtectedClaudeEdit } = require('../../scripts/permission-hook.js');
+
+const gAgent = path.join(os.homedir(), '.claude', 'agents', 'dev.md');
+const gSkill = path.join(os.homedir(), '.claude', 'skills', 'spec-writer', 'SKILL.md');
+
+describe('isProtectedClaudeEdit', () => {
+  test('denies edits to the GLOBAL ~/.claude agents and skills', () => {
+    const denied = [
+      ['Write', { file_path: gAgent }],
+      ['Edit', { file_path: gSkill }],
+      ['MultiEdit', { file_path: path.join(os.homedir(), '.claude', 'agents', 'cos.md') }],
+      ['NotebookEdit', { notebook_path: path.join(os.homedir(), '.claude', 'agents', 'x.md') }],
+    ];
+    for (const [tool, input] of denied) {
+      assert.strictEqual(isProtectedClaudeEdit(tool, input), true, `${tool} ${JSON.stringify(input)}`);
+    }
+  });
+
+  test('allows workspace .claude edits, other files, reads, and non-edit tools', () => {
+    const allowed = [
+      ['Write', { file_path: '/tmp/ws/.claude/agents/dev.md' }],   // workspace, not global home
+      ['Edit', { file_path: '/tmp/ws/.claude/skills/x/SKILL.md' }], // workspace
+      ['Write', { file_path: '/tmp/ws/notes/plan.md' }],
+      ['Edit', { file_path: '/tmp/ws/CLAUDE.md' }],
+      ['Write', { file_path: path.join(os.homedir(), '.claude', 'settings.json') }], // global .claude, but not agents/skills
+      ['Bash', { command: 'cat ' + gAgent }],                       // a read via a non-edit tool
+      ['Read', { file_path: gAgent }],
+      ['Grep', { pattern: 'x', path: path.join(os.homedir(), '.claude', 'agents') }],
+    ];
+    for (const [tool, input] of allowed) {
+      assert.strictEqual(isProtectedClaudeEdit(tool, input), false, `${tool} ${JSON.stringify(input)}`);
+    }
+  });
+
+  test('handles missing or malformed input without throwing', () => {
+    assert.strictEqual(isProtectedClaudeEdit('Write', null), false);
+    assert.strictEqual(isProtectedClaudeEdit('Write', {}), false);
+    assert.strictEqual(isProtectedClaudeEdit('Write', { file_path: 42 }), false);
+    assert.strictEqual(isProtectedClaudeEdit(undefined, undefined), false);
+  });
+});


### PR DESCRIPTION
Deterministically denies Write/Edit/MultiEdit/NotebookEdit to the GLOBAL ~/.claude/agents|skills (the invisible case a beta user hit). Workspace .claude edits stay allowed. Raises instructions display cap 2000->20000. Unit test included.