### PR TITLE
Render a number-only reply as text, not as a list marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **A reply that is only a number stays inside its message bubble:** an agent answering with just a number, such as `4471.`, was read as the opening of a numbered list. The number was then drawn as the list's marker rather than as the message itself, which put it outside the bubble, beside an empty one. A reply like that now reads as the number. Genuine numbered lists are untouched, and a list counting past ninety-nine now keeps its numbers inside the bubble too, which it did not always do before.
 - **Files that differ only by type are no longer identical in search:** a report kept as a PDF, a web page and two images produced four results with the same name, the same generic icon, and nothing to tell them apart. Results now show the file type, and each type draws its own icon, the same one the file tree uses. Notes keep their clean name, since almost every file is a note and its extension never told two of them apart. How search matches is unchanged: typing a full file name including its type already worked, and still does.
 
 ## 0.11.3: Long Sessions & Large Workspaces (2026-08-02)

--- a/public/app.js
+++ b/public/app.js
@@ -3844,6 +3844,21 @@ marked.use({
         `<button class="copy-code-btn" onclick="copyCode(this)" title="Copy code">${COPY_ICON}</button>` +
         `</div><pre><code class="hljs">${highlighted}</code></pre></div>`
       );
+    },
+    list(token) {
+      // A reply that is only a number (`4471.`) is valid ordered-list syntax,
+      // so it parses to a list whose single item is empty. The reply then
+      // exists solely as the marker, which the bubble's fixed list padding
+      // cannot contain, and it renders outside the bubble. The intent was
+      // never a list, so emit the original text instead.
+      //
+      // Decision logic lives in empty-list.js (pure, unit-tested). It returns
+      // null for anything it does not recognise, and `false` here hands the
+      // token back to marked's own renderer untouched, so every genuine list
+      // is completely unaffected.
+      const text = emptyOrderedListText(token);
+      if (text !== null) return `<p>${esc(text)}</p>\n`;
+      return false;
     }
   }
 });

--- a/public/empty-list.js
+++ b/public/empty-list.js
@@ -1,0 +1,67 @@
+'use strict';
+// Recovers the original text of an ordered list that has no content, so a
+// reply which is only a number renders as that number.
+//
+// Pure decision logic, extracted from the marked renderer so it is
+// unit-testable under node --test, following code-language.js.
+//
+// Why this exists: `4471.` is valid ordered-list syntax, so markdown parses it
+// to a list whose only item is empty. The reply then exists solely as the list
+// marker, and the message bubble's fixed list `padding-left` cannot scale to an
+// arbitrarily wide marker, so a five-character number is drawn outside the
+// bubble entirely. Markdown is behaving correctly; the intent was never a list.
+//
+// The fix is here rather than in CSS because padding cannot be made to fit
+// every marker width, and moving the marker inside the content flow would
+// change wrapping for genuine multi-line lists. A high-numbered GENUINE list
+// (`4471. real item`) is deliberately left to the padding guard: it is a real
+// list and must keep rendering as one.
+//
+// Deliberately scoped to ordered lists. A bullet marker is narrow enough that
+// it never escapes the bubble, so there is no bug to fix there, and a lone `-`
+// is more plausibly deliberate than a lone number.
+//
+// The failure that matters is the false positive: rewriting a genuine list to a
+// paragraph would silently destroy formatting. So the test is "every item is
+// empty", not "any item is empty", and anything unrecognised returns null and
+// is left exactly as it was.
+//
+// Total by design: it runs on every list the renderer sees, so junk in yields
+// null rather than taking down a whole message.
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.emptyOrderedListText = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  /**
+   * @param {object} token a marked `list` token
+   * @returns {string|null} the text to render as a paragraph, or null to leave
+   *   the list exactly as it is. Null is always the safe answer.
+   */
+  function emptyOrderedListText(token) {
+    if (!token || typeof token !== 'object') return null;
+    if (token.type !== 'list' || !token.ordered) return null;
+
+    const items = token.items;
+    if (!Array.isArray(items) || items.length === 0) return null;
+
+    // Every item, not any: a list with even one item of content is a real list.
+    // An item whose text is missing rather than empty counts as content, so an
+    // unfamiliar token shape errs towards leaving the list alone.
+    const allEmpty = items.every(
+      (item) => item && typeof item.text === 'string' && item.text.trim() === ''
+    );
+    if (!allEmpty) return null;
+
+    // `raw` is the source that produced the list, which is exactly what the
+    // user typed and therefore exactly what they should see back.
+    if (typeof token.raw !== 'string') return null;
+    // The result is a paragraph, so newlines between the bare markers collapse
+    // to spaces. This only affects input that was already degenerate; the point
+    // is that the text is not silently dropped.
+    const text = token.raw.replace(/\s*\n\s*/g, ' ').trim();
+    return text || null;
+  }
+
+  return emptyOrderedListText;
+}));

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
 <link id="hljs-light" rel="stylesheet" href="/vendor/highlight/atom-one-light.min.css" disabled>
 <script src="/vendor/highlight/highlight.min.js"></script>
 <script src="/code-language.js"></script>
