### PR TITLE
Populate the draft release title and notes from the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,15 +91,26 @@ jobs:
           printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
           echo "APPLE_API_KEY=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
 
+      - name: Extract release name and notes from the changelog
+        # Fails the build if the changelog has no entry for this version:
+        # a draft release with blank notes must never be published.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node scripts/release-notes.js "$VERSION" --out release-info
+
       - name: Build, sign, notarise, publish
         # Version comes from the tag (v1.2.3 -> 1.2.3) and overrides package.json,
         # so the built artefacts and the published release always match the tag.
+        # releaseInfo names the draft release and fills its notes from the
+        # changelog, so the draft arrives ready to review rather than blank.
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Building version $VERSION from tag $GITHUB_REF_NAME"
           npx electron-builder --mac --universal \
             -c.mac.notarize=true \
             -c.extraMetadata.version="$VERSION" \
+            -c.releaseInfo.releaseName="$(cat release-info/release-name.txt)" \
+            -c.releaseInfo.releaseNotesFile=release-info/release-notes.md \
             --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -130,13 +141,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Extract release name and notes from the changelog
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          node scripts/release-notes.js "$VERSION" --out release-info
+
       - name: Build and publish
         # Use bash (available on Windows runners) so version extraction matches macOS.
+        # Passing the same releaseInfo as the macOS job is deliberate: whichever
+        # job reaches the draft release first names it, and identical values make
+        # the order irrelevant.
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "Building Windows version $VERSION from tag $GITHUB_REF_NAME"
-          npx electron-builder --win -c.extraMetadata.version="$VERSION" --publish always
+          npx electron-builder --win \
+            -c.extraMetadata.version="$VERSION" \
+            -c.releaseInfo.releaseName="$(cat release-info/release-name.txt)" \
+            -c.releaseInfo.releaseNotesFile=release-info/release-notes.md \
+            --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * Produce the release name and notes for a version from CHANGELOG.md.
+ *
+ * The release workflow publishes a draft GitHub release for each tag; until
+ * this script existed the draft arrived untitled and empty, and the notes
+ * were retyped by hand from the changelog at publish time. Now the workflow
+ * runs this before building and passes the results to electron-builder via
+ * releaseInfo, so the draft arrives named and documented.
+ *
+ * Usage:
+ *   node scripts/release-notes.js <version> --out <dir>
+ *
+ * Writes <dir>/release-name.txt and <dir>/release-notes.md. Exits non-zero
+ * if the changelog has no entry for the version: a release with blank notes
+ * is precisely the failure this exists to prevent, so it must stop the tag
+ * build rather than let it publish.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { extractChangelogEntry } = require('./release.js');
+
+// The changelog heading is "## <version>: <Name> (<YYYY-MM-DD>)". The
+// release name matches every release published to date: version and name,
+// no date (GitHub shows its own timestamp).
+function buildReleaseInfo(version, changelogText) {
+  const entry = extractChangelogEntry(version, changelogText);
+  if (!entry) {
+    throw new Error(`CHANGELOG.md has no entry for ${version}. Add release notes before tagging.`);
+  }
+  const name = entry.title.replace(/\s*\(\d{4}-\d{2}-\d{2}\)\s*$/, '');
+  if (!entry.body) {
+    throw new Error(`The changelog entry for ${version} has an empty body. A release must not ship with blank notes.`);
+  }
+  return { name, notes: entry.body };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const version = args[0];
+  const outFlag = args.indexOf('--out');
+  const outDir = outFlag !== -1 ? args[outFlag + 1] : null;
+  if (!version || !outDir) {
+    console.error('Usage: node scripts/release-notes.js <version> --out <dir>');
+    process.exit(1);
+  }
+
+  let info;
+  try {
+    info = buildReleaseInfo(version);
+  } catch (err) {
+    console.error(`release-notes: ${err.message}`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'release-name.txt'), info.name + '\n');
+  fs.writeFileSync(path.join(outDir, 'release-notes.md'), info.notes + '\n');
+  console.log(`release-notes: "${info.name}" (${info.notes.length} chars of notes) -> ${outDir}`);
+}
+
+if (require.main === module) main();
+
+module.exports = { buildReleaseInfo };

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -106,10 +106,16 @@ function setVersion(version) {
 }
 
 // Extract the title line and body of a specific version from CHANGELOG.md.
