### PR TITLE
0.11.1: Editor & Board Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
+## Unreleased
+
+**Name:** Editor & Board Polish
+
+### Added
+
+- **Turn text into any block from the toolbar:** the formatting toolbar gains a "Text" dropdown that converts the selection to a heading (H1 to H3), a bullet list, a numbered list, or a checklist, with the current block type shown as its label. Checklists were previously only creatable by typing `- [ ]` and so were effectively hidden; they are now one click away.
+
+### Changed
+
+- **Edit links inside Rundock, not in an OS dialog:** the link button now opens a small in-app popover anchored to the toolbar, pre-filled with the current link, where Enter applies (a bare domain such as `rundock.ai` becomes an `https://` link), Escape cancels, and an unlink button clears it, replacing the browser's native prompt box.
+- **New Kanban boards start ready to use:** creating a board now seeds it with To Do, In Progress, and Done columns and shows an "Add a list" control, instead of opening an empty board with no way to add columns.
+- **Checklist checkboxes match the board:** a checkbox in a note now uses the same accent tick as Kanban cards, and ticking an item greys its text to read as done, without the board's strike-through.
+- **New files start with a sensible name:** creating a note, board, or folder pre-fills the name field with a default (for example "New note") rather than leaving it blank.
+
+### Fixed
+
+- **Switching workspaces closes the file you had open:** any open file (note, board, HTML or SVG artifact, PDF, or image) from the previous workspace is now closed when you switch workspaces, instead of staying open and reappearing in the new one. Switching views within the same workspace still reopens your file.
+- **Checklist text no longer wraps under the checkbox:** a checklist item now lays its checkbox and text out on one line.
+- **The toolbar dropdown and link popover stay on screen:** near the foot of a file they now open upward instead of spilling past the visible area, and their shadows are softer, adapt to the light theme, and no longer wash over the toolbar.
+
 ## 0.11.0: Files, Boards & Streaming (2026-07-21)
 
 ### Added

--- a/public/app.js
+++ b/public/app.js
@@ -320,6 +320,30 @@ function destroyTiptapEditorIfActive() {
     });
   }
 }
+
+// Fully close whatever file is open and reset all file-scoped state. Used when
+// switching to a DIFFERENT workspace: the previous workspace's file must never
+// be left mounted in the editor/viewer. (Switching VIEWS within a workspace
+// deliberately keeps the file open via currentFilePath; this runs only on a
+// workspace switch.) Pending debounced writes are CANCELLED, never flushed: by
+// the time this runs the server's WORKSPACE has already changed, so a flush
+// would resolve the old relative path against the new workspace and could
+// overwrite a same-named file there with stale content.
+function closeOpenFile() {
+  clearTimeout(_tiptapSaveTimer);
+  clearTimeout(saveTimer);
+  if (boardSaveTimer) { clearTimeout(boardSaveTimer); boardSaveTimer = null; }
+  boardPendingSave = null;
+  destroyActiveFileViewer();      // artifact review + iframe/board viewer
+  destroyTiptapEditorIfActive();  // tiptap editor
+  currentFilePath = null;
+  rawFileContent = ''; fileFrontmatter = ''; fileBody = '';
+  editorMode = 'preview';
+  editorDirty = false;
+  fileHistory = [];
+  closeFindBar();
+  document.querySelectorAll('.file-item.active').forEach((el) => el.classList.remove('active'));
+}
 // Session continuity: the conversation that was last opened in this workspace.
 // Seeded from the server-persisted value on workspace load, updated on every
 // openConversation call. Used by pickDefaultConversation to land the user back
@@ -4260,6 +4284,10 @@ function onWorkspaceReady(dir, analysis, isEmpty, mode, scaffoldError, isSetupCo
   }
 
   // Different workspace: reset everything
+  // Close any open file so the previous workspace's note/board/artifact does
+  // not leak into this one (the keep-your-place behaviour is intentional across
+  // view switches within a workspace, but not across workspace switches).
+  closeOpenFile();
   conversations = [];
   conversationsLoaded = false;
   activeSidebarPill = 'all';