+<script src="/empty-list.js"></script>
 <script src="/unread-state.js"></script>
 <script src="/markers.js"></script>
 <script src="/permissions.js"></script>
@@ -671,7 +672,16 @@ mark.find-match.current,
 .msg-bubble *:first-child { margin-top: 0; }
 .msg-bubble h1 { font-size: 17px; } .msg-bubble h2 { font-size: 15px; } .msg-bubble h3 { font-size: var(--body); font-weight: 600; } .msg-bubble h4 { font-size: var(--body); font-weight: 600; }
 .msg-bubble p { margin: 0 0 8px; } .msg-bubble p:last-child { margin-bottom: 0; }
-.msg-bubble ul,.msg-bubble ol { margin: 2px 0 8px; padding-left: 20px; }
+/* 32px, not 20px: the list marker is drawn inside this padding, so a marker
+   wider than it is drawn outside the bubble. Measured at 14px Inter, decimal
+   markers are 10.0px for "1.", 21.0px for "99.", 29.8px for "999." and 35.5px
+   for "4471.", so the old 20px was already half a pixel short of a list simply
+   counting to 99. 32px carries any list numbered into the hundreds. Beyond
+   that is left alone deliberately: a reply that is ONLY a number no longer
+   reaches here at all (see the list renderer in app.js), so what remains is a
+   genuine list with a four-digit start, which is rare enough not to be worth
+   indenting every ordinary list to accommodate. */
+.msg-bubble ul,.msg-bubble ol { margin: 2px 0 8px; padding-left: 32px; }
 .msg-bubble ul { list-style: disc; } .msg-bubble ol { list-style: decimal; }
 .msg-bubble li { margin-bottom: 2px; line-height: 1.5; }
 .msg-bubble li > p { margin: 0 0 2px; }

