### PR TITLE
Marketing screenshot pipeline + org-chart and search-icon fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ coverage.lcov
 # Playwright E2E artefacts
 test-results/
 playwright-report/
+
+# Marketing screenshot pipeline output (binaries, regenerated each run)
+screenshots-out/
+# Local, private banned-token overrides for the sanitization gate (never committed)
+scripts/screenshots/.banned-tokens.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@playwright/test": "^1.61.1",
         "electron": "^42.7.0",
         "electron-builder": "^26.0.0",
+        "ffmpeg-static": "^5.2.0",
         "jsdom": "^29.1.1",
         "v8-to-istanbul": "^9.3.0"
       },
@@ -229,6 +230,22 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1785,6 +1802,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1976,6 +2000,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2850,6 +2890,50 @@
         }
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -3294,6 +3378,23 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -4215,6 +4316,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -5190,6 +5297,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.28.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "dist": "node scripts/build.js",
     "release": "node scripts/release.js",
     "test:e2e": "playwright test",
-    "check:refs": "node scripts/check-internal-refs.js"
+    "check:refs": "node scripts/check-internal-refs.js",
+    "screenshots": "node scripts/screenshots/run.mjs"
   },
   "dependencies": {
     "electron-updater": "^6.6.0",
@@ -26,6 +27,7 @@
     "@playwright/test": "^1.61.1",
     "electron": "^42.7.0",
     "electron-builder": "^26.0.0",
+    "ffmpeg-static": "^5.2.0",
     "jsdom": "^29.1.1",
     "v8-to-istanbul": "^9.3.0"
   },
@@ -43,6 +45,7 @@
       "public/**/*",
       "scaffold/**/*",
       "scripts/**/*",
+      "!scripts/screenshots/**",
       "node_modules/**/*",
       "electron/**/*",
       "package.json"

--- a/public/app.js
+++ b/public/app.js
@@ -1246,7 +1246,12 @@ function renderOrgChart() {
     const nodeW = isCompact ? 220 : 280;
     const nodeH = isCompact ? 160 : 190;
     const hierarchy = d3.hierarchy(treeRoot);
-    d3.tree().nodeSize([nodeW, nodeH])(hierarchy);
+    // Uniform separation so a lead with one report takes the same width as a
+    // childless lead (it centres over its single report); a lead only widens
+    // when it has two or more reports, spanning them exactly as the top row
+    // spreads its own children. The d3 default (2x between different-parent
+    // nodes) doubled the gap between two adjacent leads that each had a report.
+    d3.tree().nodeSize([nodeW, nodeH]).separation(() => 1)(hierarchy);
 
     const cardW = (n) => Math.min(n.data.type === 'orchestrator' ? P.leader.w : P[preset].w, 320);
     const cardH = (n) => n.data.type === 'orchestrator' ? P.leader.h : P[preset].h;

--- a/public/index.html
+++ b/public/index.html
@@ -837,11 +837,16 @@ mark.find-match.current,
         <svg class="icon-filled" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
       </button>
       <!-- Universal search: opens the palette overlay rather than switching
-           views, so it carries no data-nav and never takes the active state.
-           The tooltip doubles as the shortcut teacher; app.js fills it in
-           with the platform's modifier (Cmd on macOS, Ctrl elsewhere). -->
+           views, so it carries no data-nav. It DOES take the active state while
+           the palette is open, so it has both an outline and a filled magnifier
+           and swaps to the filled one on active, consistent with every other
+           nav icon (a thin outline washes out behind the palette blur; a filled
+           accent glyph reads in both themes). The tooltip doubles as the
+           shortcut teacher; app.js fills it in with the platform's modifier
+           (Cmd on macOS, Ctrl elsewhere). -->
       <button class="nav-item" id="nav-search-btn" onclick="openPalette()" aria-label="Search workspace">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <svg class="icon-outline" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <svg class="icon-filled" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.7.7l.27.28v.79l5 4.99L20.49 19zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14z"/></svg>
       </button>
     </div>
     <div class="nav-bottom">

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -1,0 +1,75 @@
+# Marketing screenshot pipeline
+
+Generates marketing-grade visuals of every current Rundock feature: framed
+light and dark stills at retina resolution, plus short looping GIFs, all from a
+realistic but fully sanitized demo workspace driven through the real app with
+Playwright. Everything lands in a single local review folder with a manifest;
+nothing is written into the README, `docs/`, the Rundock Site, or the docs site.
+
+Spec: `Rundock/02_Areas/Rundock/Specs/Screenshot-Pipeline-Spec.md` (in the vault).
+
+## Run it
+
+```bash
+npm run screenshots
+```
+
+Output lands in the gitignored `screenshots-out/` folder at the repo root.
+Re-runnable: the folder is rebuilt from scratch each time, deterministically.
+
+## What it does
+
+1. **Generate** a sanitized demo workspace (invented nine-agent team, ~14 skills,
+   conversations, routines, and a rich file tree) plus a fake `$HOME` of Claude
+   Code transcripts, all with fixed dates.
+2. **Sanitization gate** greps the built tree for banned tokens and aborts before
+   any capture if a real name or private term slips in.
+3. **Boot** the real `server.js` against that workspace on a dedicated port.
+4. **Capture** the full still shot list in light and dark at deviceScaleFactor 2
+   (2880x1800 @2x masters), plus element-scoped crops.
+5. **Frame** the three hero shots in window chrome and every feature shot as a
+   flat clean master plus a self-framed variant, on a neutral theme-aware
+   gradient, and derive README-width sizes.
+6. **Motion**: record six scripted interactions and convert each to an optimized,
+   palette-based looping GIF.
+7. Write **`MANIFEST.md`** mapping every asset to its intended target repo, path,
+   feature, theme, and rationale, and copy in the content and copy gap analysis.
+
+## Prerequisites
+
+- **Node 22+** and the repo's dependencies (`npm install`).
+- **Playwright Chromium**, already installed with the dev dependencies.
+- **ffmpeg** for the GIFs. Resolved in order: the `FFMPEG_PATH` env, a system
+  `ffmpeg` on `PATH`, then the `ffmpeg-static` dev dependency. If none is found,
+  stills are still produced and motion is skipped with a note.
+- **sips** (macOS built-in) for resizing and format conversion. On this build it
+  cannot write WebP, so WebP derivations are skipped and the PNG masters serve
+  as the source.
+
+## Configuration
+
+- `FFMPEG_PATH` overrides which ffmpeg binary is used.
+- `RUNDOCK_CAPTURE_PORT` overrides the dedicated capture port (default 34519,
+  deliberately distinct from the e2e port 34517).
+- `RUNDOCK_BANNED_TOKENS` (comma-separated) and a gitignored
+  `scripts/screenshots/.banned-tokens.json` (a JSON array of strings) add
+  project-specific tokens to the sanitization gate, so private names never live
+  in this public repo.
+
+## Files
+
+- `generate-workspace.mjs` the sanitized demo workspace v2 plus the gate.
+- `serve.mjs` boots the real server in an isolated child process.
+- `harness.mjs` shared Playwright helpers: fixed clock, themes, seeding.
+- `capture.mjs` the still shot list and capture loop.
+- `frame.mjs` + `frame.html` the framing wrapper and per-target derivations.
+- `motion.mjs` the six clips and ffmpeg conversion.
+- `run.mjs` the orchestrator behind `npm run screenshots`.
+- `content-and-copy-gaps.md` the release content and copy gap analysis (a
+  proposal; copied into the output folder each run).
+
+## Phase 2 (not built yet)
+
+Auto-opening PRs into the Rundock repo README/`docs/`, the Rundock Site, and the
+docs site, triggered on release. Queue it once the placements in `MANIFEST.md`
+are agreed.

--- a/scripts/screenshots/capture.mjs
+++ b/scripts/screenshots/capture.mjs
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   newContext, gotoWorkspace, setTheme, settle, openFile,
-  seedWorking, seedLastActive, beginStream, pushChunk,
+  seedWorking, seedLastActive, beginStream, pushChunk, fitOrgChart,
   ORG_WORKING, ORG_LAST_ACTIVE,
 } from './harness.mjs';
 
@@ -28,6 +28,7 @@ export const SHOTS = [
       await page.waitForSelector('.org-card', { timeout: 10000 });
       await seedWorking(page, ORG_WORKING);
       await seedLastActive(page, ORG_LAST_ACTIVE);
+      await fitOrgChart(page);
       await page.waitForTimeout(200);
     },
   },
