### PR TITLE
Repair the screenshot pipeline and bring its map back in line with reality

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/liamdarmody/Documents/Projects/Rundock/node_modules

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -45,7 +45,7 @@ not expect a clean git diff to tell you whether a GIF actually changed.
 6. **Motion**: record five scripted interactions and convert each to an optimized,
    palette-based looping GIF.
 7. Write **`MANIFEST.md`** mapping every asset to its intended target repo, path,
-   feature, theme, and rationale, and copy in the content and copy gap analysis.
+   feature, theme, and rationale.
 
 ## Prerequisites
 

--- a/scripts/screenshots/README.md
+++ b/scripts/screenshots/README.md
@@ -77,8 +77,9 @@ not expect a clean git diff to tell you whether a GIF actually changed.
 - `frame.mjs` + `frame.html` the framing wrapper and per-target derivations.
 - `motion.mjs` the five clips and ffmpeg conversion.
 - `run.mjs` the orchestrator behind `npm run screenshots`.
-- `content-and-copy-gaps.md` the release content and copy gap analysis (a
-  proposal; copied into the output folder each run).
+- `content-and-copy-gaps.md` the release content and copy gap analysis. Written
+  against an earlier release and NOT copied into the output folder: check the
+  release stated at the top of it before relying on its reasoning.
 
 ## Phase 2 (not built yet)
 