--- a/test/e2e/chat-number-only-reply.spec.js
+++ b/test/e2e/chat-number-only-reply.spec.js
@@ -1,0 +1,69 @@
+'use strict';
+// A reply that is only a number must read as that number, inside its bubble.
+//
+// `4471.` is valid ordered-list syntax, so markdown parsed it into a list whose
+// only item was empty. The number then existed ONLY as the list marker, and a
+// marker is drawn inside the bubble's list padding, which was too narrow for
+// it. The result was a stray `4471.` floating to the left of an otherwise empty
+// bubble.
+//
+// Browser-driven because the bug was never in the markdown, it was in where
+// real layout put the marker. The decisive assertion is textContent: a list
+// marker is NOT part of it, so if the number is present in the bubble's text
+// the reply is genuine content rather than a marker drawn outside the box.
+const { test, expect } = require('@playwright/test');
+
+test('a reply that is only a number renders as text inside the bubble', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await page.locator('.convo-item').first().click();
+  await expect(page.locator('.messages')).toBeVisible();
+
+  const r = await page.evaluate(() => {
+    const messages = document.querySelector('.messages');
+    const render = (md, id) => {
+      const msg = document.createElement('div');
+      msg.className = 'msg msg-agent';
+      msg.innerHTML = `<div class="msg-bubble" id="${id}">` + formatMd(md) + '</div>';
+      messages.appendChild(msg);
+      return document.getElementById(id);
+    };
+
+    const bare = render('4471.', '__num_bare');
+    const real = render('1. real item\n2. second item', '__num_list');
+    const bigStart = render('999. real item', '__num_big');
+
+    const ol = bigStart.querySelector('ol');
+    return {
+      // The reported bug. Before the fix these were: an <ol>, and empty text.
+      bareHasList: !!bare.querySelector('ol'),
+      bareText: bare.textContent.trim(),
+      bareWithinBubble:
+        bare.getBoundingClientRect().left >= messages.getBoundingClientRect().left - 1,
+
+      // A genuine list must be completely unaffected.
+      realHasList: !!real.querySelector('ol'),
+      realItemCount: real.querySelectorAll('li').length,
+      realFirstItem: real.querySelector('li')?.textContent.trim(),
+
+      // The padding guard: a genuine list numbered in the hundreds keeps its
+      // marker inside the bubble. 20px was under the ~29.8px "999." needs.
+      bigStartHasList: !!ol,
+      bigStartPaddingLeft: ol ? parseFloat(getComputedStyle(ol).paddingLeft) : null,
+    };
+  });
+
+  // The number is real text in the bubble, not a marker drawn beside it.
+  expect(r.bareHasList).toBe(false);
+  expect(r.bareText).toBe('4471.');
+  expect(r.bareWithinBubble).toBe(true);
+
+  // Genuine lists are untouched.
+  expect(r.realHasList).toBe(true);
+  expect(r.realItemCount).toBe(2);
+  expect(r.realFirstItem).toBe('real item');
+
+  // And a high-numbered genuine list still has room for its marker.
+  expect(r.bigStartHasList).toBe(true);
+  expect(r.bigStartPaddingLeft).toBeGreaterThanOrEqual(30);
+});