@@ -100,7 +101,7 @@ export const SHOTS = [
     name: 'kanban-board', feature: 'Kanban board',
     crop: '.board-card',
     async setup(page) {
-      await openFile(page, 'Product Board.md');
+      await openFile(page, 'Backlog.md');
       await page.waitForSelector('.board-lane', { timeout: 10000 });
       await page.waitForTimeout(400);
     },
@@ -176,7 +177,7 @@ export async function captureStills({ browser, url, stagingDir, log = () => {} }
   const produced = [];
 
   for (const theme of THEMES) {
-    const ctx = await newContext(browser, { motion: false });
+    const ctx = await newContext(browser, { motion: false, theme });
     for (const shot of SHOTS) {
       const page = await ctx.newPage();
       try {

--- a/scripts/screenshots/capture.mjs
+++ b/scripts/screenshots/capture.mjs
@@ -1,0 +1,214 @@
+// Capture harness: drives the running Rundock client with Playwright and writes
+// flat, un-framed @2x master PNGs (plus element-scoped crops) for the full
+// still shot list, in both light and dark themes. Framing and per-target
+// derivations happen later in frame.mjs; this file only produces clean masters.
+//
+// Every shot runs in a fresh page so seeded client state never leaks between
+// shots. A shot that fails is logged and skipped rather than failing the run.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  newContext, gotoWorkspace, setTheme, settle, openFile,
+  seedWorking, seedLastActive, beginStream, pushChunk,
+  ORG_WORKING, ORG_LAST_ACTIVE,
+} from './harness.mjs';
+
+export const THEMES = ['light', 'dark'];
+
+// Shot definitions. `hero:true` marks a master that also gets the browser-chrome
+// hero treatment in framing. `crop` is an optional element selector for a tight
+// feature tile. `target` defaults to the viewport.
+export const SHOTS = [
+  {
+    name: 'org-chart', hero: true, feature: 'Team / org chart',
+    crop: '#org-chart',
+    async setup(page) {
+      await page.evaluate(() => switchNav('team'));
+      await page.waitForSelector('.org-card', { timeout: 10000 });
+      await seedWorking(page, ORG_WORKING);
+      await seedLastActive(page, ORG_LAST_ACTIVE);
+      await page.waitForTimeout(200);
+    },
+  },
+  {
+    name: 'agent-profile', feature: 'Agent profile',
+    async setup(page) {
+      await page.evaluate(() => { showProfile('dev'); if (typeof showView === 'function') showView('profile'); });
+      await page.waitForSelector('#profile-content', { state: 'visible', timeout: 10000 });
+    },
+  },
+  {
+    name: 'skills', feature: 'Skills list and detail',
+    crop: '#skill-detail-content',
+    async setup(page) {
+      await page.evaluate(() => switchNav('skills'));
+      await page.waitForSelector('#skills-sidebar-list', { timeout: 10000 });
+      await page.evaluate(() => { if (typeof selectSkill === 'function') selectSkill('spec-writer'); });
+      await page.waitForTimeout(400);
+    },
+  },
+  {
+    name: 'conversations', hero: true, feature: 'Conversation list and open thread',
+    crop: '#convo-list',
+    async setup(page) {
+      await page.evaluate(() => switchNav('conversations'));
+      await page.waitForSelector('#convo-list', { timeout: 10000 });
+      await page.evaluate(() => { if (typeof openConversation === 'function') openConversation('c1'); });
+      await page.waitForSelector('#messages .msg', { timeout: 10000 });
+      await page.waitForTimeout(300);
+    },
+  },
+  {
+    name: 'streaming', feature: 'Streaming reply',
+    async setup(page) {
+      await page.evaluate(() => switchNav('conversations'));
+      await beginStream(page, { convoId: 'c5', agentId: 'cleo' });
+      const chunks = ['Shorter is better here. ', 'Lead with the reader, ',
+        'name the outcome in six words, ', 'then let the proof points carry the rest.'];
+      for (const c of chunks) { await pushChunk(page, { convoId: 'c5', agentId: 'cleo', text: c }); await page.waitForTimeout(120); }
+      await page.waitForSelector('.streaming-text', { timeout: 8000 });
+      await page.waitForTimeout(200);
+    },
+  },
+  {
+    name: 'files', hero: true, feature: 'File tree with per-type icons',
+    crop: '#file-tree',
+    async setup(page) {
+      await openFile(page, 'Welcome.md');
+      await page.waitForSelector('#file-tree', { timeout: 10000 });
+      await page.waitForTimeout(300);
+    },
+  },
+  {
+    name: 'markdown-note', feature: 'Markdown note: frontmatter, callouts, wikilinks',
+    async setup(page) {
+      await openFile(page, 'Welcome.md');
+      await page.waitForSelector('#tiptap-properties', { timeout: 10000 });
+      await page.waitForTimeout(400);
+    },
+  },
+  {
+    name: 'callouts', feature: 'Obsidian callouts (nested)',
+    async setup(page) {
+      await openFile(page, 'Briefing.md');
+      await page.waitForSelector('.callout', { timeout: 10000 });
+      await page.waitForTimeout(400);
+    },
+  },
+  {
+    name: 'kanban-board', feature: 'Kanban board',
+    crop: '.board-card',
+    async setup(page) {
+      await openFile(page, 'Product Board.md');
+      await page.waitForSelector('.board-lane', { timeout: 10000 });
+      await page.waitForTimeout(400);
+    },
+  },
+  {
+    name: 'artifact-review', feature: 'HTML artifact preview and review',
+    crop: '.review-sidebar',
+    async setup(page) {
+      await openFile(page, 'Artifacts/Launch Page.html');
+      // Give the artifact iframe + sidecar review a moment to mount and anchor.
+      await page.waitForTimeout(1400);
+      // Try to expand the review panel if it starts minimised as a pill.
+      await page.evaluate(() => {
+        const pill = document.querySelector('.review-pill, .review-pill-btn, [data-review-pill]');
+        if (pill) pill.click();
+      }).catch(() => {});
+      await page.waitForTimeout(500);
+    },
+  },
+  {
+    name: 'image-viewer', feature: 'Image viewer',
+    async setup(page) {
+      await openFile(page, 'Assets/Cover.png');
+      await page.waitForSelector('.viewer-image-wrap img', { timeout: 10000 });
+      await page.waitForTimeout(400);
+    },
+  },
+  {
+    name: 'pdf-viewer', feature: 'PDF viewer',
+    async setup(page) {
+      await openFile(page, 'Assets/Spec.pdf');
+      await page.waitForSelector('iframe.viewer-frame', { timeout: 10000 });
+      await page.waitForTimeout(900);
+    },
+  },
+  {
+    name: 'search', feature: 'Universal search (Cmd+K)',
+    crop: '.palette',
+    async setup(page) {
+      await page.evaluate(() => switchNav('team'));
+      await page.waitForTimeout(200);
+      await page.evaluate(() => { if (typeof openPalette === 'function') openPalette(); });
+      await page.waitForSelector('#palette-input', { state: 'visible', timeout: 8000 });
+      await page.fill('#palette-input', 'launch');
+      await page.waitForTimeout(600);
+    },
+  },
+  {
+    name: 'find', feature: 'In-view find (Cmd+F)',
+    async setup(page) {
+      await openFile(page, 'Welcome.md');
+      await page.waitForSelector('#tiptap-properties', { timeout: 10000 });
+      await page.evaluate(() => { if (typeof openFindBar === 'function') openFindBar(); });
+      await page.waitForSelector('#find-bar', { state: 'visible', timeout: 8000 });
+      await page.fill('#find-input', 'workspace');
+      await page.waitForTimeout(500);
+    },
+  },
+  {
+    name: 'settings', feature: 'Settings / runtimes',
+    async setup(page) {
+      await page.evaluate(() => switchNav('settings'));
+      await page.waitForSelector('#settings-content', { state: 'visible', timeout: 8000 });
+      await page.waitForTimeout(400);
+    },
+  },
+];
+
+// Captures every shot in both themes to `stagingDir`. Returns a list of
+// produced assets: { name, theme, kind: 'flat'|'crop', feature, hero, file }.
+export async function captureStills({ browser, url, stagingDir, log = () => {} }) {
+  fs.mkdirSync(stagingDir, { recursive: true });
+  const produced = [];
+
+  for (const theme of THEMES) {
+    const ctx = await newContext(browser, { motion: false });
+    for (const shot of SHOTS) {
+      const page = await ctx.newPage();
+      try {
+        await gotoWorkspace(page, url);
+        await setTheme(page, theme);
+        await shot.setup(page);
+        await settle(page);
+
+        const flat = path.join(stagingDir, `${shot.name}.${theme}.png`);
+        await page.screenshot({ path: flat, animations: 'disabled' });
+        produced.push({ name: shot.name, theme, kind: 'flat', feature: shot.feature, hero: !!shot.hero, file: flat });
+        log(`  captured ${shot.name}.${theme} (flat)`);
+
+        if (shot.crop) {
+          const el = await page.$(shot.crop);
+          if (el) {
+            const box = await el.boundingBox();
+            if (box && box.width > 8 && box.height > 8) {
+              const crop = path.join(stagingDir, `${shot.name}-tile.${theme}.png`);
+              await el.screenshot({ path: crop, animations: 'disabled' });
+              produced.push({ name: `${shot.name}-tile`, theme, kind: 'crop', feature: shot.feature, hero: false, file: crop });
+              log(`  captured ${shot.name}-tile.${theme} (crop)`);
+            } else { log(`  ! crop ${shot.name} has no usable box, skipped`); }
+          } else { log(`  ! crop selector ${shot.crop} not found for ${shot.name}, skipped`); }
+        }
+      } catch (err) {
+        log(`  ! shot ${shot.name}.${theme} failed: ${err.message.split('\n')[0]}`);
+      } finally {
+        await page.close();
+      }
+    }
+    await ctx.close();
+  }
+  return produced;
+}

--- a/scripts/screenshots/capture.mjs
+++ b/scripts/screenshots/capture.mjs
@@ -37,6 +37,9 @@ export const SHOTS = [
     async setup(page) {
       await page.evaluate(() => { showProfile('dev'); if (typeof showView === 'function') showView('profile'); });
       await page.waitForSelector('#profile-content', { state: 'visible', timeout: 10000 });
+      // Expand the instructions so the profile pane carries real content.
+      await page.evaluate(() => document.getElementById('agent-instructions')?.classList.remove('hidden'));
+      await page.waitForTimeout(250);
     },
   },
   {
@@ -45,8 +48,12 @@ export const SHOTS = [
     async setup(page) {
       await page.evaluate(() => switchNav('skills'));
       await page.waitForSelector('#skills-sidebar-list', { timeout: 10000 });
-      await page.evaluate(() => { if (typeof selectSkill === 'function') selectSkill('spec-writer'); });
-      await page.waitForTimeout(400);
+      // Pick a skill shared by two agents (Dev + Cody) and expand its
+      // instructions, so the detail pane is inhabited rather than empty.
+      await page.evaluate(() => { if (typeof selectSkill === 'function') selectSkill('code-reviewer'); });
+      await page.waitForTimeout(300);
+      await page.evaluate(() => document.getElementById('skill-instructions-code-reviewer')?.classList.remove('hidden'));
+      await page.waitForTimeout(300);
     },
   },
   {
@@ -58,18 +65,6 @@ export const SHOTS = [
       await page.evaluate(() => { if (typeof openConversation === 'function') openConversation('c1'); });
       await page.waitForSelector('#messages .msg', { timeout: 10000 });
       await page.waitForTimeout(300);
-    },
-  },
-  {
-    name: 'streaming', feature: 'Streaming reply',
-    async setup(page) {
-      await page.evaluate(() => switchNav('conversations'));
-      await beginStream(page, { convoId: 'c5', agentId: 'cleo' });
-      const chunks = ['Shorter is better here. ', 'Lead with the reader, ',
-        'name the outcome in six words, ', 'then let the proof points carry the rest.'];
-      for (const c of chunks) { await pushChunk(page, { convoId: 'c5', agentId: 'cleo', text: c }); await page.waitForTimeout(120); }
-      await page.waitForSelector('.streaming-text', { timeout: 8000 });
-      await page.waitForTimeout(200);
     },
   },
   {
@@ -158,14 +153,6 @@ export const SHOTS = [
       await page.waitForSelector('#find-bar', { state: 'visible', timeout: 8000 });
       await page.fill('#find-input', 'workspace');
       await page.waitForTimeout(500);
-    },
-  },
-  {
-    name: 'settings', feature: 'Settings / runtimes',
-    async setup(page) {
-      await page.evaluate(() => switchNav('settings'));
-      await page.waitForSelector('#settings-content', { state: 'visible', timeout: 8000 });
-      await page.waitForTimeout(400);
     },
   },
 ];

--- a/scripts/screenshots/content-and-copy-gaps.md
+++ b/scripts/screenshots/content-and-copy-gaps.md
@@ -1,0 +1,230 @@
+# Content and Copy Gap Analysis
+
+- **Date / release context:** `package.json` reads version 0.10.0 (Search, Review & Codex, shipped 2026-07-14). The "Files, Boards & Streaming" body sits in `## Unreleased` in `Rundock/CHANGELOG.md`, staged as the imminent 0.11.0. Public site and docs imagery and feature copy date from late April (all five screenshots in `Rundock Site/images/` and the site root are stamped 29 Apr; the site feature sections have not changed since). Everything shipped from 0.10.0 onward, and the whole Unreleased block, is effectively uncommunicated.
+
+- **Method:** I read the full `Rundock/CHANGELOG.md` (Unreleased + 0.10.0 in detail, earlier entries for the feature inventory), the marketing site (`Rundock Site/index.html` in full, plus `llms.txt`, `compare.html`), and the docs site (`rundock-docs/`: `docs.json` navigation, `introduction.mdx`, all of `concepts/`, `first-run.mdx`, `reference/workspace-structure.mdx`). For each shipped capability I checked whether the behaviour is described anywhere on the Site and in the Docs, then located the exact file and section where it belongs. The Site is static HTML (hand-authored `index.html`, feature sections are `<section class="feature-section">` blocks around lines 1568-1657). The Docs are Mintlify MDX, navigation defined in `docs.json`.
+
+## Summary table
+
+| Feature | Shipped in | Shown on Site? | Shown on Docs? | Gap severity |
+|---|---|---|---|---|
+| Universal search (Cmd+K) | 0.10.0 | No | No | High |
+| In-editor review loop (CriticMarkup comments, agent accept/reject) | 0.10.0 | No | No | High |
+| Any-file-type viewer (HTML/SVG/PNG/PDF etc, locked-down preview) | Unreleased 0.11 | No (Files section says "markdown rendering" only) | No | High |
+| Rich markdown editor (format-as-you-type, tables, wikilinks) | 0.8.11 / 0.10.0 | No (still "preview and edit") | No | High |
+| Kanban boards (Obsidian-compatible) | Unreleased 0.11 | No | No | Medium |
+| Review extended to HTML/SVG artifacts | Unreleased 0.11 | No | No | Medium |
+| Codex second runtime (specialists on ChatGPT plan) | 0.10.0 | Partial (positioning only) | Yes (`runtimes.mdx`) | Low (Site), Covered (Docs) |
+| Codex streaming + permission cards mid-turn | Unreleased 0.11 | No | Stale (`runtimes.mdx` says no cards) | High (Docs, on 0.11) |
+| Frontmatter editing in the panel | Unreleased 0.11 | No | Stale (`workspaces` implies read-only era) | Medium |
+| Obsidian callouts render/edit in place | 0.8.11 / 0.11 | No | No | Low |
+| Live external file refresh + overwrite guard | Unreleased 0.11 | No | No | Low |
+| Conversation Lists | Unreleased 0.11 | No | No | Medium |
+| Files sidebar create/reveal, keeps your place | Unreleased 0.11 | No | No | Low |
+| Draft while agent responds | Unreleased 0.11 | No | No | Low |
+| Runtime-adaptive first-run setup (Codex detection step) | Unreleased 0.11 | No | Stale (`first-run.mdx`, `runtimes.mdx`) | Medium |
+| Pinned filter pill removed (pins always on top) | 0.10.0 | n/a | Stale (`conversations.mdx` still lists it) | Medium (factual error) |
+| Resizable sidebar / review panel | 0.10.0 | No | No | Low |
+
+## Site gaps
+
+The Site's four feature sections (`index.html` lines 1568-1657: Team, Conversations, Skills, Files) are the marketing surface. Match the existing pattern: a short `<h2>` behaviour headline and a one or two sentence paragraph. I am proposing one rewritten section, two new sections, and a stale-copy fix, plus a `llms.txt` refresh.
+
+### Site gap 1 (High): the "Files" section undersells the workspace to "markdown rendering"
+
+**What's missing:** Section 5d (`index.html` lines 1637-1657) still says "full markdown rendering" and "Browse, preview, and edit those same files." Since then Rundock shipped a rich editor (formats as you type, tables, wikilinks, callouts, frontmatter properties) and a viewer for any file type (HTML and SVG rendered live in a locked-down preview, images, PDFs). This is now one of the strongest reasons to use Rundock over the terminal, and the copy predates all of it.
+
+**Where to change:** `Rundock Site/index.html`, the `feature-copy` block inside section 5d (lines 1644-1647). Replace the `<h2>` and `<p>`.
+
+**Ready-to-paste copy:**
+```html
+<h2>Not just markdown. Any file your agents touch.</h2>
+<p>Open a note in an editor that formats as you type, with tables, callouts, and clickable wikilinks. Open an HTML or SVG file and see the real rendered page, not its source. Open an image or a PDF and read it in place. Edit a file's properties without touching raw YAML. It is your workspace, shown the way you would expect to see it.</p>
+```
+
+### Site gap 2 (High): universal search has no presence
+
+**What's missing:** Cmd+K searches file contents and names, conversation messages, and agent and skill names from one palette. It shipped in 0.10.0 as a headline feature and appears nowhere on the Site. For anyone weighing Rundock as a place to keep their whole business, "find anything instantly" is a strong, concrete claim.
+
+**Where to change:** `Rundock Site/index.html`. Add a new `<section class="feature-section">` after section 5d (after line 1657), before the diversity section. Use the `reverse` layout variant to keep the alternating rhythm.
+
+**Ready-to-paste copy (copy block; screenshot slot to be captured):**
+```html
+<h2>One shortcut finds everything you have.</h2>
+<p>Press Cmd+K and search across every file, every conversation, and every agent and skill at once. Type part of a word and it still finds the match. Pick a result and it opens at the right place, scrolling a conversation straight to the message you were looking for.</p>
+```
+
+### Site gap 3 (High): the review loop is invisible, and it is a real differentiator
+
+**What's missing:** You can select text in a file an agent wrote, leave an anchored comment, and the agent proposes an inline edit you accept or reject, all stored in the file itself as plain text. No competitor framing on the Site captures "review your agent's work where it lives." This is the kind of behaviour that separates a team you manage from a chatbot you copy-paste out of.
+
+**Where to change:** `Rundock Site/index.html`. Add a second new `<section class="feature-section">` alongside the search section (non-reverse layout).
+
+**Ready-to-paste copy:**
+```html
+<h2>Review your agent's work where it lives.</h2>
+<p>Select any passage in a file an agent produced and leave a comment. The agent reads it, proposes an edit inline, and you accept or reject with a click. The feedback lives in the file as plain text you can read in any editor, so nothing is locked inside Rundock.</p>
+```
+
+### Site gap 4 (Medium): Kanban boards
+
+**What's missing:** A markdown file that is an Obsidian Kanban board opens as a real column board you drag cards across, and it writes back the exact same markdown so it stays interchangeable with Obsidian. Visual and demo-friendly. Optional for the Site depending on how many feature sections you want, but it photographs well.
+
+**Where to change:** Either a fifth feature section, or fold a line into Site gap 1's Files section. If a standalone section, place it after the review section.
+
+**Ready-to-paste copy (standalone):**
+```html
+<h2>Your boards, not just your notes.</h2>
+<p>A Kanban board in your workspace opens as a real column board. Drag cards, tick them off, rename and reorder columns. It writes back the same markdown Obsidian uses, so the same board edits cleanly in both.</p>
+```
+
+### Site gap 5 (Medium): `llms.txt` Core Features list is stale
+
+**What's missing:** `Rundock Site/llms.txt` is the machine-readable feature list AI tools read. Its "Core Features" section (the `## Core Features` block) omits universal search, the review loop, the file viewer, Kanban boards, and markdown tables entirely, and its "Shared workspace" bullet still says "browse, preview, and edit those files in Rundock with markdown rendering." As agents increasingly answer "what does Rundock do", this is worth keeping current.
+
+**Where to change:** `Rundock Site/llms.txt`, the `## Core Features` list. Replace the "Shared workspace" bullet and add three bullets.
+
+**Ready-to-paste copy (add / replace bullets):**
+```
+- **Shared workspace with a real editor.** Agents and files live in one folder on your machine. You open notes in an editor that formats as you type (tables, callouts, wikilinks, editable properties), and open HTML, SVG, images, and PDFs as rendered files, not source.
+- **Universal search.** One shortcut (Cmd+K) searches file contents and names, conversation messages, and agent and skill names, with forgiving partial matching and results that open at the right place.
+- **Review agent work in place.** Comment on any passage in a file an agent produced; the agent proposes inline edits you accept or reject. Feedback is stored in the file as plain text, no lock-in.
+- **Kanban boards.** Obsidian-compatible boards open as real column boards you drag cards across, and write back the same markdown so they stay interchangeable with Obsidian.
+```
+
+## Docs gaps
+
+The Docs have no page at all covering files, the editor, boards, search, or the review loop. The `Concepts` group in `docs.json` runs how-rundock-works, how-rundock-compares, workspaces, agents, skills, conversations, runtimes, routines. Files and search are conceptually first-class now and deserve their own pages.
+
+### Docs gap 1 (High): no page covers the file viewer, editor, boards, or review loop
+
+**What's missing:** Everything about working with files. The editor (0.8.11), tables and review (0.10.0), and the any-file viewer, boards, frontmatter editing, and callouts (Unreleased) are described nowhere. `how-rundock-works.mdx` and `workspaces.mdx` mention files only as things agents read and write.
+
+**Where to add:** A new page `rundock-docs/concepts/files.mdx`, registered in `docs.json` under the `Concepts` group (suggested position: after `conversations`).
+
+**Ready-to-paste copy (new page skeleton in Rundock's voice):**
+```mdx
+---
+title: 'Files and the editor'
+description: 'How you view, edit, and review the files in your workspace, from markdown notes to HTML, images, boards, and PDFs.'
+---
+
+Your workspace is a folder of files, and Rundock is where you work with them. Agents read and write these files; you view, edit, and review the same files without leaving the app.
+
+## The markdown editor
+
+Markdown files open in an editor that formats as you type. Headings, bold, lists, and links render live rather than showing raw syntax. Wikilinks are clickable and navigate to the linked file. Tables open cell by cell: click in and type, and your file's exact spacing and alignment are preserved on save. Callouts render as coloured boxes you can expand, collapse, and edit in place.
+
+Every save is byte-honest: editing one line changes only that line, and the rest of the file comes back exactly as it was.
+
+## Properties without raw YAML
+
+A file's frontmatter appears in a properties panel above the editor. Click a value to edit it, toggle a boolean, add or remove list items, and follow property links on click. You change properties without touching the raw YAML, and an edit that would corrupt the frontmatter is refused rather than guessed.
+
+## Any file type, not just markdown
+
+Open an HTML or SVG file and Rundock shows the real rendered page, with its own styles and fonts, in a locked-down preview where scripts never run and the page cannot reach the network. Images open as images; PDFs open as readable documents. File types Rundock cannot preview say so plainly. The Edit toggle still shows editable source for text and HTML.
+
+## Kanban boards
+
+A markdown file that is an Obsidian Kanban board opens as a real column board. Drag cards between columns, add and edit cards in place, tick them off, and rename, move, sort, archive, or delete columns. Everything writes back as the exact markdown the Obsidian Kanban plugin produces, so the same board edits interchangeably in Rundock and Obsidian.
+
+## Reviewing agent work
+
+When an agent produces a file, you review it where it lives. Select a passage and press Comment to leave anchored feedback. Agents propose inline edits with Accept and Reject buttons, replies thread and resolve, and a review panel lists everything open. Feedback is stored in the file itself as CriticMarkup, a small block of plain text readable in any editor, attributed honestly: you show as "Me", agents under their names. The same review flow now covers rendered HTML and SVG files, not only markdown.
+
+## Files stay in sync
+
+A file you have open updates in place when it changes on disk, whether an agent, Obsidian, or another window changed it. If you have unsaved edits when that happens, the next save offers a clear choice, reload theirs or keep yours, instead of overwriting silently.
+```
+
+### Docs gap 2 (High): universal search has no page
+
+**What's missing:** Cmd+K and how search works (what it covers, forgiving matching, the local index in `.rundock/`) are undocumented.
+
+**Where to add:** Either a new `rundock-docs/concepts/search.mdx` in the `Concepts` group, or a "Finding things" section appended to `concepts/conversations.mdx`. A dedicated page is cleaner because search spans files, conversations, and agents, not just conversations.
+
+**Ready-to-paste copy (new page):**
+```mdx
+---
+title: 'Search'
+description: 'One palette finds file contents and names, conversation messages, and agent and skill names across the whole workspace.'
+---
+
+Press Cmd+K (Ctrl+K on Windows and Linux) to open one keyboard-first palette that searches your whole workspace at once: file contents and names, conversation messages and titles, and agent and skill names. Results are grouped and ranked, with the matching text highlighted.
+
+Matching is forgiving. You can type partial words as you go, so "rdmp" finds "Roadmap-2026". An empty query shows your recent items. Every result opens at the right place: pick a conversation and it scrolls to the matched message and highlights it.
+
+Search reaches inside rendered HTML and SVG files (visible text only, never markup or styles) and matches frontmatter property values, not just their names. Cmd+F searches within whatever you have open: a conversation, an editor, a rendered file preview, or the properties panel.
+
+## How it works
+
+The index is a small local file inside your workspace's `.rundock/` folder, rebuilt automatically. It never leaves your machine. Where the index engine is not available, search falls back to a simpler scan rather than failing.
+```
+
+### Docs gap 3 (Medium, factual error): `conversations.mdx` still lists the removed "Pinned" filter pill and omits Lists
+
+**What's missing / wrong:** `rundock-docs/concepts/conversations.mdx` line 31 lists filter pills as "(All, Unread, Pinned)". 0.10.0 removed the Pinned pill (pinned conversations are always grouped at the top now). The page also predates conversation Lists (Unreleased), which group conversations into named pills beside All and Unread.
+
+**Where to change:** `concepts/conversations.mdx`, the "What the sidebar tells you" list (lines 29-34). Fix the pill line and add a Lists bullet.
+
+**Ready-to-paste copy (replace the "Filter pills" bullet, add a bullet):**
+```mdx
+- **Filter pills** (All, Unread) sit above the list. Tap a pill to narrow the list to what needs attention right now. The Unread pill auto-hides when nothing is unread. Pinned conversations are always grouped at the top, so there is no separate Pinned pill.
+- **Lists** let you group conversations by hand. Right-click any conversation to add it to a named list, or create one on the spot. Lists appear as their own pills beside All and Unread and filter the sidebar. A conversation can belong to several lists, and deleting a list never deletes the conversations in it.
+```
+Add a short "Finding a conversation" line cross-linking to the new search page if Docs gap 2 lands.
+
+### Docs gap 4 (High on 0.11 release): `runtimes.mdx` will be stale on Codex permission behaviour
+
+**What's missing / will be wrong:** `rundock-docs/concepts/runtimes.mdx` currently states (lines 38-39) "You will not see Rundock permission cards in a Codex conversation; the sandbox confines the agent." The Unreleased entry changes exactly this: Codex agents now stream, and any action needing extra access raises the familiar permission card mid-turn, on every platform. Do not change this until 0.11 ships, but it is queued to go stale.
+
+**Where to change (on 0.11 release):** `concepts/runtimes.mdx`, "Permissions and sandboxing" section (lines 35-52). The "Codex agents use Codex's own built-in sandbox instead" bullet and the Windows subsection both need reworking to say permission cards now appear mid-turn for out-of-sandbox actions and writes.
+
+**Ready-to-paste replacement bullet (hold until 0.11):**
+```mdx
+- **Codex agents** stream their replies as they think, over one long-lived process. Any action that needs extra access, a command outside the sandbox or a write it cannot normally make, raises the same permission card you approve or deny, mid-turn, on every platform. An ignored request is declined automatically so a turn never hangs.
+```
+
+### Docs gap 5 (Medium, on 0.11 release): `first-run.mdx` and `runtimes.mdx` predate the runtime-adaptive setup
+
+**What's missing:** `first-run.mdx` describes a Claude-only wizard. The Unreleased entry makes first-run detect both Claude Code and Codex: a Codex user is told plainly why Claude Code is still needed, and a machine with the Codex CLI gets an optional Codex sign-in step, skippable and available later from Settings. `runtimes.mdx` line 32 says "Codex setup is currently manual: two commands in any terminal," which the in-wizard step supersedes.
+
+**Where to change:** `first-run.mdx`, section 3 area (add a step covering runtime detection and the optional Codex sign-in); `runtimes.mdx` line 32 (soften "currently manual").
+
+**Ready-to-paste copy (new subsection for `first-run.mdx`, hold until 0.11):**
+```mdx
+### Setup adapts to the runtimes you have
+
+First-run detects which engines are on your machine. It always sets up Claude Code, which runs your team's orchestrator and Doc himself. If you also have the Codex CLI installed, setup offers an optional step to sign in to Codex, so specialists can run on your ChatGPT plan. The step is skippable, and you can do it later from Settings. A machine without Codex sees the flow exactly as before.
+```
+
+## Cross-cutting notes
+
+- **Retire the April imagery.** Every screenshot on both properties is stamped 29 April and predates the current UI (universal search palette, the richer editor, resizable panels, the review sidebar). The Site uses `rundock-app-hero.png`, `agent-profile.png`, `conversation-flow.png`, `skills-detail.png`, `file-browser.png`; the Docs reuse `rundock-app-hero.png`, `file-browser.png`, `conversation-flow.png` in `rundock-docs/images/`. At minimum, recapture `file-browser.png` (it is now materially wrong: it shows a plain preview pane, not the editor) and the hero (to show search or the review panel). Any new Site sections for search, review, and boards need fresh captures.
+
+- **Version string is fine, feature copy is not.** The Site's structured data already reads `"softwareVersion": "0.10.0"` (`index.html` line 36), so the number is current; the prose is the stale part. When 0.11 ships, bump this line too.
+
+- **Priority order for the Site.** 1) Rewrite the Files section (gap 1, one edit, corrects an active undersell). 2) Add the search section (gap 2, headline 0.10.0 feature). 3) Add the review section (gap 3, strongest differentiator). 4) Refresh `llms.txt` (gap 5). 5) Kanban section (gap 4) if you want a fifth feature block.
+
+- **Priority order for the Docs.** 1) New `concepts/files.mdx` (gap 1, largest hole, covers five shipped capabilities). 2) New `concepts/search.mdx` (gap 2). 3) Fix the `conversations.mdx` Pinned-pill error and add Lists (gap 3, it is currently wrong). 4) Hold gaps 4 and 5 until 0.11 promotes, then update `runtimes.mdx` and `first-run.mdx` in the same pass.
+
+- **Two edits are corrections, not additions,** and should go first regardless of the 0.11 timeline: the `conversations.mdx` Pinned pill (removed in the already-shipped 0.10.0) and the Site Files section's "markdown rendering" claim (superseded since 0.8.11). Both currently tell users something untrue.
+
+- **Do not touch the compare tables to add features.** `compare.html` and `concepts/how-rundock-compares.mdx` are positioning tables (context, ownership, effort, price), not feature lists. Adding per-feature rows would dilute them. They carry "checked July 2026" GO-STALE markers on the price rows; that is a separate freshness task and the dates are current.
+
+## What is already well-covered (leave alone)
+
+- **The Codex runtime as a concept.** `rundock-docs/concepts/runtimes.mdx` is thorough and current: per-agent `runtime: codex`, the orchestrator-stays-on-Claude rule, the subscription table, sandboxing, Windows config, and Settings status. Only the permission-card behaviour goes stale on 0.11 (Docs gap 4). The Site references Codex correctly in the hero subline, pricing, the data-privacy flow (section 9), the FAQ, and "the layer that stays yours" (section 10b).
+
+- **Local-first / privacy.** Site section 9, the FAQ, `llms.txt`, `concepts/how-rundock-works.mdx` ("Conversations stay local"), and `trust/data-privacy-security.mdx` all state the local-first story consistently and accurately, including the credentials-file-existence check.
+
+- **Workspace model and file ownership.** `concepts/workspaces.mdx` and `reference/workspace-structure.mdx` are detailed and current on the folder shape, the sync / no-sync split, and workspace modes.
+
+- **Routines, agents, skills, delegation.** The core team and delegation model is well told across `introduction.mdx`, `how-rundock-works.mdx`, `concepts/agents.mdx`, `concepts/skills.mdx`, `concepts/routines.mdx`, and Site sections 5a-5c. These are stable and do not need changes for this cycle.
+
+- **Pricing, licence, get-started flow.** Consistent and correct across Site (hero, FAQ, get-started, footer), `llms.txt`, and Docs (`installation`, `first-run` except the Codex step, `quickstart`).
+
+---
+
+Note on scope: this is a proposal only. No edits were made to `Rundock/`, `Rundock Site/`, or `rundock-docs/`. The two items flagged as active factual errors (the Docs `conversations.mdx` Pinned pill and the Site Files "markdown rendering" copy) describe already-shipped 0.10.0 / 0.8.11 behaviour and can be actioned immediately; the runtimes and first-run Codex changes should wait until the Unreleased block promotes to 0.11.0.