--- a/scripts/screenshots/capture.mjs
+++ b/scripts/screenshots/capture.mjs
@@ -138,7 +138,11 @@ export const SHOTS = [
     async setup(page) {
       await page.evaluate(() => switchNav('team'));
       await page.waitForTimeout(200);
-      await page.evaluate(() => { if (typeof openPalette === 'function') openPalette(); });
+      // Click the search control in the top bar rather than calling the
+      // function behind it. Search expands in place from that control, so
+      // driving it any other way photographs a state the product does not
+      // actually produce.
+      await page.click('#tb-search');
       await page.waitForSelector('#palette-input', { state: 'visible', timeout: 8000 });
       await page.fill('#palette-input', 'launch');
       await page.waitForTimeout(600);

--- a/scripts/screenshots/content-and-copy-gaps.md
+++ b/scripts/screenshots/content-and-copy-gaps.md
@@ -1,5 +1,14 @@
 # Content and Copy Gap Analysis
 
+> **Written against release 0.10.0, with 0.11.0 then unreleased. Not maintained since.**
+>
+> This document reasons throughout from the feature set of that release, so
+> every gap it identifies and every placement it proposes should be re-checked
+> against the current CHANGELOG before being acted on. It is kept as a record
+> of the analysis, not as current advice. It is deliberately no longer copied
+> into `screenshots-out/`, because sitting beside freshly generated assets made
+> it read as current.
+
 - **Date / release context:** `package.json` reads version 0.10.0 (Search, Review & Codex, shipped 2026-07-14). The "Files, Boards & Streaming" body sits in `## Unreleased` in `Rundock/CHANGELOG.md`, staged as the imminent 0.11.0. Public site and docs imagery and feature copy date from late April (all five screenshots in `Rundock Site/images/` and the site root are stamped 29 Apr; the site feature sections have not changed since). Everything shipped from 0.10.0 onward, and the whole Unreleased block, is effectively uncommunicated.
 
 - **Method:** I read the full `Rundock/CHANGELOG.md` (Unreleased + 0.10.0 in detail, earlier entries for the feature inventory), the marketing site (`Rundock Site/index.html` in full, plus `llms.txt`, `compare.html`), and the docs site (`rundock-docs/`: `docs.json` navigation, `introduction.mdx`, all of `concepts/`, `first-run.mdx`, `reference/workspace-structure.mdx`). For each shipped capability I checked whether the behaviour is described anywhere on the Site and in the Docs, then located the exact file and section where it belongs. The Site is static HTML (hand-authored `index.html`, feature sections are `<section class="feature-section">` blocks around lines 1568-1657). The Docs are Mintlify MDX, navigation defined in `docs.json`.

--- a/scripts/screenshots/motion.mjs
+++ b/scripts/screenshots/motion.mjs
@@ -178,7 +178,16 @@ async function clipSearch(page, { mark }) {
   await page.waitForTimeout(400);
   await installCursor(page);
   mark();
-  await page.evaluate(() => { if (typeof openPalette === 'function') openPalette(); });
+  // Drive the control a user drives. Search expands in place from the field in
+  // the top bar, and this clip exists to show that behaviour, so calling the
+  // function behind the control would demonstrate the wrong thing.
+  const field = await page.$('#tb-search');
+  const box = field && await field.boundingBox();
+  if (box) {
+    await cursorTo(page, box.x + Math.min(120, box.width / 2), box.y + box.height / 2, 620);
+    await page.waitForTimeout(320);
+  }
+  await page.click('#tb-search');
   await page.waitForSelector('#palette-input', { state: 'visible', timeout: 8000 });
   await page.waitForTimeout(400);
   await page.type('#palette-input', 'launch', { delay: 150 });

--- a/scripts/screenshots/motion.mjs
+++ b/scripts/screenshots/motion.mjs
@@ -184,8 +184,13 @@ async function clipSearch(page, { mark }) {
   const field = await page.$('#tb-search');
   const box = field && await field.boundingBox();
   if (box) {
-    await cursorTo(page, box.x + Math.min(120, box.width / 2), box.y + box.height / 2, 620);
-    await page.waitForTimeout(320);
+    // cursorTo starts a CSS transition and returns immediately, so the wait
+    // has to EXCEED the travel time. Waiting less clicks while the cursor is
+    // still moving, and the panel then opens with the pointer nowhere near the
+    // control, which is the opposite of what this clip is for.
+    const TRAVEL_MS = 620;
+    await cursorTo(page, box.x + Math.min(120, box.width / 2), box.y + box.height / 2, TRAVEL_MS);
+    await page.waitForTimeout(TRAVEL_MS + 260);
   }
   await page.click('#tb-search');
   await page.waitForSelector('#palette-input', { state: 'visible', timeout: 8000 });

--- a/scripts/screenshots/placement-plan.md
+++ b/scripts/screenshots/placement-plan.md
@@ -1,5 +1,14 @@
 # Screenshot placement plan (Site, README, Docs)
 
+> **Written against release 0.10.0, with 0.11.0 then unreleased. Not maintained since.**
+>
+> This document reasons throughout from the feature set of that release, so
+> every gap it identifies and every placement it proposes should be re-checked
+> against the current CHANGELOG before being acted on. It is kept as a record
+> of the analysis, not as current advice. It is deliberately no longer copied
+> into `screenshots-out/`, because sitting beside freshly generated assets made
+> it read as current.
+
 A curated proposal for where the generated assets should go and why. The
 pipeline produces more than any surface needs on purpose; this plan uses fewer,
 better images, each earning its place, and pairs them with copy where a feature

--- a/scripts/screenshots/run.mjs
+++ b/scripts/screenshots/run.mjs
@@ -196,8 +196,13 @@ async function main() {
     }
 
     // 6. Gap analysis + MANIFEST.
-    log('[6/6] Writing gap analysis and MANIFEST...');
-    if (fs.existsSync(GAPS_SRC)) fs.copyFileSync(GAPS_SRC, path.join(OUT, 'content-and-copy-gaps.md'));
+    log('[6/6] Writing MANIFEST...');
+    // The content and copy gap analysis is deliberately NOT copied here.
+    // It was written against a specific release and reasons throughout from
+    // that feature set, so copying it beside freshly generated assets made it
+    // read as current when it was several releases behind. It stays in
+    // scripts/screenshots/ as a dated record; regenerate it against the
+    // current release before relying on it again.
     writeManifest(manifest, { built, gate, webpOk: manifest.some((m) => m.variant === 'webp') });
 
     // Cleanup staging (flat masters are already copied into stills/flat).
@@ -240,7 +245,7 @@ function writeManifest(rows, { built, gate, webpOk }) {
     '- `stills/flat/` flat clean @2x masters and element-scoped crops (`-tile`), for the Site and Docs to frame in their own containers.',
     '- `stills/framed/` self-framed variants (and README-width derivations) for plain-markdown placements.',
     '- `motion/` the five looping GIFs, light and dark.',
-    '- `content-and-copy-gaps.md` the release content and copy gap analysis (proposal only).',
+    '- The content and copy gap analysis is not included: it was written against an earlier release and would read as current. See `scripts/screenshots/content-and-copy-gaps.md`, and check its stated release before relying on it.',
     '',
     '## Sanitization',
     '',

--- a/scripts/screenshots/run.mjs
+++ b/scripts/screenshots/run.mjs
@@ -227,7 +227,7 @@ function writeManifest(rows, { built, gate, webpOk }) {
     '- **Master:** 1440x900 logical at deviceScaleFactor 2, so every flat master is 2880x1800 @2x. Per-target sizes are derived down from the master, never upscaled.',
     '- **Themes:** every still and every GIF captured in both light and dark.',
     '- **Determinism:** fixed data and a frozen clock (2026-07-18, UTC), animations disabled for stills, scrollbars and caret hidden, the connection toast suppressed, web fonts awaited before capture.',
-    '- **Framing:** transparent-background PNGs, so one framed image drops onto any page background (light or dark). The macOS window controls are drawn into the app's own top bar during capture, so every shot that includes that bar carries them and element-scoped crops do not. Hero images take wider padding; feature shots ship as a flat clean master (for destinations that CSS-frame) plus a self-framed variant (rounded corners, soft drop shadow, and a neutral hairline ring that holds the edge on dark backgrounds). Tight padding.',
+    '- **Framing:** transparent-background PNGs, so one framed image drops onto any page background (light or dark). The macOS window controls are drawn into the app\'s own top bar during capture, so every shot that includes that bar carries them and element-scoped crops do not. Hero images take wider padding; feature shots ship as a flat clean master (for destinations that CSS-frame) plus a self-framed variant (rounded corners, soft drop shadow, and a neutral hairline ring that holds the edge on dark backgrounds). Tight padding.',
     '- **Motion:** palette-optimized looping GIFs, ~1280px wide, 15fps, roughly 5-6s.',
     '',
     '## Folder layout',

--- a/scripts/screenshots/run.mjs
+++ b/scripts/screenshots/run.mjs
@@ -18,14 +18,13 @@ import { fileURLToPath } from 'node:url';
 import { buildWorkspace, checkSanitization, hasProjectBannedTokens } from './generate-workspace.mjs';
 import { startRundock } from './serve.mjs';
 import { assertAppContract } from './harness.mjs';
-import { captureStills, SHOTS } from './capture.mjs';
+import { captureStills, SHOTS, THEMES } from './capture.mjs';
 import { frameImage, FRAME_HTML_URL, resizeTo, toWebp, pngDims } from './frame.mjs';
 import { captureMotion, ffmpegAvailable, CLIPS, MOTION_THEMES } from './motion.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const OUT = path.join(REPO_ROOT, 'screenshots-out');
-const GAPS_SRC = path.join(__dirname, 'content-and-copy-gaps.md');
 
 // README-friendly derived width (GitHub's content column is ~1000px, crisp at @2x).
 const README_WIDTH = 2200;
@@ -125,6 +124,24 @@ async function main() {
     // 3. Capture flat @2x masters + crops, both themes.
     log('[3/6] Capturing stills (light + dark, @2x)...');
     const shots = await captureStills({ browser, url: server.url, stagingDir: staging, log });
+
+    // A shot that fails is caught and logged inside captureStills so one bad
+    // selector cannot lose the whole run. That is right, but on its own it is
+    // too quiet: the run still exits 0, and a missing shot shows up only as one
+    // `!` line inside a couple of hundred, then as an asset nobody notices is
+    // absent. Motion already gates on its expected count; stills did not, so a
+    // renamed selector could silently ship a set with the search shots missing.
+    const missingShots = [];
+    for (const shot of SHOTS) {
+      for (const theme of THEMES) {
+        if (!shots.some(p => p.name === shot.name && p.theme === theme && p.kind === 'flat')) {
+          missingShots.push(`${shot.name}.${theme}`);
+        }
+      }
+    }
+    if (missingShots.length) {
+      log(`      ! STILLS INCOMPLETE: expected ${SHOTS.length * THEMES.length} flat masters, got ${shots.filter(p => p.kind === 'flat').length}. Missing: ${missingShots.join(', ')}`);
+    }
 
     // 4. Frame + derive per target.
     log('[4/6] Framing (hero chrome + feature self-frame) and deriving sizes...');

--- a/scripts/screenshots/run.mjs
+++ b/scripts/screenshots/run.mjs
@@ -30,14 +30,15 @@ const GAPS_SRC = path.join(__dirname, 'content-and-copy-gaps.md');
 // README-friendly derived width (GitHub's content column is ~1000px, crisp at @2x).
 const README_WIDTH = 2200;
 
-// Per-shot destination hints, grounded in the content/copy gap analysis. Each
+// Per-shot destination hints, originally grounded in the content/copy gap
+// analysis (see that file's stated release before trusting its reasoning). Each
 // entry drives the MANIFEST rows. `hero` placements are added separately.
 const TARGETS = {
   'org-chart':        { repo: 'Rundock Site',  path: 'index.html (hero) + images/rundock-app-hero.png',       note: 'Flagship "one operator, whole team" image; replaces the stale April hero.' },
   'agent-profile':    { repo: 'rundock-docs',  path: 'concepts/agents.mdx',                                    note: 'Shows an agent profile with role, skills, and routines.' },
   'skills':           { repo: 'Rundock Site',  path: 'index.html Skills section + rundock-docs/concepts/skills.mdx', note: 'Skills list plus a skill detail; refreshes the April skills-detail.png.' },
   'conversations':    { repo: 'rundock-docs',  path: 'images/conversation-flow.png + introduction.mdx',        note: 'Conversation list plus an open thread; product-in-use hero candidate.' },
-  'streaming':        { repo: 'Rundock Site',  path: 'index.html Conversations section',                       note: 'A reply streaming in; supports the live, working-team story.' },
+  'streaming':        { repo: 'Rundock Site + rundock-docs', path: 'index.html Conversations section + docs images/conversation-handoff.gif (quickstart.mdx, concepts/how-rundock-works.mdx)', note: 'A reply streaming in; supports the live, working-team story. NOTE the docs publish this clip under the name conversation-handoff, which is what it shows rather than how it is produced. That mismatch let a stale copy survive a full estate refresh, so check both destinations.' },
   'files':            { repo: 'Rundock Site',  path: 'index.html Files section + rundock-docs/concepts/files.mdx', note: 'File tree with per-type icons; replaces the materially wrong April file-browser.png.' },
   'markdown-note':    { repo: 'rundock-docs',  path: 'concepts/files.mdx (the editor + properties)',           note: 'Frontmatter properties panel, callouts, and clickable wikilinks.' },
   'callouts':         { repo: 'rundock-docs',  path: 'concepts/files.mdx (callouts)',                          note: 'Nested Obsidian callouts rendered in place.' },
@@ -47,7 +48,10 @@ const TARGETS = {
   'pdf-viewer':       { repo: 'rundock-docs',  path: 'concepts/files.mdx (any file type)',                     note: 'PDF opens inline alongside notes and boards.' },
   'search':           { repo: 'Rundock Site',  path: 'index.html new Search section + rundock-docs/concepts/search.mdx', note: 'Cmd+K universal search; headline 0.10.0 feature, absent everywhere today.' },
   'find':             { repo: 'rundock-docs',  path: 'concepts/search.mdx (Cmd+F)',                            note: 'In-view find inside the editor.' },
-  'settings':         { repo: 'rundock-docs',  path: 'concepts/runtimes.mdx',                                  note: 'Settings and runtimes surface.' },
+  // 'settings' was listed here with a home in concepts/runtimes.mdx, but no
+  // such shot has ever been defined in capture.mjs, so the manifest described a
+  // destination for an asset that does not exist. Removed rather than left
+  // promising: add it back alongside a real capture definition.
 };
 
 // The three chrome-framed hero placements (spec: Site hero, README hero, docs

--- a/test/unit/scripts-parse.test.js
+++ b/test/unit/scripts-parse.test.js
@@ -1,0 +1,66 @@
+'use strict';
+// Unit: every script under scripts/ must parse.
+//
+// This exists because a broken one shipped. A comment rewrite put an
+// apostrophe inside a single-quoted string in the screenshot pipeline, which
+// terminated the string and left the file unparseable. It merged: the full
+// suite was green, CI was green, and review saw a documentation change.
+//
+// Nothing covered it because scripts/ is tooling rather than product. Tests do
+// not import it, the app does not load it, and it only runs when someone runs
+// it by hand, so the failure surfaced days later as a stack trace instead of
+// at the point of change.
+//
+// A syntax check is the cheapest thing that would have caught it. It is not a
+// substitute for exercising the pipeline, which needs a browser and minutes of
+// wall clock; it is the floor beneath that: whatever else is untested, the
+// files at least parse.
+//
+// Deliberately `node --check` in a child process rather than import(): several
+// of these modules run work on import, so importing them here would launch
+// browsers and servers inside the unit suite.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SCRIPTS = path.join(ROOT, 'scripts');
+
+function collect(dir, out = []) {
+  let items;
+  try { items = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { return out; }
+  for (const item of items) {
+    const full = path.join(dir, item.name);
+    if (item.isDirectory()) {
+      if (item.name === 'node_modules') continue;
+      collect(full, out);
+    } else if (/\.(mjs|cjs|js)$/.test(item.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('scripts parse', () => {
+  const files = collect(SCRIPTS);
+
+  test('there is something to check', () => {
+    assert.ok(files.length > 0, `no scripts found under ${SCRIPTS}`);
+  });
+
+  for (const file of files) {
+    const rel = path.relative(ROOT, file);
+    test(rel, () => {
+      try {
+        // --check parses without executing. ESM vs CJS is inferred from the
+        // extension, which is why .mjs files are checked correctly here.
+        execFileSync(process.execPath, ['--check', file], { stdio: 'pipe' });
+      } catch (e) {
+        const detail = (e.stderr ? e.stderr.toString() : '') || e.message;
+        assert.fail(`${rel} does not parse:\n${detail}`);
+      }
+    });
+  }
+});

--- a/test/unit/scripts-parse.test.js
+++ b/test/unit/scripts-parse.test.js
@@ -29,8 +29,10 @@ const ROOT = path.join(__dirname, '..', '..');
 const SCRIPTS = path.join(ROOT, 'scripts');
 
 function collect(dir, out = []) {
-  let items;
-  try { items = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { return out; }
+  // Deliberately NOT swallowing a read failure. Skipping an unreadable
+  // directory would let the suite pass while checking less than it claims,
+  // which is the single way this guard could report a false all-clear.
+  const items = fs.readdirSync(dir, { withFileTypes: true });
   for (const item of items) {
     const full = path.join(dir, item.name);
     if (item.isDirectory()) {
@@ -54,8 +56,8 @@ describe('scripts parse', () => {
     const rel = path.relative(ROOT, file);
     test(rel, () => {
       try {
-        // --check parses without executing. ESM vs CJS is inferred from the
-        // extension, which is why .mjs files are checked correctly here.
+        // --check parses without executing, which is the point: several of
+        // these modules would launch browsers and servers on import.
         execFileSync(process.execPath, ['--check', file], { stdio: 'pipe' });
       } catch (e) {
         const detail = (e.stderr ? e.stderr.toString() : '') || e.message;


### PR DESCRIPTION
Four fixes to the screenshot pipeline, found while reviewing it after the window-chrome work.

## The pipeline on main does not run

A comment rewrite put an apostrophe inside a single-quoted string, which ended the string and left `run.mjs` unparseable. `npm run screenshots` fails immediately with a syntax error.

It merged, and stayed broken, because nothing covers `scripts/`. Tests do not import it, the app does not load it, and it only runs when someone runs it by hand, so a full green suite and a green CI said nothing about it. The change looked like documentation, which is exactly why it was not looked at twice.

A syntax check over every script now runs in the unit suite. It is not a substitute for exercising the pipeline, which needs a browser and minutes of wall clock; it is the floor beneath that. Verified by reintroducing the fault, which fails the new test.

## Search was photographed the wrong way

Both the search still and the search clip called the function behind the search control rather than using the control. Harmless when search was a keyboard shortcut over an overlay; not now that it expands in place from the field in the top bar.

It mattered most for the clip, whose entire job is to show that behaviour, and which opened a palette with no visible cause. The clip now moves the cursor to the field and clicks it.

## The target map promised things that do not exist, and missed things that do

It listed a `settings` shot with a home in the docs, though no such shot has ever been defined. Removed.

It also listed the `streaming` clip as belonging to the marketing site only. The docs publish that same clip on two of their highest-traffic pages, under a different name: `conversation-handoff`, which is what it shows rather than how it is produced. That mismatch let a stale copy survive a full estate refresh. Both destinations are now listed, with the naming difference called out.

## An analysis that read as current

The content and copy gap analysis was copied into the output on every run. Written against an earlier release, it sat beside freshly generated assets describing gaps since filled and features since shipped, while looking like part of the current output. No longer copied; it and the placement plan now state the release they were written against.

## Verified

Pipeline re-run end to end: 128 assets, and the search clip confirmed to show the cursor reaching the field before the panel opens. Full suite green, and every commit parses individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)