### PR TITLE
A right-click menu, with the OS spelling suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 ### Added
 
 - **Copy a code block from a note in one click:** hovering a fenced code block while viewing or editing a file now shows a copy control in its corner, the same one chat messages have had. It copies the contents of the fence only, without the backtick markers or the language label, and confirms with a tick. Previously the only way to get a snippet out of a note was to select it by hand inside the editor.
+- **Right-click now works wherever you type:** the desktop app had no right-click menu in the editor or the message box, so there was no Cut, Copy, Paste or Select All, and a word the spellchecker had underlined could only be fixed by retyping it. Right-clicking editable text now offers the standard editing actions, and right-clicking an underlined word offers the corrections your system suggests, plus "Add to Dictionary" for words it should stop flagging. Added words are remembered after a restart. Right-clicking a conversation or a file in the sidebar still shows the menu it always did, and only that one.
 - **The file tree shows which folder a file belongs to:** a soft vertical line now runs down each open folder, linking everything inside it back to the folder itself, so several levels of nesting stay readable at a glance. Previously nothing connected a file to its parent, and past two or three levels you had to compare indentation by eye to work out where you were. Spacing is unchanged, so nothing shifts position.
 
 ### Fixed

--- a/electron/context-menu-template.js
+++ b/electron/context-menu-template.js
@@ -1,0 +1,72 @@
+'use strict';
+// Shape of the editor's right-click menu, as a decision over Electron's
+// `context-menu` params.
+//
+// Deliberately requires nothing from electron, so it is unit-testable under
+// node --test the same way public/code-language.js and public/empty-list.js
+// are. main.js maps the descriptors returned here onto real Menu items and
+// webContents calls; that wiring is a dozen lines and this is the half with
+// edge cases.
+//
+// Why the app needs this at all: Electron does not provide Chromium's default
+// context menu. Unless the main process listens for `context-menu` and builds
+// one, right-clicking does nothing. Rundock listened for nothing, so the
+// packaged app had no spelling suggestions and, more importantly, no Cut,
+// Copy, Paste or Select All anywhere in the editor.
+//
+// The gate is `isEditable`. The renderer draws its own context menus on
+// conversation rows and file-tree rows, and a renderer calling
+// preventDefault() does NOT stop the main-process event firing. Returning null
+// for non-editable targets is what keeps two menus off the screen at once.
+// This deliberately gives up offering Copy on selected read-only text: those
+// are exactly the rows that already have their own menu.
+
+/**
+ * @param {object} params Electron's context-menu params
+ * @returns {Array<object>|null} menu descriptors, or null for no menu
+ *
+ * Descriptor shapes:
+ *   { role, enabled }                     a standard editing item
+ *   { type: 'separator' }
+ *   { label, action: { type, word } }     a spelling item main.js wires up
+ */
+function buildContextMenuTemplate(params) {
+  if (!params || typeof params !== 'object') return null;
+  if (!params.isEditable) return null;
+
+  // editFlags should always be present; default to everything disabled rather
+  // than throwing, since this runs in the main process on every right-click.
+  const flags = (params.editFlags && typeof params.editFlags === 'object') ? params.editFlags : {};
+
+  const template = [];
+
+  const misspelled = typeof params.misspelledWord === 'string' ? params.misspelledWord : '';
+  if (misspelled) {
+    const suggestions = Array.isArray(params.dictionarySuggestions) ? params.dictionarySuggestions : [];
+    // The OS orders suggestions by confidence; preserve it rather than sorting.
+    for (const word of suggestions) {
+      if (typeof word !== 'string' || !word) continue;
+      template.push({ label: word, action: { type: 'replaceMisspelling', word } });
+    }
+    // Offered even when there are no suggestions: Hunspell returns an empty
+    // list for many proper nouns, and an underline with no way to resolve it
+    // reads as a dead end.
+    template.push({
+      label: 'Add to Dictionary',
+      action: { type: 'addToDictionary', word: misspelled },
+    });
+    template.push({ type: 'separator' });
+  }
+
+  template.push(
+    { role: 'cut', enabled: !!flags.canCut },
+    { role: 'copy', enabled: !!flags.canCopy },
+    { role: 'paste', enabled: !!flags.canPaste },
+    { type: 'separator' },
+    { role: 'selectAll', enabled: !!flags.canSelectAll }
+  );
+
+  return template;
+}
+
+module.exports = buildContextMenuTemplate;