--- a/scripts/screenshots/frame.html
+++ b/scripts/screenshots/frame.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Frame</title>
+<style>
+  /* Framing wrapper. Playwright sets the body classes (theme-* + treatment-*),
+     the --shot-w / --pad / --radius variables, the image, and the title, then
+     screenshots #stage. All framing is pure CSS, so no image library is needed
+     for the premium look (the Linear / Vercel / Apple treatment). */
+  :root { --shot-w: 1440px; --pad: 120px; --radius: 12px; }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { background: transparent; }
+  body { font-family: -apple-system, "Inter", system-ui, sans-serif; }
+
+  /* #stage shrinks to its content, so an element screenshot of it is exactly
+     the framed image plus its gradient padding, with nothing extra. */
+  #stage { display: inline-block; padding: var(--pad); }
+  body.theme-light #stage { background: linear-gradient(145deg, #f7f7f9 0%, #e9e9ee 100%); }
+  body.theme-dark  #stage { background: linear-gradient(145deg, #232327 0%, #0b0b0d 100%); }
+
+  #window { width: var(--shot-w); border-radius: var(--radius); overflow: hidden; }
+  body.theme-light #window { box-shadow: 0 40px 80px -24px rgba(0,0,0,0.30), 0 16px 32px -16px rgba(0,0,0,0.18); }
+  body.theme-dark  #window { box-shadow: 0 40px 90px -24px rgba(0,0,0,0.70), 0 16px 32px -16px rgba(0,0,0,0.55); }
+  body.theme-dark  #window { outline: 1px solid rgba(255,255,255,0.06); outline-offset: -1px; }
+
+  /* Hero chrome: a macOS-style title bar with the three traffic lights. Shown
+     only for the treatment-hero images. */
+  #titlebar { display: none; height: 40px; align-items: center; padding: 0 16px; gap: 9px; position: relative; }
+  body.treatment-hero #titlebar { display: flex; }
+  body.theme-light #titlebar { background: #ededf0; border-bottom: 1px solid rgba(0,0,0,0.06); }
+  body.theme-dark  #titlebar { background: #2b2b30; border-bottom: 1px solid rgba(255,255,255,0.06); }
+  .dot { width: 12px; height: 12px; border-radius: 50%; }
+  .dot.r { background: #ff5f57; } .dot.y { background: #febc2e; } .dot.g { background: #28c840; }
+  #title { position: absolute; left: 0; right: 0; text-align: center; font-size: 13px; font-weight: 500; pointer-events: none; }
+  body.theme-light #title { color: #6b6b72; }
+  body.theme-dark  #title { color: #9a9aa2; }
+
+  #shot { display: block; width: var(--shot-w); height: auto; }
+</style>
+</head>
+<body class="theme-light treatment-hero">
+  <div id="stage">
+    <div id="window">
+      <div id="titlebar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span id="title">Rundock</span>
+      </div>
+      <img id="shot" alt="">
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/screenshots/frame.html
+++ b/scripts/screenshots/frame.html
@@ -6,23 +6,33 @@
 <style>
   /* Framing wrapper. Playwright sets the body classes (theme-* + treatment-*),
      the --shot-w / --pad / --radius variables, the image, and the title, then
-     screenshots #stage. All framing is pure CSS, so no image library is needed
-     for the premium look (the Linear / Vercel / Apple treatment). */
-  :root { --shot-w: 1440px; --pad: 120px; --radius: 12px; }
+     screenshots #stage with omitBackground so the padding is transparent. One
+     framed image then drops onto any page background (a dark site, a light or
+     dark README, the docs) without a baked-in backdrop.
+
+     The window carries a soft drop shadow (reads on light backgrounds) plus a
+     neutral hairline ring on BOTH themes (holds the edge on dark backgrounds,
+     where the drop shadow all but disappears). The title-bar chrome stays
+     theme-aware so it matches the app screenshot it frames. */
+  :root { --shot-w: 1440px; --pad: 72px; --radius: 12px; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
   html, body { background: transparent; }
   body { font-family: -apple-system, "Inter", system-ui, sans-serif; }
 
-  /* #stage shrinks to its content, so an element screenshot of it is exactly
-     the framed image plus its gradient padding, with nothing extra. */
-  #stage { display: inline-block; padding: var(--pad); }
-  body.theme-light #stage { background: linear-gradient(145deg, #f7f7f9 0%, #e9e9ee 100%); }
-  body.theme-dark  #stage { background: linear-gradient(145deg, #232327 0%, #0b0b0d 100%); }
+  /* #stage shrinks to its content and is transparent; only the window, its
+     shadow, and its ring paint. */
+  #stage { display: inline-block; padding: var(--pad); background: transparent; }
 
-  #window { width: var(--shot-w); border-radius: var(--radius); overflow: hidden; }
-  body.theme-light #window { box-shadow: 0 40px 80px -24px rgba(0,0,0,0.30), 0 16px 32px -16px rgba(0,0,0,0.18); }
-  body.theme-dark  #window { box-shadow: 0 40px 90px -24px rgba(0,0,0,0.70), 0 16px 32px -16px rgba(0,0,0,0.55); }
-  body.theme-dark  #window { outline: 1px solid rgba(255,255,255,0.06); outline-offset: -1px; }
+  #window {
+    width: var(--shot-w);
+    border-radius: var(--radius);
+    overflow: hidden;
+    /* soft drop shadow (depth on light) + 1px neutral ring (edge on any bg) */
+    box-shadow:
+      0 24px 50px -18px rgba(0,0,0,0.34),
+      0 8px 20px -12px rgba(0,0,0,0.20),
+      0 0 0 1px rgba(150,150,150,0.35);
+  }
 
   /* Hero chrome: a macOS-style title bar with the three traffic lights. Shown
      only for the treatment-hero images. */

--- a/scripts/screenshots/frame.mjs
+++ b/scripts/screenshots/frame.mjs
@@ -38,7 +38,8 @@ export function pngDims(file) {
 export async function frameImage(page, { masterPath, outPath, theme, treatment, title = 'Rundock' }) {
   const { width } = pngDims(masterPath);
   const shotWCss = Math.round(width / DEVICE_SCALE);
-  const pad = Math.round(shotWCss * (treatment === 'hero' ? 0.085 : 0.032));
+  // Tight padding, floored so the soft drop shadow is never clipped.
+  const pad = Math.max(44, Math.round(shotWCss * (treatment === 'hero' ? 0.05 : 0.035)));
   const dataUri = 'data:image/png;base64,' + fs.readFileSync(masterPath).toString('base64');
 
   await page.evaluate(async ({ theme, treatment, shotWCss, pad, title, dataUri }) => {
@@ -56,7 +57,9 @@ export async function frameImage(page, { masterPath, outPath, theme, treatment, 
   await page.waitForTimeout(60);
   const stage = await page.$('#stage');
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  await stage.screenshot({ path: outPath });
+  // omitBackground keeps the padding transparent, so the frame drops onto any
+  // page background.
+  await stage.screenshot({ path: outPath, omitBackground: true });
   return outPath;
 }
 

--- a/scripts/screenshots/frame.mjs
+++ b/scripts/screenshots/frame.mjs
@@ -1,0 +1,81 @@
+// Polish layer: wraps a flat @2x master capture in an Apple-esque frame by
+// screenshotting a CSS wrapper page (frame.html), and derives per-target sizes
+// with the macOS image tool (sips). Two framing treatments:
+//   - hero:    browser/window chrome (traffic lights + title bar) on a neutral
+//              theme-aware gradient, for the three hero placements only.
+//   - feature: a self-framed variant (rounded corners + soft shadow + small
+//              neutral padding), for plain-markdown placements (README, raw
+//              docs). Feature "flat" masters get no frame at all and are copied
+//              or resized straight from the capture, for destinations that add
+//              their own CSS frame.
+//
+// No image library is used for the frame itself: the premium look is pure CSS.
+// sips (a system tool on macOS) does resize and format conversion, keeping the
+// dependency footprint lean.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { DEVICE_SCALE } from './harness.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const FRAME_HTML_URL = pathToFileURL(path.join(__dirname, 'frame.html')).href;
+
+// Reads a PNG's pixel dimensions straight from the IHDR chunk (bytes 16-24),
+// so framing knows the master size without decoding the whole image.
+export function pngDims(file) {
+  const fd = fs.openSync(file, 'r');
+  const buf = Buffer.alloc(24);
+  fs.readSync(fd, buf, 0, 24, 0);
+  fs.closeSync(fd);
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+// Frames a master into outPath using the given treatment and theme. The page
+// must already be on FRAME_HTML_URL in a deviceScaleFactor:2 context, so the
+// element screenshot lands at @2x.
+export async function frameImage(page, { masterPath, outPath, theme, treatment, title = 'Rundock' }) {
+  const { width } = pngDims(masterPath);
+  const shotWCss = Math.round(width / DEVICE_SCALE);
+  const pad = Math.round(shotWCss * (treatment === 'hero' ? 0.085 : 0.032));
+  const dataUri = 'data:image/png;base64,' + fs.readFileSync(masterPath).toString('base64');
+
+  await page.evaluate(async ({ theme, treatment, shotWCss, pad, title, dataUri }) => {
+    document.body.className = `theme-${theme} treatment-${treatment}`;
+    const root = document.documentElement.style;
+    root.setProperty('--shot-w', shotWCss + 'px');
+    root.setProperty('--pad', pad + 'px');
+    root.setProperty('--radius', '12px');
+    document.getElementById('title').textContent = title;
+    const img = document.getElementById('shot');
+    await new Promise((res) => { img.onload = res; img.onerror = res; img.src = dataUri; });
+    if (document.fonts && document.fonts.ready) { try { await document.fonts.ready; } catch { /* ignore */ } }
+  }, { theme, treatment, shotWCss, pad, title, dataUri });
+
+  await page.waitForTimeout(60);
+  const stage = await page.$('#stage');
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  await stage.screenshot({ path: outPath });
+  return outPath;
+}
+
+// Resizes a PNG to a target width (keeping aspect), writing a new file. Never
+// upscales: if the source is already narrower, it is copied unchanged.
+export function resizeTo(srcPath, outPath, targetWidth) {
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  const { width } = pngDims(srcPath);
+  if (targetWidth >= width) { fs.copyFileSync(srcPath, outPath); return { resized: false, width }; }
+  execFileSync('sips', ['--resampleWidth', String(targetWidth), srcPath, '--out', outPath], { stdio: 'ignore' });
+  return { resized: true, width: targetWidth };
+}
+
+// Converts a PNG to WebP via sips where supported. Returns the out path on
+// success, or null if this macOS build's sips cannot write WebP.
+export function toWebp(srcPath, outPath) {
+  try {
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    execFileSync('sips', ['-s', 'format', 'webp', srcPath, '--out', outPath], { stdio: 'ignore' });
+    return fs.existsSync(outPath) ? outPath : null;
+  } catch { return null; }
+}

--- a/scripts/screenshots/generate-workspace.mjs
+++ b/scripts/screenshots/generate-workspace.mjs
@@ -36,7 +36,9 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 // Locked roster (from the spec's "Demo workspace roster and skills"). Names,
 // roles, order and reportsTo are verbatim; colour and icon are fixed here for
 // deterministic, pleasant avatars rather than relying on the server's rotating
-// defaults (which depend on directory read order).
+// defaults (which depend on directory read order). Ana and Cody carry hues that
+// are deliberately distinct from their leads (Cleo, Dev), so the two most
+// closely related pairs never read as the same colour on the org chart.
 // ---------------------------------------------------------------------------
 export const ROSTER = [
   { id: 'cos',   displayName: 'Cos',   role: 'Chief of Staff',      type: 'orchestrator', order: 0, reportsTo: null,   colour: '#E87A5A', icon: '◆',
@@ -53,34 +55,51 @@ export const ROSTER = [
     description: 'Glen owns acquisition experiments and the growth funnel end to end.' },
   { id: 'rea',   displayName: 'Rea',   role: 'Executive Assistant', type: 'specialist',   order: 6, reportsTo: 'cos',  colour: '#5BCFC4', icon: '△',
     description: 'Rea keeps the calendar, meeting notes, and daily communications in order.' },
-  { id: 'ana',   displayName: 'Ana',   role: 'Content Analyst',     type: 'specialist',   order: 7, reportsTo: 'cleo', colour: '#7AB8E8', icon: '▦',
+  { id: 'ana',   displayName: 'Ana',   role: 'Content Analyst',     type: 'specialist',   order: 7, reportsTo: 'cleo', colour: '#6C74C4', icon: '▦',
     description: 'Ana measures what content works and pre-checks ideas against past performance.' },
-  { id: 'cody',  displayName: 'Cody',  role: 'Code Reviewer',       type: 'specialist',   order: 8, reportsTo: 'dev',  colour: '#8FCF7E', icon: '⬢',
+  { id: 'cody',  displayName: 'Cody',  role: 'Code Reviewer',       type: 'specialist',   order: 8, reportsTo: 'dev',  colour: '#B07E4E', icon: '⬢',
     description: 'Cody reviews changes for correctness, clarity, and safety before they merge.' },
 ];
 
 // ---------------------------------------------------------------------------
-// Locked skills (~12, generic, mapped onto the roster). Each becomes a
-// .claude/skills/<slug>/SKILL.md with name + description frontmatter and a
-// short generic body, and is referenced by its owning agent's frontmatter so
-// it renders as "assigned" on the org, profile and skills views.
+// Skills (~14, generic). Each becomes a .claude/skills/<slug>/SKILL.md with
+// name + description frontmatter and a short generic body. Assignment to agents
+// is via AGENT_SKILLS below (an agent's frontmatter skills list), so a skill can
+// belong to more than one agent, exactly as real skills are shared across a
+// team.
 // ---------------------------------------------------------------------------
 export const SKILLS = [
-  { slug: 'post-drafter',    owner: 'cleo',  name: 'Post Drafter',      description: 'Turns an approved angle into a publish-ready first draft.' },
-  { slug: 'hook-generator',  owner: 'cleo',  name: 'Hook Generator',    description: 'Generates and ranks opening lines for a piece of content.' },
-  { slug: 'content-planner', owner: 'cleo',  name: 'Content Planner',   description: 'Plans a week of content against goals and gaps.' },
-  { slug: 'post-auditor',    owner: 'ana',   name: 'Post Auditor',      description: 'Scores a draft for clarity and strength before it ships.' },
-  { slug: 'spec-writer',     owner: 'dev',   name: 'Spec Writer',       description: 'Writes a short spec before any non-trivial change.' },
-  { slug: 'code-reviewer',   owner: 'cody',  name: 'Code Reviewer',     description: 'Reviews a change across correctness, clarity, and safety.' },
-  { slug: 'test-generator',  owner: 'cody',  name: 'Test Generator',    description: 'Proposes tests that pin the behaviour a change relies on.' },
-  { slug: 'design-brief',    owner: 'des',   name: 'Design Brief',      description: 'Translates a request into an execution-ready design brief.' },
-  { slug: 'slide-builder',   owner: 'des',   name: 'Slide Builder',     description: 'Builds a clean slide deck from an outline.' },
-  { slug: 'weekly-digest',   owner: 'reese', name: 'Weekly Digest',     description: 'Summarises the week in the market into a short brief.' },
-  { slug: 'competitor-scan', owner: 'reese', name: 'Competitor Scan',   description: 'Tracks what comparable products are shipping and saying.' },
-  { slug: 'meeting-notes',   owner: 'rea',   name: 'Meeting Notes',     description: 'Captures decisions and actions from a meeting.' },
-  { slug: 'message-drafter', owner: 'rea',   name: 'Message Drafter',   description: 'Drafts a reply in the right tone for the channel.' },
-  { slug: 'workspace-lint',  owner: 'cos',   name: 'Workspace Lint',    description: 'Checks the workspace for stale links and missing metadata.' },
+  { slug: 'post-drafter',    name: 'Post Drafter',      description: 'Turns an approved angle into a publish-ready first draft.' },
+  { slug: 'hook-generator',  name: 'Hook Generator',    description: 'Generates and ranks opening lines for a piece of content.' },
+  { slug: 'content-planner', name: 'Content Planner',   description: 'Plans a week of content against goals and gaps.' },
+  { slug: 'post-auditor',    name: 'Post Auditor',      description: 'Scores a draft for clarity and strength before it ships.' },
+  { slug: 'spec-writer',     name: 'Spec Writer',       description: 'Writes a short spec before any non-trivial change.' },
+  { slug: 'code-reviewer',   name: 'Code Reviewer',     description: 'Reviews a change across correctness, clarity, and safety.' },
+  { slug: 'test-generator',  name: 'Test Generator',    description: 'Proposes tests that pin the behaviour a change relies on.' },
+  { slug: 'design-brief',    name: 'Design Brief',      description: 'Translates a request into an execution-ready design brief.' },
+  { slug: 'slide-builder',   name: 'Slide Builder',     description: 'Builds a clean slide deck from an outline.' },
+  { slug: 'weekly-digest',   name: 'Weekly Digest',     description: 'Summarises the week in the market into a short brief.' },
+  { slug: 'competitor-scan', name: 'Competitor Scan',   description: 'Tracks what comparable products are shipping and saying.' },
+  { slug: 'meeting-notes',   name: 'Meeting Notes',     description: 'Captures decisions and actions from a meeting.' },
+  { slug: 'message-drafter', name: 'Message Drafter',   description: 'Drafts a reply in the right tone for the channel.' },
+  { slug: 'workspace-lint',  name: 'Workspace Lint',    description: 'Checks the workspace for stale links and missing metadata.' },
 ];
+
+// Which skills each agent carries. Every lead owns two or three; a report never
+// carries more than its lead (Dev owns three, Cody two). Sharing is realistic:
+// content-planner sits with both Cleo and Ana, competitor-scan with Reese and
+// Glen, the engineering skills with both Dev and Cody.
+const AGENT_SKILLS = {
+  cos:   ['workspace-lint'],
+  cleo:  ['post-drafter', 'hook-generator', 'content-planner'],
+  dev:   ['spec-writer', 'code-reviewer', 'test-generator'],
+  des:   ['design-brief', 'slide-builder'],
+  reese: ['weekly-digest', 'competitor-scan'],
+  glen:  ['hook-generator', 'competitor-scan'],
+  rea:   ['meeting-notes', 'message-drafter'],
+  ana:   ['post-auditor', 'content-planner'],
+  cody:  ['code-reviewer', 'test-generator'],
+};
 
 // Routines seeded onto a few agents (parsed from agent frontmatter by the
 // server). Schedules use the "every <weekday> at HH:MM" grammar the scheduler
@@ -223,8 +242,8 @@ function agentFile(a) {
     `type: ${a.type}`, `order: ${a.order}`];
   if (a.reportsTo) lines.push(`reportsTo: ${a.reportsTo}`);
   lines.push(`colour: ${a.colour}`, `icon: ${a.icon}`, `description: ${a.description}`);
-  const mySkills = SKILLS.filter((s) => s.owner === a.id);
-  if (mySkills.length) { lines.push('skills:'); mySkills.forEach((s) => lines.push(`  - ${s.slug}`)); }
+  const mySkills = AGENT_SKILLS[a.id] || [];
+  if (mySkills.length) { lines.push('skills:'); mySkills.forEach((slug) => lines.push(`  - ${slug}`)); }
   const myRoutines = ROUTINES[a.id];
   if (myRoutines) {
     lines.push('routines:');
@@ -269,7 +288,7 @@ export function buildWorkspace(opts = {}) {
 
   // --- CLAUDE.md (workspace charter, generic) -------------------------------
   write('CLAUDE.md', [
-    '# Northwind Studio', '',
+    '# Fernwick Studio', '',
     'A small studio running its whole operation through an AI team. Cos routes',
     'the work; the leads own content, engineering, design, research, growth, and',
     'operations. This workspace holds the notes, boards, and files the team works',
@@ -279,21 +298,29 @@ export function buildWorkspace(opts = {}) {
   // --- Notes (frontmatter, callouts, wikilinks) -----------------------------
   write('Welcome.md', [
     '---', 'title: Welcome', 'status: active', 'tags: [demo, getting-started]',
-    'related: "[[Product Board]]"', 'updated: 2026-07-18', '---', '',
+    'related: "[[Backlog]]"', 'updated: 2026-07-18', '---', '',
     '# Welcome to the studio workspace', '',
     'This note shows how a file renders: frontmatter appears in the properties',
     'panel above, with tags as chips and `related` as a live link.', '',
-    '> [!note] Callout', '> Callouts render inline. Open the [[Product Board]] to see the board view,',
+    '> [!note] Callout', '> Callouts render inline. Open the [[Backlog]] board to see the columns,',
     '> or browse the `Assets` folder for images and a document.', '',
     '## What to try', '',
-    '- Open **Product Board.md** for the columns', '- Open **Artifacts/Launch Page.html** for a sandboxed preview',
+    '- Open **Backlog.md** and **Roadmap.md** for the boards', '- Open **Artifacts/Launch Page.html** for a sandboxed preview',
     '- Open **Assets/Cover.png**, **Photo.jpg**, and **Spec.pdf**', '',
     'See also: [[Roadmap]] and [[Notes/Weekly Plan]].', '',
   ].join('\n'));
 
+  // Roadmap is a second Kanban board (Now / Next / Later). It lives in the tree
+  // for realism; the Backlog board is the one opened in captures.
   write('Roadmap.md', [
-    '---', 'title: Roadmap', 'tags: [planning]', 'updated: 2026-07-18', '---', '',
-    '# Roadmap', '', '1. Ship the launch page', '2. Tidy the onboarding flow', '3. Gather early feedback', '',
+    '---', '', 'kanban-plugin: board', '', '---', '',
+    '## Now', '',
+    '- [ ] Ship the launch page #launch 2026-08-05', '- [ ] Tidy the onboarding flow #product', '',
+    '## Next', '',
+    '- [ ] Gather early feedback', '- [ ] Plan the follow-up release', '',
+    '## Later', '',
+    '- [ ] Explore a mobile companion', '',
+    '%% kanban:settings', '```', '{"kanban-plugin":"board"}', '```', '%%', '',
   ].join('\n'));
 
   // A briefing-style note with foldable and nested callouts plus frontmatter
@@ -308,12 +335,13 @@ export function buildWorkspace(opts = {}) {
 
   write('Notes/Weekly Plan.md', [
     '---', 'title: Weekly Plan', 'tags: [planning]', 'date: 2026-07-18', '---', '',
-    '# Weekly Plan', '', 'Focus for the week is the launch page. Actions live on the [[Product Board]].', '',
+    '# Weekly Plan', '', 'Focus for the week is the launch page. Actions live on the [[Backlog]].', '',
     '> [!todo] Follow-up', '> Confirm the launch date before Friday.', '',
   ].join('\n'));
 
-  // --- Kanban board (varied columns and cards, wikilink + tag + date) -------
-  write('Product Board.md', [
+  // --- Kanban board (varied columns and cards, wikilink + tag + date). This is
+  // the board opened in the kanban still and the drag clip. -------------------
+  write('Backlog.md', [
     '---', '', 'kanban-plugin: board', '', '---', '',
     '## Backlog', '',
     '- [ ] Draft the **launch note** #content 2026-08-05', '- [ ] Review [[Roadmap]] with the team',
@@ -333,15 +361,14 @@ export function buildWorkspace(opts = {}) {
     '  .hero h1 { font-size: 40px; margin: 0 0 12px; }',
     '  .hero p { font-size: 18px; opacity: 0.9; margin: 0; }',
     '  .body { padding: 40px 48px; max-width: 640px; }',
-    '  .stat { display: inline-block; margin-right: 32px; font-weight: 600; }',
-    '  .stat span { display: block; font-size: 28px; color: #3b6ea5; }',
+    '  .body .lead { font-size: 20px; font-weight: 600; margin: 0 0 16px; color: #22314f; }',
+    '  .body p { font-size: 16px; line-height: 1.5; margin: 0 0 12px; }',
     '</style></head>', '<body>',
     '  <div class="hero"><h1 id="headline">Run your studio from one place</h1>',
-    '  <p>A self-contained page, rendered in a locked-down preview.</p></div>',
+    '  <p>Your team, your files, and your work in one place you own.</p></div>',
     '  <div class="body">',
-    '    <p class="stat"><span>3x</span> faster reviews</p>',
-    '    <p class="stat"><span>100%</span> in your workspace</p>',
-    '    <p>This page ships its own styles. Scripts never run in the preview.</p>',
+    '    <p class="lead">Every draft, board, and review sits beside the agent that made it.</p>',
+    '    <p>This page ships its own styles, and scripts never run in the preview.</p>',
     '  </div>', '</body></html>', '',
   ].join('\n');
   write('Artifacts/Launch Page.html', launchHtml);
@@ -376,13 +403,15 @@ export function buildWorkspace(opts = {}) {
       { stdio: 'ignore' });
   } catch (e) { console.warn('  sips unavailable; skipped JPEG generation:', e.message); }
 
-  // Canonicalise the board so it is byte-stable from first open (no phantom
+  // Canonicalise both boards so they are byte-stable from first open (no phantom
   // "modified" state), exactly as build-demo-workspace.js does.
   try {
     const kanban = require(path.join(REPO_ROOT, 'public', 'kanban.js'));
-    const boardPath = path.join(workspace, 'Product Board.md');
-    fs.writeFileSync(boardPath, kanban.serialize(kanban.parse(fs.readFileSync(boardPath, 'utf8'))), 'utf8');
-  } catch (e) { console.warn('  Could not normalise the board:', e.message); }
+    for (const board of ['Backlog.md', 'Roadmap.md']) {
+      const boardPath = path.join(workspace, board);
+      fs.writeFileSync(boardPath, kanban.serialize(kanban.parse(fs.readFileSync(boardPath, 'utf8'))), 'utf8');
+    }
+  } catch (e) { console.warn('  Could not normalise the boards:', e.message); }
 
   // --- Review sidecar: anchored comments on the HTML artifact ---------------
   // Quotes are exact substrings of the artifact's RENDERED text (not markup),
@@ -399,9 +428,9 @@ export function buildWorkspace(opts = {}) {
       c2: { by: 'Des', at: '2026-07-18T10:12:00.000Z', re: 'c1',
         body: 'On it. I will mock a two-line and a one-line version.' },
       c3: { by: 'Ana', at: '2026-07-18T10:20:00.000Z',
-        quote: '3x',
-        prefix: '', suffix: ' faster reviews',
-        body: 'Do we have a source for this figure before it goes live?' },
+        quote: 'one place you own',
+        prefix: 'in ', suffix: '.',
+        body: 'The "you own" line is our strongest angle. Worth pulling into the headline?' },
     },
     suggestions: {},
     review: {},
@@ -419,13 +448,25 @@ export function buildWorkspace(opts = {}) {
   const sessions = path.join(home, '.claude', 'projects', projectHash);
   fs.mkdirSync(sessions, { recursive: true });
 
-  // s1: planning thread (long enough to fill the pane), pinned, on the leader.
-  let s1 = jsonlUser('What should we focus on this week?', '2026-07-18T09:00:00.000Z')
-    + jsonlAssistant('The launch page is the one thing that matters. Everything else waits behind it.', '2026-07-18T09:00:30.000Z');
-  for (let i = 2; i < 14; i++) {
-    s1 += jsonlUser(`Follow-up ${i}: anything blocking the launch page?`, `2026-07-18T09:${String(i).padStart(2, '0')}:00.000Z`);
-    s1 += jsonlAssistant(`Nothing blocking. Item ${i} handled; the plan holds.`, `2026-07-18T09:${String(i).padStart(2, '0')}:30.000Z`);
-  }
+  // s1: a real planning thread, pinned, on the leader. Varied, substantive
+  // turns (priority, status, deadline, tradeoff, delegation, scheduling) that
+  // fill the pane through content rather than a repeated line.
+  const s1 = [
+    jsonlUser('What should we focus on this week?', '2026-07-18T09:00:00.000Z'),
+    jsonlAssistant('The launch page is the one thing that moves the needle. I would hold everything else behind it until it ships.', '2026-07-18T09:00:40.000Z'),
+    jsonlUser('Agreed. What is the state of it right now?', '2026-07-18T09:02:00.000Z'),
+    jsonlAssistant('Cleo has a draft of the copy and Ana is auditing it. Des is on the layout. The one open risk is the headline: we are testing a shorter variant against the current one.', '2026-07-18T09:02:45.000Z'),
+    jsonlUser('Can we still hit Friday?', '2026-07-18T09:05:00.000Z'),
+    jsonlAssistant('Yes, if we lock the headline by Wednesday. If the shorter variant tests better we take it; if it is a wash we keep the current one and stop debating it.', '2026-07-18T09:05:50.000Z'),
+    jsonlUser('Good. Does the onboarding flow slip if we do that?', '2026-07-18T09:08:00.000Z'),
+    jsonlAssistant('It slips a week, and that is the right call. Splitting Dev across both would put the launch date at risk for a flow no one sees until after they sign up.', '2026-07-18T09:08:40.000Z'),
+    jsonlUser('Fine by me. Anything you need from me this week?', '2026-07-18T09:11:00.000Z'),
+    jsonlAssistant('Just the headline decision on Wednesday. I will put both variants and Ana\'s read in front of you by Tuesday night.', '2026-07-18T09:11:35.000Z'),
+    jsonlUser('One more thing: are we happy with the tone of the copy?', '2026-07-18T09:14:00.000Z'),
+    jsonlAssistant('It reads calm and direct, which is right for us. Ana flagged one line as slightly salesy and Cleo has already softened it.', '2026-07-18T09:14:40.000Z'),
+    jsonlUser('Great. Book the review for Wednesday morning.', '2026-07-18T09:16:00.000Z'),
+    jsonlAssistant('Booked for 9am Wednesday with Cleo, Des and Ana. I have added the follow-up release to the roadmap under Next so it does not get lost.', '2026-07-18T09:16:40.000Z'),
+  ].join('');
   fs.writeFileSync(path.join(sessions, 's1.jsonl'), s1);
 
   // s2: content thread (Cleo).

--- a/scripts/screenshots/generate-workspace.mjs
+++ b/scripts/screenshots/generate-workspace.mjs
@@ -1,0 +1,515 @@
+// Demo-workspace generator v2 for the marketing screenshot pipeline.
+//
+// Builds a self-contained, fully sanitized demo workspace plus a fake $HOME of
+// Claude Code session transcripts, so the capture harness can boot the real
+// server.js against a realistic-but-invented team, skill set, conversation
+// history, routines, and file tree. Every date and value is fixed, so runs do
+// not shimmer.
+//
+// It follows two proven patterns already in the repo:
+//   - test/e2e/fixture.js  (fake $HOME + agent files + conversation jsonl)
+//   - scripts/build-demo-workspace.js  (rich file tree, real PNG/PDF bytes)
+// It reads, but does not fork, public/kanban.js to canonicalise boards.
+//
+// Sanitization is a hard gate: the roster keeps only the generic role-names
+// Cos, Dev and Des; everything else is invented and free of real people,
+// clients, or business specifics. checkSanitization() greps the built tree for
+// banned tokens and throws before any capture runs.
+//
+// UK spelling in comments and prose; US spelling only where a code identifier
+// or an on-disk field name (colour is British by the app's own convention) is
+// fixed by the platform.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+// ---------------------------------------------------------------------------
+// Locked roster (from the spec's "Demo workspace roster and skills"). Names,
+// roles, order and reportsTo are verbatim; colour and icon are fixed here for
+// deterministic, pleasant avatars rather than relying on the server's rotating
+// defaults (which depend on directory read order).
+// ---------------------------------------------------------------------------
+export const ROSTER = [
+  { id: 'cos',   displayName: 'Cos',   role: 'Chief of Staff',      type: 'orchestrator', order: 0, reportsTo: null,   colour: '#E87A5A', icon: '◆',
+    description: 'Cos routes work to the right specialist, runs the daily brief, and keeps priorities visible across the team.' },
+  { id: 'cleo',  displayName: 'Cleo',  role: 'Content Lead',        type: 'specialist',   order: 1, reportsTo: 'cos',  colour: '#6B9EF0', icon: '✎',
+    description: 'Cleo owns the content pipeline from idea to publish-ready draft.' },
+  { id: 'dev',   displayName: 'Dev',   role: 'Engineering Lead',    type: 'specialist',   order: 2, reportsTo: 'cos',  colour: '#6BC67E', icon: '◎',
+    description: 'Dev owns delivery: specs, implementation, and shipping working software in small, reviewed slices.' },
+  { id: 'des',   displayName: 'Des',   role: 'Design Lead',         type: 'specialist',   order: 3, reportsTo: 'cos',  colour: '#E8A84C', icon: '◇',
+    description: 'Des owns visual execution across the product surface, from layouts to finished assets.' },
+  { id: 'reese', displayName: 'Reese', role: 'Research Lead',       type: 'specialist',   order: 4, reportsTo: 'cos',  colour: '#A07AE8', icon: '✦',
+    description: 'Reese tracks the market and the competitive landscape and turns signal into briefs.' },
+  { id: 'glen',  displayName: 'Glen',  role: 'Growth Lead',         type: 'specialist',   order: 5, reportsTo: 'cos',  colour: '#E87AAC', icon: '⬡',
+    description: 'Glen owns acquisition experiments and the growth funnel end to end.' },
+  { id: 'rea',   displayName: 'Rea',   role: 'Executive Assistant', type: 'specialist',   order: 6, reportsTo: 'cos',  colour: '#5BCFC4', icon: '△',
+    description: 'Rea keeps the calendar, meeting notes, and daily communications in order.' },
+  { id: 'ana',   displayName: 'Ana',   role: 'Content Analyst',     type: 'specialist',   order: 7, reportsTo: 'cleo', colour: '#7AB8E8', icon: '▦',
+    description: 'Ana measures what content works and pre-checks ideas against past performance.' },
+  { id: 'cody',  displayName: 'Cody',  role: 'Code Reviewer',       type: 'specialist',   order: 8, reportsTo: 'dev',  colour: '#8FCF7E', icon: '⬢',
+    description: 'Cody reviews changes for correctness, clarity, and safety before they merge.' },
+];
+
+// ---------------------------------------------------------------------------
+// Locked skills (~12, generic, mapped onto the roster). Each becomes a
+// .claude/skills/<slug>/SKILL.md with name + description frontmatter and a
+// short generic body, and is referenced by its owning agent's frontmatter so
+// it renders as "assigned" on the org, profile and skills views.
+// ---------------------------------------------------------------------------
+export const SKILLS = [
+  { slug: 'post-drafter',    owner: 'cleo',  name: 'Post Drafter',      description: 'Turns an approved angle into a publish-ready first draft.' },
+  { slug: 'hook-generator',  owner: 'cleo',  name: 'Hook Generator',    description: 'Generates and ranks opening lines for a piece of content.' },
+  { slug: 'content-planner', owner: 'cleo',  name: 'Content Planner',   description: 'Plans a week of content against goals and gaps.' },
+  { slug: 'post-auditor',    owner: 'ana',   name: 'Post Auditor',      description: 'Scores a draft for clarity and strength before it ships.' },
+  { slug: 'spec-writer',     owner: 'dev',   name: 'Spec Writer',       description: 'Writes a short spec before any non-trivial change.' },
+  { slug: 'code-reviewer',   owner: 'cody',  name: 'Code Reviewer',     description: 'Reviews a change across correctness, clarity, and safety.' },
+  { slug: 'test-generator',  owner: 'cody',  name: 'Test Generator',    description: 'Proposes tests that pin the behaviour a change relies on.' },
+  { slug: 'design-brief',    owner: 'des',   name: 'Design Brief',      description: 'Translates a request into an execution-ready design brief.' },
+  { slug: 'slide-builder',   owner: 'des',   name: 'Slide Builder',     description: 'Builds a clean slide deck from an outline.' },
+  { slug: 'weekly-digest',   owner: 'reese', name: 'Weekly Digest',     description: 'Summarises the week in the market into a short brief.' },
+  { slug: 'competitor-scan', owner: 'reese', name: 'Competitor Scan',   description: 'Tracks what comparable products are shipping and saying.' },
+  { slug: 'meeting-notes',   owner: 'rea',   name: 'Meeting Notes',     description: 'Captures decisions and actions from a meeting.' },
+  { slug: 'message-drafter', owner: 'rea',   name: 'Message Drafter',   description: 'Drafts a reply in the right tone for the channel.' },
+  { slug: 'workspace-lint',  owner: 'cos',   name: 'Workspace Lint',    description: 'Checks the workspace for stale links and missing metadata.' },
+];
+
+// Routines seeded onto a few agents (parsed from agent frontmatter by the
+// server). Schedules use the "every <weekday> at HH:MM" grammar the scheduler
+// recognises, so the routines panel reads as real scheduled work.
+const ROUTINES = {
+  cos:   [{ name: 'Daily brief',    schedule: 'every day at 08:00',    prompt: 'Summarise what needs attention today and flag anything overdue.' }],
+  reese: [{ name: 'Weekly digest',  schedule: 'every monday at 09:00', prompt: 'Run the weekly market scan and save a short brief.' }],
+  ana:   [{ name: 'Publish check',  schedule: 'every friday at 16:00', prompt: 'Reconcile what published this week against the plan.' }],
+};
+
+// Fixed run history for the routines panel (a populated .rundock/routine-state.json).
+const ROUTINE_STATE = {
+  'default:Daily brief': { lastRun: '2026-07-18T08:00:12.000Z', status: 'completed', duration: 42 },
+  'reese:Weekly digest': { lastRun: '2026-07-13T09:00:20.000Z', status: 'completed', duration: 118 },
+  'ana:Publish check':   { lastRun: '2026-07-17T16:00:08.000Z', status: 'completed', duration: 27 },
+};
+
+// Tokens that must never appear in the built workspace. The gate greps for
+// these (whole-word, case-insensitive) and throws if any are found. The
+// generic role-names Cos, Dev, Des are deliberately allowed.
+//
+// The committed default lists only already-public owner identifiers and
+// generic vault-structure markers, so this public repo never hardcodes private
+// agent names or a personal tool stack. Project-specific tokens (private team
+// names, connected tools) are supplied out of band via the
+// RUNDOCK_BANNED_TOKENS env (comma-separated) or a gitignored
+// scripts/screenshots/.banned-tokens.json, and are merged in at run time.
+export const DEFAULT_BANNED_TOKENS = [
+  'liamdarmody', 'darmody', 'obsidian vault', 'agent-workspace',
+];
+
+export function loadBannedTokens() {
+  const tokens = [...DEFAULT_BANNED_TOKENS];
+  if (process.env.RUNDOCK_BANNED_TOKENS) {
+    tokens.push(...process.env.RUNDOCK_BANNED_TOKENS.split(',').map((s) => s.trim()).filter(Boolean));
+  }
+  const localFile = path.join(__dirname, '.banned-tokens.json');
+  try {
+    if (fs.existsSync(localFile)) {
+      const extra = JSON.parse(fs.readFileSync(localFile, 'utf8'));
+      if (Array.isArray(extra)) tokens.push(...extra.filter((t) => typeof t === 'string'));
+    }
+  } catch { /* ignore a malformed local override */ }
+  return tokens;
+}
+
+// ===========================================================================
+// Binary builders (real, decodable bytes) ported from build-demo-workspace.js
+// ===========================================================================
+function buildPng(width, height, pixel) {
+  const chunk = (type, data) => {
+    const len = Buffer.alloc(4); len.writeUInt32BE(data.length);
+    const body = Buffer.concat([Buffer.from(type), data]);
+    const crc = Buffer.alloc(4); crc.writeUInt32BE(zlib.crc32(body) >>> 0);
+    return Buffer.concat([len, body, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; ihdr[9] = 2; // 8-bit depth, truecolour
+  const rows = [];
+  for (let y = 0; y < height; y++) {
+    const row = Buffer.alloc(1 + width * 3);
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = pixel(x, y, width, height);
+      row[1 + x * 3] = r; row[2 + x * 3] = g; row[3 + x * 3] = b;
+    }
+    rows.push(row);
+  }
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    chunk('IHDR', ihdr),
+    chunk('IDAT', zlib.deflateSync(Buffer.concat(rows))),
+    chunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+function coverPixel(x, y, w, h) {
+  const r = Math.round(40 + (x / w) * 200);
+  const g = Math.round(60 + (y / h) * 120);
+  const b = Math.round(150 - (x / w) * 90);
+  const band = (y > h * 0.62 && y < h * 0.78) ? -40 : 0;
+  const clamp = (n) => Math.max(0, Math.min(255, n + band));
+  return [clamp(r), clamp(g), clamp(b)];
+}
+
+function buildPdf(lines) {
+  const objs = [];
+  const add = (body) => { objs.push(body); return objs.length; };
+  const catalog = add('<< /Type /Catalog /Pages 2 0 R >>');
+  add('<< /Type /Pages /Kids [3 0 R] /Count 1 >>');
+  add('<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+    + '/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>');
+  add('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+  let text = 'BT /F1 18 Tf 72 720 Td 22 TL';
+  lines.forEach((ln, i) => {
+    const esc = ln.replace(/([\\()])/g, '\\$1');
+    text += (i === 0 ? ` (${esc}) Tj` : ` T* (${esc}) Tj`);
+    if (i === 0) text += ' /F1 12 Tf';
+  });
+  text += ' ET';
+  add(`<< /Length ${text.length} >>\nstream\n${text}\nendstream`);
+
+  let out = '%PDF-1.4\n';
+  const offsets = [];
+  objs.forEach((body, i) => { offsets.push(out.length); out += `${i + 1} 0 obj\n${body}\nendobj\n`; });
+  const xrefStart = out.length;
+  out += `xref\n0 ${objs.length + 1}\n0000000000 65535 f \n`;
+  offsets.forEach((off) => { out += `${String(off).padStart(10, '0')} 00000 n \n`; });
+  out += `trailer\n<< /Size ${objs.length + 1} /Root ${catalog} 0 R >>\n`;
+  out += `startxref\n${xrefStart}\n%%EOF\n`;
+  return Buffer.from(out, 'latin1');
+}
+
+// FNV-1a sidecar filename, ported byte-for-byte from
+// public/viewers/sidecar-controller.js so a hand-authored review sidecar lands
+// at the exact path the client loads on open.
+function sidecarNameFor(p) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < p.length; i++) {
+    h ^= p.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  const slug = p.replace(/[\\/]/g, '__').replace(/[^\w.-]/g, '_').slice(0, 60);
+  return `${slug}-${h.toString(16).padStart(8, '0')}.json`;
+}
+
+// ===========================================================================
+// jsonl helpers (fixed timestamps)
+// ===========================================================================
+function jsonlUser(text, ts) {
+  return JSON.stringify({ type: 'user', message: { role: 'user', content: text }, timestamp: ts }) + '\n';
+}
+function jsonlAssistant(text, ts) {
+  return JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text }] }, timestamp: ts }) + '\n';
+}
+
+function agentFile(a) {
+  const lines = ['---', `name: ${a.id}`, `displayName: ${a.displayName}`, `role: ${a.role}`,
+    `type: ${a.type}`, `order: ${a.order}`];
+  if (a.reportsTo) lines.push(`reportsTo: ${a.reportsTo}`);
+  lines.push(`colour: ${a.colour}`, `icon: ${a.icon}`, `description: ${a.description}`);
+  const mySkills = SKILLS.filter((s) => s.owner === a.id);
+  if (mySkills.length) { lines.push('skills:'); mySkills.forEach((s) => lines.push(`  - ${s.slug}`)); }
+  const myRoutines = ROUTINES[a.id];
+  if (myRoutines) {
+    lines.push('routines:');
+    myRoutines.forEach((r) => lines.push(`  - name: ${r.name}`, `    schedule: ${r.schedule}`, `    prompt: ${r.prompt}`));
+  }
+  lines.push('---', '', `You are ${a.displayName}, the ${a.role}. ${a.description}`, '');
+  return lines.join('\n');
+}
+
+function skillFile(s) {
+  return ['---', `name: ${s.name}`, `description: ${s.description}`, '---', '',
+    `# ${s.name}`, '', s.description, '',
+    '## When to use', '', `Use ${s.name} when the task matches its purpose above.`, '',
+    '## Steps', '', '1. Confirm the goal and constraints.', '2. Do the work in one focused pass.',
+    '3. Hand back a clear, checkable result.', ''].join('\n');
+}
+
+// ===========================================================================
+// Main builder
+// ===========================================================================
+export function buildWorkspace(opts = {}) {
+  const root = opts.root || path.join(os.tmpdir(), 'rundock-marketing');
+  const workspace = path.join(root, 'workspace');
+  const home = path.join(root, 'home');
+
+  // Fully re-runnable: wipe and rebuild so every run is byte-identical.
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(home, { recursive: true });
+
+  const write = (rel, contents) => {
+    const full = path.join(workspace, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  };
+
+  // --- Agents ---------------------------------------------------------------
+  for (const a of ROSTER) write(path.join('.claude', 'agents', `${a.id}.md`), agentFile(a));
+
+  // --- Skills ---------------------------------------------------------------
+  for (const s of SKILLS) write(path.join('.claude', 'skills', s.slug, 'SKILL.md'), skillFile(s));
+
+  // --- CLAUDE.md (workspace charter, generic) -------------------------------
+  write('CLAUDE.md', [
+    '# Northwind Studio', '',
+    'A small studio running its whole operation through an AI team. Cos routes',
+    'the work; the leads own content, engineering, design, research, growth, and',
+    'operations. This workspace holds the notes, boards, and files the team works',
+    'from.', '',
+  ].join('\n'));
+
+  // --- Notes (frontmatter, callouts, wikilinks) -----------------------------
+  write('Welcome.md', [
+    '---', 'title: Welcome', 'status: active', 'tags: [demo, getting-started]',
+    'related: "[[Product Board]]"', 'updated: 2026-07-18', '---', '',
+    '# Welcome to the studio workspace', '',
+    'This note shows how a file renders: frontmatter appears in the properties',
+    'panel above, with tags as chips and `related` as a live link.', '',
+    '> [!note] Callout', '> Callouts render inline. Open the [[Product Board]] to see the board view,',
+    '> or browse the `Assets` folder for images and a document.', '',
+    '## What to try', '',
+    '- Open **Product Board.md** for the columns', '- Open **Artifacts/Launch Page.html** for a sandboxed preview',
+    '- Open **Assets/Cover.png**, **Photo.jpg**, and **Spec.pdf**', '',
+    'See also: [[Roadmap]] and [[Notes/Weekly Plan]].', '',
+  ].join('\n'));
+
+  write('Roadmap.md', [
+    '---', 'title: Roadmap', 'tags: [planning]', 'updated: 2026-07-18', '---', '',
+    '# Roadmap', '', '1. Ship the launch page', '2. Tidy the onboarding flow', '3. Gather early feedback', '',
+  ].join('\n'));
+
+  // A briefing-style note with foldable and nested callouts plus frontmatter
+  // wikilinks (one live, one deliberately dead so the dead-link state shows).
+  write('Briefing.md', [
+    '---', 'title: "Morning Briefing"', 'related:', '  - "[[Roadmap]]"', '  - "[[Missing Note]]"', '---', '',
+    '> [!abstract]+ Today at a glance', '> Two reviews, one launch date to hold.', '',
+    '> [!warning]- Watch items', '> The launch page copy is still in review.',
+    '> > [!note]- Context', '> > Cleo has a draft; Ana is auditing it now.', '',
+    'Plain paragraph after the callouts.', '',
+  ].join('\n'));
+
+  write('Notes/Weekly Plan.md', [
+    '---', 'title: Weekly Plan', 'tags: [planning]', 'date: 2026-07-18', '---', '',
+    '# Weekly Plan', '', 'Focus for the week is the launch page. Actions live on the [[Product Board]].', '',
+    '> [!todo] Follow-up', '> Confirm the launch date before Friday.', '',
+  ].join('\n'));
+
+  // --- Kanban board (varied columns and cards, wikilink + tag + date) -------
+  write('Product Board.md', [
+    '---', '', 'kanban-plugin: board', '', '---', '',
+    '## Backlog', '',
+    '- [ ] Draft the **launch note** #content 2026-08-05', '- [ ] Review [[Roadmap]] with the team',
+    '- [ ] Collect assets for the `Assets` folder', '',
+    '## In Progress', '', '- [ ] Build the launch page #design', '- [ ] Wire up the [[Welcome]] walkthrough 2026-07-28', '',
+    '## In Review', '', '- [ ] Onboarding copy pass #content', '',
+    '## Done', '', '- [x] Set up the workspace', '- [x] Add the board', '',
+    '%% kanban:settings', '```', '{"kanban-plugin":"board"}', '```', '%%', '',
+  ].join('\n'));
+
+  // --- HTML artifact (unique phrases used as review anchors) ----------------
+  const launchHtml = [
+    '<!doctype html>', '<html lang="en"><head><meta charset="utf-8"><title>Launch Page</title>',
+    '<style>',
+    '  body { margin: 0; font-family: -apple-system, system-ui, sans-serif; color: #1a1a1a; }',
+    '  .hero { padding: 64px 48px; background: linear-gradient(135deg, #22314f, #3b6ea5); color: #fff; }',
+    '  .hero h1 { font-size: 40px; margin: 0 0 12px; }',
+    '  .hero p { font-size: 18px; opacity: 0.9; margin: 0; }',
+    '  .body { padding: 40px 48px; max-width: 640px; }',
+    '  .stat { display: inline-block; margin-right: 32px; font-weight: 600; }',
+    '  .stat span { display: block; font-size: 28px; color: #3b6ea5; }',
+    '</style></head>', '<body>',
+    '  <div class="hero"><h1 id="headline">Run your studio from one place</h1>',
+    '  <p>A self-contained page, rendered in a locked-down preview.</p></div>',
+    '  <div class="body">',
+    '    <p class="stat"><span>3x</span> faster reviews</p>',
+    '    <p class="stat"><span>100%</span> in your workspace</p>',
+    '    <p>This page ships its own styles. Scripts never run in the preview.</p>',
+    '  </div>', '</body></html>', '',
+  ].join('\n');
+  write('Artifacts/Launch Page.html', launchHtml);
+
+  // --- SVG artifact ---------------------------------------------------------
+  write('Artifacts/Architecture.svg', [
+    '<svg xmlns="http://www.w3.org/2000/svg" width="480" height="240" viewBox="0 0 480 240">',
+    '  <rect width="480" height="240" fill="#0f172a"/>',
+    '  <rect x="40" y="90" width="120" height="60" rx="8" fill="#2b6cb0"/>',
+    '  <rect x="180" y="90" width="120" height="60" rx="8" fill="#3b82f6"/>',
+    '  <rect x="320" y="90" width="120" height="60" rx="8" fill="#60a5fa"/>',
+    '  <line x1="160" y1="120" x2="180" y2="120" stroke="#94a3b8" stroke-width="3"/>',
+    '  <line x1="300" y1="120" x2="320" y2="120" stroke="#94a3b8" stroke-width="3"/>',
+    '  <text x="100" y="125" fill="#fff" font-family="sans-serif" font-size="15" text-anchor="middle">Client</text>',
+    '  <text x="240" y="125" fill="#fff" font-family="sans-serif" font-size="15" text-anchor="middle">Server</text>',
+    '  <text x="380" y="125" fill="#fff" font-family="sans-serif" font-size="15" text-anchor="middle">Files</text>',
+    '</svg>', '',
+  ].join('\n'));
+
+  // --- Images + PDF ---------------------------------------------------------
+  write('Assets/Cover.png', buildPng(600, 360, coverPixel));
+  write('Assets/Spec.pdf', buildPdf([
+    'Product Specification', 'A sample document rendered in the file viewer.',
+    'It opens inline alongside notes, boards, and images.', '',
+    'Section 1  Overview', 'Section 2  Requirements', 'Section 3  Rollout',
+  ]));
+
+  // JPEG from the PNG via the macOS image tool (real JPEG bytes).
+  try {
+    execFileSync('sips', ['-s', 'format', 'jpeg',
+      path.join(workspace, 'Assets', 'Cover.png'), '--out', path.join(workspace, 'Assets', 'Photo.jpg')],
+      { stdio: 'ignore' });
+  } catch (e) { console.warn('  sips unavailable; skipped JPEG generation:', e.message); }
+
+  // Canonicalise the board so it is byte-stable from first open (no phantom
+  // "modified" state), exactly as build-demo-workspace.js does.
+  try {
+    const kanban = require(path.join(REPO_ROOT, 'public', 'kanban.js'));
+    const boardPath = path.join(workspace, 'Product Board.md');
+    fs.writeFileSync(boardPath, kanban.serialize(kanban.parse(fs.readFileSync(boardPath, 'utf8'))), 'utf8');
+  } catch (e) { console.warn('  Could not normalise the board:', e.message); }
+
+  // --- Review sidecar: anchored comments on the HTML artifact ---------------
+  // Quotes are exact substrings of the artifact's RENDERED text (not markup),
+  // so the anchoring engine locates them and draws the review marks on open.
+  const artifactRel = 'Artifacts/Launch Page.html';
+  const sidecar = {
+    format: 'rundock-review-sidecar/1',
+    path: artifactRel,
+    comments: {
+      c1: { by: 'Cos', at: '2026-07-18T10:04:00.000Z',
+        quote: 'Run your studio from one place',
+        prefix: '', suffix: 'A self-contained',
+        body: 'Strong headline. Can we test a shorter variant next to it?' },
+      c2: { by: 'Des', at: '2026-07-18T10:12:00.000Z', re: 'c1',
+        body: 'On it. I will mock a two-line and a one-line version.' },
+      c3: { by: 'Ana', at: '2026-07-18T10:20:00.000Z',
+        quote: '3x',
+        prefix: '', suffix: ' faster reviews',
+        body: 'Do we have a source for this figure before it goes live?' },
+    },
+    suggestions: {},
+    review: {},
+  };
+  write(path.join('.rundock', 'reviews', sidecarNameFor(artifactRel)),
+    JSON.stringify(sidecar, null, 2));
+
+  // --- Routine run state ----------------------------------------------------
+  write(path.join('.rundock', 'routine-state.json'), JSON.stringify(ROUTINE_STATE, null, 2));
+
+  // --- Conversations: metadata + fake $HOME transcripts ---------------------
+  // The projects subfolder name is the absolute workspace path with every
+  // slash replaced by a dash (server.js derivation).
+  const projectHash = workspace.replace(/\//g, '-');
+  const sessions = path.join(home, '.claude', 'projects', projectHash);
+  fs.mkdirSync(sessions, { recursive: true });
+
+  // s1: planning thread (long enough to fill the pane), pinned, on the leader.
+  let s1 = jsonlUser('What should we focus on this week?', '2026-07-18T09:00:00.000Z')
+    + jsonlAssistant('The launch page is the one thing that matters. Everything else waits behind it.', '2026-07-18T09:00:30.000Z');
+  for (let i = 2; i < 14; i++) {
+    s1 += jsonlUser(`Follow-up ${i}: anything blocking the launch page?`, `2026-07-18T09:${String(i).padStart(2, '0')}:00.000Z`);
+    s1 += jsonlAssistant(`Nothing blocking. Item ${i} handled; the plan holds.`, `2026-07-18T09:${String(i).padStart(2, '0')}:30.000Z`);
+  }
+  fs.writeFileSync(path.join(sessions, 's1.jsonl'), s1);
+
+  // s2: content thread (Cleo).
+  fs.writeFileSync(path.join(sessions, 's2.jsonl'),
+    jsonlUser('Draft the launch note for the studio page.', '2026-07-17T14:00:00.000Z')
+    + jsonlAssistant('Here is a first pass. The hook leads with the one-place idea, then two proof points.', '2026-07-17T14:00:40.000Z')
+    + jsonlUser('Tighten the opening line.', '2026-07-17T14:05:00.000Z')
+    + jsonlAssistant('Tightened. It now opens on the reader, not the product.', '2026-07-17T14:05:30.000Z'));
+
+  // s3: engineering thread (Dev), references binary outputs by wikilink.
+  fs.writeFileSync(path.join(sessions, 's3.jsonl'),
+    jsonlUser('Where did the export land?', '2026-07-16T11:00:00.000Z')
+    + jsonlAssistant('Saved the render to [[Cover.png]] and the summary to [[Spec.pdf]].', '2026-07-16T11:00:30.000Z'));
+
+  // s4: research thread (Reese).
+  fs.writeFileSync(path.join(sessions, 's4.jsonl'),
+    jsonlUser('What changed in the market this week?', '2026-07-13T09:05:00.000Z')
+    + jsonlAssistant('Three things worth noting. I have saved the short version to the weekly digest.', '2026-07-13T09:05:45.000Z'));
+
+  // s5: the streaming-look thread (Cleo). Prior turns here; the harness injects
+  // a live streaming reply on top at capture time.
+  fs.writeFileSync(path.join(sessions, 's5.jsonl'),
+    jsonlUser('Rework the landing hook to be shorter.', '2026-07-18T11:00:00.000Z')
+    + jsonlAssistant('Good idea. A shorter hook reads faster above the fold.', '2026-07-18T11:00:30.000Z'));
+
+  // Conversation metadata. One pinned + others, ordered so pinned-first
+  // grouping is visible. A couple carry a listId so the Lists pills populate.
+  fs.mkdirSync(path.join(workspace, '.rundock'), { recursive: true });
+  fs.writeFileSync(path.join(workspace, '.rundock', 'conversations.json'), JSON.stringify([
+    { id: 'c1', agentId: 'default', sessionId: 's1', sessionIds: [], title: 'Plan the week', status: 'active', pinned: true, pinnedAt: '2026-07-18T09:05:00.000Z', listIds: ['launch'], createdAt: '2026-07-18T08:59:00.000Z', lastActiveAt: '2026-07-18T09:30:00.000Z' },
+    { id: 'c5', agentId: 'cleo', sessionId: 's5', sessionIds: [], title: 'Rework the landing hook', status: 'active', listIds: ['launch'], createdAt: '2026-07-18T10:59:00.000Z', lastActiveAt: '2026-07-18T11:01:00.000Z' },
+    { id: 'c2', agentId: 'cleo', sessionId: 's2', sessionIds: [], title: 'Draft the launch note', status: 'active', listIds: ['launch'], createdAt: '2026-07-17T13:59:00.000Z', lastActiveAt: '2026-07-17T14:06:00.000Z' },
+    { id: 'c3', agentId: 'dev', sessionId: 's3', sessionIds: [], title: 'Export handoff', status: 'active', createdAt: '2026-07-16T10:59:00.000Z', lastActiveAt: '2026-07-16T11:01:00.000Z' },
+    { id: 'c4', agentId: 'reese', sessionId: 's4', sessionIds: [], title: 'Weekly market scan', status: 'active', createdAt: '2026-07-13T09:04:00.000Z', lastActiveAt: '2026-07-13T09:06:00.000Z' },
+  ], null, 2));
+
+  // Named lists so the Lists pills render beside All and Unread.
+  fs.writeFileSync(path.join(workspace, '.rundock', 'lists.json'), JSON.stringify([
+    { id: 'launch', name: 'Launch', createdAt: '2026-07-17T09:00:00.000Z' },
+  ], null, 2));
+
+  return { root, workspace, home, projectHash };
+}
+
+// ===========================================================================
+// Sanitization gate
+// ===========================================================================
+export function checkSanitization(workspace) {
+  const hits = [];
+  // Whole-token matching (word boundaries), so a short three-letter token
+  // cannot false-positive inside ordinary words such as "leads" or "release".
+  // Multi-word tokens (e.g. "acme corp") match with a flexible internal space.
+  const patterns = loadBannedTokens().map((token) => {
+    const body = token.trim().replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+    return { token, re: new RegExp(`(?<![\\w-])${body}(?![\\w-])`, 'i') };
+  });
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      // Only scan text; skip real binaries (png/jpg/pdf) which carry no prose.
+      if (/\.(png|jpe?g|gif|webp|pdf)$/i.test(entry.name)) continue;
+      let text;
+      try { text = fs.readFileSync(full, 'utf8'); } catch { continue; }
+      for (const { token, re } of patterns) {
+        if (re.test(text)) hits.push({ file: path.relative(workspace, full), token });
+      }
+    }
+  };
+  walk(workspace);
+  return { ok: hits.length === 0, hits };
+}
+
+// Allow standalone use: `node generate-workspace.mjs [root]` builds the tree
+// and runs the gate, printing where it landed.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const built = buildWorkspace({ root: process.argv[2] });
+  const gate = checkSanitization(built.workspace);
+  console.log('Workspace built at:', built.workspace);
+  console.log('Home built at:', built.home);
+  if (!gate.ok) {
+    console.error('SANITIZATION FAILED:');
+    for (const h of gate.hits) console.error(`  ${h.file}: "${h.token}"`);
+    process.exit(1);
+  }
+  console.log('Sanitization gate: PASS');
+}

--- a/scripts/screenshots/generate-workspace.mjs
+++ b/scripts/screenshots/generate-workspace.mjs
@@ -341,14 +341,23 @@ export function buildWorkspace(opts = {}) {
 
   // --- Kanban board (varied columns and cards, wikilink + tag + date). This is
   // the board opened in the kanban still and the drag clip. -------------------
+  // Three columns so all lanes fit the frame without clipping, each with a few
+  // cards so the board reads as a full, busy surface.
   write('Backlog.md', [
     '---', '', 'kanban-plugin: board', '', '---', '',
     '## Backlog', '',
-    '- [ ] Draft the **launch note** #content 2026-08-05', '- [ ] Review [[Roadmap]] with the team',
-    '- [ ] Collect assets for the `Assets` folder', '',
-    '## In Progress', '', '- [ ] Build the launch page #design', '- [ ] Wire up the [[Welcome]] walkthrough 2026-07-28', '',
-    '## In Review', '', '- [ ] Onboarding copy pass #content', '',
-    '## Done', '', '- [x] Set up the workspace', '- [x] Add the board', '',
+    '- [ ] Draft the **launch note** #content 2026-08-05',
+    '- [ ] Review [[Roadmap]] with the team',
+    '- [ ] Collect assets for the `Assets` folder',
+    '- [ ] Draft the onboarding copy #content', '',
+    '## In Progress', '',
+    '- [ ] Build the launch page #design',
+    '- [ ] Wire up the [[Welcome]] walkthrough 2026-07-28',
+    '- [ ] Tighten the hero headline #content', '',
+    '## Done', '',
+    '- [x] Set up the workspace',
+    '- [x] Add the board',
+    '- [x] Agree the launch date', '',
     '%% kanban:settings', '```', '{"kanban-plugin":"board"}', '```', '%%', '',
   ].join('\n'));
 
@@ -368,6 +377,8 @@ export function buildWorkspace(opts = {}) {
     '  <p>Your team, your files, and your work in one place you own.</p></div>',
     '  <div class="body">',
     '    <p class="lead">Every draft, board, and review sits beside the agent that made it.</p>',
+    '    <p>Open a note, a board, an image, or a page like this one in the same window, in a workspace that stays on your machine.</p>',
+    '    <p>Review what an agent produces where it lives: select a line, leave a comment, and it acts on your feedback in place.</p>',
     '    <p>This page ships its own styles, and scripts never run in the preview.</p>',
     '  </div>', '</body></html>', '',
   ].join('\n');

--- a/scripts/screenshots/harness.mjs
+++ b/scripts/screenshots/harness.mjs
@@ -1,0 +1,166 @@
+// Shared Playwright harness helpers for the screenshot pipeline: deterministic
+// context setup (fixed clock, UTC timezone, retina viewport), theme control,
+// workspace navigation, and client-state seeding. Both capture.mjs (stills) and
+// motion.mjs (GIF clips) build on these so the two stay consistent.
+
+// Locked capture geometry: 1440x900 logical at deviceScaleFactor 2 gives a
+// 2880x1800 @2x master.
+export const VIEWPORT = { width: 1440, height: 900 };
+export const DEVICE_SCALE = 2;
+
+// Fixed "now" for the whole run, so relative labels ("2h ago", "Yesterday",
+// "09:30") never shimmer between runs. Paired with a UTC timezone so the local
+// time formatters resolve identically on any machine.
+export const FIXED_EPOCH = Date.UTC(2026, 6, 18, 12, 0, 0); // 2026-07-18T12:00:00Z
+export const TIMEZONE = 'UTC';
+
+// Injected before any page script runs: freezes Date.now()/new Date() to
+// FIXED_EPOCH while leaving explicit-argument parsing and timers intact.
+function clockScript(fixed) {
+  const RealDate = Date;
+  class FakeDate extends RealDate {
+    constructor(...args) { if (args.length === 0) super(fixed); else super(...args); }
+    static now() { return fixed; }
+  }
+  FakeDate.parse = RealDate.parse;
+  FakeDate.UTC = RealDate.UTC;
+  // eslint-disable-next-line no-global-assign
+  window.Date = FakeDate;
+}
+
+// Stills: kill every animation and transition, hide scrollbars, hide the text
+// caret. Applied as an init style so it is present from first paint.
+export const STILL_CSS = `
+  *,*::before,*::after{animation:none!important;transition:none!important;animation-duration:0s!important;animation-delay:0s!important;caret-color:transparent!important}
+  ::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
+  *{scrollbar-width:none!important}
+  #connection-bar,#external-edit-banner{display:none!important}
+`;
+
+// Motion: keep animations (the org pulse and streaming type-in must run), just
+// hide scrollbars and the caret so clips read clean.
+export const MOTION_CSS = `
+  ::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}
+  *{scrollbar-width:none!important;caret-color:transparent!important}
+  #connection-bar,#external-edit-banner{display:none!important}
+`;
+
+// Creates a deterministic context. `motion:true` keeps animations and can
+// record video to `recordVideoDir`.
+export async function newContext(browser, { motion = false, recordVideoDir = null } = {}) {
+  const ctx = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: DEVICE_SCALE,
+    timezoneId: TIMEZONE,
+    reducedMotion: motion ? 'no-preference' : 'reduce',
+    ...(recordVideoDir ? { recordVideo: { dir: recordVideoDir, size: VIEWPORT } } : {}),
+  });
+  await ctx.addInitScript(clockScript, FIXED_EPOCH);
+  const css = motion ? MOTION_CSS : STILL_CSS;
+  await ctx.addInitScript((c) => {
+    const apply = () => {
+      const s = document.createElement('style');
+      s.id = '__capture_css__';
+      s.textContent = c;
+      (document.head || document.documentElement).appendChild(s);
+    };
+    if (document.head) apply(); else document.addEventListener('DOMContentLoaded', apply);
+  }, css);
+  return ctx;
+}
+
+// Navigates to the app and waits for the workspace to connect (nav revealed)
+// and the first agents/skills payloads to arrive.
+export async function gotoWorkspace(page, url) {
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('.nav-item[data-nav="team"]', { state: 'visible', timeout: 20000 });
+  // Let the initial agents/skills/conversations messages settle.
+  await page.evaluate(() => document.fonts && document.fonts.ready).catch(() => {});
+  await page.waitForTimeout(400);
+}
+
+// Sets light or dark. Theme is a single class on <body> (dark is the default).
+export async function setTheme(page, theme) {
+  await page.evaluate((t) => {
+    document.body.classList.toggle('light', t === 'light');
+    if (typeof applyHljsTheme === 'function') applyHljsTheme(t === 'light');
+  }, theme);
+}
+
+// Org-chart status story (locked by the spec): Dev, Cleo and Reese are working
+// (pulsing green); Cody, Ana and Glen were active at varied recent times. Cody
+// reports to Dev and Ana to Cleo, so it reads as reports handing back to their
+// lead. Times are fixed relative to FIXED_EPOCH (2026-07-18T12:00:00Z), giving
+// "2h ago", "25m ago" and "20h ago".
+export const ORG_WORKING = ['dev', 'cleo', 'reese'];
+export const ORG_LAST_ACTIVE = {
+  cody: '2026-07-18T10:00:00.000Z', // 2h ago
+  ana: '2026-07-18T11:35:00.000Z',  // 25m ago
+  glen: '2026-07-17T16:00:00.000Z', // 20h ago
+};
+
+// Seeds three conversations as actively processing so the given agent ids show
+// the working (pulsing) state on the org chart and in the sidebar list. Mirrors
+// the product's real code path (getWorkingAgentIds reads convoState).
+export async function seedWorking(page, agentIds) {
+  await page.evaluate((ids) => {
+    window.convoState = window.convoState || {};
+    ids.forEach((id, i) => { convoState['__seed_' + i] = { isProcessing: true, activeAgentId: id }; });
+    if (typeof renderOrgChart === 'function') renderOrgChart();
+    if (typeof renderAgentList === 'function') renderAgentList();
+  }, agentIds);
+}
+
+// Seeds fixed "last active" times on agents so the sidebar list shows varied
+// recent states. `entries` is { agentId: isoString }.
+export async function seedLastActive(page, entries) {
+  await page.evaluate((map) => {
+    window.agentLastActivity = window.agentLastActivity || {};
+    for (const [id, iso] of Object.entries(map)) {
+      agentLastActivity[id] = { time: new Date(iso), label: '' };
+    }
+    if (typeof renderAgentList === 'function') renderAgentList();
+    if (typeof renderOrgChart === 'function') renderOrgChart();
+  }, entries);
+}
+
+// Opens a workspace file by relative path through the same read_file path the
+// tree row uses, then waits for the editor surface to mount.
+export async function openFile(page, relPath) {
+  await page.evaluate((p) => {
+    if (typeof switchNav === 'function') switchNav('files');
+    ws.send(JSON.stringify({ type: 'read_file', path: p }));
+  }, relPath);
+  await page.waitForTimeout(700);
+}
+
+// Opens a conversation and puts it into a live "streaming a reply" state by
+// driving the same client entry points the WebSocket path uses. Leaves the
+// conversation processing (no result frame), so the streaming bubble persists
+// for a still or grows chunk by chunk for a clip.
+export async function beginStream(page, { convoId, agentId, pid = 'p-stream' }) {
+  await page.evaluate(({ convoId, pid }) => {
+    if (typeof openConversation === 'function') openConversation(convoId);
+    startProcessing(convoId);
+    const st = getConvoState(convoId);
+    st.activeProcessId = pid;
+  }, { convoId, agentId, pid });
+  await page.waitForTimeout(400);
+}
+
+// Pushes one streaming text delta into the open conversation, exactly as a
+// 'stream_event' WebSocket frame would.
+export async function pushChunk(page, { convoId, agentId, text, pid = 'p-stream' }) {
+  await page.evaluate(({ convoId, agentId, text, pid }) => {
+    handle({
+      type: 'stream_event', _conversationId: convoId, _processId: pid, _agent: agentId,
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
+    });
+  }, { convoId, agentId, text, pid });
+}
+
+// Waits for web fonts and a short settle before a screenshot.
+export async function settle(page, ms = 300) {
+  await page.evaluate(() => document.fonts && document.fonts.ready).catch(() => {});
+  await page.waitForTimeout(ms);
+}

--- a/scripts/screenshots/harness.mjs
+++ b/scripts/screenshots/harness.mjs
@@ -160,6 +160,13 @@ export async function openFile(page, relPath) {
     ws.send(JSON.stringify({ type: 'read_file', path: p }));
   }, relPath);
   await page.waitForTimeout(700);
+  // Re-assert the real "reveal and highlight in the tree" behaviour after the
+  // tree has finished any re-render, so the open file shows selected (a bare
+  // read_file can race the tree render and lose the highlight).
+  await page.evaluate((p) => {
+    if (typeof highlightFileInSidebar === 'function') highlightFileInSidebar(p);
+  }, relPath);
+  await page.waitForTimeout(150);
 }
 
 // Opens a conversation and puts it into a live "streaming a reply" state by

--- a/scripts/screenshots/harness.mjs
+++ b/scripts/screenshots/harness.mjs
@@ -46,8 +46,10 @@ export const MOTION_CSS = `
 `;
 
 // Creates a deterministic context. `motion:true` keeps animations and can
-// record video to `recordVideoDir`.
-export async function newContext(browser, { motion = false, recordVideoDir = null } = {}) {
+// record video to `recordVideoDir`. `theme` boots the app already in light or
+// dark (the client reads localStorage on load), so a clip never flips theme
+// mid-recording.
+export async function newContext(browser, { motion = false, recordVideoDir = null, theme = 'dark' } = {}) {
   const ctx = await browser.newContext({
     viewport: VIEWPORT,
     deviceScaleFactor: DEVICE_SCALE,
@@ -56,6 +58,7 @@ export async function newContext(browser, { motion = false, recordVideoDir = nul
     ...(recordVideoDir ? { recordVideo: { dir: recordVideoDir, size: VIEWPORT } } : {}),
   });
   await ctx.addInitScript(clockScript, FIXED_EPOCH);
+  await ctx.addInitScript((t) => { try { localStorage.setItem('rundock-theme', t); } catch { /* ignore */ } }, theme);
   const css = motion ? MOTION_CSS : STILL_CSS;
   await ctx.addInitScript((c) => {
     const apply = () => {
@@ -124,6 +127,31 @@ export async function seedLastActive(page, entries) {
   }, entries);
 }
 
+// Zooms the org chart up until the tree nearly fills the panel, so the hero
+// does not sit in a third of the frame. The app auto-fits only downward (scale
+// capped at 1), so a small team renders small; this bumps orgZoomOffset until
+// one more step would overflow, then backs off. Deterministic for a fixed
+// roster. Call after the chart has rendered.
+export async function fitOrgChart(page, { fill = 0.94 } = {}) {
+  await page.evaluate((fill) => {
+    const chart = document.getElementById('org-chart');
+    if (!chart || typeof renderOrgChart !== 'function') return;
+    const layout = () => chart.querySelector('.org-layout');
+    const overflows = () => {
+      const l = layout();
+      if (!l) return true;
+      return l.offsetWidth > (chart.clientWidth * fill) || l.offsetHeight > (chart.clientHeight * fill);
+    };
+    // eslint-disable-next-line no-global-assign
+    if (typeof orgZoomOffset === 'undefined') return;
+    for (let i = 0; i < 40; i++) {
+      if (overflows()) { orgZoomOffset -= 0.08; renderOrgChart(); break; }
+      orgZoomOffset += 0.08; renderOrgChart();
+    }
+  }, fill);
+  await page.waitForTimeout(120);
+}
+
 // Opens a workspace file by relative path through the same read_file path the
 // tree row uses, then waits for the editor surface to mount.
 export async function openFile(page, relPath) {
@@ -157,6 +185,31 @@ export async function pushChunk(page, { convoId, agentId, text, pid = 'p-stream'
       event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
     });
   }, { convoId, agentId, text, pid });
+}
+
+// Injects a synthetic pointer cursor, since Playwright video renders none. The
+// pointer-driven clips (a drag, a click) then read as an actual hand moving.
+export async function installCursor(page) {
+  await page.evaluate(() => {
+    if (document.getElementById('__mkcursor')) return;
+    const c = document.createElement('div');
+    c.id = '__mkcursor';
+    c.innerHTML = '<svg width="26" height="26" viewBox="0 0 24 24" fill="none"><path d="M5 3l14 7-5.6 1.6L10.5 18 5 3z" fill="#131313" stroke="#fff" stroke-width="1.3" stroke-linejoin="round"/></svg>';
+    Object.assign(c.style, {
+      position: 'fixed', left: '0', top: '0', zIndex: '2147483647', pointerEvents: 'none',
+      transform: 'translate(-120px,-120px)', filter: 'drop-shadow(0 2px 3px rgba(0,0,0,0.35))',
+    });
+    document.body.appendChild(c);
+    window.__cursorAt = (x, y, ms) => {
+      c.style.transition = `transform ${ms || 550}ms cubic-bezier(.4,0,.2,1)`;
+      c.style.transform = `translate(${x}px, ${y}px)`;
+    };
+  });
+}
+
+// Moves the synthetic cursor to a point over `ms` milliseconds.
+export async function cursorTo(page, x, y, ms = 550) {
+  await page.evaluate(({ x, y, ms }) => window.__cursorAt && window.__cursorAt(x, y, ms), { x, y, ms });
 }
 
 // Waits for web fonts and a short settle before a screenshot.

--- a/scripts/screenshots/motion.mjs
+++ b/scripts/screenshots/motion.mjs
@@ -1,0 +1,219 @@
+// Motion layer: records the six scripted interactions with Playwright video,
+// then converts each to a web-optimized, palette-optimized, infinitely looping
+// GIF with ffmpeg (palettegen/paletteuse). Clips are short (roughly 4-6s),
+// silent, and loopable.
+//
+// ffmpeg is resolved in priority order: FFMPEG_PATH env, a system ffmpeg on
+// PATH, then the ffmpeg-static dev dependency. The first that works wins, so CI
+// can use a system binary while a local run falls back to ffmpeg-static.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import {
+  newContext, gotoWorkspace, setTheme, openFile, beginStream, pushChunk,
+  seedWorking, seedLastActive, ORG_WORKING, ORG_LAST_ACTIVE,
+} from './harness.mjs';
+
+const require = createRequire(import.meta.url);
+
+// --- ffmpeg resolution -----------------------------------------------------
+let _ffmpeg;
+export function resolveFfmpeg() {
+  if (_ffmpeg) return _ffmpeg;
+  const candidates = [];
+  if (process.env.FFMPEG_PATH) candidates.push(process.env.FFMPEG_PATH);
+  candidates.push('ffmpeg'); // system PATH
+  try { candidates.push(require('ffmpeg-static')); } catch { /* not installed */ }
+  for (const c of candidates) {
+    if (!c) continue;
+    try { execFileSync(c, ['-version'], { stdio: 'ignore' }); _ffmpeg = c; return c; }
+    catch { /* try next */ }
+  }
+  throw new Error('No usable ffmpeg found (set FFMPEG_PATH, install ffmpeg, or `npm install`).');
+}
+
+export function ffmpegAvailable() {
+  try { resolveFfmpeg(); return true; } catch { return false; }
+}
+
+// Two-pass palette conversion: webm -> optimized looping GIF.
+export function gifFromWebm(webmPath, gifPath, { fps = 15, width = 1280 } = {}) {
+  const ffmpeg = resolveFfmpeg();
+  const palette = path.join(os.tmpdir(), `pal-${path.basename(gifPath, '.gif')}-${width}.png`);
+  const filters = `fps=${fps},scale=${width}:-1:flags=lanczos`;
+  execFileSync(ffmpeg, ['-y', '-i', webmPath, '-vf', `${filters},palettegen=stats_mode=diff`, palette], { stdio: 'ignore' });
+  execFileSync(ffmpeg, ['-y', '-i', webmPath, '-i', palette,
+    '-lavfi', `${filters} [x]; [x][1:v] paletteuse=dither=bayer:bayer_scale=3`,
+    '-loop', '0', gifPath], { stdio: 'ignore' });
+  try { fs.unlinkSync(palette); } catch { /* ignore */ }
+  return gifPath;
+}
+
+// --- Clip scripts ----------------------------------------------------------
+// Each clip drives one scripted interaction. Kept short and loopable.
+
+async function clipKanbanDrag(page) {
+  await openFile(page, 'Product Board.md');
+  await page.waitForSelector('.board-card', { timeout: 10000 });
+  await page.waitForTimeout(700);
+  // Animate a lifted clone gliding from the first Backlog card to the In
+  // Progress lane, then dispatch the real HTML5 drag-and-drop so the board
+  // model actually moves the card and re-renders it in the target lane.
+  await page.evaluate(() => {
+    const card = document.querySelector('.board-lane .board-card');
+    const lanes = document.querySelectorAll('.board-lane-body');
+    const target = lanes[1] || lanes[0];
+    const cr = card.getBoundingClientRect();
+    const tr = target.getBoundingClientRect();
+    const clone = card.cloneNode(true);
+    Object.assign(clone.style, {
+      position: 'fixed', left: cr.left + 'px', top: cr.top + 'px', width: cr.width + 'px',
+      margin: '0', zIndex: '9999', pointerEvents: 'none', transition: 'transform 0.9s cubic-bezier(.2,.7,.3,1)',
+      boxShadow: '0 18px 40px rgba(0,0,0,0.28)', transform: 'scale(1.03)',
+    });
+    document.body.appendChild(clone);
+    card.style.opacity = '0.35';
+    const dx = (tr.left + 24) - cr.left;
+    const dy = (tr.top + 16) - cr.top;
+    requestAnimationFrame(() => { clone.style.transform = `translate(${dx}px, ${dy}px) scale(1.03)`; });
+    window.__dragClone = clone; window.__dragCard = card; window.__dragTarget = target;
+  });
+  await page.waitForTimeout(1050);
+  await page.evaluate(() => {
+    const card = window.__dragCard, target = window.__dragTarget;
+    const dt = new DataTransfer();
+    const fire = (el, type, cx, cy) => el.dispatchEvent(new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: dt, clientX: cx, clientY: cy }));
+    const cr = card.getBoundingClientRect(), tr = target.getBoundingClientRect();
+    fire(card, 'dragstart', cr.left + cr.width / 2, cr.top + cr.height / 2);
+    fire(target, 'dragenter', tr.left + tr.width / 2, tr.top + 20);
+    fire(target, 'dragover', tr.left + tr.width / 2, tr.top + 20);
+    fire(target, 'drop', tr.left + tr.width / 2, tr.top + 20);
+    fire(card, 'dragend', tr.left + tr.width / 2, tr.top + 20);
+    if (window.__dragClone) window.__dragClone.remove();
+  });
+  await page.waitForTimeout(1100);
+}
+
+async function clipLiveRefresh(page, { workspace }) {
+  await openFile(page, 'Roadmap.md');
+  await page.waitForTimeout(1400);
+  // Change the file on disk, as an agent or another window would. The open
+  // file updates in place.
+  const target = path.join(workspace, 'Roadmap.md');
+  const updated = ['---', 'title: Roadmap', 'tags: [planning]', 'updated: 2026-07-18', '---', '',
+    '# Roadmap', '', '1. Ship the launch page', '2. Tidy the onboarding flow', '3. Gather early feedback',
+    '4. Line up the follow-up release', ''].join('\n');
+  fs.writeFileSync(target, updated);
+  await page.waitForTimeout(2200);
+}
+
+async function clipArtifactComment(page) {
+  await openFile(page, 'Artifacts/Launch Page.html');
+  await page.waitForTimeout(1600);
+  // Select a phrase inside the sandboxed preview iframe and raise the Comment
+  // affordance, exactly as a user selecting text would.
+  await page.evaluate(() => {
+    const frame = document.querySelector('iframe.viewer-frame');
+    if (!frame) return;
+    const doc = frame.contentDocument;
+    const el = [...doc.querySelectorAll('p, h1, .stat')].find((n) => /faster reviews/i.test(n.textContent));
+    if (!el) return;
+    const range = doc.createRange();
+    range.selectNodeContents(el);
+    const sel = frame.contentWindow.getSelection();
+    sel.removeAllRanges(); sel.addRange(range);
+    doc.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+  await page.waitForTimeout(900);
+  // Click the Comment button if it surfaced.
+  const btn = await page.$('.artifact-comment-btn.visible, .artifact-comment-btn');
+  if (btn) { await btn.click().catch(() => {}); await page.waitForTimeout(700); }
+  // Type into the comment composer if it opened.
+  const composer = await page.$('.review-comment-input, textarea.review-input, .review-sidebar textarea');
+  if (composer) { await composer.type('Worth adding a source note here.', { delay: 35 }); await page.waitForTimeout(700); }
+  await page.waitForTimeout(700);
+}
+
+async function clipSearch(page) {
+  await page.evaluate(() => switchNav('team'));
+  await page.waitForTimeout(500);
+  await page.evaluate(() => { if (typeof openPalette === 'function') openPalette(); });
+  await page.waitForSelector('#palette-input', { state: 'visible', timeout: 8000 });
+  await page.waitForTimeout(500);
+  await page.type('#palette-input', 'launch', { delay: 160 });
+  await page.waitForTimeout(1600);
+}
+
+async function clipStreaming(page) {
+  await page.evaluate(() => switchNav('conversations'));
+  await beginStream(page, { convoId: 'c5', agentId: 'cleo' });
+  const chunks = ['Shorter is better here. ', 'Lead with the reader, ', 'name the outcome in six words, ',
+    'then let the proof points carry the rest. ', 'I will draft two options and mark my pick.'];
+  for (const c of chunks) { await pushChunk(page, { convoId: 'c5', agentId: 'cleo', text: c }); await page.waitForTimeout(700); }
+  await page.waitForTimeout(1000);
+}
+
+async function clipOrgStatus(page) {
+  await page.evaluate(() => switchNav('team'));
+  await page.waitForSelector('.org-card', { timeout: 10000 });
+  await seedWorking(page, ORG_WORKING);
+  await seedLastActive(page, ORG_LAST_ACTIVE);
+  // Let the CSS pulse (orgPulse, 2s loop) run for a couple of cycles.
+  await page.waitForTimeout(4200);
+}
+
+// Clip registry. `themes` is which themes to record (theme reads in all of
+// these, but the spec only mandates parity for the org-status clip; the others
+// default to both for completeness).
+// `gif` overrides the default {fps:15, width:1280} for clips that would
+// otherwise crowd the file-size budget (the review clip has a lot of motion:
+// a selection highlight plus type-in).
+export const CLIPS = [
+  { name: 'kanban-drag', feature: 'Kanban card drag between columns', run: clipKanbanDrag },
+  { name: 'live-refresh', feature: 'Live external refresh updating the open file', run: clipLiveRefresh },
+  { name: 'review-comment', feature: 'Adding a comment on an artifact', run: clipArtifactComment, gif: { width: 1152 } },
+  { name: 'search', feature: 'Cmd+K universal search', run: clipSearch },
+  { name: 'streaming', feature: 'Streaming reply typing in', run: clipStreaming },
+  { name: 'org-chart-status', feature: 'Org chart live status', run: clipOrgStatus },
+];
+
+export const MOTION_THEMES = ['light', 'dark'];
+
+// Records every clip in both themes and converts each to an optimized GIF in
+// `outDir`. Returns produced assets: { name, theme, feature, file, bytes }.
+export async function captureMotion({ browser, url, workspace, outDir, log = () => {} }) {
+  fs.mkdirSync(outDir, { recursive: true });
+  const videoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-motion-'));
+  const produced = [];
+
+  for (const clip of CLIPS) {
+    for (const theme of MOTION_THEMES) {
+      let ctx;
+      try {
+        ctx = await newContext(browser, { motion: true, recordVideoDir: videoDir });
+        const page = await ctx.newPage();
+        await gotoWorkspace(page, url);
+        await setTheme(page, theme);
+        await clip.run(page, { workspace });
+        const video = page.video();
+        await page.close();
+        const webm = await video.path();
+        await ctx.close(); ctx = null;
+
+        const gif = path.join(outDir, `${clip.name}.${theme}.gif`);
+        gifFromWebm(webm, gif, { fps: clip.gif?.fps ?? 15, width: clip.gif?.width ?? 1280 });
+        const bytes = fs.statSync(gif).size;
+        produced.push({ name: clip.name, theme, feature: clip.feature, file: gif, bytes });
+        log(`  motion ${clip.name}.${theme} -> ${(bytes / 1e6).toFixed(2)} MB`);
+      } catch (err) {
+        log(`  ! clip ${clip.name}.${theme} failed: ${err.message.split('\n')[0]}`);
+        if (ctx) { try { await ctx.close(); } catch { /* ignore */ } }
+      }
+    }
+  }
+  try { fs.rmSync(videoDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  return produced;
+}

--- a/scripts/screenshots/motion.mjs
+++ b/scripts/screenshots/motion.mjs
@@ -13,8 +13,9 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import {
-  newContext, gotoWorkspace, setTheme, openFile, beginStream, pushChunk,
-  seedWorking, seedLastActive, ORG_WORKING, ORG_LAST_ACTIVE,
+  newContext, gotoWorkspace, openFile, beginStream, pushChunk,
+  seedWorking, seedLastActive, fitOrgChart, installCursor, cursorTo,
+  ORG_WORKING, ORG_LAST_ACTIVE,
 } from './harness.mjs';
 
 const require = createRequire(import.meta.url);
@@ -39,13 +40,15 @@ export function ffmpegAvailable() {
   try { resolveFfmpeg(); return true; } catch { return false; }
 }
 
-// Two-pass palette conversion: webm -> optimized looping GIF.
-export function gifFromWebm(webmPath, gifPath, { fps = 15, width = 1280 } = {}) {
+// Two-pass palette conversion: webm -> optimized looping GIF. `ss` trims the
+// pre-roll (navigation and settling) so the GIF opens on the feature itself.
+export function gifFromWebm(webmPath, gifPath, { fps = 15, width = 1280, ss = 0 } = {}) {
   const ffmpeg = resolveFfmpeg();
   const palette = path.join(os.tmpdir(), `pal-${path.basename(gifPath, '.gif')}-${width}.png`);
   const filters = `fps=${fps},scale=${width}:-1:flags=lanczos`;
-  execFileSync(ffmpeg, ['-y', '-i', webmPath, '-vf', `${filters},palettegen=stats_mode=diff`, palette], { stdio: 'ignore' });
-  execFileSync(ffmpeg, ['-y', '-i', webmPath, '-i', palette,
+  const seek = ss > 0.05 ? ['-ss', ss.toFixed(2)] : [];
+  execFileSync(ffmpeg, ['-y', ...seek, '-i', webmPath, '-vf', `${filters},palettegen=stats_mode=diff`, palette], { stdio: 'ignore' });
+  execFileSync(ffmpeg, ['-y', ...seek, '-i', webmPath, '-i', palette,
     '-lavfi', `${filters} [x]; [x][1:v] paletteuse=dither=bayer:bayer_scale=3`,
     '-loop', '0', gifPath], { stdio: 'ignore' });
   try { fs.unlinkSync(palette); } catch { /* ignore */ }
@@ -55,14 +58,23 @@ export function gifFromWebm(webmPath, gifPath, { fps = 15, width = 1280 } = {}) 
 // --- Clip scripts ----------------------------------------------------------
 // Each clip drives one scripted interaction. Kept short and loopable.
 
-async function clipKanbanDrag(page) {
-  await openFile(page, 'Product Board.md');
+async function clipKanbanDrag(page, { mark }) {
+  await openFile(page, 'Backlog.md');
   await page.waitForSelector('.board-card', { timeout: 10000 });
-  await page.waitForTimeout(700);
-  // Animate a lifted clone gliding from the first Backlog card to the In
-  // Progress lane, then dispatch the real HTML5 drag-and-drop so the board
-  // model actually moves the card and re-renders it in the target lane.
-  await page.evaluate(() => {
+  await installCursor(page);
+  await page.waitForTimeout(500);
+  // Bring the cursor onto the first Backlog card before the drag begins.
+  const start = await page.evaluate(() => {
+    const r = document.querySelector('.board-lane .board-card').getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  });
+  await cursorTo(page, start.x, start.y, 450);
+  await page.waitForTimeout(450);
+  mark();
+  // Animate a lifted clone (and the cursor) gliding from the first Backlog card
+  // to the In Progress lane, then dispatch the real HTML5 drag-and-drop so the
+  // board model actually moves the card and re-renders it in the target lane.
+  const dest = await page.evaluate(() => {
     const card = document.querySelector('.board-lane .board-card');
     const lanes = document.querySelectorAll('.board-lane-body');
     const target = lanes[1] || lanes[0];
@@ -80,8 +92,10 @@ async function clipKanbanDrag(page) {
     const dy = (tr.top + 16) - cr.top;
     requestAnimationFrame(() => { clone.style.transform = `translate(${dx}px, ${dy}px) scale(1.03)`; });
     window.__dragClone = clone; window.__dragCard = card; window.__dragTarget = target;
+    return { x: tr.left + 60, y: tr.top + 34 };
   });
-  await page.waitForTimeout(1050);
+  await cursorTo(page, dest.x, dest.y, 900);
+  await page.waitForTimeout(1000);
   await page.evaluate(() => {
     const card = window.__dragCard, target = window.__dragTarget;
     const dt = new DataTransfer();
@@ -97,29 +111,45 @@ async function clipKanbanDrag(page) {
   await page.waitForTimeout(1100);
 }
 
-async function clipLiveRefresh(page, { workspace }) {
-  await openFile(page, 'Roadmap.md');
-  await page.waitForTimeout(1400);
-  // Change the file on disk, as an agent or another window would. The open
-  // file updates in place.
-  const target = path.join(workspace, 'Roadmap.md');
-  const updated = ['---', 'title: Roadmap', 'tags: [planning]', 'updated: 2026-07-18', '---', '',
-    '# Roadmap', '', '1. Ship the launch page', '2. Tidy the onboarding flow', '3. Gather early feedback',
-    '4. Line up the follow-up release', ''].join('\n');
+async function clipLiveRefresh(page, { workspace, mark }) {
+  await openFile(page, 'Notes/Weekly Plan.md');
+  await page.waitForTimeout(1200);
+  mark();
+  // Change the note on disk, as an agent or another window would. The open file
+  // updates in place.
+  const target = path.join(workspace, 'Notes', 'Weekly Plan.md');
+  const updated = ['---', 'title: Weekly Plan', 'tags: [planning]', 'date: 2026-07-18', '---', '',
+    '# Weekly Plan', '', 'Focus for the week is the launch page. Actions live on the [[Backlog]].', '',
+    'The headline review is booked for Wednesday at 9am.', '',
+    '> [!todo] Follow-up', '> Confirm the launch date before Friday.', ''].join('\n');
   fs.writeFileSync(target, updated);
   await page.waitForTimeout(2200);
 }
 
-async function clipArtifactComment(page) {
+async function clipArtifactComment(page, { mark }) {
   await openFile(page, 'Artifacts/Launch Page.html');
   await page.waitForTimeout(1600);
-  // Select a phrase inside the sandboxed preview iframe and raise the Comment
+  await installCursor(page);
+  // Move the cursor onto the lead line before selecting it.
+  const at = await page.evaluate(() => {
+    const frame = document.querySelector('iframe.viewer-frame');
+    if (!frame) return null;
+    const fr = frame.getBoundingClientRect();
+    const doc = frame.contentDocument;
+    const el = [...doc.querySelectorAll('p.lead, p, h1')].find((n) => /sits beside the agent/i.test(n.textContent));
+    if (!el) return null;
+    const er = el.getBoundingClientRect();
+    return { x: fr.left + er.left + er.width / 2, y: fr.top + er.top + er.height / 2 };
+  });
+  if (at) { await cursorTo(page, at.x, at.y, 500); await page.waitForTimeout(450); }
+  mark();
+  // Select the lead line inside the sandboxed preview and raise the Comment
   // affordance, exactly as a user selecting text would.
   await page.evaluate(() => {
     const frame = document.querySelector('iframe.viewer-frame');
     if (!frame) return;
     const doc = frame.contentDocument;
-    const el = [...doc.querySelectorAll('p, h1, .stat')].find((n) => /faster reviews/i.test(n.textContent));
+    const el = [...doc.querySelectorAll('p.lead, p, h1')].find((n) => /sits beside the agent/i.test(n.textContent));
     if (!el) return;
     const range = doc.createRange();
     range.selectNodeContents(el);
@@ -127,40 +157,49 @@ async function clipArtifactComment(page) {
     sel.removeAllRanges(); sel.addRange(range);
     doc.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
   });
-  await page.waitForTimeout(900);
+  await page.waitForTimeout(800);
   // Click the Comment button if it surfaced.
   const btn = await page.$('.artifact-comment-btn.visible, .artifact-comment-btn');
-  if (btn) { await btn.click().catch(() => {}); await page.waitForTimeout(700); }
+  if (btn) {
+    const bb = await btn.boundingBox();
+    if (bb) { await cursorTo(page, bb.x + bb.width / 2, bb.y + bb.height / 2, 400); await page.waitForTimeout(320); }
+    await btn.click().catch(() => {}); await page.waitForTimeout(700);
+  }
   // Type into the comment composer if it opened.
   const composer = await page.$('.review-comment-input, textarea.review-input, .review-sidebar textarea');
-  if (composer) { await composer.type('Worth adding a source note here.', { delay: 35 }); await page.waitForTimeout(700); }
+  if (composer) { await composer.type('Agreed, let us pull this line up.', { delay: 35 }); await page.waitForTimeout(700); }
   await page.waitForTimeout(700);
 }
 
-async function clipSearch(page) {
+async function clipSearch(page, { mark }) {
   await page.evaluate(() => switchNav('team'));
-  await page.waitForTimeout(500);
+  await page.waitForTimeout(400);
+  await installCursor(page);
+  mark();
   await page.evaluate(() => { if (typeof openPalette === 'function') openPalette(); });
   await page.waitForSelector('#palette-input', { state: 'visible', timeout: 8000 });
-  await page.waitForTimeout(500);
-  await page.type('#palette-input', 'launch', { delay: 160 });
-  await page.waitForTimeout(1600);
+  await page.waitForTimeout(400);
+  await page.type('#palette-input', 'launch', { delay: 150 });
+  await page.waitForTimeout(1700);
 }
 
-async function clipStreaming(page) {
+async function clipStreaming(page, { mark }) {
   await page.evaluate(() => switchNav('conversations'));
   await beginStream(page, { convoId: 'c5', agentId: 'cleo' });
+  mark();
   const chunks = ['Shorter is better here. ', 'Lead with the reader, ', 'name the outcome in six words, ',
     'then let the proof points carry the rest. ', 'I will draft two options and mark my pick.'];
-  for (const c of chunks) { await pushChunk(page, { convoId: 'c5', agentId: 'cleo', text: c }); await page.waitForTimeout(700); }
+  for (const c of chunks) { await pushChunk(page, { convoId: 'c5', agentId: 'cleo', text: c }); await page.waitForTimeout(650); }
   await page.waitForTimeout(1000);
 }
 
-async function clipOrgStatus(page) {
+async function clipOrgStatus(page, { mark }) {
   await page.evaluate(() => switchNav('team'));
   await page.waitForSelector('.org-card', { timeout: 10000 });
   await seedWorking(page, ORG_WORKING);
   await seedLastActive(page, ORG_LAST_ACTIVE);
+  await fitOrgChart(page);
+  mark();
   // Let the CSS pulse (orgPulse, 2s loop) run for a couple of cycles.
   await page.waitForTimeout(4200);
 }
@@ -176,7 +215,9 @@ export const CLIPS = [
   { name: 'live-refresh', feature: 'Live external refresh updating the open file', run: clipLiveRefresh },
   { name: 'review-comment', feature: 'Adding a comment on an artifact', run: clipArtifactComment, gif: { width: 1152 } },
   { name: 'search', feature: 'Cmd+K universal search', run: clipSearch },
-  { name: 'streaming', feature: 'Streaming reply typing in', run: clipStreaming },
+  // Streaming has continuous type-in (high entropy); trim width and fps to stay
+  // inside the size budget.
+  { name: 'streaming', feature: 'Streaming reply typing in', run: clipStreaming, gif: { fps: 12, width: 1100 } },
   { name: 'org-chart-status', feature: 'Org chart live status', run: clipOrgStatus },
 ];
 
@@ -193,18 +234,24 @@ export async function captureMotion({ browser, url, workspace, outDir, log = () 
     for (const theme of MOTION_THEMES) {
       let ctx;
       try {
-        ctx = await newContext(browser, { motion: true, recordVideoDir: videoDir });
+        // Boot already in the target theme so the clip never flips mid-record.
+        ctx = await newContext(browser, { motion: true, recordVideoDir: videoDir, theme });
         const page = await ctx.newPage();
+        const recStart = Date.now();
         await gotoWorkspace(page, url);
-        await setTheme(page, theme);
-        await clip.run(page, { workspace });
+        // mark() fires when the demonstrated action begins; everything before it
+        // (load, navigation, settling) is trimmed so the GIF opens on the feature.
+        let actionAt = null;
+        const mark = () => { if (actionAt === null) actionAt = Date.now(); };
+        await clip.run(page, { workspace, mark });
         const video = page.video();
         await page.close();
         const webm = await video.path();
         await ctx.close(); ctx = null;
 
+        const ss = actionAt ? Math.max(0, (actionAt - recStart) / 1000 - 0.4) : 0;
         const gif = path.join(outDir, `${clip.name}.${theme}.gif`);
-        gifFromWebm(webm, gif, { fps: clip.gif?.fps ?? 15, width: clip.gif?.width ?? 1280 });
+        gifFromWebm(webm, gif, { fps: clip.gif?.fps ?? 15, width: clip.gif?.width ?? 1280, ss });
         const bytes = fs.statSync(gif).size;
         produced.push({ name: clip.name, theme, feature: clip.feature, file: gif, bytes });
         log(`  motion ${clip.name}.${theme} -> ${(bytes / 1e6).toFixed(2)} MB`);

--- a/scripts/screenshots/placement-plan.md
+++ b/scripts/screenshots/placement-plan.md
@@ -57,20 +57,24 @@ one GIF is wanted, `org-chart-status` is the most on-brand.
 
 ## rundock-docs (Mintlify MDX)
 
-The workhorse: this is where the long tail belongs, one or two images per
-concept page, tied to explanatory copy. Docs frame in their own containers, so
-prefer **flat** masters; use **self-framed** only on any raw-markdown page.
+**One image per concept page.** An earlier draft of this plan padded
+`files.mdx` with eight images plus two GIFs, which was a dumping ground, not
+curation. A concept page needs a single image that anchors the idea. Docs frame
+in their own containers, so use the **flat** masters.
 
-| Page | Asset(s) | Notes |
+| Page | Asset | Why |
 |---|---|---|
-| `introduction.mdx` (hero) | `conversations` (hero, chrome) | Product-in-use hero. |
-| `concepts/files.mdx` (new) | `files`, `markdown-note`, `callouts`, `kanban-board`, `artifact-review`, `image-viewer`, `pdf-viewer`; `live-refresh` GIF; `kanban-drag` GIF | The largest hole (gap analysis Docs gap 1). One image per subsection: editor, properties, any-file, boards, review, sync. |
-| `concepts/search.mdx` (new) | `search`, `find` | New page (gap analysis Docs gap 2). |
-| `concepts/agents.mdx` | `agent-profile`, `org-chart` | Role, skills, routines on a profile; the hierarchy. |
-| `concepts/skills.mdx` | `skills` + `skills-tile` | List plus a detail. |
-| `concepts/conversations.mdx` | `conversations`, `streaming` GIF | Also fixes the Pinned-pill error and adds Lists (gap analysis Docs gap 3). |
-| `concepts/routines.mdx` | `org-chart` (routines panel visible) | The scheduled-work panel. |
-| `concepts/runtimes.mdx` | `settings` | Runtimes surface. |
+| `introduction.mdx` (hero) | `org-chart` hero | The team model, up front. |
+| `concepts/files.mdx` (new) | `markdown-note` | Files render richly (properties, callouts, wikilinks); boards and review get their own coverage rather than a pile here. |
+| `concepts/agents.mdx` | `agent-profile` | How an agent is actually configured. |
+| `concepts/skills.mdx` | `skills` | List plus a populated detail. |
+| `concepts/conversations.mdx` | `conversations` | The daily surface; also fixes the Pinned-pill error and adds Lists (gap analysis Docs gap 3). |
+| `concepts/search.mdx` (new) | `search` | Cmd+K, one shot. |
+
+Boards and review already appear on the Site and README; in Docs, add them to
+`files.mdx` inline only if a section genuinely needs them, and use a GIF only
+where the motion is the point. No dedicated `find`, `settings`, `pdf-viewer`, or
+`image-viewer` pages: those are reference states, not concept anchors.
 
 ## Copy that placement needs
 
@@ -81,22 +85,31 @@ prefer **flat** masters; use **self-framed** only on any raw-markdown page.
   under each image and alt text on every image.
 - **README:** a one-line caption under each of the three feature images.
 
-## What to drop
+## Cut from the shortlist (they earn no place)
 
-Not every shot earns a home. `find`, `image-viewer`, `pdf-viewer`, and the
-`settings` still are reference-only: keep them for the Docs `files`/`runtimes`
-pages if useful, but they are not Site or README material. The `review-comment`
-GIF overlaps the `artifact-review` still; pick one per surface (still for the
-Site section, GIF only if a page wants the motion).
+Honest curation means some shots are used nowhere:
+- **`streaming` still** and **`settings` still**: dropped from the pipeline (the
+  first was a buggy capture, the second leaked a build path). Streaming lives as
+  a GIF; runtimes are text, not a hero.
+- **`pdf-viewer`, `image-viewer`, `find`**: placeholder-file and
+  duplicate-of-search shots. "Any file opens inline" is proven once inside
+  `files.mdx`; it does not need dedicated shots of a synthetic PDF and a gradient
+  image, and `find` overlaps `search`.
+- **`callouts` and the `-tile` crops** as standalone assets: fold into their
+  parents (`markdown-note`, `skills`).
+
+The set that actually carries each surface:
+- **Site (new user):** `org-chart` hero, `artifact-review`, and the `search` and
+  `kanban-drag` GIFs. Four assets do the pitch.
+- **Docs (existing user):** `agent-profile`, `conversations`, `markdown-note`,
+  with `kanban-board` and `artifact-review` where a page needs them.
 
 ## Open composition note
 
-The `org-chart` still leaves vertical breathing room: the tree is wide and short,
-so it fits the panel width at a small scale and cannot zoom up without
-overflowing. It reads as a balanced, centred composition rather than the old
-top-third dead canvas, but it is not edge-to-edge. Two ways to tighten it if you
-want a denser hero: (a) a content-aware crop that trims the empty lower-right of
-the main panel, or (b) hide the left sidebar for the hero so the tree fills the
-full width (this also removes the tree/sidebar name duplication the review
-flagged, at the cost of the routines-panel context). Flagged for a decision, not
-yet applied.
+The `org-chart` still leaves vertical breathing room: the tree is wide and
+short, so it fits the panel width at a small scale and cannot zoom up. It now
+reads as balanced and centred rather than top-third dead canvas, but it is not
+edge-to-edge, the platform "Doc" node sits low, and the sidebar duplicates every
+name. The strongest fix, endorsed by both design reviews: hide the left sidebar
+for the hero so the tree fills the width and the duplication disappears. Flagged
+for a decision, not yet applied.

--- a/scripts/screenshots/placement-plan.md
+++ b/scripts/screenshots/placement-plan.md
@@ -1,0 +1,102 @@
+# Screenshot placement plan (Site, README, Docs)
+
+A curated proposal for where the generated assets should go and why. The
+pipeline produces more than any surface needs on purpose; this plan uses fewer,
+better images, each earning its place, and pairs them with copy where a feature
+is not self-evident. Proposal only; wiring the repos is Phase 2.
+
+Principle: a still shows a state, a GIF shows a behaviour. Use a GIF only where
+the motion is the point (a drag, a live update, a reply streaming in, the org
+pulse). Everywhere else, a still is lighter and clearer.
+
+## Asset inventory (per theme, unless noted)
+
+- **Stills:** org-chart, agent-profile, skills, conversations, streaming, files,
+  markdown-note, callouts, kanban-board, artifact-review, image-viewer,
+  pdf-viewer, search, find, settings (plus element-scoped `-tile` crops).
+- **GIFs:** kanban-drag, live-refresh, review-comment, search, streaming,
+  org-chart-status.
+- **Framing variants:** `hero/` (window chrome), `stills/flat/` (clean master
+  for destinations that CSS-frame), `stills/framed/` (self-framed, for
+  plain-markdown). All transparent-background, so they drop onto any page.
+
+## Rundock Site (`Rundock Site/index.html`)
+
+The strongest surface. One hero, then a tight run of feature sections. The Site
+frames images in its own rounded containers, so it takes the **flat** masters
+(or the hero for the top).
+
+| Slot | Asset | Variant | Why | Copy |
+|---|---|---|---|---|
+| Hero | `org-chart` | hero (chrome), dark | The flagship "one operator, a whole team" image; the org pulse and routines make it read as alive. Replaces the April `rundock-app-hero.png`. | Keep the existing hero headline. |
+| Team section (5a) | `org-chart-status` GIF | dark | The live pulse sells "your team, working" better than a still. | Existing Team copy. |
+| Conversations (5b) | `streaming` GIF | dark | A reply streaming in is the point; a still of a chat is inert. | Existing copy. |
+| Files (5d, rewrite) | `files` or `markdown-note` | flat | Corrects the "markdown rendering" undersell (see gap analysis Site gap 1). | New copy from gap analysis. |
+| New: Search | `search` still (or `search` GIF) | flat / dark | Cmd+K is a headline 0.10.0 feature, absent today. | New section, gap analysis Site gap 2. |
+| New: Review | `artifact-review` | flat | The strongest differentiator: review your agent's work in place. | New section, gap analysis Site gap 3. |
+| New: Boards | `kanban-drag` GIF | dark | Boards are new and photograph as motion. | New section, gap analysis Site gap 4. |
+| Skills (5c) | `skills` | flat | Refreshes the April `skills-detail.png`. | Existing copy. |
+
+Retire the April `agent-profile.png`, `conversation-flow.png`, `file-browser.png`
+once the above land.
+
+## GitHub README (`Rundock/README.md`, `docs/`)
+
+A README is not a gallery. One hero and at most three features, all
+plain-markdown, so use the **self-framed** variants (README-width derivations).
+
+| Slot | Asset | Variant | Why |
+|---|---|---|---|
+| Hero | `org-chart` | hero, README-width, dark | The single strongest image. |
+| Feature | `artifact-review` | self-framed, README-width | The differentiator, reads in one glance. |
+| Feature | `search` | self-framed, README-width | Concrete, universally understood. |
+| Feature | `kanban-board` | self-framed, README-width | Shows the workspace is more than chat. |
+
+Hold GIFs out of the README (weight, and they autoplay unevenly on GitHub). If
+one GIF is wanted, `org-chart-status` is the most on-brand.
+
+## rundock-docs (Mintlify MDX)
+
+The workhorse: this is where the long tail belongs, one or two images per
+concept page, tied to explanatory copy. Docs frame in their own containers, so
+prefer **flat** masters; use **self-framed** only on any raw-markdown page.
+
+| Page | Asset(s) | Notes |
+|---|---|---|
+| `introduction.mdx` (hero) | `conversations` (hero, chrome) | Product-in-use hero. |
+| `concepts/files.mdx` (new) | `files`, `markdown-note`, `callouts`, `kanban-board`, `artifact-review`, `image-viewer`, `pdf-viewer`; `live-refresh` GIF; `kanban-drag` GIF | The largest hole (gap analysis Docs gap 1). One image per subsection: editor, properties, any-file, boards, review, sync. |
+| `concepts/search.mdx` (new) | `search`, `find` | New page (gap analysis Docs gap 2). |
+| `concepts/agents.mdx` | `agent-profile`, `org-chart` | Role, skills, routines on a profile; the hierarchy. |
+| `concepts/skills.mdx` | `skills` + `skills-tile` | List plus a detail. |
+| `concepts/conversations.mdx` | `conversations`, `streaming` GIF | Also fixes the Pinned-pill error and adds Lists (gap analysis Docs gap 3). |
+| `concepts/routines.mdx` | `org-chart` (routines panel visible) | The scheduled-work panel. |
+| `concepts/runtimes.mdx` | `settings` | Runtimes surface. |
+
+## Copy that placement needs
+
+- **Site:** three new section headers and one rewrite, all drafted in
+  `content-and-copy-gaps.md` (Files rewrite, Search, Review, Boards).
+- **Docs:** two new pages (`concepts/files.mdx`, `concepts/search.mdx`) with
+  skeletons already drafted in `content-and-copy-gaps.md`, plus one-line captions
+  under each image and alt text on every image.
+- **README:** a one-line caption under each of the three feature images.
+
+## What to drop
+
+Not every shot earns a home. `find`, `image-viewer`, `pdf-viewer`, and the
+`settings` still are reference-only: keep them for the Docs `files`/`runtimes`
+pages if useful, but they are not Site or README material. The `review-comment`
+GIF overlaps the `artifact-review` still; pick one per surface (still for the
+Site section, GIF only if a page wants the motion).
+
+## Open composition note
+
+The `org-chart` still leaves vertical breathing room: the tree is wide and short,
+so it fits the panel width at a small scale and cannot zoom up without
+overflowing. It reads as a balanced, centred composition rather than the old
+top-third dead canvas, but it is not edge-to-edge. Two ways to tighten it if you
+want a denser hero: (a) a content-aware crop that trims the empty lower-right of
+the main panel, or (b) hide the left sidebar for the hero so the tree fills the
+full width (this also removes the tree/sidebar name duplication the review
+flagged, at the cost of the routines-panel context). Flagged for a decision, not
+yet applied.

--- a/scripts/screenshots/run.mjs
+++ b/scripts/screenshots/run.mjs
@@ -92,7 +92,11 @@ async function main() {
   const server = await startRundock({ workspace: built.workspace, home: built.home });
   log(`      ${server.url}`);
 
-  const browser = await chromium.launch();
+  // Prefer system Chrome (bundles PDFium, so the PDF viewer renders); fall back
+  // to the bundled Chromium where Chrome is not installed.
+  let browser;
+  try { browser = await chromium.launch({ channel: 'chrome' }); }
+  catch { browser = await chromium.launch(); }
   const manifest = [];
   const staging = path.join(OUT, '.staging');
 
@@ -196,7 +200,7 @@ function writeManifest(rows, { built, gate, webpOk }) {
     '- **Master:** 1440x900 logical at deviceScaleFactor 2, so every flat master is 2880x1800 @2x. Per-target sizes are derived down from the master, never upscaled.',
     '- **Themes:** every still and every GIF captured in both light and dark.',
     '- **Determinism:** fixed data and a frozen clock (2026-07-18, UTC), animations disabled for stills, scrollbars and caret hidden, the connection toast suppressed, web fonts awaited before capture.',
-    '- **Framing:** window chrome on the three hero images only; feature shots ship as a flat clean master (for destinations that CSS-frame) plus a self-framed variant (rounded corners + soft shadow + neutral padding, for plain-markdown placements). Neutral, theme-aware gradient.',
+    '- **Framing:** transparent-background PNGs, so one framed image drops onto any page background (light or dark). Window chrome on the three hero images only; feature shots ship as a flat clean master (for destinations that CSS-frame) plus a self-framed variant (rounded corners, soft drop shadow, and a neutral hairline ring that holds the edge on dark backgrounds). Tight padding.',
     '- **Motion:** palette-optimized looping GIFs, ~1280px wide, 15fps, roughly 5-6s.',
     '',
     '## Folder layout',
@@ -215,7 +219,7 @@ function writeManifest(rows, { built, gate, webpOk }) {
     '## Notes',
     '',
     `- **WebP:** ${webpOk ? 'produced for hero flats via sips.' : 'this macOS build’s sips cannot write WebP, so WebP derivations were skipped; the PNG masters serve as the source, and the Site can generate WebP at deploy time.'}`,
-    '- **PDF viewer:** headless Chromium may render the PDF pane blank; recapture in a headed run if the PDF shot is needed.',
+    '- **Rendering:** captured through system Chrome (bundles PDFium) so the PDF viewer renders; falls back to bundled Chromium where Chrome is absent (the PDF pane may then be blank).',
     '- Re-run any time with `npm run screenshots`; the output folder is rebuilt from scratch and is gitignored.',
     '',
     `## Stills (${stills.length})`,

--- a/scripts/screenshots/run.mjs
+++ b/scripts/screenshots/run.mjs
@@ -1,0 +1,234 @@
+// Orchestrator behind `npm run screenshots`. Runs the whole Phase 1 pipeline:
+//   generate sanitized workspace -> sanitization gate -> boot server ->
+//   capture stills (both themes, @2x) -> frame (hero chrome + feature
+//   self-frame) -> derive per-target sizes -> record motion -> convert to GIFs
+//   -> write everything plus MANIFEST.md into the gitignored screenshots-out/
+//   review folder at the repo root.
+//
+// Nothing is written into the README/docs/, Rundock Site, or rundock-docs.
+// Liam reviews screenshots-out/ and cherry-picks; wiring the target repos is
+// Phase 2.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { chromium } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+
+import { buildWorkspace, checkSanitization } from './generate-workspace.mjs';
+import { startRundock } from './serve.mjs';
+import { captureStills, SHOTS } from './capture.mjs';
+import { frameImage, FRAME_HTML_URL, resizeTo, toWebp, pngDims } from './frame.mjs';
+import { captureMotion, ffmpegAvailable, CLIPS, MOTION_THEMES } from './motion.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const OUT = path.join(REPO_ROOT, 'screenshots-out');
+const GAPS_SRC = path.join(__dirname, 'content-and-copy-gaps.md');
+
+// README-friendly derived width (GitHub's content column is ~1000px, crisp at @2x).
+const README_WIDTH = 2200;
+
+// Per-shot destination hints, grounded in the content/copy gap analysis. Each
+// entry drives the MANIFEST rows. `hero` placements are added separately.
+const TARGETS = {
+  'org-chart':        { repo: 'Rundock Site',  path: 'index.html (hero) + images/rundock-app-hero.png',       note: 'Flagship "one operator, whole team" image; replaces the stale April hero.' },
+  'agent-profile':    { repo: 'rundock-docs',  path: 'concepts/agents.mdx',                                    note: 'Shows an agent profile with role, skills, and routines.' },
+  'skills':           { repo: 'Rundock Site',  path: 'index.html Skills section + rundock-docs/concepts/skills.mdx', note: 'Skills list plus a skill detail; refreshes the April skills-detail.png.' },
+  'conversations':    { repo: 'rundock-docs',  path: 'images/conversation-flow.png + introduction.mdx',        note: 'Conversation list plus an open thread; product-in-use hero candidate.' },
+  'streaming':        { repo: 'Rundock Site',  path: 'index.html Conversations section',                       note: 'A reply streaming in; supports the live, working-team story.' },
+  'files':            { repo: 'Rundock Site',  path: 'index.html Files section + rundock-docs/concepts/files.mdx', note: 'File tree with per-type icons; replaces the materially wrong April file-browser.png.' },
+  'markdown-note':    { repo: 'rundock-docs',  path: 'concepts/files.mdx (the editor + properties)',           note: 'Frontmatter properties panel, callouts, and clickable wikilinks.' },
+  'callouts':         { repo: 'rundock-docs',  path: 'concepts/files.mdx (callouts)',                          note: 'Nested Obsidian callouts rendered in place.' },
+  'kanban-board':     { repo: 'Rundock Site',  path: 'index.html new Boards section + rundock-docs/concepts/files.mdx', note: 'Kanban board with columns and rich cards; new capability, no current imagery.' },
+  'artifact-review':  { repo: 'Rundock Site',  path: 'index.html new Review section + rundock-docs/concepts/files.mdx', note: 'Anchored review comments on a rendered artifact; the strongest differentiator.' },
+  'image-viewer':     { repo: 'rundock-docs',  path: 'concepts/files.mdx (any file type)',                     note: 'Image viewer for a real decoded image.' },
+  'pdf-viewer':       { repo: 'rundock-docs',  path: 'concepts/files.mdx (any file type)',                     note: 'PDF opens inline alongside notes and boards.' },
+  'search':           { repo: 'Rundock Site',  path: 'index.html new Search section + rundock-docs/concepts/search.mdx', note: 'Cmd+K universal search; headline 0.10.0 feature, absent everywhere today.' },
+  'find':             { repo: 'rundock-docs',  path: 'concepts/search.mdx (Cmd+F)',                            note: 'In-view find inside the editor.' },
+  'settings':         { repo: 'rundock-docs',  path: 'concepts/runtimes.mdx',                                  note: 'Settings and runtimes surface.' },
+};
+
+// The three chrome-framed hero placements (spec: Site hero, README hero, docs
+// intro hero). Each is fed by a hero-designated master.
+const HERO_PLACEMENTS = {
+  'org-chart':     { repo: 'Rundock Site',  path: 'index.html hero (near full-bleed) + Rundock repo README hero', note: 'The flagship org-chart hero, chrome-framed.' },
+  'conversations': { repo: 'rundock-docs',  path: 'introduction.mdx hero',                                        note: 'Product-in-use hero for the docs introduction.' },
+  'files':         { repo: 'Rundock',       path: 'README.md secondary / docs/ hero',                             note: 'Spare chrome-framed hero showing the file workspace.' },
+};
+
+function rel(p) { return path.relative(OUT, p); }
+function mb(bytes) { return (bytes / 1e6).toFixed(2) + ' MB'; }
+
+async function main() {
+  const t0 = Date.now();
+  const log = (m) => console.log(m);
+
+  // Clean, re-runnable output folder.
+  fs.rmSync(OUT, { recursive: true, force: true });
+  fs.mkdirSync(OUT, { recursive: true });
+  const dirs = {
+    hero: path.join(OUT, 'hero'),
+    flat: path.join(OUT, 'stills', 'flat'),
+    framed: path.join(OUT, 'stills', 'framed'),
+    motion: path.join(OUT, 'motion'),
+  };
+  Object.values(dirs).forEach((d) => fs.mkdirSync(d, { recursive: true }));
+
+  // 1. Generate + sanitize (hard gate).
+  log('\n[1/6] Generating sanitized demo workspace...');
+  const built = buildWorkspace();
+  const gate = checkSanitization(built.workspace);
+  if (!gate.ok) {
+    console.error('SANITIZATION FAILED. Aborting before any capture:');
+    for (const h of gate.hits) console.error(`  ${h.file}: "${h.token}"`);
+    process.exit(1);
+  }
+  log(`      workspace: ${built.workspace}`);
+  log('      sanitization gate: PASS');
+
+  // 2. Boot the real server against it.
+  log('[2/6] Booting Rundock server...');
+  const server = await startRundock({ workspace: built.workspace, home: built.home });
+  log(`      ${server.url}`);
+
+  const browser = await chromium.launch();
+  const manifest = [];
+  const staging = path.join(OUT, '.staging');
+
+  try {
+    // 3. Capture flat @2x masters + crops, both themes.
+    log('[3/6] Capturing stills (light + dark, @2x)...');
+    const shots = await captureStills({ browser, url: server.url, stagingDir: staging, log });
+
+    // 4. Frame + derive per target.
+    log('[4/6] Framing (hero chrome + feature self-frame) and deriving sizes...');
+    const frameCtx = await browser.newContext({ deviceScaleFactor: 2 });
+    const framePage = await frameCtx.newPage();
+    await framePage.goto(FRAME_HTML_URL);
+
+    for (const asset of shots) {
+      const isTile = asset.kind === 'crop';
+      const base = `${asset.name}.${asset.theme}.png`;
+      // Crops (-tile) inherit their parent shot's destination.
+      const target = TARGETS[asset.name.replace(/-tile$/, '')] || { repo: 'Rundock Site', path: '(to place)', note: asset.feature };
+
+      // Flat clean master (for destinations that CSS-frame their own containers).
+      const flatOut = path.join(dirs.flat, base);
+      fs.copyFileSync(asset.file, flatOut);
+      manifest.push({ file: rel(flatOut), repo: target.repo, path: target.path, feature: asset.feature, theme: asset.theme, variant: isTile ? 'flat crop' : 'flat master', note: `${target.note} Clean @2x master; destination frames it in its own container.` });
+
+      // Self-framed variant (for plain-markdown placements: README, raw docs).
+      const framedOut = path.join(dirs.framed, base);
+      await frameImage(framePage, { masterPath: asset.file, outPath: framedOut, theme: asset.theme, treatment: 'feature' });
+      manifest.push({ file: rel(framedOut), repo: 'Rundock', path: 'README.md / raw markdown', feature: asset.feature, theme: asset.theme, variant: isTile ? 'self-framed crop' : 'self-framed', note: `${asset.feature}: rounded corners + shadow baked in, for plain-markdown placements that cannot CSS-frame.` });
+
+      // README-width derivation of the self-framed variant (feature stills only).
+      if (!isTile) {
+        const readmeOut = path.join(dirs.framed, `${asset.name}.${asset.theme}.readme.png`);
+        resizeTo(framedOut, readmeOut, README_WIDTH);
+        manifest.push({ file: rel(readmeOut), repo: 'Rundock', path: 'README.md / docs/', feature: asset.feature, theme: asset.theme, variant: `self-framed ${README_WIDTH}px`, note: `README-ready width (${README_WIDTH}px) derived from the self-framed master.` });
+      }
+
+      // Hero chrome for hero-designated masters.
+      if (asset.hero && !isTile) {
+        const heroOut = path.join(dirs.hero, base);
+        await frameImage(framePage, { masterPath: asset.file, outPath: heroOut, theme: asset.theme, treatment: 'hero' });
+        const hp = HERO_PLACEMENTS[asset.name] || { repo: 'Rundock Site', path: 'hero', note: 'Chrome-framed hero.' };
+        manifest.push({ file: rel(heroOut), repo: hp.repo, path: hp.path, feature: asset.feature, theme: asset.theme, variant: 'hero (window chrome)', note: hp.note });
+
+        const heroReadme = path.join(dirs.hero, `${asset.name}.${asset.theme}.readme.png`);
+        resizeTo(heroOut, heroReadme, README_WIDTH);
+        manifest.push({ file: rel(heroReadme), repo: 'Rundock', path: 'README.md hero', feature: asset.feature, theme: asset.theme, variant: `hero ${README_WIDTH}px`, note: `README-width hero derived from the chrome-framed master.` });
+
+        // Site hero also gets a WebP where the platform can produce it.
+        const webp = toWebp(flatOut, path.join(dirs.flat, `${asset.name}.${asset.theme}.webp`));
+        if (webp) manifest.push({ file: rel(webp), repo: 'Rundock Site', path: 'hero (WebP with PNG fallback)', feature: asset.feature, theme: asset.theme, variant: 'webp', note: 'WebP for the site page, PNG master as fallback.' });
+      }
+    }
+    await frameCtx.close();
+
+    // 5. Motion.
+    log('[5/6] Recording motion and converting to GIFs...');
+    if (ffmpegAvailable()) {
+      const clips = await captureMotion({ browser, url: server.url, workspace: built.workspace, outDir: dirs.motion, log });
+      for (const c of clips) {
+        const target = TARGETS[c.name] || { repo: 'Rundock Site', path: '(to place)', note: c.feature };
+        manifest.push({ file: rel(c.file), repo: target.repo, path: target.path, feature: c.feature, theme: c.theme, variant: `gif (${mb(c.bytes)})`, note: `${c.feature}: web-optimized looping GIF.` });
+      }
+    } else {
+      log('      ! ffmpeg not available; skipped motion. Set FFMPEG_PATH or run `npm install`.');
+    }
+
+    // 6. Gap analysis + MANIFEST.
+    log('[6/6] Writing gap analysis and MANIFEST...');
+    if (fs.existsSync(GAPS_SRC)) fs.copyFileSync(GAPS_SRC, path.join(OUT, 'content-and-copy-gaps.md'));
+    writeManifest(manifest, { built, gate, webpOk: manifest.some((m) => m.variant === 'webp') });
+
+    // Cleanup staging (flat masters are already copied into stills/flat).
+    fs.rmSync(staging, { recursive: true, force: true });
+
+    const secs = ((Date.now() - t0) / 1000).toFixed(0);
+    log(`\nDone in ${secs}s. ${manifest.length} assets in ${OUT}`);
+    log('Review screenshots-out/ and cherry-pick. Nothing was written to the target repos.');
+  } finally {
+    await browser.close();
+    await server.stop();
+  }
+}
+
+function writeManifest(rows, { built, gate, webpOk }) {
+  const stills = rows.filter((r) => !r.variant.includes('gif'));
+  const gifs = rows.filter((r) => r.variant.includes('gif'));
+  const table = (list) => [
+    '| File | Target repo | Target path | Feature | Theme | Variant | Rationale |',
+    '|---|---|---|---|---|---|---|',
+    ...list.map((r) => `| \`${r.file}\` | ${r.repo} | ${r.path} | ${r.feature} | ${r.theme} | ${r.variant} | ${r.note} |`),
+  ].join('\n');
+
+  const md = [
+    '# Screenshot pipeline: review manifest',
+    '',
+    'Generated by `npm run screenshots` (`scripts/screenshots/`). Every asset below is a candidate; nothing has been written into the README, `docs/`, `Rundock Site`, or `rundock-docs`. Review, then cherry-pick. Wiring the target repos is Phase 2.',
+    '',
+    '## Standards',
+    '',
+    '- **Master:** 1440x900 logical at deviceScaleFactor 2, so every flat master is 2880x1800 @2x. Per-target sizes are derived down from the master, never upscaled.',
+    '- **Themes:** every still and every GIF captured in both light and dark.',
+    '- **Determinism:** fixed data and a frozen clock (2026-07-18, UTC), animations disabled for stills, scrollbars and caret hidden, the connection toast suppressed, web fonts awaited before capture.',
+    '- **Framing:** window chrome on the three hero images only; feature shots ship as a flat clean master (for destinations that CSS-frame) plus a self-framed variant (rounded corners + soft shadow + neutral padding, for plain-markdown placements). Neutral, theme-aware gradient.',
+    '- **Motion:** palette-optimized looping GIFs, ~1280px wide, 15fps, roughly 5-6s.',
+    '',
+    '## Folder layout',
+    '',
+    '- `hero/` the three chrome-framed hero images (full plus a README-width derivation), light and dark.',
+    '- `stills/flat/` flat clean @2x masters and element-scoped crops (`-tile`), for the Site and Docs to frame in their own containers.',
+    '- `stills/framed/` self-framed variants (and README-width derivations) for plain-markdown placements.',
+    '- `motion/` the six looping GIFs, light and dark.',
+    '- `content-and-copy-gaps.md` the release content and copy gap analysis (proposal only).',
+    '',
+    '## Sanitization',
+    '',
+    `- Banned-token grep over the generated workspace: **${gate.ok ? 'PASS' : 'FAIL'}**. The demo team is invented (only the generic role-names Cos, Dev, Des are kept); no real people, clients, content, or business specifics.`,
+    '- A human glance over the assets is still required before anything is published.',
+    '',
+    '## Notes',
+    '',
+    `- **WebP:** ${webpOk ? 'produced for hero flats via sips.' : 'this macOS build’s sips cannot write WebP, so WebP derivations were skipped; the PNG masters serve as the source, and the Site can generate WebP at deploy time.'}`,
+    '- **PDF viewer:** headless Chromium may render the PDF pane blank; recapture in a headed run if the PDF shot is needed.',
+    '- Re-run any time with `npm run screenshots`; the output folder is rebuilt from scratch and is gitignored.',
+    '',
+    `## Stills (${stills.length})`,
+    '',
+    table(stills),
+    '',
+    `## Motion (${gifs.length})`,
+    '',
+    gifs.length ? table(gifs) : '_No GIFs produced (ffmpeg unavailable)._',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(OUT, 'MANIFEST.md'), md);
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/scripts/screenshots/serve.mjs
+++ b/scripts/screenshots/serve.mjs
@@ -1,0 +1,80 @@
+// Boots the real Rundock server (server.js) against a given workspace + fake
+// $HOME, in an isolated child process, on a dedicated port. Returns a handle
+// with the base URL and a stop() that tears the child down.
+//
+// The child is separate from the harness process on purpose: server.js starts
+// a routine scheduler and search warm-up on boot, and keeping those timers out
+// of the Playwright-driving process keeps the harness clean and killable.
+//
+// It reuses server.js exactly as e2e does (env HOME/WORKSPACE + startServer),
+// without forking it.
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SERVER = path.join(REPO_ROOT, 'server.js');
+
+// Dedicated capture port, deliberately distinct from the e2e port (34517) so
+// captures and the e2e suite can run at the same time.
+export const CAPTURE_PORT = Number(process.env.RUNDOCK_CAPTURE_PORT || 34519);
+
+async function waitForReady(url, { timeoutMs = 20000, intervalMs = 150 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      if (res.ok) return true;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`Rundock server did not become ready at ${url} within ${timeoutMs}ms`);
+}
+
+// Boots the server. `workspace` and `home` come from the generator.
+export async function startRundock({ workspace, home, port = CAPTURE_PORT, quiet = true } = {}) {
+  const bootScript = `require(${JSON.stringify(SERVER)}).startServer({ port: ${port} })`;
+  const child = spawn(process.execPath, ['-e', bootScript], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,      // Windows equivalent
+      WORKSPACE: workspace,
+      RUNDOCK_ELECTRON: '1',  // keep the recent-workspaces file inside the fake home
+    },
+    stdio: quiet ? ['ignore', 'ignore', 'pipe'] : 'inherit',
+  });
+
+  let stderr = '';
+  if (quiet && child.stderr) child.stderr.on('data', (d) => { stderr += d.toString(); });
+
+  const url = `http://localhost:${port}`;
+  const exited = new Promise((_, reject) => {
+    child.on('exit', (code) => reject(new Error(`Rundock server exited early (code ${code}).\n${stderr}`)));
+  });
+
+  try {
+    await Promise.race([waitForReady(url), exited]);
+  } catch (err) {
+    try { child.kill('SIGKILL'); } catch { /* ignore */ }
+    throw err;
+  }
+
+  return {
+    url,
+    port,
+    stop() {
+      return new Promise((resolve) => {
+        if (child.exitCode != null || child.signalCode) { resolve(); return; }
+        child.removeAllListeners('exit');
+        child.on('exit', () => resolve());
+        child.kill('SIGTERM');
+        // Hard stop if it lingers.
+        setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* ignore */ } resolve(); }, 3000);
+      });
+    },
+  };
+}

--- a/test/e2e/org-chart.spec.js
+++ b/test/e2e/org-chart.spec.js
@@ -1,0 +1,61 @@
+'use strict';
+// Org chart layout: a lead with a single report must occupy the same width as
+// a childless lead, so the row of leads stays evenly spaced. A lead only
+// widens when it has two or more reports (to span them), exactly like the top
+// row spreads its own children. Regression guard for the d3.tree separation
+// setting in renderOrgChart(): without a uniform separation, a single report
+// (a cousin of the other leads' slots) doubles a gap and the row goes lopsided.
+const { test, expect } = require('@playwright/test');
+
+// A controlled roster injected straight into the client, independent of the
+// shared workspace fixture: four leads under one orchestrator, with two
+// ADJACENT leads (Two and Three) each carrying a single report. Their reports
+// are adjacent cousins, which the default d3 separation spaces at 2x, doubling
+// the Two<->Three gap. This mirrors the real roster (Cleo and Dev each with one
+// report) that surfaced the lopsided layout.
+const ROSTER = [
+  { id: 'boss', name: 'boss', displayName: 'Boss',    role: 'Lead', type: 'orchestrator', order: 0, status: 'onTeam', colour: '#E87A5A', icon: 'B' },
+  { id: 'l1',   name: 'l1',   displayName: 'One',     role: 'Spec', type: 'specialist',   order: 1, reportsTo: 'boss', status: 'onTeam', colour: '#6B9EF0', icon: '1' },
+  { id: 'l2',   name: 'l2',   displayName: 'Two',     role: 'Spec', type: 'specialist',   order: 2, reportsTo: 'boss', status: 'onTeam', colour: '#6BC67E', icon: '2' },
+  { id: 'l3',   name: 'l3',   displayName: 'Three',   role: 'Spec', type: 'specialist',   order: 3, reportsTo: 'boss', status: 'onTeam', colour: '#E8A84C', icon: '3' },
+  { id: 'l4',   name: 'l4',   displayName: 'Four',    role: 'Spec', type: 'specialist',   order: 4, reportsTo: 'boss', status: 'onTeam', colour: '#A07AE8', icon: '4' },
+  { id: 'r2',   name: 'r2',   displayName: 'ReportA', role: 'Sub',  type: 'specialist',   order: 5, reportsTo: 'l2',   status: 'onTeam', colour: '#5BCFC4', icon: 'A' },
+  { id: 'r3',   name: 'r3',   displayName: 'ReportB', role: 'Sub',  type: 'specialist',   order: 6, reportsTo: 'l3',   status: 'onTeam', colour: '#7AB8E8', icon: 'B' },
+];
+
+test('a single-report lead does not widen the org row', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('.nav-item[data-nav="team"]', { state: 'visible' });
+
+  await page.evaluate((roster) => {
+    // eslint-disable-next-line no-global-assign
+    agents = roster;
+    switchNav('team');
+    renderOrgChart();
+  }, ROSTER);
+  await page.waitForSelector('.org-card');
+
+  // Horizontal centre of each card, keyed by its displayed name.
+  const centres = await page.$$eval('.org-card', (cards) => {
+    const out = {};
+    for (const c of cards) {
+      const name = c.querySelector('.org-card-name')?.textContent?.trim();
+      const b = c.getBoundingClientRect();
+      if (name) out[name] = b.left + b.width / 2;
+    }
+    return out;
+  });
+
+  const leads = ['One', 'Two', 'Three', 'Four'].map((n) => centres[n]);
+  expect(leads.every((x) => typeof x === 'number')).toBe(true);
+
+  // Even spacing: consecutive gaps differ by at most a couple of rounding
+  // pixels. With the default (non-uniform) separation, the single-report lead
+  // doubles a gap and this deviation blows past the tolerance.
+  const gaps = [leads[1] - leads[0], leads[2] - leads[1], leads[3] - leads[2]];
+  expect(Math.max(...gaps) - Math.min(...gaps)).toBeLessThan(4);
+
+  // Each single-report lead sits centred over its report: no lopsided width.
+  expect(Math.abs(centres['Two'] - centres['ReportA'])).toBeLessThan(4);
+  expect(Math.abs(centres['Three'] - centres['ReportB'])).toBeLessThan(4);
+});


### PR DESCRIPTION
Adds scripts/screenshots/ (the marketing screenshot pipeline, output gitignored), plus two product fixes it depends on: even org-chart lead spacing and the active search-icon fill. e2e test for the org spacing included. Pipeline run and image placement are a follow-up.