--- a/test/unit/empty-list.test.js
+++ b/test/unit/empty-list.test.js
@@ -1,0 +1,89 @@
+'use strict';
+// A reply that is only a number renders outside its message bubble.
+//
+// The cause is markdown behaving correctly. `4471.` is valid ordered-list
+// syntax, so it parses to a list whose single item has no content. The whole
+// reply then exists only as the list marker, and because the bubble sets a
+// fixed `padding-left` for lists, a five-character marker is drawn to the left
+// of the bubble entirely. Reported from a manual pass: a stray `4471.`
+// floating outside an otherwise empty bubble.
+//
+// The decision is tested here against REAL marked tokens rather than
+// hand-built ones, following code-language.test.js: the whole point is what
+// this specific parser produces, so a fabricated token would test nothing.
+//
+// The dangerous direction is the false positive. Turning a genuine list into a
+// paragraph would silently destroy formatting, so the cases that must be left
+// alone are tested at least as hard as the case being fixed.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { marked } = require('marked');
+const emptyOrderedListText = require('../../public/empty-list.js');
+
+// The first token of a source string, which for every case here is the list
+// or paragraph the whole reply consists of.
+const tok = (src) => marked.lexer(src)[0];
+
+describe('emptyOrderedListText', () => {
+  describe('the reported bug: a reply that is only a number', () => {
+    test('recovers the original text from a bare number and full stop', () => {
+      assert.strictEqual(emptyOrderedListText(tok('4471.')), '4471.');
+    });
+
+    test('handles the close-paren list delimiter markdown also accepts', () => {
+      assert.strictEqual(emptyOrderedListText(tok('4471)')), '4471)');
+    });
+
+    test('handles a single digit, not just long numbers', () => {
+      assert.strictEqual(emptyOrderedListText(tok('1.')), '1.');
+    });
+
+    test('collapses a run of bare numbers onto one line rather than dropping them', () => {
+      // Degenerate input, but it must not silently lose the text. Newlines
+      // become spaces because the result is a paragraph, not a list.
+      assert.strictEqual(emptyOrderedListText(tok('1.\n2.\n3.')), '1. 2. 3.');
+    });
+  });
+
+  describe('genuine lists must be left completely alone', () => {
+    test('a list with content is not touched', () => {
+      assert.strictEqual(emptyOrderedListText(tok('1. real item')), null);
+    });
+
+    test('a list is kept when only SOME items are empty', () => {
+      // The empty middle item is a real, if odd, list item. Rewriting the whole
+      // list to a paragraph here would destroy the two items that have content.
+      assert.strictEqual(emptyOrderedListText(tok('1. real\n2.\n3. also real')), null);
+    });
+
+    test('a high-numbered genuine list is kept, since that is the padding guard\'s job', () => {
+      assert.strictEqual(emptyOrderedListText(tok('4471. real item')), null);
+    });
+
+    test('an unordered list is never rewritten', () => {
+      // Scoped deliberately to ordered lists. A bullet marker is narrow enough
+      // that it never escapes the bubble, so there is no bug to fix, and a lone
+      // `-` is more plausibly deliberate than a lone number.
+      assert.strictEqual(emptyOrderedListText(tok('-')), null);
+    });
+  });
+
+  describe('inputs markdown already treats as prose are unreachable, and stay that way', () => {
+    // These are the false positives that would matter most. They never reach
+    // the list renderer at all, and this pins that.
+    for (const src of ['Q3 was 4471.', 'v1.', '4471. ']) {
+      test(`${JSON.stringify(src)} parses as a paragraph, not a list`, () => {
+        assert.notStrictEqual(tok(src).type, 'list');
+      });
+    }
+  });
+
+  describe('total: it runs on every list the renderer sees', () => {
+    test('returns null rather than throwing on a malformed or foreign token', () => {
+      for (const junk of [null, undefined, {}, { type: 'list' }, { type: 'list', items: null }, 'nonsense', 42]) {
+        assert.strictEqual(emptyOrderedListText(junk), null);
+      }
+    });
+  });
+});


### PR DESCRIPTION
An agent replying with only `4471.` produced a stray number to the **left** of an otherwise empty bubble.

Markdown was behaving correctly: `4471.` is valid ordered-list syntax, so it parsed to a list whose single item had no content. The reply then existed solely as the list marker, and a marker is drawn inside the list's left padding, which was far too narrow for a five-character one.

## Why the fix is at the renderer, not in CSS

Padding cannot be made to fit an arbitrary marker width, and moving the marker into the content flow would change wrapping for genuine multi-line lists. A line that is only a number and a full stop was never a list in intent, so it is emitted as the text that was typed.

The decision is a pure function in `public/empty-list.js`, extracted from the renderer so it is unit-testable, following `code-language.js`. It requires **every** item to be empty, not any, and returns `null` for anything it does not recognise, so a genuine list is never rewritten.

## A second bug found while measuring

The bubble's list padding was **already too narrow**. Measured at 14px Inter, decimal markers are 21.0px at `99.` and 29.8px at `999.`, against a 20px padding — so any list simply counting to ninety-nine was clipping. Widened to 32px.

## Testing

- 12 unit tests over the decision, against **real parser tokens** rather than hand-built ones
- 1 e2e asserting the number appears in the bubble's `textContent`, which a list marker never is, making it the sharpest available proof
- **The e2e was confirmed to fail before this change**, then restored

`1. real`, `1. real / 2. / 3. also real`, and unordered lists are all pinned as untouched. `Q3 was 4471.` and `v1.` are pinned as never reaching the list renderer at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)