--- a/public/app.js
+++ b/public/app.js
@@ -3320,10 +3320,16 @@ function promptCreate(menu, type, folder) {
   field.className = 'files-menu-field';
   const input = document.createElement('input');
   input.type = 'text';
-  input.placeholder = type.kind === 'folder' ? 'Folder name' : type.label.replace('New ', '') + ' name';
+  // Note, board, and folder all behave identically. The default name is the
+  // single source of truth: pre-filled and selected so the user types over it
+  // or accepts it with Enter. The placeholder is a plain fallback for the rare
+  // cleared-field state (the type is already obvious from the menu item).
+  input.value = type.label;
+  input.placeholder = 'Name';
   field.appendChild(input);
   menu.appendChild(field);
   input.focus();
+  input.select();
   const submit = () => {
     const rel = FilesMenuModel.creatablePath(folder, input.value, type.ext);
     if (!rel) { closeFilesMenu(); return; }

--- a/public/editor/panels/floating-toolbar.js
+++ b/public/editor/panels/floating-toolbar.js
@@ -13,6 +13,7 @@
 
 // ---- Icons (Lucide, monochrome, currentColor so they sit flush with text) ----
 const LINK_ICON_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>';
+const UNLINK_ICON_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 0 1 4 8"/><line x1="8" y1="12" x2="12" y2="12"/><line x1="2" y1="2" x2="22" y2="22"/></svg>';
 const COMMENT_ICON_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
 const CHEVRON_SVG = '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>';
 const CHECK_SVG = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
@@ -88,6 +89,19 @@ function renderInlineButton(b) {
   return `<button type="button" class="tb-btn" data-cmd="${b.id}" title="${escapeHtml(b.title)}"${styled}>${content}</button>`;
 }
 
+// The in-UI link popover: an input plus apply/remove controls, anchored under
+// the toolbar. Rendered only when the toolbar carries a link button. Replaces
+// the OS-native window.prompt so link editing stays inside the app chrome
+// (the Notion/Bear pattern): pre-filled with the current href, Enter applies,
+// Escape cancels, the unlink control clears the mark.
+function renderLinkPopover() {
+  return '<div class="tb-linkpop" role="dialog" aria-label="Link">'
+    + '<input type="text" class="tb-link-input" placeholder="Paste or type a link" spellcheck="false" autocomplete="off" />'
+    + `<button type="button" class="tb-link-apply" title="Apply link (Enter)" aria-label="Apply link">${CHECK_SVG}</button>`
+    + `<button type="button" class="tb-link-unlink" title="Remove link" aria-label="Remove link">${UNLINK_ICON_SVG}</button>`
+    + '</div>';
+}
+
 function renderBlockMenu() {
   const items = BLOCK_TYPES.map((t) => {
     if (t.sep) return '<div class="tb-menu-sep"></div>';
@@ -114,7 +128,20 @@ export function renderToolbarHTML(withComment, buttonIds = null) {
   const comment = withComment
     ? `<span class="tb-sep"></span><button type="button" class="tb-comment" data-cmd="comment" title="Comment on selection">${COMMENT_ICON_SVG}<span>Comment</span></button>`
     : '';
-  return `<div class="tb-row">${dropdown}${inline}${comment}</div>${menu}`;
+  const linkpop = inlineDefs.some((b) => b.id === 'link') ? renderLinkPopover() : '';
+  return `<div class="tb-row">${dropdown}${inline}${comment}</div>${menu}${linkpop}`;
+}
+
+// Applies (or clears) a link on the current selection. Empty/whitespace URL
+// removes the mark; otherwise the href is normalised and set. extendMarkRange
+// means editing an existing link updates the whole link, not just the part
+// under the caret. Exported so callers (and tests) can drive links directly.
+export function applyLink(editor, url) {
+  if (!editor) return;
+  const chain = editor.chain().focus().extendMarkRange('link');
+  const norm = normaliseLinkHref(String(url == null ? '' : url).trim());
+  if (norm === '') return chain.unsetLink().run();
+  return chain.setLink({ href: norm, rel: 'noopener noreferrer' }).run();
 }
 
 export function applyCommand(editor, id) {
@@ -124,13 +151,8 @@ export function applyCommand(editor, id) {
     case 'bold':   return chain.toggleBold().run();
     case 'italic': return chain.toggleItalic().run();
     case 'code':   return chain.toggleCode().run();
-    case 'link': {
-      const prev = editor.getAttributes('link').href || '';
-      const url = window.prompt('Link URL', prev);
-      if (url === null) return;
-      if (url === '')   return chain.unsetLink().run();
-      return chain.setLink({ href: normaliseLinkHref(url), rel: 'noopener noreferrer' }).run();
-    }
+    // 'link' is intentionally absent: links are edited through the in-UI link
+    // popover (openLinkPopover / applyLink), not this dispatch.
     case 'h1': return chain.toggleHeading({ level: 1 }).run();
     case 'h2': return chain.toggleHeading({ level: 2 }).run();
     case 'h3': return chain.toggleHeading({ level: 3 }).run();
@@ -194,11 +216,57 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
     const open = menuEl.classList.toggle('open');
     if (dropdownBtn) dropdownBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
   };
-  // Removing 'visible' anywhere must also close the menu, so a hidden toolbar
-  // never leaves an orphaned open menu.
-  const hide = () => { toolbarElement.classList.remove('visible'); closeMenu(); };
+  // The in-UI link popover. While it is open the editor is blurred (the input
+  // holds focus), so the blur/reposition handlers must not tear the toolbar
+  // down: linkPopoverOpen guards them.
+  const linkPopEl = toolbarElement.querySelector('.tb-linkpop');
+  const linkInput = toolbarElement.querySelector('.tb-link-input');
+  let linkPopoverOpen = false;
+  const closeLinkPopover = () => {
+    if (linkPopEl) linkPopEl.classList.remove('open');
+    linkPopoverOpen = false;
+  };
+  const openLinkPopover = () => {
+    if (!linkPopEl || !linkInput) return;
+    linkPopoverOpen = true; // set BEFORE focusing the input so onBlur is guarded
+    linkInput.value = editor.getAttributes('link').href || '';
+    linkPopEl.classList.add('open');
+    linkInput.focus();
+    linkInput.select();
+  };
+  const commitLink = () => {
+    if (!linkInput) return;
+    applyLink(editor, linkInput.value);
+    closeLinkPopover();
+    updateActiveStates(editor, toolbarElement);
+  };
+  const removeLink = () => {
+    applyLink(editor, '');
+    closeLinkPopover();
+    updateActiveStates(editor, toolbarElement);
+  };
+  const cancelLink = () => {
+    closeLinkPopover();
+    editor.chain().focus().run(); // restore the caret/selection in the document
+  };
+
+  // Removing 'visible' anywhere must also close the menu and link popover, so a
+  // hidden toolbar never leaves an orphaned open panel.
+  const hide = () => { toolbarElement.classList.remove('visible'); closeMenu(); closeLinkPopover(); };
 
   const onClick = (event) => {
+    // Link popover: let the input take the caret; the apply/unlink buttons act.
+    if (event.target.closest('.tb-link-input')) return;
+    if (event.target.closest('.tb-link-apply')) {
+      event.preventDefault(); event.stopPropagation();
+      commitLink();
+      return;
+    }
+    if (event.target.closest('.tb-link-unlink')) {
+      event.preventDefault(); event.stopPropagation();
+      removeLink();
+      return;
+    }
     if (event.target.closest('.tb-dd')) {
       event.preventDefault(); event.stopPropagation();
       toggleMenu();
@@ -217,6 +285,12 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
     event.preventDefault(); event.stopPropagation();
     closeMenu();
     const cmd = btn.getAttribute('data-cmd');
+    if (cmd === 'link') {
+      // Toggle the in-UI link popover instead of an OS dialog.
+      if (linkPopoverOpen) cancelLink();
+      else openLinkPopover();
+      return;
+    }
     if (cmd === 'comment') {
       if (typeof onReviewAction === 'function') onReviewAction('comment');
       hide();
@@ -229,13 +303,20 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
 
   // Stop selection-collapse on any toolbar interaction by preventing the host
   // from losing focus during the brief mousedown on a control.
+  // Keep the document focus on any toolbar control EXCEPT the link input, which
+  // must be able to take focus so the user can type a URL.
   const preventBlur = (e) => {
-    if (e.target.closest('.tb-btn, .tb-comment, .tb-dd, .tb-menu-item')) e.preventDefault();
+    if (e.target.closest('.tb-link-input')) return;
+    if (e.target.closest('.tb-btn, .tb-comment, .tb-dd, .tb-menu-item, .tb-link-apply, .tb-link-unlink')) e.preventDefault();
   };
   toolbarElement.addEventListener('mousedown', preventBlur);
 
-  // Escape closes an open menu without collapsing the selection.
+  // Enter/Escape drive the link input; Escape otherwise closes an open menu.
   const onKeyDown = (e) => {
+    if (linkPopoverOpen && e.target.closest('.tb-link-input')) {
+      if (e.key === 'Enter')  { e.preventDefault(); commitLink(); return; }
+      if (e.key === 'Escape') { e.preventDefault(); cancelLink();  return; }
+    }
     if (e.key === 'Escape' && menuEl && menuEl.classList.contains('open')) {
       e.preventDefault();
       closeMenu();
@@ -244,6 +325,9 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
   toolbarElement.addEventListener('keydown', onKeyDown);
 
   const position = () => {
+    // While the link popover holds focus the editor is blurred and the toolbar
+    // must stay put; don't let the usual empty/blur checks tear it down.
+    if (linkPopoverOpen) return;
     const { from, to, empty } = editor.state.selection;
     if (empty || !editor.isFocused) { hide(); return; }
     // An atom node selection (e.g. clicking a callout) is not inline-formattable,
@@ -297,10 +381,12 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
   };
 
   // A real selection change (moving the caret, clicking into other text, or a
-  // block command's own transaction) closes any open menu, then repositions.
-  const onSelection = () => { closeMenu(); position(); };
+  // block command's own transaction) closes any open menu/link popover, then
+  // repositions. Closing the popover first clears its guard so the toolbar can
+  // follow the new selection (e.g. the user clicked back into the document).
+  const onSelection = () => { closeLinkPopover(); closeMenu(); position(); };
   const onUpdate    = () => position();
-  const onBlur      = () => hide();
+  const onBlur      = () => { if (linkPopoverOpen) return; hide(); };
 
   editor.on('selectionUpdate', onSelection);
   editor.on('transaction',     onUpdate);

--- a/public/editor/panels/floating-toolbar.js
+++ b/public/editor/panels/floating-toolbar.js
@@ -206,14 +206,33 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
 
   const dropdownBtn = toolbarElement.querySelector('.tb-dd');
   const menuEl = toolbarElement.querySelector('.tb-menu');
+
+  // A dropped panel (the block menu or the link popover) opens below the toolbar
+  // by default. Near the foot of the viewport that would spill past the visible
+  // area (and extend the editor's scroll region), so flip it to open UPWARD when
+  // there is not enough room below but there is more room above. The `up` class
+  // is measured after the panel is already `.open` (so its height is real).
+  const flipPanelIfNeeded = (panel) => {
+    if (!panel) return;
+    panel.classList.remove('up');
+    const tbRect = toolbarElement.getBoundingClientRect();
+    const panelH = panel.getBoundingClientRect().height;
+    const gap = 8;
+    const roomBelow = window.innerHeight - tbRect.bottom;
+    const roomAbove = tbRect.top;
+    if (roomBelow < panelH + gap && roomAbove > roomBelow) panel.classList.add('up');
+  };
+
   const closeMenu = () => {
     if (!menuEl) return;
-    menuEl.classList.remove('open');
+    menuEl.classList.remove('open', 'up');
     if (dropdownBtn) dropdownBtn.setAttribute('aria-expanded', 'false');
   };
   const toggleMenu = () => {
     if (!menuEl) return;
     const open = menuEl.classList.toggle('open');
+    if (open) flipPanelIfNeeded(menuEl);
+    else menuEl.classList.remove('up');
     if (dropdownBtn) dropdownBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
   };
   // The in-UI link popover. While it is open the editor is blurred (the input
@@ -223,7 +242,7 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
   const linkInput = toolbarElement.querySelector('.tb-link-input');
   let linkPopoverOpen = false;
   const closeLinkPopover = () => {
-    if (linkPopEl) linkPopEl.classList.remove('open');
+    if (linkPopEl) linkPopEl.classList.remove('open', 'up');
     linkPopoverOpen = false;
   };
   const openLinkPopover = () => {
@@ -231,6 +250,7 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
     linkPopoverOpen = true; // set BEFORE focusing the input so onBlur is guarded
     linkInput.value = editor.getAttributes('link').href || '';
     linkPopEl.classList.add('open');
+    flipPanelIfNeeded(linkPopEl);
     linkInput.focus();
     linkInput.select();
   };

--- a/public/editor/panels/floating-toolbar.js
+++ b/public/editor/panels/floating-toolbar.js
@@ -1,32 +1,46 @@
 // Floating toolbar: appears on text selection, positioned above the cursor.
-// Buttons cover bold, italic, code, link, h1, h2, h3 (per the spec).
-// Hides when the selection is empty or when focus leaves the editor.
 //
-// The toolbar element lives in index.html under #floating-toolbar. This
-// module owns the show/hide/position logic and the click bindings.
+// Layout: a "Text" block-type dropdown (paragraph, headings, and all three
+// list types) followed by the inline marks (bold, italic, code, link), and an
+// optional review Comment bar. Headings and lists live in the dropdown rather
+// than as inline buttons so the bar stays narrow while exposing more (the
+// Tiptap/Notion pattern); the dropdown label reflects the current block.
+//
+// The toolbar element lives in index.html under #floating-toolbar. This module
+// owns the show/hide/position logic, the dropdown menu open/close, and the
+// click bindings. A reduced toolbar (buttonIds set, e.g. board cards) renders
+// only the chosen inline marks and no dropdown.
 
-// Lucide chain-link icon, monochrome, picks up the button's text colour via
-// stroke=currentColor so it sits flush with the B / I / </> / H1 / H2 / H3
-// text buttons rather than reading as an emoji.
+// ---- Icons (Lucide, monochrome, currentColor so they sit flush with text) ----
 const LINK_ICON_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>';
-
-// Lucide message-square icon for the review Comment action.
 const COMMENT_ICON_SVG = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>';
+const CHEVRON_SVG = '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>';
+const CHECK_SVG = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+const BULLET_ICON_SVG = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>';
+const NUMBERED_ICON_SVG = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="10" y1="6" x2="21" y2="6"/><line x1="10" y1="12" x2="21" y2="12"/><line x1="10" y1="18" x2="21" y2="18"/><path d="M4 6h1v4"/><path d="M4 10h2"/><path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1"/></svg>';
+const CHECKLIST_ICON_SVG = '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><line x1="13" y1="6" x2="21" y2="6"/><line x1="13" y1="12" x2="21" y2="12"/><line x1="13" y1="18" x2="21" y2="18"/></svg>';
 
-// Formatting buttons render as a row; the review Comment action renders as a
-// full-width bar beneath them (an established review-UI pattern: commenting
-// is the primary review gesture, so it gets primary prominence). Suggesting
-// was deliberately removed from the human toolbar: a human in
-// an editable document just makes the edit; suggestions remain the AGENT's
-// authoring direction, decided via the sidebar's Accept/Reject.
-const BUTTON_DEFS = [
+// Inline marks (the row after the dropdown). Suggesting was deliberately kept
+// out of the human toolbar: a human in an editable document just makes the
+// edit; suggestions remain the AGENT's authoring direction via the sidebar.
+const INLINE_DEFS = [
   { id: 'bold',   label: 'B',   title: 'Bold (Cmd/Ctrl+B)',   styled: 'b' },
   { id: 'italic', label: 'I',   title: 'Italic (Cmd/Ctrl+I)', styled: 'i' },
   { id: 'code',   label: '</>', title: 'Inline code',          styled: '' },
   { id: 'link',   icon:  LINK_ICON_SVG, title: 'Link',          styled: '' },
-  { id: 'h1',     label: 'H1',  title: 'Heading 1',            styled: '' },
-  { id: 'h2',     label: 'H2',  title: 'Heading 2',            styled: '' },
-  { id: 'h3',     label: 'H3',  title: 'Heading 3',            styled: '' },
+];
+
+// The block-type dropdown. `label` is both the menu item text and, when active,
+// the dropdown's trigger label. `svg: true` marks an SVG icon (else a glyph).
+const BLOCK_TYPES = [
+  { id: 'paragraph',   label: 'Text',          icon: 'T' },
+  { id: 'h1',          label: 'Heading 1',     icon: 'H1' },
+  { id: 'h2',          label: 'Heading 2',     icon: 'H2' },
+  { id: 'h3',          label: 'Heading 3',     icon: 'H3' },
+  { sep: true },
+  { id: 'bulletList',  label: 'Bullet list',   icon: BULLET_ICON_SVG,    svg: true },
+  { id: 'orderedList', label: 'Numbered list', icon: NUMBERED_ICON_SVG,  svg: true },
+  { id: 'taskList',    label: 'Checklist',     icon: CHECKLIST_ICON_SVG, svg: true },
 ];
 
 function escapeHtml(s) {
@@ -52,23 +66,58 @@ function normaliseLinkHref(url) {
   return url;
 }
 
-function renderToolbarHTML(withComment, buttonIds = null) {
-  const defs = buttonIds ? BUTTON_DEFS.filter(b => buttonIds.includes(b.id)) : BUTTON_DEFS;
-  const buttons = defs
-    .map(b => {
-      const styled = b.styled ? ` data-style="${b.styled}"` : '';
-      // SVG icons are hardcoded above and trusted; text labels are escaped.
-      const content = b.icon ? b.icon : escapeHtml(b.label || '');
-      return `<button type="button" class="tb-btn" data-cmd="${b.id}" title="${escapeHtml(b.title)}"${styled}>${content}</button>`;
-    })
-    .join('');
-  const commentBar = withComment
-    ? `<button type="button" class="tb-comment" data-cmd="comment" title="Comment on selection">${COMMENT_ICON_SVG}<span>Comment</span></button>`
-    : '';
-  return `<div class="tb-row">${buttons}</div>${commentBar}`;
+const blockLabel = (id) => (BLOCK_TYPES.find((t) => t.id === id) || { label: 'Text' }).label;
+
+// The block type the current selection sits in, used for the dropdown label and
+// the menu's active tick. Lists are checked first: a list item's content is a
+// paragraph, so the list wrapper is the meaningful "what is this block" answer.
+export function activeBlockType(editor) {
+  if (!editor) return 'paragraph';
+  if (editor.isActive('bulletList'))  return 'bulletList';
+  if (editor.isActive('orderedList')) return 'orderedList';
+  if (editor.isActive('taskList'))    return 'taskList';
+  if (editor.isActive('heading', { level: 1 })) return 'h1';
+  if (editor.isActive('heading', { level: 2 })) return 'h2';
+  if (editor.isActive('heading', { level: 3 })) return 'h3';
+  return 'paragraph';
 }
 
-function applyCommand(editor, id) {
+function renderInlineButton(b) {
+  const styled = b.styled ? ` data-style="${b.styled}"` : '';
+  const content = b.icon ? b.icon : escapeHtml(b.label || '');
+  return `<button type="button" class="tb-btn" data-cmd="${b.id}" title="${escapeHtml(b.title)}"${styled}>${content}</button>`;
+}
+
+function renderBlockMenu() {
+  const items = BLOCK_TYPES.map((t) => {
+    if (t.sep) return '<div class="tb-menu-sep"></div>';
+    const icon = t.svg ? t.icon : escapeHtml(t.icon);
+    return `<button type="button" class="tb-menu-item" role="menuitem" data-cmd="${t.id}">`
+      + `<span class="tb-menu-ic">${icon}</span>`
+      + `<span class="tb-menu-label">${escapeHtml(t.label)}</span>`
+      + `<span class="tb-menu-check">${CHECK_SVG}</span></button>`;
+  }).join('');
+  return `<div class="tb-menu" role="menu">${items}</div>`;
+}
+
+// buttonIds set (e.g. board cards) -> a reduced, inline-only toolbar with no
+// block-type dropdown. Otherwise the full toolbar: dropdown + inline marks.
+export function renderToolbarHTML(withComment, buttonIds = null) {
+  const inlineDefs = buttonIds ? INLINE_DEFS.filter((b) => buttonIds.includes(b.id)) : INLINE_DEFS;
+  const inline = inlineDefs.map(renderInlineButton).join('');
+  const dropdown = buttonIds
+    ? ''
+    : `<button type="button" class="tb-dd" data-cmd="__blockmenu" title="Turn into…" aria-haspopup="true" aria-expanded="false"><span class="tb-dd-label">Text</span>${CHEVRON_SVG}</button><span class="tb-sep"></span>`;
+  const menu = buttonIds ? '' : renderBlockMenu();
+  // Comment lives inline on the single row, after a separator (matches the
+  // narrower dropdown-based bar), not as a full-width second-line bar.
+  const comment = withComment
+    ? `<span class="tb-sep"></span><button type="button" class="tb-comment" data-cmd="comment" title="Comment on selection">${COMMENT_ICON_SVG}<span>Comment</span></button>`
+    : '';
+  return `<div class="tb-row">${dropdown}${inline}${comment}</div>${menu}`;
+}
+
+export function applyCommand(editor, id) {
   if (!editor) return;
   const chain = editor.chain().focus();
   switch (id) {
@@ -85,13 +134,24 @@ function applyCommand(editor, id) {
     case 'h1': return chain.toggleHeading({ level: 1 }).run();
     case 'h2': return chain.toggleHeading({ level: 2 }).run();
     case 'h3': return chain.toggleHeading({ level: 3 }).run();
-    default:   return;
+    case 'bulletList':  return chain.toggleBulletList().run();
+    case 'orderedList': return chain.toggleOrderedList().run();
+    case 'taskList':    return chain.toggleTaskList().run();
+    case 'paragraph': {
+      // "Turn into Text": unwrap any surrounding list first so a list item
+      // becomes a plain paragraph, not a paragraph still inside the list.
+      if (editor.isActive('bulletList'))       chain.toggleBulletList();
+      else if (editor.isActive('orderedList')) chain.toggleOrderedList();
+      else if (editor.isActive('taskList'))    chain.toggleTaskList();
+      return chain.setParagraph().run();
+    }
+    default: return;
   }
 }
 
 function updateActiveStates(editor, toolbar) {
   if (!editor) return;
-  toolbar.querySelectorAll('.tb-btn').forEach(btn => {
+  toolbar.querySelectorAll('.tb-btn').forEach((btn) => {
     const cmd = btn.getAttribute('data-cmd');
     let active = false;
     switch (cmd) {
@@ -99,16 +159,19 @@ function updateActiveStates(editor, toolbar) {
       case 'italic': active = editor.isActive('italic'); break;
       case 'code':   active = editor.isActive('code');   break;
       case 'link':   active = editor.isActive('link');   break;
-      case 'h1':     active = editor.isActive('heading', { level: 1 }); break;
-      case 'h2':     active = editor.isActive('heading', { level: 2 }); break;
-      case 'h3':     active = editor.isActive('heading', { level: 3 }); break;
     }
     btn.classList.toggle('active', active);
   });
+  const active = activeBlockType(editor);
+  const label = toolbar.querySelector('.tb-dd-label');
+  if (label) label.textContent = blockLabel(active);
+  toolbar.querySelectorAll('.tb-menu-item').forEach((item) => {
+    item.classList.toggle('active', item.getAttribute('data-cmd') === active);
+  });
 }
 
-// Attach the toolbar to an editor instance. Returns a teardown function so
-// the editor module can clean up when the editor is destroyed.
+// Attach the toolbar to an editor instance. Returns a teardown function so the
+// editor module can clean up when the editor is destroyed.
 export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onReviewAction = null, buttonIds = null, fixed = false }) {
   if (!toolbarElement || !editor) return () => {};
   // fixed: anchor to the viewport (position: fixed) instead of a scrolling host
@@ -119,15 +182,44 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
   toolbarElement.classList.remove('visible');
   if (fixed) toolbarElement.style.position = 'fixed';
 
+  const dropdownBtn = toolbarElement.querySelector('.tb-dd');
+  const menuEl = toolbarElement.querySelector('.tb-menu');
+  const closeMenu = () => {
+    if (!menuEl) return;
+    menuEl.classList.remove('open');
+    if (dropdownBtn) dropdownBtn.setAttribute('aria-expanded', 'false');
+  };
+  const toggleMenu = () => {
+    if (!menuEl) return;
+    const open = menuEl.classList.toggle('open');
+    if (dropdownBtn) dropdownBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  };
+  // Removing 'visible' anywhere must also close the menu, so a hidden toolbar
+  // never leaves an orphaned open menu.
+  const hide = () => { toolbarElement.classList.remove('visible'); closeMenu(); };
+
   const onClick = (event) => {
+    if (event.target.closest('.tb-dd')) {
+      event.preventDefault(); event.stopPropagation();
+      toggleMenu();
+      return;
+    }
+    const item = event.target.closest('.tb-menu-item');
+    if (item) {
+      event.preventDefault(); event.stopPropagation();
+      applyCommand(editor, item.getAttribute('data-cmd'));
+      closeMenu();
+      updateActiveStates(editor, toolbarElement);
+      return;
+    }
     const btn = event.target.closest('.tb-btn, .tb-comment');
     if (!btn) return;
-    event.preventDefault();
-    event.stopPropagation();
+    event.preventDefault(); event.stopPropagation();
+    closeMenu();
     const cmd = btn.getAttribute('data-cmd');
     if (cmd === 'comment') {
       if (typeof onReviewAction === 'function') onReviewAction('comment');
-      toolbarElement.classList.remove('visible');
+      hide();
       return;
     }
     applyCommand(editor, cmd);
@@ -135,36 +227,37 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
   };
   toolbarElement.addEventListener('mousedown', onClick);
 
-  // Stop selection-collapse on toolbar click by preventing the host element
-  // from losing focus during the brief mousedown on the button.
-  toolbarElement.addEventListener('mousedown', (e) => {
-    if (e.target.closest('.tb-btn, .tb-comment')) e.preventDefault();
-  });
+  // Stop selection-collapse on any toolbar interaction by preventing the host
+  // from losing focus during the brief mousedown on a control.
+  const preventBlur = (e) => {
+    if (e.target.closest('.tb-btn, .tb-comment, .tb-dd, .tb-menu-item')) e.preventDefault();
+  };
+  toolbarElement.addEventListener('mousedown', preventBlur);
+
+  // Escape closes an open menu without collapsing the selection.
+  const onKeyDown = (e) => {
+    if (e.key === 'Escape' && menuEl && menuEl.classList.contains('open')) {
+      e.preventDefault();
+      closeMenu();
+    }
+  };
+  toolbarElement.addEventListener('keydown', onKeyDown);
 
   const position = () => {
     const { from, to, empty } = editor.state.selection;
-    if (empty || !editor.isFocused) {
-      toolbarElement.classList.remove('visible');
-      return;
-    }
+    if (empty || !editor.isFocused) { hide(); return; }
     // An atom node selection (e.g. clicking a callout) is not inline-formattable,
     // so the formatting toolbar has nothing to act on: keep it hidden. Callouts
     // are edited through their own in-place editor, not these marks.
     const sel = editor.state.selection;
-    if (sel.node && sel.node.type && sel.node.type.isAtom) {
-      toolbarElement.classList.remove('visible');
-      return;
-    }
+    if (sel.node && sel.node.type && sel.node.type.isAtom) { hide(); return; }
     const view = editor.view;
     let startCoords;
     let endCoords;
     try {
       startCoords = view.coordsAtPos(from);
       endCoords   = view.coordsAtPos(to);
-    } catch {
-      toolbarElement.classList.remove('visible');
-      return;
-    }
+    } catch { hide(); return; }
     // The host element is the scrolling container (overflow-y: auto), so the
     // absolutely-positioned toolbar inside it is positioned relative to the
     // host's CONTENT box, not its visible viewport. coordsAtPos returns
@@ -190,9 +283,9 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
     const scrollLeft = hostElement.scrollLeft || 0;
     const midX = (startCoords.left + endCoords.left) / 2 - hostRect.left + scrollLeft;
     const aboveTop = startCoords.top - hostRect.top + scrollTop - tbRect.height - 8;
-    // Above the selection by default. If the selection sits near the top of
-    // the pane content with no room above for the toolbar, drop it to just
-    // below the selection instead so it never overlaps the highlighted text.
+    // Above the selection by default. If the selection sits near the top of the
+    // pane content with no room above for the toolbar, drop it to just below
+    // the selection instead so it never overlaps the highlighted text.
     const top = aboveTop >= 8
       ? aboveTop
       : endCoords.bottom - hostRect.top + scrollTop + 8;
@@ -203,9 +296,11 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
     updateActiveStates(editor, toolbarElement);
   };
 
-  const onSelection = () => position();
+  // A real selection change (moving the caret, clicking into other text, or a
+  // block command's own transaction) closes any open menu, then repositions.
+  const onSelection = () => { closeMenu(); position(); };
   const onUpdate    = () => position();
-  const onBlur      = () => toolbarElement.classList.remove('visible');
+  const onBlur      = () => hide();
 
   editor.on('selectionUpdate', onSelection);
   editor.on('transaction',     onUpdate);
@@ -216,6 +311,8 @@ export function attachFloatingToolbar({ toolbarElement, hostElement, editor, onR
     editor.off('transaction',     onUpdate);
     editor.off('blur',            onBlur);
     toolbarElement.removeEventListener('mousedown', onClick);
+    toolbarElement.removeEventListener('mousedown', preventBlur);
+    toolbarElement.removeEventListener('keydown', onKeyDown);
     toolbarElement.classList.remove('visible');
     toolbarElement.innerHTML = '';
   };

--- a/public/editor/styles.js
+++ b/public/editor/styles.js
@@ -437,26 +437,24 @@ const CSS = `
   }
 }
 
-/* --- Review: floating toolbar additions ---------------------------------- */
-.floating-toolbar.visible { flex-direction: column; }
-.floating-toolbar .tb-row { display: flex; gap: 2px; }
+/* --- Review: floating toolbar Comment action (inline, single line) ------- */
+.floating-toolbar .tb-row { display: flex; align-items: center; gap: 2px; }
 .floating-toolbar .tb-comment {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
   gap: 6px;
-  width: 100%;
-  margin-top: 4px;
-  padding: 5px 10px;
-  border-top: 1px solid var(--border);
-  border-radius: 0 0 4px 4px;
+  height: 28px;
+  padding: 0 10px;
   background: transparent;
-  color: var(--text-1);
-  font-size: 12px;
+  color: var(--text-2);
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
   font-weight: 600;
   font-family: inherit;
   cursor: pointer;
 }
+.floating-toolbar .tb-comment svg { display: block; }
 .floating-toolbar .tb-comment:hover {
   background: var(--accent-glow, rgba(232, 122, 90, 0.15));
   color: var(--accent, #E87A5A);

--- a/public/index.html
+++ b/public/index.html
@@ -582,7 +582,7 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
    silent revert, so the typed text is kept and the reason is visible. */
 .tiptap-editor .ProseMirror .callout-edit.callout-edit-invalid { border-color: var(--danger, #d9534f); box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger, #d9534f) 30%, transparent); animation: callout-edit-shake 0.3s ease; }
 @keyframes callout-edit-shake { 0%,100% { transform: translateX(0); } 25% { transform: translateX(-3px); } 75% { transform: translateX(3px); } }
-.floating-toolbar { position: absolute; display: none; gap: 2px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 6px; box-shadow: 0 4px 12px rgba(0,0,0,0.25); z-index: 50; left: 0; top: 0; }
+.floating-toolbar { position: absolute; display: none; gap: 2px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 6px; box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 4px 12px rgba(0,0,0,0.16); z-index: 50; left: 0; top: 0; }
 .floating-toolbar.visible { display: inline-flex; }
 .floating-toolbar .tb-btn { display: inline-flex; align-items: center; justify-content: center; min-width: 28px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-2); border: none; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
 .floating-toolbar .tb-btn[data-style="b"] { font-weight: 700; }
@@ -597,7 +597,7 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .floating-toolbar .tb-dd { display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-1); border: none; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
 .floating-toolbar .tb-dd:hover, .floating-toolbar .tb-dd[aria-expanded="true"] { background: var(--accent-glow); color: var(--accent); }
 .floating-toolbar .tb-dd svg { display: block; opacity: 0.75; }
-.floating-toolbar .tb-menu { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; width: 216px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 26px rgba(0,0,0,0.45); z-index: 51; }
+.floating-toolbar .tb-menu { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; width: 216px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.10), 0 8px 20px rgba(0,0,0,0.16); z-index: 51; }
 .floating-toolbar .tb-menu.open { display: block; }
 /* Flip upward near the foot of the viewport so the menu never spills past the
    bottom (or extends the editor's scroll region). */
@@ -612,7 +612,12 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .floating-toolbar .tb-menu-sep { height: 1px; background: var(--border); margin: 4px 6px; }
 /* In-UI link popover: an input row anchored under the toolbar (replaces the
    OS-native prompt). Absolutely positioned so it sits below the flex row. */
-.floating-toolbar .tb-linkpop { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; align-items: center; gap: 4px; width: 288px; max-width: 80vw; padding: 5px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 26px rgba(0,0,0,0.45); z-index: 51; }
+.floating-toolbar .tb-linkpop { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; align-items: center; gap: 4px; width: 288px; max-width: 80vw; padding: 5px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.10), 0 8px 20px rgba(0,0,0,0.16); z-index: 51; }
+/* Light theme: pure-black shadows read harsher on a light background, so use a
+   lighter ambient. Toolbar and its dropped panels form one elevation cluster. */
+body.light .floating-toolbar { box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.10); }
+body.light .floating-toolbar .tb-menu,
+body.light .floating-toolbar .tb-linkpop { box-shadow: 0 2px 6px rgba(0,0,0,0.06), 0 8px 20px rgba(0,0,0,0.10); }
 .floating-toolbar .tb-linkpop.open { display: flex; }
 .floating-toolbar .tb-linkpop.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; }
 .floating-toolbar .tb-link-input { flex: 1; min-width: 0; height: 28px; padding: 0 8px; background: var(--elevated); border: 1px solid var(--border); border-radius: 5px; color: var(--text-1); font-size: 13px; font-family: inherit; outline: none; }

--- a/public/index.html
+++ b/public/index.html
@@ -537,6 +537,11 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror ul[data-type="taskList"] > li { display: flex; align-items: flex-start; gap: 8px; }
 .tiptap-editor .ProseMirror ul[data-type="taskList"] > li > label { flex: 0 0 auto; margin-top: 0.3em; user-select: none; }
 .tiptap-editor .ProseMirror ul[data-type="taskList"] > li > div { flex: 1 1 auto; min-width: 0; }
+/* Accent-tinted checkbox (orange tick), matching the board card. A ticked item
+   greys its text to read as done, but is NOT struck through (that heavier
+   line-through treatment is reserved for the board). */
+.tiptap-editor .ProseMirror ul[data-type="taskList"] input[type="checkbox"] { accent-color: var(--accent); }
+.tiptap-editor .ProseMirror ul[data-type="taskList"] > li[data-checked="true"] > div { color: var(--text-2); }
 .tiptap-editor .ProseMirror blockquote { border-left: 2px solid var(--border); padding-left: 16px; margin: 0 0 12px 0; color: var(--text-2); }
 .tiptap-editor .ProseMirror code { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; background: var(--card); padding: 2px 6px; border-radius: 4px; color: var(--text-1); }
 .tiptap-editor .ProseMirror pre { background: var(--card); border-radius: 8px; padding: 12px 16px; margin: 0 0 12px 0; overflow-x: auto; }

--- a/public/index.html
+++ b/public/index.html
@@ -602,6 +602,17 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .floating-toolbar .tb-menu-check { display: none; color: var(--accent); }
 .floating-toolbar .tb-menu-item.active .tb-menu-check { display: inline-flex; }
 .floating-toolbar .tb-menu-sep { height: 1px; background: var(--border); margin: 4px 6px; }
+/* In-UI link popover: an input row anchored under the toolbar (replaces the
+   OS-native prompt). Absolutely positioned so it sits below the flex row. */
+.floating-toolbar .tb-linkpop { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; align-items: center; gap: 4px; width: 288px; max-width: 80vw; padding: 5px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 26px rgba(0,0,0,0.45); z-index: 51; }
+.floating-toolbar .tb-linkpop.open { display: flex; }
+.floating-toolbar .tb-link-input { flex: 1; min-width: 0; height: 28px; padding: 0 8px; background: var(--elevated); border: 1px solid var(--border); border-radius: 5px; color: var(--text-1); font-size: 13px; font-family: inherit; outline: none; }
+.floating-toolbar .tb-link-input:focus { border-color: var(--accent); }
+.floating-toolbar .tb-link-input::placeholder { color: var(--text-2); }
+.floating-toolbar .tb-link-apply, .floating-toolbar .tb-link-unlink { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; flex: 0 0 auto; background: transparent; color: var(--text-2); border: none; border-radius: 5px; cursor: pointer; }
+.floating-toolbar .tb-link-apply:hover { background: var(--accent-glow); color: var(--accent); }
+.floating-toolbar .tb-link-unlink:hover { background: var(--accent-glow); color: var(--attention); }
+.floating-toolbar .tb-link-apply svg, .floating-toolbar .tb-link-unlink svg { display: block; }
 
 /* In-view find bar (Cmd+F / Ctrl+F). Positioned absolutely against the main
    panel area so it floats over whichever view is active. Match highlights

--- a/public/index.html
+++ b/public/index.html
@@ -529,6 +529,14 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror ul, .tiptap-editor .ProseMirror ol { padding-left: 24px; margin: 0 0 12px 0; }
 .tiptap-editor .ProseMirror li { margin: 4px 0; }
 .tiptap-editor .ProseMirror li > p { margin: 0; }
+/* Task lists: the TaskItem nodeView renders <li><label/><div/></li> with both
+   children block-level, which stacks the text under the checkbox. Lay the item
+   out as a row and drop the list bullet. Direct-child selectors so nested task
+   lists inherit the same layout. */
+.tiptap-editor .ProseMirror ul[data-type="taskList"] { list-style: none; padding-left: 4px; }
+.tiptap-editor .ProseMirror ul[data-type="taskList"] > li { display: flex; align-items: flex-start; gap: 8px; }
+.tiptap-editor .ProseMirror ul[data-type="taskList"] > li > label { flex: 0 0 auto; margin-top: 0.3em; user-select: none; }
+.tiptap-editor .ProseMirror ul[data-type="taskList"] > li > div { flex: 1 1 auto; min-width: 0; }
 .tiptap-editor .ProseMirror blockquote { border-left: 2px solid var(--border); padding-left: 16px; margin: 0 0 12px 0; color: var(--text-2); }
 .tiptap-editor .ProseMirror code { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; background: var(--card); padding: 2px 6px; border-radius: 4px; color: var(--text-1); }
 .tiptap-editor .ProseMirror pre { background: var(--card); border-radius: 8px; padding: 12px 16px; margin: 0 0 12px 0; overflow-x: auto; }

--- a/public/index.html
+++ b/public/index.html
@@ -577,6 +577,23 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .floating-toolbar .tb-btn:hover { background: var(--accent-glow); color: var(--accent); }
 .floating-toolbar .tb-btn.active { background: var(--accent); color: #fff; }
 .floating-toolbar .tb-btn svg { display: block; }
+/* Block-type dropdown: a "Text" trigger + a menu of paragraph / headings /
+   list types. The menu is position:absolute so it never changes the toolbar's
+   measured box (which the positioning math depends on). */
+.floating-toolbar .tb-sep { width: 1px; align-self: stretch; margin: 4px 4px; background: var(--border); }
+.floating-toolbar .tb-dd { display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-1); border: none; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
+.floating-toolbar .tb-dd:hover, .floating-toolbar .tb-dd[aria-expanded="true"] { background: var(--accent-glow); color: var(--accent); }
+.floating-toolbar .tb-dd svg { display: block; opacity: 0.75; }
+.floating-toolbar .tb-menu { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; width: 216px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 26px rgba(0,0,0,0.45); z-index: 51; }
+.floating-toolbar .tb-menu.open { display: block; }
+.floating-toolbar .tb-menu-item { display: flex; align-items: center; gap: 11px; width: 100%; height: 32px; padding: 0 10px; background: transparent; border: none; border-radius: 6px; color: var(--text-1); font-size: 13.5px; font-family: inherit; text-align: left; cursor: pointer; }
+.floating-toolbar .tb-menu-item:hover { background: var(--accent-glow); }
+.floating-toolbar .tb-menu-ic { width: 22px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; color: var(--text-2); font-size: 11px; font-weight: 700; font-family: 'SF Mono', ui-monospace, monospace; }
+.floating-toolbar .tb-menu-ic svg { display: block; }
+.floating-toolbar .tb-menu-label { flex: 1; }
+.floating-toolbar .tb-menu-check { display: none; color: var(--accent); }
+.floating-toolbar .tb-menu-item.active .tb-menu-check { display: inline-flex; }
+.floating-toolbar .tb-menu-sep { height: 1px; background: var(--border); margin: 4px 6px; }
 
 /* In-view find bar (Cmd+F / Ctrl+F). Positioned absolutely against the main
    panel area so it floats over whichever view is active. Match highlights

--- a/public/index.html
+++ b/public/index.html
@@ -599,6 +599,9 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .floating-toolbar .tb-dd svg { display: block; opacity: 0.75; }
 .floating-toolbar .tb-menu { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; width: 216px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 26px rgba(0,0,0,0.45); z-index: 51; }
 .floating-toolbar .tb-menu.open { display: block; }
+/* Flip upward near the foot of the viewport so the menu never spills past the
+   bottom (or extends the editor's scroll region). */
+.floating-toolbar .tb-menu.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; }
 .floating-toolbar .tb-menu-item { display: flex; align-items: center; gap: 11px; width: 100%; height: 32px; padding: 0 10px; background: transparent; border: none; border-radius: 6px; color: var(--text-1); font-size: 13.5px; font-family: inherit; text-align: left; cursor: pointer; }
 .floating-toolbar .tb-menu-item:hover { background: var(--accent-glow); }
 .floating-toolbar .tb-menu-ic { width: 22px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; color: var(--text-2); font-size: 11px; font-weight: 700; font-family: 'SF Mono', ui-monospace, monospace; }
@@ -611,6 +614,7 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
    OS-native prompt). Absolutely positioned so it sits below the flex row. */
 .floating-toolbar .tb-linkpop { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; align-items: center; gap: 4px; width: 288px; max-width: 80vw; padding: 5px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 26px rgba(0,0,0,0.45); z-index: 51; }
 .floating-toolbar .tb-linkpop.open { display: flex; }
+.floating-toolbar .tb-linkpop.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; }
 .floating-toolbar .tb-link-input { flex: 1; min-width: 0; height: 28px; padding: 0 8px; background: var(--elevated); border: 1px solid var(--border); border-radius: 5px; color: var(--text-1); font-size: 13px; font-family: inherit; outline: none; }
 .floating-toolbar .tb-link-input:focus { border-color: var(--accent); }
 .floating-toolbar .tb-link-input::placeholder { color: var(--text-2); }

--- a/public/index.html
+++ b/public/index.html
@@ -601,7 +601,7 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .floating-toolbar .tb-menu.open { display: block; }
 /* Flip upward near the foot of the viewport so the menu never spills past the
    bottom (or extends the editor's scroll region). */
-.floating-toolbar .tb-menu.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; }
+.floating-toolbar .tb-menu.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; box-shadow: 0 -2px 6px rgba(0,0,0,0.10), 0 -8px 20px rgba(0,0,0,0.16); }
 .floating-toolbar .tb-menu-item { display: flex; align-items: center; gap: 11px; width: 100%; height: 32px; padding: 0 10px; background: transparent; border: none; border-radius: 6px; color: var(--text-1); font-size: 13.5px; font-family: inherit; text-align: left; cursor: pointer; }
 .floating-toolbar .tb-menu-item:hover { background: var(--accent-glow); }
 .floating-toolbar .tb-menu-ic { width: 22px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; color: var(--text-2); font-size: 11px; font-weight: 700; font-family: 'SF Mono', ui-monospace, monospace; }
@@ -618,8 +618,13 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 body.light .floating-toolbar { box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.10); }
 body.light .floating-toolbar .tb-menu,
 body.light .floating-toolbar .tb-linkpop { box-shadow: 0 2px 6px rgba(0,0,0,0.06), 0 8px 20px rgba(0,0,0,0.10); }
+/* Flipped upward (opens above the toolbar): direct the shadow up onto the
+   document, never down onto the toolbar. Needs the .up + body.light specificity
+   to win over the down-shadow rule above. */
+body.light .floating-toolbar .tb-menu.up,
+body.light .floating-toolbar .tb-linkpop.up { box-shadow: 0 -2px 6px rgba(0,0,0,0.06), 0 -8px 20px rgba(0,0,0,0.10); }
 .floating-toolbar .tb-linkpop.open { display: flex; }
-.floating-toolbar .tb-linkpop.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; }
+.floating-toolbar .tb-linkpop.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; box-shadow: 0 -2px 6px rgba(0,0,0,0.10), 0 -8px 20px rgba(0,0,0,0.16); }
 .floating-toolbar .tb-link-input { flex: 1; min-width: 0; height: 28px; padding: 0 8px; background: var(--elevated); border: 1px solid var(--border); border-radius: 5px; color: var(--text-1); font-size: 13px; font-family: inherit; outline: none; }
 .floating-toolbar .tb-link-input:focus { border-color: var(--accent); }
 .floating-toolbar .tb-link-input::placeholder { color: var(--text-2); }

--- a/public/kanban.js
+++ b/public/kanban.js
@@ -37,7 +37,18 @@
   // block: that appears on the first save, because parse hoists
   // kanban-plugin into settings (mirrored below).
   function newBoardContent() {
-    return ['---', '', 'kanban-plugin: board', '', '---', '', ''].join('\n');
+    // Rundock seeds a new board with three standard columns so it opens ready
+    // to use rather than blank. (Obsidian's new board is frontmatter-only,
+    // which in Rundock rendered as an empty board with no way to add the first
+    // column.) Building it through parse + serialize yields the exact canonical
+    // bytes the serialiser produces, so the very first save never reformats it.
+    const template = [
+      '---', '', 'kanban-plugin: board', '', '---', '',
+      '## To Do', '', '',
+      '## In Progress', '', '',
+      '## Done', '', '',
+    ].join('\n');
+    return serialize(parse(template));
   }
 
   // Board detection, mirroring hasFrontmatterKeyRaw: any file whose

--- a/public/viewers/board-view.js
+++ b/public/viewers/board-view.js
@@ -91,6 +91,15 @@ function ensureStyles(doc) {
     .board-add-field:focus-within .board-add-submit.ready, .board-add-submit.ready { background: var(--accent); color: #fff; opacity: 1; box-shadow: 0 2px 8px rgba(232,122,90,0.30); }
     .board-add-open { margin: 4px 8px 8px; padding: 8px 10px; border-radius: 8px; color: var(--text-2); font-size: var(--body); text-align: left; }
     .board-add-open:hover { background: var(--elevated); color: var(--text-1); }
+    /* Trailing "Add a list" column: always present at the end of the row, so it
+       doubles as the empty-board state (a board with zero lists shows only this,
+       which is the only way to add the first column). */
+    .board-add-lane { flex: 0 0 272px; align-self: flex-start; }
+    .board-add-lane-empty { flex: 0 0 320px; }
+    .board-add-lane-open { width: 100%; padding: 12px 14px; border: 1px dashed var(--border); border-radius: 12px; color: var(--text-2); font-size: var(--body); text-align: left; background: transparent; transition: color .15s ease, background .15s ease, border-color .15s ease; }
+    .board-add-lane-open:hover { color: var(--text-1); background: var(--surface); border-color: var(--text-2); }
+    .board-add-lane .board-add-field { background: var(--surface); }
+    .board-add-lane-input { flex: 1; min-width: 0; border: none; background: transparent; color: var(--text-1); font: inherit; font-size: var(--body); outline: none; }
     .board-dropped-warn { margin: 8px 20px; padding: 10px 14px; border-radius: 8px; background: rgba(232,168,76,0.12); border: 1px solid rgba(232,168,76,0.35); color: var(--text-1); font-size: var(--caption); }
   `;
   doc.head.appendChild(style);
@@ -185,6 +194,7 @@ export function mountBoardView({ paneElement, content, onWikilink }, Kanban) {
     if (staleToast) staleToast.remove();
     scroll.innerHTML = '';
     board.lanes.forEach((lane, laneIndex) => scroll.appendChild(renderLane(lane, laneIndex)));
+    scroll.appendChild(renderAddLane());
     const oldWarn = paneElement.querySelector('.board-dropped-warn');
     if (oldWarn) oldWarn.remove(); // never stack banners across renders
     if (board.dropped && board.dropped.length) {
@@ -578,6 +588,52 @@ export function mountBoardView({ paneElement, content, onWikilink }, Kanban) {
     toast.appendChild(btn);
     paneElement.appendChild(toast);
     undoTimer = setTimeout(() => toast.remove(), 6000);
+  }
+
+  // Trailing "Add a list" column. Mirrors the add-card composer grammar (open
+  // button -> inline field -> Enter/submit commits, Escape/empty-blur cancels)
+  // but adds a lane via Kanban.insertLane. Always rendered, so an empty board
+  // (zero lists) can be built and a fully-deleted board is never a dead end.
+  function renderAddLane() {
+    const empty = board.lanes.length === 0;
+    const wrap = doc.createElement('div');
+    wrap.className = 'board-add-lane' + (empty ? ' board-add-lane-empty' : '');
+    const openBtn = doc.createElement('button');
+    openBtn.type = 'button';
+    openBtn.className = 'board-add-lane-open';
+    openBtn.textContent = empty ? '+ Add your first list' : '+ Add list';
+    wrap.appendChild(openBtn);
+
+    openBtn.addEventListener('click', () => {
+      wrap.innerHTML = '';
+      const field = doc.createElement('div');
+      field.className = 'board-add-field';
+      const input = doc.createElement('input');
+      input.type = 'text';
+      input.placeholder = 'List name';
+      input.className = 'board-add-lane-input';
+      const submit = doc.createElement('button');
+      submit.type = 'button';
+      submit.className = 'board-add-submit';
+      submit.appendChild(plusIcon(doc));
+      field.appendChild(input);
+      field.appendChild(submit);
+      wrap.appendChild(field);
+      input.focus();
+      input.addEventListener('input', () => submit.classList.toggle('ready', input.value.trim().length > 0));
+      const commit = () => {
+        const v = input.value.trim();
+        if (v) { Kanban.insertLane(board, board.lanes.length, v); onChange(); }
+        render();
+      };
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') { e.preventDefault(); commit(); }
+        else if (e.key === 'Escape') { e.preventDefault(); render(); }
+      });
+      submit.addEventListener('mousedown', (e) => { e.preventDefault(); commit(); });
+      input.addEventListener('blur', () => { if (!input.value.trim()) render(); });
+    });
+    return wrap;
   }
 
   function addComposer(laneIndex) {

--- a/test/e2e/board-add-lane.spec.js
+++ b/test/e2e/board-add-lane.spec.js
@@ -1,0 +1,45 @@
+'use strict';
+// E2E: the Kanban board's "Add a list" affordance.
+//
+// Browser-driven because the affordance is a DOM interaction on the real board
+// view: a trailing "+ Add list" column that is always present, so a board with
+// zero columns can still be built (before this, the only way to add a list was
+// through an existing lane's menu, so an empty board was a dead end).
+const { test, expect } = require('@playwright/test');
+
+async function openBoard(page, name) {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await page.locator('.nav-item[data-nav="files"]').click();
+  await page.locator('.file-item', { hasText: name }).first().click();
+  await expect(page.locator('.board-add-lane-open')).toBeVisible();
+}
+
+test('a populated board shows a trailing "+ Add list", and it adds a column', async ({ page }) => {
+  await openBoard(page, 'board.md');
+
+  await expect(page.locator('.board-lane')).toHaveCount(3);
+  await expect(page.locator('.board-add-lane-open')).toHaveText('+ Add list');
+
+  await page.locator('.board-add-lane-open').click();
+  await page.locator('.board-add-lane-input').fill('Review');
+  await page.locator('.board-add-lane-input').press('Enter');
+
+  await expect(page.locator('.board-lane')).toHaveCount(4);
+  await expect(page.locator('.board-lane-title', { hasText: 'Review' })).toBeVisible();
+});
+
+test('an empty board is not a dead end: it offers "Add your first list"', async ({ page }) => {
+  await openBoard(page, 'empty-board.md');
+
+  // Zero columns, but the affordance is present and labelled for the empty state.
+  await expect(page.locator('.board-lane')).toHaveCount(0);
+  await expect(page.locator('.board-add-lane-open')).toHaveText('+ Add your first list');
+
+  await page.locator('.board-add-lane-open').click();
+  await page.locator('.board-add-lane-input').fill('To Do');
+  await page.locator('.board-add-lane-input').press('Enter');
+
+  await expect(page.locator('.board-lane')).toHaveCount(1);
+  await expect(page.locator('.board-lane-title', { hasText: 'To Do' })).toBeVisible();
+});

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -128,6 +128,10 @@ function buildFixture() {
   // to prove the board registry view renders columns and round-trips bytes.
   fs.writeFileSync(path.join(workspace, 'board.md'),
     "---\n\nkanban-plugin: board\n\n---\n\n## To do\n\n- [ ] Draft the outline\n- [ ] **Review** the brief\n\n\n## Doing\n\n- [ ] Wire the [[Board]] view\n\n\n## Done\n\n- [ ] Ship it\n\n\n\n\n%% kanban:settings\n```\n{\"kanban-plugin\":\"board\",\"list-collapse\":[false,false,false]}\n```\n%%");
+  // A frontmatter-only board (zero columns): opens as a board, and must offer
+  // the "Add your first list" affordance so an empty board is never a dead end.
+  fs.writeFileSync(path.join(workspace, 'empty-board.md'),
+    "---\n\nkanban-plugin: board\n\n---\n\n");
   // A board with block-style frontmatter (a multi-line tag list): a save must
   // preserve it verbatim rather than flattening it away.
   fs.writeFileSync(path.join(workspace, 'tagged-board.md'),

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -63,6 +63,12 @@ function buildFixture() {
   fs.writeFileSync(path.join(workspace, 'Roadmap-2026.md'),
     '# Roadmap 2026\n\nQuarterly targets and the mobile milestone.\n');
 
+  // A tall note that overflows the editor viewport, so the floating toolbar's
+  // dropdown can be exercised near the foot of the visible area (where the menu
+  // must flip to open upward rather than spilling past the bottom).
+  fs.writeFileSync(path.join(workspace, 'long-note.md'),
+    '# Long Note\n\n' + Array.from({ length: 60 }, (_, i) => `Paragraph ${i + 1} of the long note body.`).join('\n\n') + '\n\nFinal line at the very bottom of the file.\n');
+
   // A note whose body paragraph carries two inline wikilinks. Pressing Enter
   // at the end of this line must split the block cleanly and keep every
   // wikilink and its surrounding text (a contenteditable + inline-atom

--- a/test/e2e/toolbar-block-dropdown.spec.js
+++ b/test/e2e/toolbar-block-dropdown.spec.js
@@ -78,3 +78,52 @@ test('a checklist item lays out the checkbox and its text on the same line (not 
   // And the checkbox sits to the LEFT of the text, not above it.
   expect(box.x + box.width).toBeLessThanOrEqual(txt.x + 1);
 });
+
+test('the link button opens an in-UI popover that sets, pre-fills, and removes a link', async ({ page }) => {
+  await openNote(page, 'Roadmap-2026.md');
+  const NEEDLE = 'Quarterly targets';
+
+  // Select the paragraph text and open the link popover from the toolbar.
+  await page.locator('.ProseMirror p', { hasText: NEEDLE }).first().click({ clickCount: 3 });
+  await expect(page.locator('#tiptap-toolbar.visible')).toBeVisible();
+  const popover = page.locator('#tiptap-toolbar .tb-linkpop');
+  const input = page.locator('#tiptap-toolbar .tb-link-input');
+  await expect(popover).toBeHidden();
+  await page.locator('#tiptap-toolbar .tb-btn[data-cmd="link"]').click();
+  await expect(popover).toBeVisible();
+  await expect(input).toBeFocused();
+
+  // Type a bare domain and apply with Enter. It is normalised to https:// and
+  // the selected text becomes a link; the popover closes.
+  await input.fill('rundock.ai');
+  await input.press('Enter');
+  await expect(popover).toBeHidden();
+  const link = page.locator('.ProseMirror a[href="https://rundock.ai"]');
+  await expect(link).toHaveCount(1);
+
+  // Reopening on the linked text pre-fills the existing href.
+  await link.click({ clickCount: 3 });
+  await expect(page.locator('#tiptap-toolbar.visible')).toBeVisible();
+  await page.locator('#tiptap-toolbar .tb-btn[data-cmd="link"]').click();
+  await expect(input).toHaveValue('https://rundock.ai');
+
+  // The unlink control removes the link.
+  await page.locator('#tiptap-toolbar .tb-link-unlink').click();
+  await expect(popover).toBeHidden();
+  await expect(page.locator('.ProseMirror a[href="https://rundock.ai"]')).toHaveCount(0);
+});
+
+test('Escape closes the link popover without changing the document', async ({ page }) => {
+  await openNote(page, 'Roadmap-2026.md');
+  const NEEDLE = 'Quarterly targets';
+
+  await page.locator('.ProseMirror p', { hasText: NEEDLE }).first().click({ clickCount: 3 });
+  await page.locator('#tiptap-toolbar .tb-btn[data-cmd="link"]').click();
+  const input = page.locator('#tiptap-toolbar .tb-link-input');
+  await expect(input).toBeFocused();
+  await input.fill('rundock.ai');
+  await input.press('Escape');
+
+  await expect(page.locator('#tiptap-toolbar .tb-linkpop')).toBeHidden();
+  await expect(page.locator('.ProseMirror a')).toHaveCount(0);
+});

--- a/test/e2e/toolbar-block-dropdown.spec.js
+++ b/test/e2e/toolbar-block-dropdown.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+// E2E: the floating toolbar's "Text" block-type dropdown.
+//
+// Browser-driven because it exercises real selection, the menu open/close, the
+// Tiptap block transforms, and the dropdown label tracking the active block.
+const { test, expect } = require('@playwright/test');
+
+async function openNote(page, name) {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await page.locator('.nav-item[data-nav="files"]').click();
+  await page.locator('.file-item', { hasText: name }).first().click();
+  await expect(page.locator('.ProseMirror').first()).toBeVisible();
+}
+
+// Triple-click the block containing `needle` (revealing the toolbar), open the
+// dropdown, and pick a block type.
+async function transform(page, needle, cmd) {
+  await page.locator('.ProseMirror').getByText(needle, { exact: false }).first().click({ clickCount: 3 });
+  await expect(page.locator('#tiptap-toolbar.visible')).toBeVisible();
+  await page.locator('#tiptap-toolbar .tb-dd').click();
+  await expect(page.locator('#tiptap-toolbar .tb-menu.open')).toBeVisible();
+  await page.locator(`#tiptap-toolbar .tb-menu-item[data-cmd="${cmd}"]`).click();
+}
+
+test('the "Text" dropdown transforms a paragraph into lists and headings, and reflects the active block', async ({ page }) => {
+  await openNote(page, 'Roadmap-2026.md');
+  const NEEDLE = 'Quarterly targets';
+  const label = page.locator('#tiptap-toolbar .tb-dd-label');
+
+  // A paragraph reads as "Text"; the dropdown offers all seven block types.
+  await page.locator('.ProseMirror p', { hasText: NEEDLE }).first().click({ clickCount: 3 });
+  await expect(page.locator('#tiptap-toolbar.visible')).toBeVisible();
+  await expect(label).toHaveText('Text');
+  await page.locator('#tiptap-toolbar .tb-dd').click();
+  await expect(page.locator('#tiptap-toolbar .tb-menu-item')).toHaveCount(7);
+  await page.locator('#tiptap-toolbar .tb-menu-item[data-cmd="bulletList"]').click();
+  await expect(page.locator('.ProseMirror ul li')).toHaveCount(1);
+  await expect(label).toHaveText('Bullet list');
+
+  // "Text" unwraps the list back to a paragraph.
+  await transform(page, NEEDLE, 'paragraph');
+  await expect(page.locator('.ProseMirror ul')).toHaveCount(0);
+  await expect(label).toHaveText('Text');
+
+  // The checkbox path (the discoverability motivator): Text -> Checklist.
+  await transform(page, NEEDLE, 'taskList');
+  await expect(page.locator('.ProseMirror input[type="checkbox"]')).toHaveCount(1);
+  await expect(label).toHaveText('Checklist');
+
+  // And a heading, from a clean paragraph.
+  await transform(page, NEEDLE, 'paragraph');
+  await transform(page, NEEDLE, 'h2');
+  await expect(page.locator('.ProseMirror h2')).toHaveCount(1);
+  await expect(label).toHaveText('Heading 2');
+});

--- a/test/e2e/toolbar-block-dropdown.spec.js
+++ b/test/e2e/toolbar-block-dropdown.spec.js
@@ -79,6 +79,41 @@ test('a checklist item lays out the checkbox and its text on the same line (not 
   expect(box.x + box.width).toBeLessThanOrEqual(txt.x + 1);
 });
 
+test('a checklist uses the accent checkbox and greys (not strikes) checked text', async ({ page }) => {
+  await openNote(page, 'Roadmap-2026.md');
+  const NEEDLE = 'Quarterly targets';
+  await transform(page, NEEDLE, 'taskList');
+
+  const li = page.locator('.ProseMirror ul[data-type="taskList"] > li').first();
+  const checkbox = li.locator('input[type="checkbox"]');
+  const content = li.locator('> div');
+
+  // Resolve the theme tokens to rgb so we can compare computed styles against them.
+  const resolve = (v) => page.evaluate((val) => {
+    const p = document.createElement('span');
+    p.style.color = val;
+    document.body.appendChild(p);
+    const c = getComputedStyle(p).color;
+    p.remove();
+    return c;
+  }, v);
+  const accent = await resolve('var(--accent)');
+  const muted = await resolve('var(--text-2)');
+
+  // The checkbox is tinted with the accent (orange), matching the board.
+  await expect(checkbox).toHaveCSS('accent-color', accent);
+  // Unchecked text is full-strength (not the muted colour).
+  expect(await content.evaluate((el) => getComputedStyle(el).color)).not.toBe(muted);
+
+  // Tick it: the text greys out but is NOT struck through (unlike the board card).
+  // A global `* { transition: color 0.2s }` animates the colour change, so use
+  // the auto-retrying toHaveCSS to let the transition settle before asserting.
+  await checkbox.click();
+  await expect(li).toHaveAttribute('data-checked', 'true');
+  await expect(content).toHaveCSS('color', muted);
+  await expect(content).toHaveCSS('text-decoration-line', 'none');
+});
+
 test('the link button opens an in-UI popover that sets, pre-fills, and removes a link', async ({ page }) => {
   await openNote(page, 'Roadmap-2026.md');
   const NEEDLE = 'Quarterly targets';

--- a/test/e2e/toolbar-block-dropdown.spec.js
+++ b/test/e2e/toolbar-block-dropdown.spec.js
@@ -54,3 +54,27 @@ test('the "Text" dropdown transforms a paragraph into lists and headings, and re
   await expect(page.locator('.ProseMirror h2')).toHaveCount(1);
   await expect(label).toHaveText('Heading 2');
 });
+
+test('a checklist item lays out the checkbox and its text on the same line (not stacked)', async ({ page }) => {
+  await openNote(page, 'Roadmap-2026.md');
+  const NEEDLE = 'Quarterly targets';
+
+  await transform(page, NEEDLE, 'taskList');
+  // The TaskItem nodeView builds the <li> programmatically (no data-type on the
+  // li), so anchor on the taskList container instead.
+  const checkbox = page.locator('.ProseMirror ul[data-type="taskList"] > li input[type="checkbox"]');
+  const content = page.locator('.ProseMirror ul[data-type="taskList"] > li > div');
+  await expect(checkbox).toHaveCount(1);
+  await expect(content).toHaveCount(1);
+
+  const box = await checkbox.boundingBox();
+  const txt = await content.boundingBox();
+
+  // Same line: their vertical spans overlap (the text does not start below the
+  // checkbox). If the layout stacks, txt.y would sit at/after the checkbox's
+  // bottom edge and this overlap check fails.
+  const overlap = Math.min(box.y + box.height, txt.y + txt.height) - Math.max(box.y, txt.y);
+  expect(overlap).toBeGreaterThan(0);
+  // And the checkbox sits to the LEFT of the text, not above it.
+  expect(box.x + box.width).toBeLessThanOrEqual(txt.x + 1);
+});

--- a/test/e2e/toolbar-block-dropdown.spec.js
+++ b/test/e2e/toolbar-block-dropdown.spec.js
@@ -79,6 +79,38 @@ test('a checklist item lays out the checkbox and its text on the same line (not 
   expect(box.x + box.width).toBeLessThanOrEqual(txt.x + 1);
 });
 
+test('the block dropdown flips upward when there is no room below', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 600 });
+  await openNote(page, 'long-note.md');
+
+  // Scroll the editor to its foot so the final line sits low in the viewport.
+  await page.locator('.ProseMirror').first().evaluate((pm) => {
+    let el = pm;
+    while (el && el !== document.body) {
+      if (el.scrollHeight > el.clientHeight + 4 && getComputedStyle(el).overflowY !== 'visible') { el.scrollTop = el.scrollHeight; return; }
+      el = el.parentElement;
+    }
+  });
+
+  // Triple-click the last line at its real coordinates (page.mouse does not
+  // auto-scroll it back to the centre, unlike a locator click).
+  const box = await page.locator('.ProseMirror p', { hasText: 'Final line at the very bottom' }).first().boundingBox();
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { clickCount: 3 });
+  await expect(page.locator('#tiptap-toolbar.visible')).toBeVisible();
+
+  // Open the "Text" dropdown: with the toolbar near the foot of the viewport it
+  // must flip upward and stay on-screen.
+  await page.locator('#tiptap-toolbar .tb-dd').click();
+  const menu = page.locator('#tiptap-toolbar .tb-menu.open');
+  await expect(menu).toBeVisible();
+  await expect(menu).toHaveClass(/\bup\b/);
+
+  const menuBottom = await menu.evaluate((el) => el.getBoundingClientRect().bottom);
+  const ddTop = await page.locator('#tiptap-toolbar .tb-dd').evaluate((el) => el.getBoundingClientRect().top);
+  expect(menuBottom).toBeLessThanOrEqual(ddTop + 1);   // opened above the trigger
+  expect(menuBottom).toBeLessThanOrEqual(600);          // never spills past the viewport foot
+});
+
 test('a checklist uses the accent checkbox and greys (not strikes) checked text', async ({ page }) => {
   await openNote(page, 'Roadmap-2026.md');
   const NEEDLE = 'Quarterly targets';

--- a/test/e2e/workspace-switch.spec.js
+++ b/test/e2e/workspace-switch.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+// E2E: switching workspaces must close the open file.
+//
+// The intended behaviour is a fine line the fix must respect: an open file
+// persists across VIEW switches WITHIN a workspace (the "keep your place"
+// feature), but is CLOSED when you switch WORKSPACES, so the previous
+// workspace's note/board/artifact never leaks into the new one.
+const { test, expect } = require('@playwright/test');
+const { buildFixture } = require('./fixture.js');
+
+test('a view switch within a workspace keeps the open file; a workspace switch closes it', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+
+  // Open a board in workspace A.
+  await page.locator('.nav-item[data-nav="files"]').click();
+  await page.locator('.file-item', { hasText: 'board.md' }).first().click();
+  await expect(page.locator('.board-lane').first()).toBeVisible();
+  expect(await page.evaluate(() => currentFilePath)).toBe('board.md');
+
+  // A VIEW switch within the same workspace keeps the file open (keep-your-place).
+  await page.locator('.nav-item[data-nav="conversations"]').click();
+  await page.locator('.nav-item[data-nav="files"]').click();
+  expect(await page.evaluate(() => currentFilePath)).toBe('board.md');
+
+  // A WORKSPACE switch closes it: the file is torn down and nothing leaks.
+  const workspaceB = buildFixture().workspace;
+  await page.evaluate((dir) => selectWorkspace(dir), workspaceB);
+
+  await expect.poll(() => page.evaluate(() => currentFilePath)).toBeNull();
+  await expect(page.locator('.board-lane')).toHaveCount(0);
+  await expect(page.locator('.file-item.active')).toHaveCount(0);
+});

--- a/test/unit/floating-toolbar.test.js
+++ b/test/unit/floating-toolbar.test.js
@@ -4,7 +4,7 @@
 // rendered markup. The DOM menu open/close and positioning are covered by e2e.
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { renderToolbarHTML, applyCommand, activeBlockType } from '../../public/editor/panels/floating-toolbar.js';
+import { renderToolbarHTML, applyCommand, applyLink, activeBlockType } from '../../public/editor/panels/floating-toolbar.js';
 
 // A mock editor whose chain records each command call in order, so we can
 // assert exactly which Tiptap commands a toolbar action dispatches without a
@@ -53,6 +53,22 @@ describe('floating toolbar markup', () => {
     assert.doesNotMatch(renderToolbarHTML(false), /data-cmd="comment"/);
     assert.match(renderToolbarHTML(true), /data-cmd="comment"/);
   });
+
+  test('the link popover is rendered whenever a link button is present, and omitted otherwise', () => {
+    // Full toolbar carries a link mark -> in-UI popover markup is present.
+    const full = renderToolbarHTML(false);
+    assert.match(full, /class="tb-linkpop"/, 'full toolbar has the link popover');
+    assert.match(full, /class="tb-link-input"/, 'popover has an input');
+    assert.match(full, /class="tb-link-apply"/, 'popover has an apply control');
+    assert.match(full, /class="tb-link-unlink"/, 'popover has an unlink control');
+
+    // A reduced toolbar without a link button omits the popover entirely.
+    const noLink = renderToolbarHTML(false, ['bold', 'italic']);
+    assert.doesNotMatch(noLink, /class="tb-linkpop"/, 'no popover without a link button');
+
+    // A reduced toolbar that keeps the link button keeps the popover.
+    assert.match(renderToolbarHTML(false, ['bold', 'link']), /class="tb-linkpop"/);
+  });
 });
 
 describe('applyCommand dispatch', () => {
@@ -94,6 +110,49 @@ describe('applyCommand dispatch', () => {
 
   test('a null editor is a no-op', () => {
     assert.doesNotThrow(() => applyCommand(null, 'bold'));
+  });
+
+  test('link is not handled by applyCommand (it goes through the popover/applyLink)', () => {
+    const ed = mockEditor();
+    applyCommand(ed, 'link');
+    // The link case is a no-op: no link command dispatched and the chain never runs.
+    assert.ok(!ed.calls.some((c) => c.startsWith('setLink(')), 'no setLink');
+    assert.ok(!ed.calls.includes('unsetLink'), 'no unsetLink');
+    assert.ok(!ed.calls.includes('run'), 'the chain is never run');
+  });
+});
+
+describe('applyLink', () => {
+  test('sets a link, extending over the whole existing link range, and normalises a bare domain', () => {
+    const ed = mockEditor();
+    applyLink(ed, 'rundock.ai');
+    assert.ok(ed.calls.includes('extendMarkRange("link")'), 'extends the link range');
+    const setCall = ed.calls.find((c) => c.startsWith('setLink('));
+    assert.ok(setCall, 'calls setLink');
+    assert.match(setCall, /https:\/\/rundock\.ai/, 'bare domain normalised to https');
+    assert.match(setCall, /noopener noreferrer/, 'sets a safe rel');
+    assert.equal(ed.calls.at(-1), 'run');
+  });
+
+  test('leaves an explicit protocol untouched', () => {
+    const ed = mockEditor();
+    applyLink(ed, 'mailto:hi@rundock.ai');
+    const setCall = ed.calls.find((c) => c.startsWith('setLink('));
+    assert.match(setCall, /mailto:hi@rundock\.ai/);
+  });
+
+  test('an empty or whitespace URL unsets the link', () => {
+    for (const val of ['', '   ', null, undefined]) {
+      const ed = mockEditor();
+      applyLink(ed, val);
+      assert.ok(ed.calls.includes('unsetLink'), `"${val}" removes the link`);
+      assert.ok(!ed.calls.some((c) => c.startsWith('setLink(')), 'never sets a link');
+      assert.equal(ed.calls.at(-1), 'run');
+    }
+  });
+
+  test('a null editor is a no-op', () => {
+    assert.doesNotThrow(() => applyLink(null, 'rundock.ai'));
   });
 });
 

--- a/test/unit/floating-toolbar.test.js
+++ b/test/unit/floating-toolbar.test.js
@@ -1,0 +1,114 @@
+'use strict';
+// Floating toolbar pure logic: the "Text" block-type dropdown's command
+// dispatch, active-block detection (which drives the dropdown label), and the
+// rendered markup. The DOM menu open/close and positioning are covered by e2e.
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderToolbarHTML, applyCommand, activeBlockType } from '../../public/editor/panels/floating-toolbar.js';
+
+// A mock editor whose chain records each command call in order, so we can
+// assert exactly which Tiptap commands a toolbar action dispatches without a
+// real ProseMirror instance.
+function mockEditor(active = {}) {
+  const calls = [];
+  const chain = new Proxy({}, {
+    get(_t, prop) {
+      if (prop === 'run') return () => { calls.push('run'); return true; };
+      return (...args) => {
+        calls.push(args.length ? `${String(prop)}(${JSON.stringify(args[0])})` : String(prop));
+        return chain;
+      };
+    },
+  });
+  return {
+    calls,
+    chain: () => chain,
+    isActive: (name, attrs) => !!active[attrs ? `${name}:${JSON.stringify(attrs)}` : name],
+    getAttributes: () => ({}),
+  };
+}
+
+describe('floating toolbar markup', () => {
+  test('the full toolbar renders a block-type dropdown with every block type, and no inline heading buttons', () => {
+    const html = renderToolbarHTML(false);
+    assert.match(html, /class="tb-dd"/, 'has the dropdown trigger');
+    for (const cmd of ['paragraph', 'h1', 'h2', 'h3', 'bulletList', 'orderedList', 'taskList']) {
+      assert.match(html, new RegExp(`data-cmd="${cmd}"`), `dropdown menu has ${cmd}`);
+    }
+    for (const cmd of ['bold', 'italic', 'code', 'link']) {
+      assert.match(html, new RegExp(`data-cmd="${cmd}"`), `inline mark ${cmd} remains`);
+    }
+    // Headings moved into the dropdown, so no inline .tb-btn heading buttons.
+    assert.doesNotMatch(html, /class="tb-btn"[^>]*data-cmd="h1"/, 'no inline H1 button');
+  });
+
+  test('a reduced toolbar (board cards: buttonIds set) has no dropdown, only the chosen inline marks', () => {
+    const html = renderToolbarHTML(false, ['bold', 'italic', 'code', 'link']);
+    assert.doesNotMatch(html, /class="tb-dd"/, 'no dropdown on the reduced toolbar');
+    assert.doesNotMatch(html, /data-cmd="bulletList"/, 'no block types on the reduced toolbar');
+    assert.match(html, /data-cmd="bold"/);
+  });
+
+  test('the comment bar appears only when review is enabled', () => {
+    assert.doesNotMatch(renderToolbarHTML(false), /data-cmd="comment"/);
+    assert.match(renderToolbarHTML(true), /data-cmd="comment"/);
+  });
+});
+
+describe('applyCommand dispatch', () => {
+  const cases = [
+    ['bold', 'toggleBold'],
+    ['italic', 'toggleItalic'],
+    ['code', 'toggleCode'],
+    ['h1', 'toggleHeading({"level":1})'],
+    ['h2', 'toggleHeading({"level":2})'],
+    ['h3', 'toggleHeading({"level":3})'],
+    ['bulletList', 'toggleBulletList'],
+    ['orderedList', 'toggleOrderedList'],
+    ['taskList', 'toggleTaskList'],
+  ];
+  for (const [id, expected] of cases) {
+    test(`${id} dispatches ${expected} and runs`, () => {
+      const ed = mockEditor();
+      applyCommand(ed, id);
+      assert.ok(ed.calls.includes(expected), `expected ${expected} in ${JSON.stringify(ed.calls)}`);
+      assert.equal(ed.calls.at(-1), 'run', 'the chain is run');
+    });
+  }
+
+  test('paragraph on a plain block sets a paragraph', () => {
+    const ed = mockEditor();
+    applyCommand(ed, 'paragraph');
+    assert.ok(ed.calls.includes('setParagraph'));
+    assert.equal(ed.calls.at(-1), 'run');
+  });
+
+  test('paragraph inside a list unwraps that list first, then sets a paragraph', () => {
+    for (const [listName, toggle] of [['bulletList', 'toggleBulletList'], ['orderedList', 'toggleOrderedList'], ['taskList', 'toggleTaskList']]) {
+      const ed = mockEditor({ [listName]: true });
+      applyCommand(ed, 'paragraph');
+      assert.ok(ed.calls.includes(toggle), `${listName}: unwraps via ${toggle}`);
+      assert.ok(ed.calls.includes('setParagraph'), `${listName}: then sets a paragraph`);
+    }
+  });
+
+  test('a null editor is a no-op', () => {
+    assert.doesNotThrow(() => applyCommand(null, 'bold'));
+  });
+});
+
+describe('activeBlockType (drives the dropdown label)', () => {
+  test('a plain paragraph is "paragraph"', () => {
+    assert.equal(activeBlockType(mockEditor()), 'paragraph');
+  });
+  test('headings map to h1/h2/h3', () => {
+    assert.equal(activeBlockType(mockEditor({ 'heading:{"level":1}': true })), 'h1');
+    assert.equal(activeBlockType(mockEditor({ 'heading:{"level":2}': true })), 'h2');
+    assert.equal(activeBlockType(mockEditor({ 'heading:{"level":3}': true })), 'h3');
+  });
+  test('lists map to their type and take priority over the inner paragraph', () => {
+    assert.equal(activeBlockType(mockEditor({ bulletList: true })), 'bulletList');
+    assert.equal(activeBlockType(mockEditor({ orderedList: true })), 'orderedList');
+    assert.equal(activeBlockType(mockEditor({ taskList: true })), 'taskList');
+  });
+});

--- a/test/unit/kanban-new-board.test.js
+++ b/test/unit/kanban-new-board.test.js
@@ -1,0 +1,25 @@
+'use strict';
+// Rundock seeds a new Kanban board with three standard columns so "New board"
+// opens ready to use instead of blank (Obsidian's new board is frontmatter-only,
+// which in Rundock rendered as an empty, un-buildable board). The seed must be
+// byte-exact canonical form so the very first save never reformats the file.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const Kanban = require('../../public/kanban.js');
+
+describe('newBoardContent: seeded three-column board', () => {
+  test('is detected as a board file', () => {
+    assert.ok(Kanban.isBoardFile(Kanban.newBoardContent()));
+  });
+
+  test('parses to three empty standard columns', () => {
+    const board = Kanban.parse(Kanban.newBoardContent());
+    assert.deepEqual(board.lanes.map((l) => l.title), ['To Do', 'In Progress', 'Done']);
+    assert.ok(board.lanes.every((l) => l.items.length === 0), 'every column starts empty');
+  });
+
+  test('is byte-exact canonical form (first save does not reformat it)', () => {
+    const content = Kanban.newBoardContent();
+    assert.equal(Kanban.serialize(Kanban.parse(content)), content);
+  });
+});

--- a/test/unit/kanban.test.js
+++ b/test/unit/kanban.test.js
@@ -368,8 +368,9 @@ describe('lane operations (column parity byte discipline, backlog)', () => {
 });
 
 describe('board creation and detection lifecycle', () => {
-  test('newBoardContent is byte-exact to the plugin basicFrontmatter', () => {
-    assert.strictEqual(Kanban.newBoardContent(), '---\n\nkanban-plugin: board\n\n---\n\n');
+  test('newBoardContent seeds three standard columns (byte-exact spec in kanban-new-board.test.js)', () => {
+    assert.deepStrictEqual(Kanban.parse(Kanban.newBoardContent()).lanes.map((l) => l.title),
+      ['To Do', 'In Progress', 'Done']);
   });
 
   test('isBoardFile mirrors hasFrontmatterKeyRaw', () => {
@@ -379,15 +380,15 @@ describe('board creation and detection lifecycle', () => {
     assert.strictEqual(Kanban.isBoardFile('# Just markdown\n'), false);
   });
 
-  test('fresh board: zero lanes, settings hoisted from frontmatter', () => {
-    const fresh = Kanban.parse(Kanban.newBoardContent());
+  test('a frontmatter-only board parses to zero lanes with settings hoisted from frontmatter', () => {
+    const fresh = Kanban.parse('---\n\nkanban-plugin: board\n\n---\n\n');
     assert.strictEqual(fresh.lanes.length, 0);
     assert.strictEqual(fresh.dropped.length, 0);
     assert.deepStrictEqual(fresh.settings, { 'kanban-plugin': 'board' });
   });
 
   test('first save adds the settings block in the plugin first-save shape; idempotent', () => {
-    const fresh = Kanban.parse(Kanban.newBoardContent());
+    const fresh = Kanban.parse('---\n\nkanban-plugin: board\n\n---\n\n');
     Kanban.insertLane(fresh, 0, 'To do');
     const firstSave = Kanban.serialize(fresh);
     assert.strictEqual(firstSave,
@@ -422,12 +423,5 @@ describe('board creation and detection lifecycle', () => {
     Kanban.toggleItem(board, 0, 0);
     const toggled = Kanban.serialize(board);
     assert.ok(toggled.includes('tags:\n  - project\n  - kanban'), 'tags still intact after a card edit');
-  });
-
-  test('a fresh board built via newBoardContent still emits the canonical first-save shape', () => {
-    const fresh = Kanban.parse(Kanban.newBoardContent());
-    Kanban.insertLane(fresh, 0, 'To do');
-    assert.strictEqual(Kanban.serialize(fresh),
-      '---\n\nkanban-plugin: board\n\n---\n\n## To do\n\n\n\n\n\n%% kanban:settings\n```\n{"kanban-plugin":"board","list-collapse":[false]}\n```\n%%');
   });
 });


### PR DESCRIPTION
Editor and board polish for the 0.11.1 patch. Ten commits, all test-first; full suites green locally (unit 1047, e2e 82), refs hygiene clean.

## Added
- **"Text" block-type dropdown** in the formatting toolbar (headings, bullet/numbered/checklist), exposing checklists that were previously only creatable by typing `- [ ]`.

## Changed
- **In-UI link popover** replaces the OS `window.prompt` (pre-fill, Enter applies, Escape cancels, unlink).
- **New Kanban boards seed To Do / In Progress / Done** columns plus an "Add a list" affordance (no more empty dead-end board).
- **Accent checklist checkboxes** matching the board, and checked items grey (not struck through).
- **New-file name field** pre-fills a sensible default.

## Fixed
- **Workspace switch closes the open file** of any type (was leaking across workspaces); within-workspace view switches still restore it.
- **Checklist text** lays out on one line (was wrapping under the checkbox).
- **Toolbar dropdown / link popover flip upward** near the viewport foot instead of spilling past it; shadows softened, theme-aware, and no longer washing over the toolbar.

CHANGELOG `## Unreleased` updated (promotes to `0.11.1: Editor & Board Polish` on cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)