-function extractChangelogEntry(version) {
-  const changelogPath = path.join(ROOT, 'CHANGELOG.md');
-  if (!fs.existsSync(changelogPath)) return null;
-  const lines = fs.readFileSync(changelogPath, 'utf8').split('\n');
+// Pass `changelogText` to parse supplied content (used by tests and by
+// scripts/release-notes.js); omit it to read the repository's CHANGELOG.md.
+function extractChangelogEntry(version, changelogText) {
+  let text = changelogText;
+  if (typeof text !== 'string') {
+    const changelogPath = path.join(ROOT, 'CHANGELOG.md');
+    if (!fs.existsSync(changelogPath)) return null;
+    text = fs.readFileSync(changelogPath, 'utf8');
+  }
+  const lines = text.split('\n');
   const matchesHeading = (line) => {
     if (version === 'Unreleased') return /^## Unreleased\s*$/.test(line);
     return line.startsWith(`## ${version}:`);
@@ -193,15 +199,21 @@ function commitTagPush(version) {
 // Main
 // ---------------------------------------------------------------------------
 
-const version = getVersion();
-preflight(version);
-setVersion(version);
-promoteUnreleasedChangelog(version);
-commitTagPush(version);
+// Guarded so the changelog helpers are requireable (by tests and by
+// scripts/release-notes.js) without starting a release.
+if (require.main === module) {
+  const version = getVersion();
+  preflight(version);
+  setVersion(version);
+  promoteUnreleasedChangelog(version);
+  commitTagPush(version);
 
-console.log('');
-log('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
-log('done', `Watch the build:   https://github.com/${REPO}/actions`);
-log('done', `Review + publish:  https://github.com/${REPO}/releases`);
-log('done', `Then bump the Rundock Site download links to v${version}.`);
-log('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+  console.log('');
+  log('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
+  log('done', `Watch the build:   https://github.com/${REPO}/actions`);
+  log('done', `Review + publish:  https://github.com/${REPO}/releases`);
+  log('done', `Then bump the Rundock Site download links to v${version}.`);
+  log('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+}
+
+module.exports = { extractChangelogEntry, promoteUnreleasedChangelog };

--- a/test/unit/release-notes.test.js
+++ b/test/unit/release-notes.test.js
@@ -1,0 +1,100 @@
+// Tests for release-notes extraction (scripts/release.js and
+// scripts/release-notes.js).
+//
+// The tag build publishes a draft GitHub release, and until now that draft
+// arrived with no title and no notes: they were retyped by hand from
+// CHANGELOG.md at publish time, or forgotten. These tests pin the extraction
+// that feeds the draft automatically.
+//
+// The failure mode that matters most: a version with no changelog entry must
+// be an ERROR, never an empty release published with blank notes.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { extractChangelogEntry } = require('../../scripts/release.js');
+const { buildReleaseInfo } = require('../../scripts/release-notes.js');
+
+const CHANGELOG = `# Changelog
+
+Header prose.
+
+## Unreleased
+
+**Name:** Something In Flight
+
+### Fixed
+
+- An unreleased fix.
+
+## 0.11.4: Window Chrome & Search (2026-08-05)
+
+### Added
+
+- **Window controls inside the app.**
+
+---
+
+## 0.11.3: Long Sessions & Large Workspaces (2026-08-03)
+
+### Fixed
+
+- A fix.
+`;
+
+describe('extractChangelogEntry', () => {
+  test('finds a versioned entry and returns its heading and body', () => {
+    const entry = extractChangelogEntry('0.11.4', CHANGELOG);
+    assert.strictEqual(entry.title, '0.11.4: Window Chrome & Search (2026-08-05)');
+    assert.ok(entry.body.includes('Window controls inside the app'));
+  });
+
+  test('the body stops at the next version heading', () => {
+    const entry = extractChangelogEntry('0.11.4', CHANGELOG);
+    assert.ok(!entry.body.includes('Long Sessions'));
+    assert.ok(!entry.body.includes('unreleased fix'));
+  });
+
+  test('horizontal rules are stripped from the body', () => {
+    const entry = extractChangelogEntry('0.11.4', CHANGELOG);
+    assert.ok(!/^---\s*$/m.test(entry.body));
+  });
+
+  test('finds the Unreleased block by its exact heading', () => {
+    const entry = extractChangelogEntry('Unreleased', CHANGELOG);
+    assert.strictEqual(entry.title, 'Unreleased');
+    assert.ok(entry.body.includes('An unreleased fix'));
+  });
+
+  test('a version with no entry returns null', () => {
+    assert.strictEqual(extractChangelogEntry('9.9.9', CHANGELOG), null);
+  });
+});
+
+describe('buildReleaseInfo', () => {
+  test('the release name is the heading without the date suffix', () => {
+    // Matches the naming of every published release to date, which until now
+    // was retyped by hand: "0.11.4: Window Chrome & Search".
+    const info = buildReleaseInfo('0.11.4', CHANGELOG);
+    assert.strictEqual(info.name, '0.11.4: Window Chrome & Search');
+  });
+
+  test('the notes are the entry body', () => {
+    const info = buildReleaseInfo('0.11.4', CHANGELOG);
+    assert.ok(info.notes.includes('Window controls inside the app'));
+  });
+
+  test('a heading without a date is used as-is', () => {
+    const log = '## 0.12.0: No Date Yet\n\n- A change.\n';
+    const info = buildReleaseInfo('0.12.0', log);
+    assert.strictEqual(info.name, '0.12.0: No Date Yet');
+  });
+
+  test('a missing entry throws rather than producing an empty release', () => {
+    assert.throws(() => buildReleaseInfo('9.9.9', CHANGELOG), /9\.9\.9/);
+  });
+
+  test('an empty body throws rather than producing an empty release', () => {
+    const log = '## 0.12.0: Hollow (2026-01-01)\n\n## 0.11.9: Previous (2025-12-01)\n\n- x\n';
+    assert.throws(() => buildReleaseInfo('0.12.0', log), /empty/i);
+  });
+});


### PR DESCRIPTION
## What this changes

The tag build publishes a draft GitHub release, and until now that draft arrived untitled and empty: the name and notes were retyped by hand from CHANGELOG.md at publish time. Now:

- A pre-build step (`scripts/release-notes.js`) extracts the version's changelog entry and hands electron-builder `releaseInfo.releaseName` and `releaseInfo.releaseNotesFile`, so the draft arrives named and documented.
- The release name is the changelog heading without its date suffix, matching every release published to date (verified by running the extraction against the previous release's entry: it reproduces the hand-written title exactly).
- A version with no changelog entry, or an empty body, fails the build before any artefact uploads. A release must never ship with blank notes.
- Both build jobs pass identical values, so whichever reaches the draft first names it and the order is irrelevant.
- `scripts/release.js` is now requireable: its main flow sits behind a `require.main` guard (previously, requiring it began running a release), and the changelog helpers are exported and unit-tested.

## Testing

10 new unit tests on the extraction and formatting; full suite 1206 passing. The workflow change itself is exercised by the next tag build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
