### PR TITLE
Copy a code block from a note in one click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Added
 
+- **Copy a code block from a note in one click:** hovering a fenced code block while viewing or editing a file now shows a copy control in its corner, the same one chat messages have had. It copies the contents of the fence only, without the backtick markers or the language label, and confirms with a tick. Previously the only way to get a snippet out of a note was to select it by hand inside the editor.
 - **The file tree shows which folder a file belongs to:** a soft vertical line now runs down each open folder, linking everything inside it back to the folder itself, so several levels of nesting stay readable at a glance. Previously nothing connected a file to its parent, and past two or three levels you had to compare indentation by eye to work out where you were. Spacing is unchanged, so nothing shifts position.
 
 ### Fixed

--- a/public/editor/factory.js
+++ b/public/editor/factory.js
@@ -22,6 +22,7 @@ import { tableExtensions, tableDirtyKey } from './nodes/table.js';
 import { criticExtensions } from './nodes/critic-marks.js';
 import { mathExtensions } from './nodes/math.js';
 import { FindExtension } from './plugins/find.js';
+import { CodeCopyExtension } from './plugins/code-copy.js';
 
 export function createEditorInstance({ element, initialBody, onUpdate, onSelectionChange }) {
   if (!element) throw new Error('createEditorInstance: element is required');
@@ -90,6 +91,7 @@ export function createEditorInstance({ element, initialBody, onUpdate, onSelecti
       ...criticExtensions,
       ...mathExtensions,
       FindExtension,
+      CodeCopyExtension,
       Markdown.configure({
         // html:false closes the XSS surface that the prototype's regex
         // pre-processors required. Wikilink and Callout source-side parsing

--- a/public/editor/plugins/code-copy.js
+++ b/public/editor/plugins/code-copy.js
@@ -1,0 +1,126 @@
+// Copy button for code blocks in the file view editor.
+//
+// Chat messages have had a copy control on fenced code since 0.10.0
+// (copyCode in app.js); the file view editor did not, so the only way to get a
+// snippet out of a note was to select it by hand inside a contentEditable,
+// which is exactly where selection is most awkward.
+//
+// Built as a ProseMirror widget decoration rather than a NodeView. This editor
+// round-trips markdown byte-exactly and the serialiser is documented as
+// fragile, so the safe move is the one find.js already takes: decorations never
+// become document content, so save and round-trip cannot be affected by them.
+// A NodeView would have to reimplement code-block rendering and would sit
+// directly in the path this editor is most careful about.
+//
+// The copied text is the code block's own text content, which is the fence
+// contents WITHOUT the backtick markers, because the markers are markdown
+// syntax and never enter the document as text.
+import { Extension, Plugin, PluginKey, Decoration, DecorationSet } from '../../vendor/tiptap-bundle.mjs';
+
+const codeCopyPluginKey = new PluginKey('rundock-code-copy');
+
+const COPY_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+const CHECK_ICON = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
+/**
+ * Write text to the clipboard, falling back to a hidden textarea.
+ *
+ * navigator.clipboard is undefined in non-secure contexts, which includes
+ * Rundock served over plain http from a VPS. app.js carries the same fallback
+ * for the chat button; it is repeated rather than shared because this module
+ * must not reach into a global defined by a classic script.
+ */
+function writeClipboard(text, onDone) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).then(onDone).catch(() => {});
+    return;
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand('copy');
+    ta.remove();
+    onDone();
+  } catch {
+    // Copy unavailable: leave the button as it was rather than claim success.
+  }
+}
+
+function buildButton(getText) {
+  const btn = document.createElement('button');
+  btn.className = 'editor-copy-code-btn';
+  btn.type = 'button';
+  btn.title = 'Copy code';
+  btn.setAttribute('aria-label', 'Copy code');
+  // The editor is contentEditable; without this the button becomes editable
+  // content and the caret can be placed inside it.
+  btn.contentEditable = 'false';
+  btn.innerHTML = COPY_ICON;
+
+  // mousedown, not click: ProseMirror acts on mousedown to place the caret, so
+  // preventing the default here stops the click stealing focus into the block.
+  btn.addEventListener('mousedown', (e) => { e.preventDefault(); e.stopPropagation(); });
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    writeClipboard(getText(), () => {
+      btn.innerHTML = CHECK_ICON;
+      btn.classList.add('copied');
+      setTimeout(() => { btn.innerHTML = COPY_ICON; btn.classList.remove('copied'); }, 2000);
+    });
+  });
+  return btn;
+}
+
+function buildDecorations(doc) {
+  const decorations = [];
+  doc.descendants((node, pos) => {
+    if (node.type.name !== 'codeBlock') return;
+    // Captured lazily so the text read on click is the CURRENT content of the
+    // block, not whatever it held when the decoration was built.
+    const getText = () => node.textContent;
+    decorations.push(
+      Decoration.widget(pos + 1, () => buildButton(getText), {
+        // Render before the block's text so the button is the first child and
+        // the caret at position 0 still lands on the code, not after it.
+        side: -1,
+        // The widget is chrome, not content: it must never be treated as part
+        // of a selection or copied along with the code.
+        ignoreSelection: true,
+        // Keep every event on the button out of ProseMirror's handlers.
+        stopEvent: () => true,
+      })
+    );
+    // Code blocks hold only text, so there is nothing to walk into.
+    return false;
+  });
+  return DecorationSet.create(doc, decorations);
+}
+
+function codeCopyPlugin() {
+  return new Plugin({
+    key: codeCopyPluginKey,
+    state: {
+      init(_, { doc }) { return buildDecorations(doc); },
+      apply(tr, old) {
+        // Only rebuild when the document actually changed. Selection-only
+        // transactions fire constantly while typing and moving the caret.
+        return tr.docChanged ? buildDecorations(tr.doc) : old;
+      },
+    },
+    props: {
+      decorations(state) { return codeCopyPluginKey.getState(state); },
+    },
+  });
+}
+
+export const CodeCopyExtension = Extension.create({
+  name: 'rundockCodeCopy',
+  addProseMirrorPlugins() {
+    return [codeCopyPlugin()];
+  },
+});

