### PR TITLE
Wait for idle reaping instead of sleeping a guessed duration

### DIFF
--- a/test/helpers/harness.js
+++ b/test/helpers/harness.js
@@ -175,6 +175,32 @@ async function connect() {
 // must be asserted (e.g. "no auto-resume"). Bounded and explicit.
 function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
 
+// Wait for something to BECOME true, rather than sleeping a guessed duration
+// and asserting it already has.
+//
+// Use this whenever a background timer drives the state under test. Idle
+// reaping is the motivating case: the sweep interval is floored at 1000ms
+// (REAP_SWEEP_MS in server.js) no matter how small RUNDOCK_IDLE_REAP_MS is,
+// so a test that sleeps a multiple of the idle window is racing that floor,
+// not the behaviour. That race failed CI on Node 24 while Node 22 passed the
+// same commit.
+//
+// Only for asserting a state is REACHED. To assert a state is never reached,
+// delay() is still correct: proving a negative needs real elapsed time.
+//
+// Resolves rather than throwing on timeout, so the caller's own assertion
+// reports the failure. Those assertions explain what broke and interpolate
+// live state; a generic timeout from in here would replace that with less.
+// Callers therefore assert the same predicate straight after.
+async function waitUntil(predicate, { timeout = 8000, interval = 25 } = {}) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (predicate()) return true;
+    if (Date.now() >= deadline) return false;
+    await delay(interval);
+  }
+}
+
 // Kill every process attached to a conversation entry (delegate + parked
 // parents). Test-level cleanup for scenarios that intentionally leave live
 // processes behind.
@@ -221,7 +247,7 @@ module.exports = {
   boot, shutdown, connect, writeScenario, writeCodexScenario, codexTurnPrompts,
   readInvocations, clearInvocations,
   readGrandchildren, pidAlive, waitForPidExit,
-  delay, freshConvoId, reapConvo,
+  delay, waitUntil, freshConvoId, reapConvo,
   get internal() { return internal; },
   get port() { return port; },
   get workspaceDir() { return workspaceDir; },

--- a/test/integration/process-lifecycle.test.js
+++ b/test/integration/process-lifecycle.test.js
@@ -86,7 +86,7 @@ describe('idle agent processes', () => {
     ]);
 
     await completeTurn(convoId, 'no-background-here');
-    await h.delay(REAP_MS * 5);
+    await h.waitUntil(() => !h.internal.chatProcesses.has(convoId));
 
     assert.ok(!h.internal.chatProcesses.has(convoId),
       'the background guard must apply only to conversations that actually started one');
@@ -109,8 +109,8 @@ describe('idle agent processes', () => {
     assert.strictEqual(liveEntries().length, CONVOS,
       'precondition: every completed conversation leaves a live process');
 
-    // Well past the configured idle window, with nothing working.
-    await h.delay(REAP_MS * 4);
+    // Nothing is working, so the sweep must retire at least one of them.
+    await h.waitUntil(() => liveEntries().length < CONVOS);
 
     const after = liveEntries();
     assert.ok(after.length < CONVOS,
@@ -135,7 +135,7 @@ describe('idle agent processes', () => {
     const sessionId = h.internal.chatProcesses.get(convoId)?.sessionId;
     assert.ok(sessionId, 'precondition: the first turn established a session');
 
-    await h.delay(REAP_MS * 4);
+    await h.waitUntil(() => !h.internal.chatProcesses.has(convoId));
     assert.ok(!h.internal.chatProcesses.has(convoId), 'precondition: it was reaped');
 
     // The client sends the session id back, exactly as it does after a restart.
@@ -199,7 +199,7 @@ describe('idle agent processes', () => {
     assert.ok(parked && !parked.exited,
       'precondition: delegating parks the caller alive behind the delegate');
 
-    await h.delay(REAP_MS * 4);
+    await h.waitUntil(() => parked.exited || !h.pidAlive(parked.process.pid));
 
     assert.ok(parked.exited || !h.pidAlive(parked.process.pid),
       'a parked ancestor holds its own agent process and its own set of tool servers. '


### PR DESCRIPTION
## Why

`Test (Node 24)` failed on the 0.11.4 release commit ([run 31054051661](https://github.com/liamdarmody/rundock/actions/runs/31054051661)) while **Node 22 and E2E passed the same code**. The failure was in `a conversation used again after reaping resumes with its context`, and the assertion that fired was the *precondition*, not the behaviour under test:

```
AssertionError: precondition: it was reaped
```

## Root cause

`REAP_SWEEP_MS` is floored at 1000ms regardless of how small `RUNDOCK_IDLE_REAP_MS` is:

```js
const REAP_SWEEP_MS = Math.max(1000, Math.min(IDLE_REAP_MS || 0, 60 * 1000) || 60 * 1000);
```

The tests set the idle window to **300ms** and slept `REAP_MS * 4` = **1200ms** before asserting the reap had already happened. That reads as a comfortable 4x margin, but only if you assume the sweep interval tracks the idle window. It does not. A process becomes *eligible* at 300ms and is *actually* reaped on the next sweep tick, at 1000ms. **The real margin was 200ms.**

Corroborating: the two tests that sleep `REAP_MS * 5` (a 500ms margin) have never flaked. Same arithmetic from the other side.

## What changed

Adds `waitUntil` to the harness and converts the **three sites that assert a state is REACHED**:

| Site | Was | Now |
|---|---|---|
| ordinary turn is reaped | `delay(REAP_MS * 5)` | poll until gone |
| idle processes don't accumulate | `delay(REAP_MS * 4)` | poll until count drops |
| reaped conversation resumes | `delay(REAP_MS * 4)` | poll until gone |
| parked ancestor is reaped too | `delay(REAP_MS * 4)` | poll until exited |

The race margin goes from **200ms to 7000ms**.

`waitUntil` **resolves rather than throwing** on timeout, so each test's own assertion still reports the failure. Those messages explain the user-facing consequence and interpolate live state (surviving agent IDs, counts); a generic timeout from inside the helper would replace that with less.

## What deliberately did not change

The **two sites that assert a state is NEVER reached** keep their fixed `delay`:

- `a conversation that started a background task is never reaped`
- `a process that is still working is never reaped`

Proving a negative needs real elapsed time. Polling there would be wrong.

## Verification

Full suite on **Node 24**, the version that failed: **1161 pass, 0 fail**. Plus six consecutive runs of the affected file, all green.

Worth being precise: local runs are weak evidence, since the flake never reproduced locally either. The argument for the fix is the mechanism, not the run count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)