### PR TITLE
Lower the top bar to 50px with visually even field and corner insets

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -451,8 +451,9 @@ function setupAutoUpdate() {
 // ===== MAIN WINDOW =====
 
 // Height of the app's top bar, which the window controls now sit inside.
-// Must match --topbar-height in public/index.html.
-const TOPBAR_HEIGHT = 60;
+// Must match --topbar-height in public/index.html. Deliberately NOT tied to
+// the nav rail width any more: the bar is 48 and the rail stays 60.
+const TOPBAR_HEIGHT = 48;
 
 // Colours for the Windows caption buttons, which the OS draws for us from
 // values we pass. They must track the app theme, so they are re-sent whenever
@@ -473,10 +474,12 @@ const OVERLAY_COLOURS = {
 function chromeWindowOptions() {
   if (process.platform === 'darwin') {
     // We position the traffic lights ourselves, which is why the renderer's
-    // left inset is a constant rather than a measurement: x=20 puts the
-    // 52px-wide cluster at 20..72, and the inset reserves 88 so the first
-    // interface element is not flush against it. y centres them in the bar.
-    return { titleBarStyle: 'hidden', trafficLightPosition: { x: 20, y: (TOPBAR_HEIGHT - 12) / 2 } };
+    // left inset is a constant rather than a measurement: x=9 puts the
+    // 52px-wide cluster at 9..61, and the inset reserves 77 so the first
+    // interface element is not flush against it. The 9px matches the nav
+    // rail's icon inset, so the lights sit on the rail column's rhythm.
+    // y centres them in the bar.
+    return { titleBarStyle: 'hidden', trafficLightPosition: { x: 9, y: (TOPBAR_HEIGHT - 12) / 2 } };
   }
   if (process.platform === 'win32') {
     // Enabling the overlay is also what switches on the Window Controls

--- a/electron/main.js
+++ b/electron/main.js
@@ -452,8 +452,11 @@ function setupAutoUpdate() {
 
 // Height of the app's top bar, which the window controls now sit inside.
 // Must match --topbar-height in public/index.html. Deliberately NOT tied to
-// the nav rail width any more: the bar is 48 and the rail stays 60.
-const TOPBAR_HEIGHT = 48;
+// the nav rail width any more: the bar is 50 and the rail stays 60. The 50
+// is derived from the search field reading as evenly padded on screen:
+// macOS draws a 1px highlight along the window's top edge, so 1 + 6.5 + 36
+// + 6.5 is the shortest bar where the field's visible gaps match.
+const TOPBAR_HEIGHT = 50;
 
 // Colours for the Windows caption buttons, which the OS draws for us from
 // values we pass. They must track the app theme, so they are re-sent whenever
@@ -474,12 +477,13 @@ const OVERLAY_COLOURS = {
 function chromeWindowOptions() {
   if (process.platform === 'darwin') {
     // We position the traffic lights ourselves, which is why the renderer's
-    // left inset is a constant rather than a measurement: x=9 puts the
-    // 52px-wide cluster at 9..61, and the inset reserves 77 so the first
-    // interface element is not flush against it. The 9px matches the nav
-    // rail's icon inset, so the lights sit on the rail column's rhythm.
-    // y centres them in the bar.
-    return { titleBarStyle: 'hidden', trafficLightPosition: { x: 9, y: (TOPBAR_HEIGHT - 12) / 2 } };
+    // left inset is a constant rather than a measurement: x=19 puts the
+    // 52px-wide cluster at 19..71, and the inset reserves 87 so the first
+    // interface element is not flush against it. x equals the centred y, so
+    // the cluster's padding from the left edge matches its padding from the
+    // top: the corner reads as one even inset. (A tighter x matching the nav
+    // rail's 9px icon inset was tried and sat too close to the corner.)
+    return { titleBarStyle: 'hidden', trafficLightPosition: { x: 19, y: (TOPBAR_HEIGHT - 12) / 2 } };
   }
   if (process.platform === 'win32') {
     // Enabling the overlay is also what switches on the Window Controls

--- a/public/chrome-insets.js
+++ b/public/chrome-insets.js
@@ -22,14 +22,14 @@
 }(typeof self !== 'undefined' ? self : this, function () {
 
   // Room for the macOS traffic lights. The cluster is three 12px buttons with
-  // 8px gaps starting at x=9, so it ends at 61; 77 leaves a margin before the
-  // first interface element rather than butting straight up against them.
-  // The 9px start matches the nav rail's own icon inset, so the lights read
-  // as part of the rail column's rhythm.
+  // 8px gaps starting at x=19, so it ends at 71; 87 leaves a margin before
+  // the first interface element rather than butting straight up against them.
+  // The 19px start equals the cluster's distance from the top of the bar, so
+  // the corner reads as one even inset.
   // A constant, not a measurement, because macOS exposes no equivalent of the
   // Window Controls Overlay API: the lights are positioned BY us, via
   // trafficLightPosition, so their location is something we choose.
-  const MAC_TRAFFIC_LIGHTS = 77;
+  const MAC_TRAFFIC_LIGHTS = 87;
 
   const ZERO = { left: 0, right: 0 };
 

--- a/public/chrome-insets.js
+++ b/public/chrome-insets.js
@@ -22,12 +22,14 @@
 }(typeof self !== 'undefined' ? self : this, function () {
 
   // Room for the macOS traffic lights. The cluster is three 12px buttons with
-  // 8px gaps starting at x=20, so it ends at 72; 88 leaves a margin before the
+  // 8px gaps starting at x=9, so it ends at 61; 77 leaves a margin before the
   // first interface element rather than butting straight up against them.
+  // The 9px start matches the nav rail's own icon inset, so the lights read
+  // as part of the rail column's rhythm.
   // A constant, not a measurement, because macOS exposes no equivalent of the
   // Window Controls Overlay API: the lights are positioned BY us, via
   // trafficLightPosition, so their location is something we choose.
-  const MAC_TRAFFIC_LIGHTS = 88;
+  const MAC_TRAFFIC_LIGHTS = 77;
 
   const ZERO = { left: 0, right: 0 };
 

--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,7 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
    Help button plus 8px padding). The gutter each side is then the LARGER of
    the two sides' total occupancy, which is what keeps the middle column
    centred on the WINDOW rather than on the leftover space. */
-:root { --chrome-inset-left: 0px; --chrome-inset-right: 0px; --nav-rail-width: 60px; --topbar-height: 60px; --content-radius: 12px;
+:root { --chrome-inset-left: 0px; --chrome-inset-right: 0px; --nav-rail-width: 60px; --topbar-height: 48px; --content-radius: 12px;
         --tb-cluster: 38px;
         --chrome-gutter: max(var(--chrome-inset-left), calc(var(--chrome-inset-right) + var(--tb-cluster))); }
 

--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,7 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
    Help button plus 8px padding). The gutter each side is then the LARGER of
    the two sides' total occupancy, which is what keeps the middle column
    centred on the WINDOW rather than on the leftover space. */
-:root { --chrome-inset-left: 0px; --chrome-inset-right: 0px; --nav-rail-width: 60px; --topbar-height: 48px; --content-radius: 12px;
+:root { --chrome-inset-left: 0px; --chrome-inset-right: 0px; --nav-rail-width: 60px; --topbar-height: 50px; --content-radius: 12px;
         --tb-cluster: 38px;
         --chrome-gutter: max(var(--chrome-inset-left), calc(var(--chrome-inset-right) + var(--tb-cluster))); }
 
@@ -130,6 +130,13 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
      rather than by a formula. 32px of breathing room stops it sitting flush
      against whatever occupies the gutter. */
   grid-column: 2; justify-self: center;
+  /* Visual centring, not geometric. Two things eat into the apparent top
+     gap: macOS draws a 1px highlight line along the window's top edge, and
+     the bar's transparent 1px bottom border sits inside its border-box, so
+     plain centring lands the field 1px high before the highlight is even
+     counted. Nudging down 2px makes the gap above and below read equal on
+     screen. Measured, not guessed; remeasure if the bar height changes. */
+  margin-top: 2px;
   width: min(680px, calc(100% - 32px));
   background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
   color: var(--text-2); font-size: var(--caption); font-family: inherit;

--- a/public/index.html
+++ b/public/index.html
@@ -186,7 +186,6 @@ body.palette-open .tb-search { visibility: hidden; }
 .nav-item .icon-filled { display: none; }
 .nav-item.active .icon-outline { display: none; }
 .nav-item.active .icon-filled { display: block; }
-.nav-separator { width: 24px; height: 1px; background: var(--border); margin: 8px 0; }
 
 /* Sidebar */
 /* Top-left corner of the content region. The notch reveals the chrome behind
@@ -1132,7 +1131,6 @@ mark.find-match.current,
       <button class="nav-item" onclick="toggleTheme()" data-tooltip="Theme" id="theme-toggle">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       </button>
-      <div class="nav-separator"></div>
       <button class="nav-item" data-nav="settings" onclick="switchNav('settings')" data-tooltip="Settings">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9c.26.604.852.997 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
       </button>

--- a/test/unit/chrome-insets.test.js
+++ b/test/unit/chrome-insets.test.js
@@ -28,6 +28,15 @@ describe('computeChromeInsets', () => {
       assert.strictEqual(i.right, 0);
     });
 
+    test('the reserve matches where the lights are actually placed', () => {
+      // The lights sit at x=9 (electron/main.js, trafficLightPosition), the
+      // 52px cluster ends at 61, and 16px of margin follows. If either side
+      // of that arrangement changes, this number and that one must move
+      // together; the pinned value is what forces the revisit.
+      const i = computeChromeInsets({ platform: 'darwin', viewportWidth: 1280 });
+      assert.strictEqual(i.left, 77);
+    });
+
     test('collapses to zero in fullscreen, where the lights are hidden', () => {
       // Leaving the inset would carry a permanent empty gap in fullscreen.
       const i = computeChromeInsets({ platform: 'darwin', viewportWidth: 1280, fullScreen: true });

--- a/test/unit/chrome-insets.test.js
+++ b/test/unit/chrome-insets.test.js
@@ -29,12 +29,12 @@ describe('computeChromeInsets', () => {
     });
 
     test('the reserve matches where the lights are actually placed', () => {
-      // The lights sit at x=9 (electron/main.js, trafficLightPosition), the
-      // 52px cluster ends at 61, and 16px of margin follows. If either side
+      // The lights sit at x=19 (electron/main.js, trafficLightPosition), the
+      // 52px cluster ends at 71, and 16px of margin follows. If either side
       // of that arrangement changes, this number and that one must move
       // together; the pinned value is what forces the revisit.
       const i = computeChromeInsets({ platform: 'darwin', viewportWidth: 1280 });
-      assert.strictEqual(i.left, 77);
+      assert.strictEqual(i.left, 87);
     });
 
     test('collapses to zero in fullscreen, where the lights are hidden', () => {


### PR DESCRIPTION
## What this changes

The top bar drops from 60px to 50px and the macOS traffic lights move to x=19, y=19.

- The 36px search field keeps its size and now reads as evenly padded on screen. Visual centring, not geometric: macOS draws a 1px highlight along the window's top edge, and the bar's transparent bottom border sits inside its border-box, so plain centring landed the field visibly high. 50px is the shortest bar where the highlight plus even 6.5px gaps fit around the field.
- The traffic lights sit at x=19, equal to their centred distance from the top, so the corner reads as one even inset. A tighter x aligned to the nav rail's icon inset was tried and reviewed on screen as too close to the corner.
- The renderer's reserved left inset moves to 87, pinned by a unit test so the reserve and the light position must be revisited together.
- The divider between the theme and settings buttons at the bottom of the nav rail is removed; the gap separates them fine.
- Windows caption buttons need no code change: the overlay height tracks the bar height constant. The nav rail deliberately stays 60px wide.

## Testing

Full suite passing. Geometry is constant-driven with the inset pinned by test; the final values were measured and reviewed live on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)