--- a/public/index.html
+++ b/public/index.html
@@ -551,7 +551,29 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror ul[data-type="taskList"] > li[data-checked="true"] > div { color: var(--text-2); }
 .tiptap-editor .ProseMirror blockquote { border-left: 2px solid var(--border); padding-left: 16px; margin: 0 0 12px 0; color: var(--text-2); }
 .tiptap-editor .ProseMirror code { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; background: var(--card); padding: 2px 6px; border-radius: 4px; color: var(--text-1); }
-.tiptap-editor .ProseMirror pre { background: var(--card); border-radius: 8px; padding: 12px 16px; margin: 0 0 12px 0; overflow-x: auto; }
+.tiptap-editor .ProseMirror pre { background: var(--card); border-radius: 8px; padding: 12px 16px; margin: 0 0 12px 0; overflow-x: auto; position: relative; }
+/* Copy control on editor code blocks, injected as a widget decoration (see
+   editor/plugins/code-copy.js) so it never becomes document content.
+   `float: right` keeps it out of the text flow, so the first line of code is
+   not indented around it.
+   position: sticky rather than absolute. Measured: these blocks do not
+   scroll today, because ProseMirror gives code blocks white-space: pre-wrap,
+   so even a very long single-line command wraps and scrollWidth never exceeds
+   clientWidth. The `overflow-x: auto` above is therefore dormant. Sticky is
+   used anyway because it costs nothing and behaves identically when there is
+   no scrolling, while staying correct if the wrapping ever changes; absolute
+   would silently scroll the button out of view the day it does. */
+.tiptap-editor .ProseMirror pre .editor-copy-code-btn {
+  position: sticky; float: right; right: 0; top: 0; z-index: 2;
+  background: var(--card); border: none; color: var(--text-2); cursor: pointer;
+  padding: 4px; border-radius: 4px; display: flex; align-items: center;
+  justify-content: center; line-height: 0; opacity: 0;
+  transition: color 0.15s ease, opacity 0.15s ease;
+}
+.tiptap-editor .ProseMirror pre:hover .editor-copy-code-btn { opacity: 1; }
+.tiptap-editor .ProseMirror pre .editor-copy-code-btn:hover { color: var(--text-1); }
+.tiptap-editor .ProseMirror pre .editor-copy-code-btn:focus-visible { opacity: 1; outline: 2px solid var(--accent); outline-offset: 1px; }
+.tiptap-editor .ProseMirror pre .editor-copy-code-btn.copied { opacity: 1; color: var(--success); }
 .tiptap-editor .ProseMirror pre code { background: transparent; padding: 0; font-size: 13px; line-height: 1.5; }
 .tiptap-editor .ProseMirror a { color: var(--accent); text-decoration: underline; cursor: pointer; }
 .tiptap-editor .ProseMirror a.wikilink { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; padding: 0 2px; border-radius: 3px; transition: background 0.15s ease, color 0.15s ease; }

