### PR TITLE
fix(deps): clear the high-severity advisory in the shipped updater

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,3 +15,19 @@ I aim to acknowledge reports within 72 hours and to fix or scope a fix within tw
 In scope: Rundock itself. The desktop app, the Node.js server, the WebSocket protocol, the local API surface, and how Rundock reads, writes, and spawns from agent and skill files.
 
 Out of scope: vulnerabilities in third-party tools that Rundock invokes (Claude Code and Anthropic's API, the Codex CLI and OpenAI's API, Node.js, Electron). Report those upstream.
+
+## Accepted dependency advisories
+
+Advisories in shipped (production) dependencies that are knowingly carried, with the reason. Reviewed whenever `npm audit --omit=dev` reports something new. Anything not listed here is expected to be fixed rather than accepted.
+
+### GHSA-5p4m-2wfm-xmqj: quadratic CPU consumption in `js-yaml` `!!omap`
+
+**Status:** accepted, tracked, not fixed.
+
+`js-yaml` 4.3.0 reaches the production tree only through `electron-updater`, which declares `js-yaml: ^4.1.0`. The fix was not backported to the 4.x line and the patched release is 5.x, a major version outside that range, so no in-range fix exists. Forcing 5.x through a dependency override would put `electron-updater` on a transitive major it does not declare support for, on the exact code path that installs updates. That trade is not worth a denial-of-service advisory.
+
+**Why the impact is limited on this path:** `electron-updater` uses `js-yaml` to parse the update manifests (`latest-mac.yml`, `latest.yml`) that Rundock itself publishes to its own GitHub releases. The input is not attacker-controlled in normal operation, and the failure mode is a slow or hung update check rather than code execution.
+
+**Revisit when** `electron-updater` widens its `js-yaml` range or ships a release depending on 5.x. Re-run `npm audit --omit=dev` at that point and remove this entry.
+
+**Note, separate from the above:** the same advisory also applies to a *second*, independent copy of `js-yaml` (4.1.0) vendored inside `public/vendor/tiptap-bundle.mjs`, which parses frontmatter in files the user opens. `npm audit` cannot see that copy because it is pre-built. That exposure is different in kind and is tracked on its own backlog item, not accepted here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "rundock",
-  "version": "0.10.0",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rundock",
-      "version": "0.10.0",
+      "version": "0.11.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "electron-updater": "^6.6.0",
+        "electron-updater": "^6.8.9",
         "marked": "^17.0.5",
         "ws": "^8.18.0"
       },
@@ -1626,6 +1626,7 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2603,12 +2604,12 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
-      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "license": "MIT",
       "dependencies": {
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -2616,6 +2617,19 @@
         "lodash.isequal": "^4.5.0",
         "semver": "~7.7.3",
         "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "screenshots": "node scripts/screenshots/run.mjs"
   },
   "dependencies": {
-    "electron-updater": "^6.6.0",
+    "electron-updater": "^6.8.9",
     "marked": "^17.0.5",
     "ws": "^8.18.0"
   },


### PR DESCRIPTION
## What was there

Installing production dependencies alone reported high-severity advisories against packages that ship inside the application rather than staying on a developer machine.

The production footprint is only three direct dependencies (`electron-updater`, `marked`, `ws`), and both advisories arrived transitively through `electron-updater`. So one bump clears them.

| Package | Before | After | Advisory | Outcome |
|---|---|---|---|---|
| `builder-util-runtime` | 9.5.1 | 9.7.0 | GHSA-p2f4-r6v6-j797 | **Resolved** |
| `js-yaml` | 4.3.0 | 4.3.0 | GHSA-5p4m-2wfm-xmqj | **Accepted**, see below |

Deliberately not `npm audit fix`, which would churn development dependencies for no benefit and risk the small production footprint the project keeps on purpose.

## The accepted advisory, and why

`electron-updater` declares `js-yaml: ^4.1.0`. The fix was not backported to the 4.x line and the patched release is 5.x, a major version outside that range, so no in-range fix exists. Forcing 5.x through a dependency override would put `electron-updater` on an undeclared transitive major, on the exact code path that installs updates. That is a worse trade than carrying a denial-of-service advisory whose input is the update manifests Rundock publishes itself.

Recorded in `SECURITY.md` under a new "Accepted dependency advisories" section, with the condition for revisiting it.

## Verification

- 1161 tests, 236 suites, 0 failures
- The Electron app boots: server listening within ~2s, clean startup log through to loading the window
- `setFeedURL`, `forceDevUpdateConfig`, `allowDowngrade` and `quitAndInstall` are all present in 6.8.9; `GenericProvider` is not re-exported from the package entry point and needs a deep import

## A separate finding, not fixed here

The same `js-yaml` advisory applies to a second, independent copy: `js-yaml` 4.1.0 vendored inside `public/vendor/tiptap-bundle.mjs`, which parses frontmatter in files the user opens. `npm audit` cannot see it because it is pre-built.

Measured rather than assumed: parse time scales 3.0x, 3.8x, 4.1x per doubling of input, converging on 4x, which is quadratic as the advisory describes. 64,000 `!!omap` entries (1.1MB) takes 2.4s; extrapolated, roughly 5MB would freeze the editor for about 40 seconds. Realistic frontmatter is tens of entries and costs microseconds, so this needs a crafted file, and the impact is a hang rather than a compromise.

That is a different exposure to the one accepted above (user content rather than our own manifests), and fixing it means rebuilding the vendor bundle on a major version with the frontmatter round-trip fixtures as the gate. Tracked separately rather than folded in here.

CI has not run: GitHub Actions is in a major outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)