--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, Menu, nativeImage, dialog, ipcMain, shell } = requir
 const path = require('path');
 const fs = require('fs');
 const { execSync } = require('child_process');
+const buildContextMenuTemplate = require('./context-menu-template.js');
 
 let autoUpdater;
 try {
@@ -429,6 +430,42 @@ function setupAutoUpdate() {
 
 // ===== MAIN WINDOW =====
 
+// Electron does not provide Chromium's default context menu: unless the main
+// process listens for `context-menu` and builds one, right-clicking does
+// nothing at all. Without this the packaged app had no spelling suggestions
+// and, more consequentially, no Cut, Copy, Paste or Select All in the editor
+// or the chat composer.
+//
+// The menu's SHAPE is decided in context-menu-template.js, which requires
+// nothing from electron and is unit-tested. This function is only the wiring.
+//
+// The template returns null for anything that is not editable, which is what
+// keeps this menu off the conversation rows and file-tree rows that draw their
+// own. A renderer calling preventDefault() does NOT suppress this event, so
+// that gate is load-bearing rather than defensive. The chat composer is
+// editable and so is covered by the same gate, with no extra wiring.
+function attachContextMenu(webContents) {
+  webContents.on('context-menu', (event, params) => {
+    const descriptors = buildContextMenuTemplate(params);
+    if (!descriptors) return;
+
+    const template = descriptors.map((item) => {
+      if (!item.action) return item;
+      const { type, word } = item.action;
+      return {
+        label: item.label,
+        click: () => {
+          if (type === 'replaceMisspelling') webContents.replaceMisspelling(word);
+          // Learned words persist in the session's dictionary across restarts.
+          else if (type === 'addToDictionary') webContents.session.addWordToSpellCheckerDictionary(word);
+        },
+      };
+    });
+
+    Menu.buildFromTemplate(template).popup({ window: BrowserWindow.fromWebContents(webContents) });
+  });
+}
+
 function createMainWindow(port) {
   mainWindow = new BrowserWindow({
     width: 1280,
@@ -443,6 +480,8 @@ function createMainWindow(port) {
       contextIsolation: true,
     },
   });
+
+  attachContextMenu(mainWindow.webContents);
 
   const url = `http://localhost:${port}`;
   console.log(`[Electron] Loading ${url}`);

--- a/test/unit/context-menu-template.test.js
+++ b/test/unit/context-menu-template.test.js
@@ -1,0 +1,162 @@
+'use strict';
+// The editor's right-click menu, as a decision rather than as Electron wiring.
+//
+// Electron does not give an app Chromium's default context menu: unless the
+// main process listens for `context-menu` and builds one, right-clicking does
+// nothing at all. Rundock listened for nothing, so the packaged app had no
+// spelling suggestions AND no Cut / Copy / Paste / Select All anywhere.
+//
+// The shape of the menu is pure logic over the `params` Electron hands us, so
+// it lives in a module that never requires electron and is tested directly.
+// The Electron-facing half of this feature is a dozen lines of wiring; this is
+// the half that has edge cases.
+//
+// The gating case is the one that matters most. The renderer has its own
+// custom menus on conversation rows and file-tree rows. A renderer calling
+// preventDefault() does NOT stop the main-process event firing, so without a
+// gate the app would show two menus at once on those rows.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const buildContextMenuTemplate = require('../../electron/context-menu-template.js');
+
+// A realistic Electron `params` object, overridable per case.
+const params = (over = {}) => ({
+  isEditable: true,
+  misspelledWord: '',
+  dictionarySuggestions: [],
+  editFlags: { canCut: false, canCopy: false, canPaste: true, canSelectAll: true },
+  ...over,
+});
+
+const labels = (t) => (t || []).map((i) => i.label || i.role || i.type);
+const actions = (t) => (t || []).filter((i) => i.action).map((i) => i.action);
+
+describe('buildContextMenuTemplate', () => {
+  describe('gating: only editable targets get a menu', () => {
+    test('a non-editable target gets no menu at all, so renderer menus stand alone', () => {
+      // A conversation row or file-tree row. The renderer draws its own menu
+      // here; returning null is what stops the two racing.
+      assert.strictEqual(buildContextMenuTemplate(params({ isEditable: false })), null);
+    });
+
+    test('a non-editable target with a selection still gets no menu', () => {
+      // Tempting to offer Copy on selected read-only text, but that would put
+      // a second menu on top of the renderer's own on those same rows.
+      const t = buildContextMenuTemplate(params({
+        isEditable: false,
+        editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+      }));
+      assert.strictEqual(t, null);
+    });
+
+    test('an editable target always gets a menu, even with nothing selected', () => {
+      const t = buildContextMenuTemplate(params());
+      assert.ok(Array.isArray(t) && t.length > 0);
+    });
+  });
+
+  describe('the standard editing items, which the app never had', () => {
+    test('offers cut, copy, paste and select all', () => {
+      const l = labels(buildContextMenuTemplate(params()));
+      for (const role of ['cut', 'copy', 'paste', 'selectAll']) assert.ok(l.includes(role), `missing ${role}`);
+    });
+
+    test('cut and copy are disabled with no selection, paste is not', () => {
+      const t = buildContextMenuTemplate(params());
+      const by = Object.fromEntries(t.filter((i) => i.role).map((i) => [i.role, i]));
+      assert.strictEqual(by.cut.enabled, false);
+      assert.strictEqual(by.copy.enabled, false);
+      assert.strictEqual(by.paste.enabled, true);
+    });
+
+    test('cut and copy enable once there is a selection', () => {
+      const t = buildContextMenuTemplate(params({
+        editFlags: { canCut: true, canCopy: true, canPaste: true, canSelectAll: true },
+      }));
+      const by = Object.fromEntries(t.filter((i) => i.role).map((i) => [i.role, i]));
+      assert.strictEqual(by.cut.enabled, true);
+      assert.strictEqual(by.copy.enabled, true);
+    });
+
+    test('enabled state is taken from Electron, not guessed', () => {
+      // Paste depends on the clipboard, which this module cannot see.
+      const t = buildContextMenuTemplate(params({
+        editFlags: { canCut: false, canCopy: false, canPaste: false, canSelectAll: false },
+      }));
+      const by = Object.fromEntries(t.filter((i) => i.role).map((i) => [i.role, i]));
+      assert.strictEqual(by.paste.enabled, false);
+      assert.strictEqual(by.selectAll.enabled, false);
+    });
+  });
+
+  describe('spelling suggestions', () => {
+    const misspelled = () => params({
+      misspelledWord: 'teh',
+      dictionarySuggestions: ['the', 'tech', 'ten'],
+    });
+
+    test('every suggestion is offered, in the order the OS gave them', () => {
+      const l = labels(buildContextMenuTemplate(misspelled()));
+      assert.deepStrictEqual(l.slice(0, 3), ['the', 'tech', 'ten']);
+    });
+
+    test('choosing a suggestion replaces the misspelling with that word', () => {
+      const a = actions(buildContextMenuTemplate(misspelled()));
+      assert.deepStrictEqual(a[0], { type: 'replaceMisspelling', word: 'the' });
+      assert.deepStrictEqual(a[1], { type: 'replaceMisspelling', word: 'tech' });
+    });
+
+    test('offers adding the word to the dictionary', () => {
+      const a = actions(buildContextMenuTemplate(misspelled()));
+      assert.ok(a.some((x) => x.type === 'addToDictionary' && x.word === 'teh'));
+    });
+
+    test('suggestions come first, above a separator, so the fix is the nearest item', () => {
+      const l = labels(buildContextMenuTemplate(misspelled()));
+      const firstSeparator = l.indexOf('separator');
+      assert.ok(firstSeparator > 0);
+      assert.ok(l.indexOf('cut') > firstSeparator, 'editing items must sit below the separator');
+    });
+
+    test('a misspelling the OS has no suggestions for still offers the dictionary', () => {
+      // Hunspell returns an empty list for many proper nouns. Offering nothing
+      // at all would make the underline look like a dead end.
+      const t = buildContextMenuTemplate(params({ misspelledWord: 'Rundock', dictionarySuggestions: [] }));
+      const a = actions(t);
+      assert.ok(a.some((x) => x.type === 'addToDictionary' && x.word === 'Rundock'));
+      assert.ok(!a.some((x) => x.type === 'replaceMisspelling'));
+      assert.ok(labels(t).includes('cut'), 'the editing items must still be there');
+    });
+
+    test('correctly spelled text gets the editing items and nothing spelling-related', () => {
+      const t = buildContextMenuTemplate(params());
+      assert.deepStrictEqual(actions(t), []);
+      assert.ok(labels(t).includes('paste'));
+    });
+
+    test('never begins or ends with a separator', () => {
+      for (const p of [params(), misspelled()]) {
+        const l = labels(buildContextMenuTemplate(p));
+        assert.notStrictEqual(l[0], 'separator');
+        assert.notStrictEqual(l[l.length - 1], 'separator');
+      }
+    });
+  });
+
+  describe('total: it runs on every right-click in the app', () => {
+    test('malformed or partial params yield null rather than throwing', () => {
+      for (const junk of [null, undefined, {}, 'nonsense', 42, { isEditable: true }]) {
+        assert.doesNotThrow(() => buildContextMenuTemplate(junk));
+      }
+    });
+
+    test('an editable target with no editFlags still produces a usable menu', () => {
+      // Defensive: params should always carry editFlags, but a menu with
+      // everything disabled is better than a crash in the main process.
+      const t = buildContextMenuTemplate({ isEditable: true });
+      assert.ok(Array.isArray(t));
+      assert.ok(labels(t).includes('copy'));
+    });
+  });
+});


### PR DESCRIPTION
Electron does not provide Chromium's default context menu. Unless the main process listens for `context-menu` and builds one, right-clicking does **nothing at all** — and nothing in `main.js` listened.

So the packaged app had no spelling suggestions and, more consequentially, **no Cut, Copy, Paste or Select All anywhere you could type**. The spellchecker was already running and already underlining words; only the means to act on them was missing.

## The gate is load-bearing, not defensive

The renderer draws its own menus on conversation rows and file-tree rows, and **a renderer calling `preventDefault()` does not suppress the main-process event**. Without the `isEditable` gate, both menus would appear at once on those rows.

It also means the **chat composer is covered with zero extra wiring**, since it is editable like any other input. The card listed that as a "consider"; it turns out to be free.

## Small decisions

"Add to Dictionary" is offered **even when the system returns no suggestions**, which Hunspell does for many proper nouns. An underline with no way to resolve it reads as a dead end.

Enabled state comes from Electron's own `editFlags` rather than being guessed — this module cannot see the clipboard.

## Structure

The menu's shape is a pure function in `electron/context-menu-template.js` that requires nothing from electron and is unit-tested directly, following `public/code-language.js`. `main.js` keeps only the wiring. **16 cases** cover the gate, enabled state, suggestion ordering, the no-suggestions path, and separator placement.

## ⚠️ Not yet verified in the app

This is the one branch in 0.11.4 merging on tests alone. Nobody has confirmed that Electron actually fires the event, that suggestions appear, that replacement lands correctly in a `contentEditable`, or that the sidebar menus do not double.

**Windows differs materially:** it uses Hunspell with dictionaries fetched on first use, rather than the native macOS spellchecker, so its first-run behaviour needs checking on a real machine.

All of this is covered by the consolidated 0.11.4 manual test plan, which runs against the integrated build rather than this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)