### PR TITLE
test: run the suite on Windows by letting node expand the glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node server.js",
-    "test": "node --test $(find test -name '*.test.js')",
-    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=server.js --test-coverage-include=search.js --test-coverage-include=codex.js --test-coverage-include=codex-appserver.js --test-coverage-include=public/markers.js --test-coverage-include=public/conversation-state.js --test-coverage-include=public/permissions.js --test-coverage-include=public/conversation-list.js --test-coverage-include=public/palette-model.js --test-coverage-include=public/code-language.js --test-coverage-include=public/unread-state.js --test-coverage-include=permission-routing.js --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage.lcov $(find test -name '*.test.js') && node test/tools/coverage-areas.js coverage.lcov",
+    "test": "node --test \"test/**/*.test.js\"",
+    "test:coverage": "node --test --experimental-test-coverage --test-coverage-include=server.js --test-coverage-include=search.js --test-coverage-include=codex.js --test-coverage-include=codex-appserver.js --test-coverage-include=public/markers.js --test-coverage-include=public/conversation-state.js --test-coverage-include=public/permissions.js --test-coverage-include=public/conversation-list.js --test-coverage-include=public/palette-model.js --test-coverage-include=public/code-language.js --test-coverage-include=public/unread-state.js --test-coverage-include=permission-routing.js --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage.lcov \"test/**/*.test.js\" && node test/tools/coverage-areas.js coverage.lcov",
     "update": "git pull origin main && npm install && echo '\\n  Rundock updated. Run: npm start'",
     "electron": "electron .",
     "build:mac": "electron-builder --mac",


### PR DESCRIPTION
## Problem

`npm test` was `node --test $(find test -name '*.test.js')`. The `$(...)` subshell is POSIX syntax and npm runs scripts through `cmd.exe` on Windows, so the command failed outright there. No contributor on Windows has ever been able to run the suite, which is almost certainly why it has never been validated on the platform despite Rundock shipping there.

## Fix

Quote a glob instead, so the shell passes the pattern through untouched and node expands it itself.

## Verification

**The mechanism works on any platform.** With the quotes, the program receives a single argv entry `test/**/*.test.js`, the shell used here has globstar off, and node still collects and runs all 87 files. That is the property that makes it work under `cmd.exe`, which does no glob expansion at all.

**The file set is unchanged**, which is the thing that had to stay true: 87 files, 1161 tests, 236 suites, before and after. The `find` output and the glob expansion are byte-identical sets.

**The coverage script** carried the same construct and gets the same fix. Re-run clean, delegation engine at 89.2%.

Note that `node --test test` is NOT equivalent and was not used: it executes the helper and fixture files as though they were tests.

No CHANGELOG entry: this changes no user-facing behaviour.

## Not yet verified

Actual execution on Windows. I cannot run it locally, and CI has not run on this branch because GitHub Actions is in a major outage. The mechanism is proven; the platform run is not. Worth a manual `npm test` on a Windows machine before merge, given that platform is the whole point of the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)