### PR TITLE
Make desktop update installs deterministic and legible

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const { execSync } = require('child_process');
 const buildContextMenuTemplate = require('./context-menu-template.js');
 const { resolveUpdateFeed } = require('./update-feed.js');
+const { decideUpdateUi } = require('./update-state.js');
 
 let autoUpdater;
 try {
@@ -317,6 +318,10 @@ function setupMenu() {
     }
     isCheckingManually = true;
     autoUpdater.checkForUpdates().catch((err) => {
+      // Failures normally surface through the updater's error event, which
+      // resets the flag before this rejection lands. Only report here if
+      // that event never fired, so the user gets one dialog, not two.
+      if (!isCheckingManually) return;
       isCheckingManually = false;
       dialog.showMessageBox(mainWindow, {
         type: 'error',
@@ -420,24 +425,44 @@ function setupAutoUpdate() {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
+  // Everything the user sees about an update is decided by the pure module
+  // (electron/update-state.js); this function only carries state between
+  // events and delivers the result. The renderer receives every decision on
+  // the existing channel so it can show update state in place; dialogs are
+  // shown here because they are native.
+  let updateState = { phase: 'idle', percent: null, version: null, manual: false, launchesSinceDownload: 0 };
+
+  function showUpdateUi(patch) {
+    updateState = { ...updateState, ...patch };
+    const ui = decideUpdateUi(updateState);
+    if (mainWindow) mainWindow.webContents.send('rundock-update', ui);
+    return ui;
+  }
+
   autoUpdater.on('update-available', (info) => {
-    if (mainWindow) {
-      mainWindow.webContents.send('rundock-update', { type: 'available', version: info.version });
-    }
-    if (isCheckingManually) {
-      isCheckingManually = false;
-      dialog.showMessageBox(mainWindow, {
-        type: 'info',
-        message: `Update available: ${info.version}`,
-        detail: 'Downloading in the background. Rundock will install the update on next quit.',
-        buttons: ['OK'],
-      });
-    }
+    const ui = showUpdateUi({
+      phase: 'available',
+      version: info && info.version ? info.version : null,
+      percent: null,
+      manual: isCheckingManually,
+    });
+    isCheckingManually = false;
+    updateState.manual = false;
+    if (ui.dialog) dialog.showMessageBox(mainWindow, ui.dialog);
+  });
+
+  autoUpdater.on('download-progress', (progress) => {
+    showUpdateUi({
+      phase: 'downloading',
+      percent: progress && typeof progress.percent === 'number' ? progress.percent : null,
+    });
   });
 
   autoUpdater.on('update-not-available', () => {
-    if (isCheckingManually) {
-      isCheckingManually = false;
+    const wasManual = isCheckingManually;
+    isCheckingManually = false;
+    showUpdateUi({ phase: 'idle', version: null, percent: null, manual: false });
+    if (wasManual) {
       dialog.showMessageBox(mainWindow, {
         type: 'info',
         message: 'Rundock is up to date.',
@@ -448,21 +473,21 @@ function setupAutoUpdate() {
   });
 
   autoUpdater.on('error', (err) => {
-    if (isCheckingManually) {
-      isCheckingManually = false;
-      dialog.showMessageBox(mainWindow, {
-        type: 'error',
-        message: 'Could not check for updates',
-        detail: err && err.message ? err.message : String(err),
-        buttons: ['OK'],
-      });
-    }
+    const ui = showUpdateUi({
+      phase: 'error',
+      manual: isCheckingManually,
+      error: err && err.message ? err.message : String(err),
+    });
+    isCheckingManually = false;
+    updateState.manual = false;
+    if (ui.dialog) dialog.showMessageBox(mainWindow, ui.dialog);
   });
 
-  autoUpdater.on('update-downloaded', () => {
-    if (mainWindow) {
-      mainWindow.webContents.send('rundock-update', { type: 'ready' });
-    }
+  autoUpdater.on('update-downloaded', (info) => {
+    showUpdateUi({
+      phase: 'downloaded',
+      version: info && info.version ? info.version : updateState.version,
+    });
   });
 
   // Check for updates silently on launch (don't block startup)

--- a/electron/main.js
+++ b/electron/main.js
@@ -436,6 +436,9 @@ function setupAutoUpdate() {
   const feed = resolveUpdateFeed(process.env);
   if (feed.kind === 'invalid') {
     console.warn(`[Electron] ${feed.reason}. Auto-updates disabled for this run.`);
+    // Nulling the handle disables every update path, including the menu
+    // item, which would otherwise still check against the production feed.
+    autoUpdater = null;
     return;
   }
   if (feed.kind === 'feed') {
@@ -450,11 +453,6 @@ function setupAutoUpdate() {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
-  // Everything the user sees about an update is decided by the pure module
-  // (electron/update-state.js); this function only carries state between
-  // events and delivers the result. The renderer receives every decision on
-  // the existing channel so it can show update state in place; dialogs are
-  // shown here because they are native.
   // If the previous run left an update downloaded and this run is still on
   // the old version, that install failed; count the launch so repeated
   // failures eventually switch the downloaded prompt to the escape hatch.
@@ -470,6 +468,11 @@ function setupAutoUpdate() {
     launchesSinceDownload: launch.launchesSinceDownload,
   };
 
+  // Everything the user sees about an update is decided by the pure module
+  // (electron/update-state.js); this function only carries state between
+  // events and delivers the result. The renderer receives every decision on
+  // the existing channel so it can show update state in place; dialogs are
+  // shown here because they are native.
   function showUpdateUi(patch) {
     updateState = { ...updateState, ...patch };
     const ui = decideUpdateUi(updateState);
@@ -558,8 +561,12 @@ function setupAutoUpdate() {
     }).catch(() => { /* window closed mid-dialog; the update installs on quit */ });
   }
 
-  // Check for updates silently on launch (don't block startup)
-  autoUpdater.checkForUpdatesAndNotify().catch(() => {});
+  // Check for updates silently on launch (don't block startup). Plain
+  // checkForUpdates, not checkForUpdatesAndNotify: the built-in OS
+  // notification announces that the update "will be automatically installed
+  // on exit", which is the promise this updater no longer makes. The
+  // downloaded prompt above is the announcement now.
+  autoUpdater.checkForUpdates().catch(() => {});
 }
 
 // ===== MAIN WINDOW =====

--- a/electron/main.js
+++ b/electron/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const { execSync } = require('child_process');
 const buildContextMenuTemplate = require('./context-menu-template.js');
+const { resolveUpdateFeed } = require('./update-feed.js');
 
 let autoUpdater;
 try {
@@ -395,6 +396,26 @@ let isCheckingManually = false;
 
 function setupAutoUpdate() {
   if (!autoUpdater) return;
+
+  // RUNDOCK_UPDATE_FEED points the updater at any static server hosting the
+  // artefacts electron-builder generates (see scripts/update-harness/), so
+  // the full update cycle can be exercised locally before anything ships.
+  // An unusable value disables the updater for the run rather than silently
+  // falling back to the production feed: whoever set it is testing, and a
+  // test that quietly hits the wrong feed passes for the wrong reason.
+  const feed = resolveUpdateFeed(process.env);
+  if (feed.kind === 'invalid') {
+    console.warn(`[Electron] ${feed.reason}. Auto-updates disabled for this run.`);
+    return;
+  }
+  if (feed.kind === 'feed') {
+    autoUpdater.setFeedURL({ provider: 'generic', url: feed.url });
+    // Unpacked dev builds refuse update checks unless forced, and moving
+    // back to the older test version is how the cycle repeats.
+    autoUpdater.forceDevUpdateConfig = true;
+    autoUpdater.allowDowngrade = true;
+    console.log(`[Electron] Update feed overridden: ${feed.url}`);
+  }
 
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;

--- a/electron/main.js
+++ b/electron/main.js
@@ -484,11 +484,37 @@ function setupAutoUpdate() {
   });
 
   autoUpdater.on('update-downloaded', (info) => {
-    showUpdateUi({
+    const ui = showUpdateUi({
       phase: 'downloaded',
       version: info && info.version ? info.version : updateState.version,
     });
+    presentInstallPrompt(ui);
   });
+
+  // The decided UI names its buttons and the action each one performs, so
+  // this stays a dumb translator: show the dialog, run the chosen action.
+  // "Restart now" calling quitAndInstall() directly is the core fix: the
+  // install used to depend entirely on autoInstallOnAppQuit winning a race
+  // at process exit, which it often lost. That setting remains as a
+  // fallback, but the explicit call is what makes the install deterministic.
+  function presentInstallPrompt(ui) {
+    if (ui.kind !== 'ready' && ui.kind !== 'stuck') return;
+    dialog.showMessageBox(mainWindow, {
+      type: 'info',
+      message: ui.text,
+      detail: ui.detail,
+      buttons: ui.buttons,
+      defaultId: ui.defaultId,
+      cancelId: ui.actions.indexOf('dismiss'),
+    }).then(({ response }) => {
+      const action = ui.actions[response];
+      if (action === 'quitAndInstall') {
+        autoUpdater.quitAndInstall();
+      } else if (action === 'openDownloadPage') {
+        shell.openExternal(ui.downloadUrl);
+      }
+    }).catch(() => { /* window closed mid-dialog; the update installs on quit */ });
+  }
 
   // Check for updates silently on launch (don't block startup)
   autoUpdater.checkForUpdatesAndNotify().catch(() => {});

--- a/electron/main.js
+++ b/electron/main.js
@@ -751,7 +751,8 @@ app.whenReady().then(async () => {
   }
 
   // Setup confirmed (installed + signed in): remember it so future launches
-  // skip the auth API call. The 401 recovery card covers later expiry.
+  // skip the auth API call. Sign-in expiry after this point is handled
+  // separately, when a later request fails authentication.
   try { fs.writeFileSync(setupMarker, new Date().toISOString()); } catch { /* non-fatal */ }
 
   // Start the embedded server on an OS-assigned port

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,6 +5,7 @@ const { execSync } = require('child_process');
 const buildContextMenuTemplate = require('./context-menu-template.js');
 const { resolveUpdateFeed } = require('./update-feed.js');
 const { decideUpdateUi } = require('./update-state.js');
+const { reconcileOnLaunch, recordDownloaded } = require('./update-launches.js');
 
 let autoUpdater;
 try {
@@ -399,6 +400,30 @@ function setupMenu() {
 // pops a dialog unprompted.
 let isCheckingManually = false;
 
+// How many times the app has launched with an update downloaded but not yet
+// installed (see electron/update-launches.js for the counting rules). The
+// record survives restarts in userData; reading or writing it is
+// best-effort, because losing the count only delays the escape-hatch
+// message, while crashing here would break updates entirely.
+function launchRecordPath() {
+  return path.join(app.getPath('userData'), 'update-launches.json');
+}
+
+function readLaunchRecord() {
+  try {
+    return JSON.parse(fs.readFileSync(launchRecordPath(), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function writeLaunchRecord(record) {
+  try {
+    if (record) fs.writeFileSync(launchRecordPath(), JSON.stringify(record));
+    else fs.rmSync(launchRecordPath(), { force: true });
+  } catch { /* best-effort, see above */ }
+}
+
 function setupAutoUpdate() {
   if (!autoUpdater) return;
 
@@ -430,7 +455,20 @@ function setupAutoUpdate() {
   // events and delivers the result. The renderer receives every decision on
   // the existing channel so it can show update state in place; dialogs are
   // shown here because they are native.
-  let updateState = { phase: 'idle', percent: null, version: null, manual: false, launchesSinceDownload: 0 };
+  // If the previous run left an update downloaded and this run is still on
+  // the old version, that install failed; count the launch so repeated
+  // failures eventually switch the downloaded prompt to the escape hatch.
+  const launch = reconcileOnLaunch({ currentVersion: app.getVersion(), stored: readLaunchRecord() });
+  writeLaunchRecord(launch.record);
+  let pendingRecord = launch.record;
+
+  let updateState = {
+    phase: 'idle',
+    percent: null,
+    version: null,
+    manual: false,
+    launchesSinceDownload: launch.launchesSinceDownload,
+  };
 
   function showUpdateUi(patch) {
     updateState = { ...updateState, ...patch };
@@ -484,10 +522,14 @@ function setupAutoUpdate() {
   });
 
   autoUpdater.on('update-downloaded', (info) => {
-    const ui = showUpdateUi({
-      phase: 'downloaded',
-      version: info && info.version ? info.version : updateState.version,
-    });
+    const version = info && info.version ? info.version : updateState.version;
+    let launchesSinceDownload = updateState.launchesSinceDownload;
+    if (version) {
+      pendingRecord = recordDownloaded(version, pendingRecord);
+      writeLaunchRecord(pendingRecord);
+      launchesSinceDownload = pendingRecord.launches;
+    }
+    const ui = showUpdateUi({ phase: 'downloaded', version, launchesSinceDownload });
     presentInstallPrompt(ui);
   });
 

--- a/electron/update-feed.js
+++ b/electron/update-feed.js
@@ -1,0 +1,45 @@
+// Update feed override. Pure: no Electron, no I/O.
+//
+// RUNDOCK_UPDATE_FEED points the updater at any static server that hosts the
+// artefacts electron-builder generates (see scripts/update-harness/). That
+// lets the whole update cycle run against a local feed instead of a published
+// release, which is the only way to verify updater changes before shipping
+// them through the very mechanism under repair.
+//
+// The one rule: a value that is set but unusable is reported as invalid,
+// never silently ignored. Whoever sets the override believes their updates
+// are coming from their own feed. Falling back to the production feed on a
+// typo would make their test pass against the wrong thing.
+
+'use strict';
+
+const ENV_VAR = 'RUNDOCK_UPDATE_FEED';
+
+/**
+ * Read the update feed override from an environment object.
+ *
+ * @param {object|undefined} env  typically process.env
+ * @returns {{ kind: 'none' } | { kind: 'feed', url: string } | { kind: 'invalid', reason: string }}
+ */
+function resolveUpdateFeed(env) {
+  const raw = env && typeof env[ENV_VAR] === 'string' ? env[ENV_VAR].trim() : '';
+  if (!raw) return { kind: 'none' };
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { kind: 'invalid', reason: `${ENV_VAR} is not a URL: "${raw}"` };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return {
+      kind: 'invalid',
+      reason: `${ENV_VAR} must be an http or https URL, got "${raw}"`,
+    };
+  }
+
+  return { kind: 'feed', url: raw };
+}
+
+module.exports = { resolveUpdateFeed, ENV_VAR };

--- a/electron/update-launches.js
+++ b/electron/update-launches.js
@@ -1,0 +1,66 @@
+// Pending-update launch counting. Pure: no Electron, no I/O.
+//
+// When an update downloads but fails to install, every subsequent app launch
+// is evidence of that failure. electron/update-state.js switches to an
+// escape-hatch message once the count is high enough; this module owns the
+// counting itself. Reading and writing the record to disk stays in
+// electron/main.js with the rest of the wiring.
+//
+// The record is { downloadedVersion, launches }: which version is sitting
+// downloaded-but-unapplied, and how many times the app has started since.
+
+'use strict';
+
+/**
+ * Called once per app launch with whatever record the previous run left.
+ *
+ * @param {object} args
+ * @param {string} args.currentVersion  the version actually running
+ * @param {*} args.stored  the persisted record, or null/garbage
+ * @returns {{ record: object|null, launchesSinceDownload: number }}
+ *   record is what should be persisted for the next launch (null clears it);
+ *   launchesSinceDownload feeds decideUpdateUi.
+ */
+function reconcileOnLaunch({ currentVersion, stored }) {
+  const none = { record: null, launchesSinceDownload: 0 };
+
+  if (!stored || typeof stored !== 'object') return none;
+  if (typeof stored.downloadedVersion !== 'string' || !stored.downloadedVersion) return none;
+
+  // Running the version that was pending means the install worked. Clear
+  // the record, or a once-stuck user would be told the updater is broken
+  // forever, on every version after the one that failed.
+  if (stored.downloadedVersion === currentVersion) return none;
+
+  const previous = typeof stored.launches === 'number' && Number.isFinite(stored.launches)
+    ? Math.max(0, Math.floor(stored.launches))
+    : 0;
+  const launches = previous + 1;
+
+  return {
+    record: { downloadedVersion: stored.downloadedVersion, launches },
+    launchesSinceDownload: launches,
+  };
+}
+
+/**
+ * Called when a download completes.
+ *
+ * A stuck install downloads the same update again on every launch, so a
+ * completed download of the version already pending must keep the existing
+ * count; resetting it would make the escape-hatch threshold unreachable by
+ * exactly the users who need it. A different version starts a fresh count:
+ * a newer download deserves a fresh chance before being called stuck.
+ */
+function recordDownloaded(version, existing) {
+  if (
+    existing && typeof existing === 'object' &&
+    existing.downloadedVersion === version &&
+    typeof existing.launches === 'number' && Number.isFinite(existing.launches)
+  ) {
+    return { downloadedVersion: version, launches: Math.max(0, Math.floor(existing.launches)) };
+  }
+  return { downloadedVersion: version, launches: 0 };
+}
+
+module.exports = { reconcileOnLaunch, recordDownloaded };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
       "scaffold/**/*",
       "scripts/**/*",
       "!scripts/screenshots/**",
+      "!scripts/update-harness/**",
       "node_modules/**/*",
       "electron/**/*",
       "package.json"

--- a/scripts/update-harness/build.mjs
+++ b/scripts/update-harness/build.mjs
@@ -28,10 +28,11 @@ const FEED = join(HERE, 'feed');
 const DIST = join(ROOT, 'dist');
 
 function parseArgs(argv) {
-  const out = { version: null, platform: process.platform === 'win32' ? 'win' : 'mac', clean: false };
+  const out = { version: null, platform: process.platform === 'win32' ? 'win' : 'mac', clean: false, out: null };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--version' && argv[i + 1]) out.version = argv[++i];
     else if (argv[i] === '--platform' && argv[i + 1]) out.platform = argv[++i];
+    else if (argv[i] === '--out' && argv[i + 1]) out.out = argv[++i];
     else if (argv[i] === '--clean') out.clean = true;
   }
   return out;
@@ -45,7 +46,16 @@ const WANTED = {
   win: (f) => f === 'latest.yml' || (f.endsWith('.exe') || f.endsWith('.exe.blockmap')),
 };
 
-const { version, platform, clean } = parseArgs(process.argv.slice(2));
+const { version, platform, clean, out } = parseArgs(process.argv.slice(2));
+
+// --out redirects electron-builder's output. Needed when the repo lives in a
+// folder managed by a sync service (iCloud Drive, Dropbox, OneDrive): those
+// re-stamp Finder and file-provider metadata onto freshly written bundles
+// while the build is still running, and codesign then rejects the app with
+// "resource fork, Finder information, or similar detritus not allowed".
+// Building into an unmanaged location (for example under /tmp) avoids the
+// race entirely.
+const outDir = out ? resolve(out) : DIST;
 
 if (clean) {
   if (existsSync(FEED)) rmSync(FEED, { recursive: true, force: true });
@@ -54,7 +64,7 @@ if (clean) {
 }
 
 if (!version) {
-  console.error('Usage: node scripts/update-harness/build.mjs --version <version> [--platform mac|win]');
+  console.error('Usage: node scripts/update-harness/build.mjs --version <version> [--platform mac|win] [--out <dir>]');
   console.error('       node scripts/update-harness/build.mjs --clean');
   process.exit(1);
 }
@@ -85,7 +95,9 @@ writeFileSync(PKG, JSON.stringify(pkg, null, 2) + '\n');
 
 // --publish never: the whole point is that nothing leaves this machine.
 const target = platform === 'mac' ? '--mac' : '--win';
-execFileSync('npx', ['electron-builder', target, '--publish', 'never'], {
+const builderArgs = ['electron-builder', target, '--publish', 'never'];
+if (outDir !== DIST) builderArgs.push(`--config.directories.output=${outDir}`);
+execFileSync('npx', builderArgs, {
   cwd: ROOT,
   stdio: 'inherit',
 });
@@ -93,15 +105,15 @@ execFileSync('npx', ['electron-builder', target, '--publish', 'never'], {
 mkdirSync(FEED, { recursive: true });
 const keep = WANTED[platform];
 let copied = 0;
-for (const f of readdirSync(DIST)) {
+for (const f of readdirSync(outDir)) {
   if (!keep(f)) continue;
-  copyFileSync(join(DIST, f), join(FEED, f));
+  copyFileSync(join(outDir, f), join(FEED, f));
   console.log(`  -> feed/${f}`);
   copied++;
 }
 
 if (copied === 0) {
-  console.error(`\nNothing matched in ${DIST}. Did the build actually produce artefacts?`);
+  console.error(`\nNothing matched in ${outDir}. Did the build actually produce artefacts?`);
   process.exit(1);
 }
 

--- a/test/unit/update-feed.test.js
+++ b/test/unit/update-feed.test.js
@@ -1,0 +1,79 @@
+// Tests for the update feed override (electron/update-feed.js).
+//
+// The updater can be pointed at a locally served feed through the
+// RUNDOCK_UPDATE_FEED environment variable, so the whole update cycle can be
+// exercised against scripts/update-harness/ without publishing anything.
+//
+// The property these tests defend: a value that is set but unusable is
+// reported as invalid, never silently ignored. Someone who sets the override
+// believes they are testing against their own feed. If a typo made the app
+// fall back to the production feed, their test would pass against the wrong
+// updates, which is worse than no test at all.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { resolveUpdateFeed } = require('../../electron/update-feed.js');
+
+describe('no override set', () => {
+  test('an absent variable means no override', () => {
+    assert.deepStrictEqual(resolveUpdateFeed({}), { kind: 'none' });
+  });
+
+  test('an empty string means no override', () => {
+    assert.deepStrictEqual(resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: '' }), { kind: 'none' });
+  });
+
+  test('whitespace only means no override', () => {
+    assert.deepStrictEqual(resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: '   ' }), { kind: 'none' });
+  });
+
+  test('a missing env object means no override', () => {
+    assert.deepStrictEqual(resolveUpdateFeed(undefined), { kind: 'none' });
+  });
+});
+
+describe('a usable override', () => {
+  test('an http URL is accepted', () => {
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: 'http://localhost:8384' });
+    assert.strictEqual(feed.kind, 'feed');
+    assert.strictEqual(feed.url, 'http://localhost:8384');
+  });
+
+  test('an https URL is accepted', () => {
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: 'https://feeds.example.com/rundock' });
+    assert.strictEqual(feed.kind, 'feed');
+    assert.strictEqual(feed.url, 'https://feeds.example.com/rundock');
+  });
+
+  test('surrounding whitespace is trimmed', () => {
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: '  http://localhost:8384  ' });
+    assert.strictEqual(feed.kind, 'feed');
+    assert.strictEqual(feed.url, 'http://localhost:8384');
+  });
+});
+
+describe('an unusable override is invalid, never ignored', () => {
+  test('a non-URL value is invalid', () => {
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: 'not a url' });
+    assert.strictEqual(feed.kind, 'invalid');
+    assert.ok(feed.reason.length > 0);
+  });
+
+  test('a non-http scheme is invalid', () => {
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: 'ftp://localhost:8384' });
+    assert.strictEqual(feed.kind, 'invalid');
+  });
+
+  test('a host without a scheme is invalid', () => {
+    // The URL parser reads "localhost:8384" as scheme "localhost:", so this
+    // must be rejected explicitly rather than accidentally accepted.
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: 'localhost:8384' });
+    assert.strictEqual(feed.kind, 'invalid');
+  });
+
+  test('the invalid result echoes the value so the typo is findable', () => {
+    const feed = resolveUpdateFeed({ RUNDOCK_UPDATE_FEED: 'htp://localhost:8384' });
+    assert.strictEqual(feed.kind, 'invalid');
+    assert.ok(feed.reason.includes('htp://localhost:8384'));
+  });
+});

--- a/test/unit/update-launches.test.js
+++ b/test/unit/update-launches.test.js
@@ -1,0 +1,106 @@
+// Tests for the pending-update launch counter (electron/update-launches.js).
+//
+// When an update downloads but does not install, each subsequent launch is
+// evidence the install is failing. After enough of them the app stops
+// pretending the next restart will work and offers a direct download instead
+// (see electron/update-state.js). This module owns the counting; these tests
+// pin down what counts as "another launch with the update still pending".
+//
+// The property that matters most: the counter must reset the moment an
+// update actually applies, or a user whose install once got stuck would see
+// the failure message forever, on every version, for the rest of time.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { reconcileOnLaunch, recordDownloaded } = require('../../electron/update-launches.js');
+
+describe('nothing pending', () => {
+  test('no stored record means zero launches pending', () => {
+    assert.deepStrictEqual(
+      reconcileOnLaunch({ currentVersion: '0.11.5', stored: null }),
+      { record: null, launchesSinceDownload: 0 }
+    );
+  });
+
+  test('a malformed record is discarded, not counted', () => {
+    assert.deepStrictEqual(
+      reconcileOnLaunch({ currentVersion: '0.11.5', stored: { junk: true } }),
+      { record: null, launchesSinceDownload: 0 }
+    );
+  });
+
+  test('a record that is not an object is discarded', () => {
+    assert.deepStrictEqual(
+      reconcileOnLaunch({ currentVersion: '0.11.5', stored: 'corrupt' }),
+      { record: null, launchesSinceDownload: 0 }
+    );
+  });
+});
+
+describe('the update applied', () => {
+  test('running the downloaded version clears the record', () => {
+    const out = reconcileOnLaunch({
+      currentVersion: '0.11.6',
+      stored: { downloadedVersion: '0.11.6', launches: 2 },
+    });
+    assert.deepStrictEqual(out, { record: null, launchesSinceDownload: 0 });
+  });
+});
+
+describe('the update is still pending', () => {
+  test('each launch on the old version increments the count', () => {
+    const out = reconcileOnLaunch({
+      currentVersion: '0.11.5',
+      stored: { downloadedVersion: '0.11.6', launches: 1 },
+    });
+    assert.deepStrictEqual(out, {
+      record: { downloadedVersion: '0.11.6', launches: 2 },
+      launchesSinceDownload: 2,
+    });
+  });
+
+  test('a record with a corrupt count restarts from one', () => {
+    const out = reconcileOnLaunch({
+      currentVersion: '0.11.5',
+      stored: { downloadedVersion: '0.11.6', launches: 'many' },
+    });
+    assert.deepStrictEqual(out, {
+      record: { downloadedVersion: '0.11.6', launches: 1 },
+      launchesSinceDownload: 1,
+    });
+  });
+});
+
+describe('a fresh download', () => {
+  test('starts the count at zero for that version', () => {
+    assert.deepStrictEqual(recordDownloaded('0.11.6'), {
+      downloadedVersion: '0.11.6',
+      launches: 0,
+    });
+  });
+
+  test('re-downloading the same pending version keeps the count', () => {
+    // A stuck install downloads the same update again on every launch. If
+    // that reset the count, the count could never reach the threshold and
+    // the escape hatch would be unreachable by exactly the users who need
+    // it.
+    const out = recordDownloaded('0.11.6', { downloadedVersion: '0.11.6', launches: 2 });
+    assert.deepStrictEqual(out, { downloadedVersion: '0.11.6', launches: 2 });
+  });
+
+  test('a different pending version starts over', () => {
+    const out = recordDownloaded('0.11.7', { downloadedVersion: '0.11.6', launches: 2 });
+    assert.deepStrictEqual(out, { downloadedVersion: '0.11.7', launches: 0 });
+  });
+
+  test('a newer download replaces the count, not extends it', () => {
+    // 0.11.6 got stuck at 3 launches, then 0.11.7 downloads. The new
+    // version deserves a fresh chance before being called stuck.
+    const afterNewDownload = recordDownloaded('0.11.7');
+    const out = reconcileOnLaunch({ currentVersion: '0.11.5', stored: afterNewDownload });
+    assert.deepStrictEqual(out, {
+      record: { downloadedVersion: '0.11.7', launches: 1 },
+      launchesSinceDownload: 1,
+    });
+  });
+});


### PR DESCRIPTION
## What this changes

The desktop updater downloaded updates reliably but installed them unreliably, and said nothing while either was happening. This wires the already-merged decision logic (`electron/update-state.js`) into the app:

- **A Restart now / Later prompt when an update has downloaded.** Restart now calls `quitAndInstall()` explicitly instead of relying on `autoInstallOnAppQuit` winning a race at process exit, which it often lost with the embedded server and CLI child processes still attached. The fallback setting remains for users who choose Later and simply quit.
- **Download progress is handled for the first time.** Every progress event reaches the renderer channel, so a 200MB download is no longer minutes of silence. Nothing in the UI subscribes yet; the visible surface lands separately.
- **No more broken promises.** The update-available dialog and the built-in OS notification both claimed the update would install on next quit, which was frequently untrue. The dialog copy now describes only what is happening, and the startup check uses `checkForUpdates` rather than `checkForUpdatesAndNotify`.
- **An escape hatch when installs keep failing.** The app counts launches that start with an update still pending (persisted in userData, cleared the moment the downloaded version actually runs). After three, the prompt stops claiming a restart will work, says the update has not installed, and offers a direct download link.
- **A local feed override for testing.** `RUNDOCK_UPDATE_FEED` points the updater at any static server hosting the artefacts electron-builder generates (see `scripts/update-harness/`), so the whole update cycle can be exercised locally before anything ships. An unusable value disables updates for the run rather than silently falling back to the production feed.

## Testing

- Launch counting and feed parsing are pure modules with unit tests (21 new; full suite 1217 passing).
- The end-to-end cycle against the local feed (install one version, watch it update to the next) has not been run yet and is the next step. This PR does not claim the production install path is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
