### PR TITLE
feat(files): indent guides in the file tree sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ## Unreleased
 
+### Added
+
+- **The file tree shows which folder a file belongs to:** a soft vertical line now runs down each open folder, linking everything inside it back to the folder itself, so several levels of nesting stay readable at a glance. Previously nothing connected a file to its parent, and past two or three levels you had to compare indentation by eye to work out where you were. Spacing is unchanged, so nothing shifts position.
+
 ### Fixed
 
 - **Files that differ only by type are no longer identical in search:** a report kept as a PDF, a web page and two images produced four results with the same name, the same generic icon, and nothing to tell them apart. Results now show the file type, and each type draws its own icon, the same one the file tree uses. Notes keep their clean name, since almost every file is a note and its extension never told two of them apart. How search matches is unchanged: typing a full file name including its type already worked, and still does.

--- a/public/index.html
+++ b/public/index.html
@@ -205,7 +205,12 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
 .folder-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; cursor: pointer; font-size: var(--body); font-weight: 600; color: var(--text-1); user-select: none; }
 .folder-item:hover { background: var(--elevated); }
 .folder-icon { font-size: 10px; color: var(--text-2); width: 12px; text-align: center; }
-.file-children { padding-left: 20px; }
+.file-children { padding-left: 20px; position: relative; }
+/* Indent guide: a subtle vertical line in the indent gutter, aligned under the
+   parent folder's icon, spanning the folder's children. One per nesting level
+   (cascades because each .file-children nests in its parent), so deep
+   indentation stays easy to follow. */
+.file-children::before { content: ''; position: absolute; left: 15px; top: 0; bottom: 0; width: 1px; background: var(--border); }
 .file-children.collapsed { display: none; }
 .file-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; cursor: pointer; font-size: var(--body); color: var(--text-1); }
 .file-item:hover { background: var(--elevated); }

--- a/test/e2e/file-tree-indent-guides.spec.js
+++ b/test/e2e/file-tree-indent-guides.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+// Indent guides: each expanded folder draws a subtle vertical line down its
+// children so the eye can follow deep nesting. Implemented as a ::before on the
+// `.file-children` container (one guide per level, cascading), which changes
+// nothing about the indent metrics.
+const { test, expect } = require('@playwright/test');
+
+test('the file tree draws an indent guide down each expanded folder', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await page.locator('.nav-item[data-nav="files"]').click();
+
+  // Expand a folder (the fixture has a `notes/` folder) so its children
+  // container is visible, then inspect the guide.
+  await page.locator('.folder-item', { hasText: 'notes' }).first().click();
+  const children = page.locator('.file-children:not(.collapsed)').first();
+  await expect(children).toBeVisible();
+
+  const guide = await children.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    const before = getComputedStyle(el, '::before');
+    return {
+      position: cs.position,
+      content: before.content,
+      width: before.width,
+      bg: before.backgroundColor,
+    };
+  });
+
+  expect(guide.position).toBe('relative');     // anchors the absolute guide
+  expect(guide.content).not.toBe('none');      // the ::before guide exists
+  expect(guide.width).toBe('1px');             // a thin line
+  expect(guide.bg).not.toBe('rgba(0, 0, 0, 0)'); // and it has a colour
+});


### PR DESCRIPTION
Draw a subtle vertical guide line down each expanded folder's children so deep nesting is easy to follow at a glance.

## What changed

- `public/index.html`: a `::before` on the `.file-children` container renders one guide per nesting level, cascading, aligned under the parent folder's icon. Indent metrics are unchanged.
- `test/e2e/file-tree-indent-guides.spec.js`: new e2e computed-style check covering the guide's existence, width, colour, and the `position: relative` anchor that places it.

## Verification

- `npm test`: green (1063 tests)
- `npm run test:e2e -- test/e2e/file-tree-indent-guides.spec.js`: green (1 passed)
- `npm run check:refs`: clean

## Notes

CSS-only presentation change. No behaviour change to the file tree's indent metrics, expand/collapse, or selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)