--- a/test/e2e/editor-code-copy.spec.js
+++ b/test/e2e/editor-code-copy.spec.js
@@ -1,0 +1,95 @@
+'use strict';
+// E2E: the copy control on code blocks in the file view editor.
+//
+// Chat has had one since 0.10.0; the editor did not, so getting a snippet out
+// of a note meant hand-selecting inside a contentEditable.
+//
+// Browser-driven for two reasons. The control is injected as a ProseMirror
+// widget decoration, so it only exists once a real editor has mounted and
+// rendered. And the assertion that actually matters is about SAVING: this
+// editor round-trips markdown byte-exactly, so the one way this feature could
+// do real damage is by leaking its own markup into the document. That is
+// checked here by comparing what was loaded against what would be written.
+const { test, expect } = require('@playwright/test');
+
+async function openCodeNote(page) {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await page.locator('.nav-item[data-nav="files"]').click();
+  await page.locator('.file-item', { hasText: 'code-blocks.md' }).first().click();
+  await expect(page.locator('.ProseMirror pre').first()).toBeVisible();
+}
+
+test('code blocks get a copy control, and inline code does not', async ({ page }) => {
+  await openCodeNote(page);
+
+  // Two fences in the fixture: one labelled `js`, one unlabelled. The control
+  // must not depend on a language being present.
+  await expect(page.locator('.ProseMirror pre')).toHaveCount(2);
+  await expect(page.locator('.ProseMirror pre .editor-copy-code-btn')).toHaveCount(2);
+
+  // Inline code is a mark, not a block, and must be left alone.
+  const inlineButtons = await page.evaluate(() => {
+    const inline = [...document.querySelectorAll('.ProseMirror code')]
+      .filter((c) => !c.closest('pre'));
+    return {
+      inlineCount: inline.length,
+      withButtons: inline.filter((c) => c.querySelector('.editor-copy-code-btn')).length,
+    };
+  });
+  expect(inlineButtons.inlineCount).toBeGreaterThan(0);
+  expect(inlineButtons.withButtons).toBe(0);
+});
+
+test('the control copies the fence contents, without the backtick markers', async ({ page }) => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await openCodeNote(page);
+
+  const firstPre = page.locator('.ProseMirror pre').first();
+  await firstPre.hover();
+  await firstPre.locator('.editor-copy-code-btn').click();
+
+  // The button confirms visually, which is the part a user relies on.
+  await expect(firstPre.locator('.editor-copy-code-btn.copied')).toBeVisible();
+
+  const copied = await page.evaluate(() => navigator.clipboard.readText());
+  // The fence's contents, and nothing else: no ``` markers, no language label.
+  expect(copied).toBe('const total = 4471;\nconsole.log(total);');
+  expect(copied).not.toContain('```');
+  expect(copied).not.toContain('js');
+});
+
+test('the injected control never becomes document content', async ({ page }) => {
+  await openCodeNote(page);
+
+  // rawFileContent is what was read from disk; currentLiveContent() is exactly
+  // what a save would write. If the widget had leaked into the document, the
+  // serialisation would differ from the source.
+  const r = await page.evaluate(() => ({
+    loaded: rawFileContent,
+    wouldSave: currentLiveContent(),
+  }));
+
+  expect(r.wouldSave).toBe(r.loaded);
+  expect(r.wouldSave).not.toContain('editor-copy-code-btn');
+  expect(r.wouldSave).not.toContain('<button');
+  expect(r.wouldSave).not.toContain('<svg');
+  // And the fences themselves survived intact.
+  expect(r.wouldSave).toContain('```js\nconst total = 4471;');
+});
+
+test('the control survives an edit, and still does not leak', async ({ page }) => {
+  await openCodeNote(page);
+
+  // Decorations are rebuilt on every document change. An edit is where a
+  // naive implementation duplicates or drops them.
+  await page.locator('.ProseMirror p').first().click();
+  await page.keyboard.type(' edited');
+
+  await expect(page.locator('.ProseMirror pre .editor-copy-code-btn')).toHaveCount(2);
+
+  const wouldSave = await page.evaluate(() => currentLiveContent());
+  expect(wouldSave).not.toContain('editor-copy-code-btn');
+  expect(wouldSave).toContain(' edited');
+  expect(wouldSave).toContain('```js\nconst total = 4471;');
+});

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -67,6 +67,15 @@ function buildFixture() {
   fs.writeFileSync(path.join(workspace, 'Roadmap-2026.md'),
     '# Roadmap 2026\n\nQuarterly targets and the mobile milestone.\n');
 
+  // A note with fenced code blocks, for the editor's copy control. Three
+  // fences on purpose: a labelled one, an unlabelled one (the copy control
+  // must not depend on a language), and inline code, which must NOT get a
+  // button. The exact bytes matter: the round-trip assertion compares this
+  // file before and after a save to prove the injected button never becomes
+  // document content.
+  fs.writeFileSync(path.join(workspace, 'code-blocks.md'),
+    '# Code Blocks\n\nA labelled fence:\n\n```js\nconst total = 4471;\nconsole.log(total);\n```\n\nAn unlabelled fence:\n\n```\nplain fenced content\n```\n\nInline `code` must not gain a button.\n');
+
   // A tall note that overflows the editor viewport, so the floating toolbar's
   // dropdown can be exercised near the foot of the visible area (where the menu
   // must flip to open upward rather than spilling past the bottom).


### PR DESCRIPTION
Chat messages have had a copy control on fenced code since 0.10.0; the file view editor had none, so the only way to get a snippet out of a note was to hand-select it inside a `contentEditable`, which is exactly where selection is most awkward.

## Why a decoration, not a NodeView

This editor round-trips markdown byte-exactly and its serialiser is documented as fragile. The safe route is the one `find.js` already takes: **decorations never become document content**, so save and round-trip cannot be affected by them. A NodeView would have to reimplement code-block rendering, and would sit directly in the path this editor is most careful about.

## What gets copied

The fence contents only. The backtick markers and language label are markdown syntax and never enter the document as text, so reading the block's text content yields exactly what a user wants pasted.

## Testing

Four e2e cases. The one that matters asserts **what a save would write is byte-identical to what was loaded** — the only way this feature could have done real damage. Also covered: buttons on both fences but not on inline code, correct clipboard contents, and no leak after an edit (decorations rebuild on every doc change, which is where a naive version duplicates or drops them).

Verified manually too: typed a character into a real file, saved, diffed. Only the character changed, zero button markup leaked.

## One thing measured rather than assumed

I first wrote a comment claiming the `<pre>` scrolls horizontally, justifying `position: sticky`. Then measured it: ProseMirror gives code blocks `white-space: pre-wrap`, so even a long single-line command wraps and `scrollWidth` never exceeds `clientWidth`. Sticky is kept because it is identical while there is no scrolling and stays correct if the wrapping changes, but the comment now says what is actually true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)