### PR TITLE
Persist renderer state across launches despite the per-launch port

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -280,6 +280,30 @@ ipcMain.handle('select-directory', async () => {
 
 ipcMain.handle('get-app-version', () => app.getVersion());
 
+// ===== RENDERER STORAGE =====
+
+// Durable storage for the renderer (see electron/renderer-storage.js). The
+// page's origin changes every launch with the OS-assigned port, so anything
+// the renderer needs across sessions is kept here, under userData, where no
+// port ever enters the path. The snapshot read is synchronous because
+// preload fetches it once before the page loads.
+const { loadRendererStorage, setRendererStorageKey } = require('./renderer-storage.js');
+
+ipcMain.on('rundock-storage-snapshot', (event) => {
+  event.returnValue = loadRendererStorage(app.getPath('userData'));
+});
+
+ipcMain.handle('rundock-storage-set', (event, key, value) => {
+  try {
+    setRendererStorageKey(app.getPath('userData'), key, value);
+  } catch (err) {
+    // A failed persist must never surface as a renderer error: the value is
+    // already applied in-page for this session, and losing it on relaunch is
+    // the lesser harm.
+    console.warn('[Electron] Failed to persist renderer storage:', err && err.message ? err.message : err);
+  }
+});
+
 // The Windows caption buttons are drawn by the OS from colours we pass, so
 // they keep the old ones until re-sent. The renderer calls this on every theme
 // change AND on the restore-from-storage path at launch: sending only on

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -22,6 +22,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('rundock-update', (event, data) => callback(data));
   },
 
+  // Durable renderer storage. The page's origin includes an OS-assigned port
+  // that changes every launch, so localStorage cannot hold anything across
+  // sessions; durable state lives in the main process instead. The snapshot
+  // is fetched synchronously here, before the page loads, so boot-time reads
+  // (the theme) apply without a flash of the wrong value. The one sendSync is
+  // a single small read during preload, never on the hot path.
+  storage: {
+    snapshot: ipcRenderer.sendSync('rundock-storage-snapshot'),
+    set: (key, value) => ipcRenderer.invoke('rundock-storage-set', key, value),
+  },
+
   // Window chrome. macOS hides the traffic lights in fullscreen, so the
   // renderer drops its left inset in response rather than carrying an empty
   // gap. Windows caption buttons are drawn by the OS from colours we pass, so

--- a/electron/renderer-storage.js
+++ b/electron/renderer-storage.js
@@ -1,0 +1,53 @@
+// Renderer persistence. Plain Node: no Electron imports, unit-testable.
+//
+// The desktop app loads http://localhost:<port> with an OS-assigned port, so
+// the web origin changes every launch and localStorage silently loses
+// everything between sessions. Durable renderer state therefore lives here,
+// in a JSON file under userData, which no port ever touches. The renderer
+// reads a snapshot synchronously at boot (via preload) and writes through
+// IPC; in a plain browser the app keeps using localStorage.
+//
+// Semantics mirror localStorage: string keys, string values. Values are
+// coerced with String() on write and non-strings found in the file are
+// dropped on load, so the renderer can trust the shape without checking.
+//
+// Storage loss must never break boot: a missing, corrupt, or wrongly-shaped
+// file loads as empty storage.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const FILE_NAME = 'renderer-storage.json';
+
+function loadRendererStorage(dir) {
+  try {
+    const raw = fs.readFileSync(path.join(dir, FILE_NAME), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const clean = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof v === 'string') clean[k] = v;
+    }
+    return clean;
+  } catch {
+    return {};
+  }
+}
+
+function setRendererStorageKey(dir, key, value) {
+  const snapshot = loadRendererStorage(dir);
+  snapshot[String(key)] = String(value);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, FILE_NAME);
+  // Write-then-rename so a crash mid-write leaves the previous file intact
+  // rather than a truncated one (which would load as empty and silently
+  // discard every stored preference).
+  const tmp = file + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(snapshot, null, 2) + '\n');
+  fs.renameSync(tmp, file);
+  return snapshot;
+}
+
+module.exports = { loadRendererStorage, setRendererStorageKey };

--- a/public/app.js
+++ b/public/app.js
@@ -24,6 +24,32 @@
 
 // ===== 1. CONSTANTS & STATE =====
 
+// Durable key-value persistence. In the desktop app the page's origin is
+// http://localhost:<port> with an OS-assigned port, so localStorage is
+// scoped to an origin that changes every launch and silently loses
+// everything. There, durable state lives in the main process (a file under
+// userData): preload exposes a synchronous snapshot, taken before this
+// script runs, so boot-time reads like the theme apply without a flash, and
+// writes go through IPC. In a plain browser localStorage behaves normally
+// and is used as before. Same semantics either way: string in, string out,
+// null when absent, and a write that cannot persist never throws.
+const persist = (() => {
+  const api = typeof window !== 'undefined' && window.electronAPI && window.electronAPI.storage;
+  if (api && api.snapshot) {
+    return {
+      get(key) { return Object.prototype.hasOwnProperty.call(api.snapshot, key) ? api.snapshot[key] : null; },
+      set(key, value) {
+        api.snapshot[key] = String(value);
+        try { api.set(key, String(value)); } catch (e) { /* best-effort */ }
+      },
+    };
+  }
+  return {
+    get(key) { try { return localStorage.getItem(key); } catch (e) { return null; } },
+    set(key, value) { try { localStorage.setItem(key, String(value)); } catch (e) { /* private mode */ } },
+  };
+})();
+
 const sunIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>`;
 const moonIcon = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>`;
 
@@ -1720,10 +1746,8 @@ function createConversation(agentId, title) {
 function maybeShowCodexFirstRun(agent) {
   if (!agent || agent.runtime !== 'codex') return;
   const key = 'rundock:codexFirstRun:' + agent.id;
-  try {
-    if (localStorage.getItem(key)) return;
-    localStorage.setItem(key, '1');
-  } catch (e) { return; }
+  if (persist.get(key)) return;
+  persist.set(key, '1');
   const m = document.getElementById('messages');
   if (!m) return;
   const el = document.createElement('div');
@@ -3179,7 +3203,7 @@ function initSidebarResize() {
     document.documentElement.style.setProperty('--sidebar-width', `${clamped}px`);
     return clamped;
   };
-  let width = applySidebarWidth(Number(localStorage.getItem(SIDEBAR_WIDTH_KEY)) || 280);
+  let width = applySidebarWidth(Number(persist.get(SIDEBAR_WIDTH_KEY)) || 280);
   const handle = document.createElement('div');
   handle.className = 'sidebar-resize-handle';
   handle.title = 'Drag to resize';
@@ -3203,7 +3227,7 @@ function initSidebarResize() {
       handle.classList.remove('dragging');
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
-      try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width)); } catch (e2) { /* private mode */ }
+      persist.set(SIDEBAR_WIDTH_KEY, String(width));
     };
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
@@ -3261,9 +3285,9 @@ function showView(v) { currentView=v; ['workspace','home','profile','chat','conv
 function goHome() { discardIfEmpty(); activeConversation=null; switchNav('conversations'); }
 
 // Theme
-function toggleTheme() { document.body.classList.toggle('light'); const isLight=document.body.classList.contains('light'); document.getElementById('theme-toggle').innerHTML=isLight?moonIcon:sunIcon; if(typeof applyHljsTheme==='function')applyHljsTheme(isLight); syncTitleBarOverlay(isLight); try{localStorage.setItem('rundock-theme',isLight?'light':'dark');}catch(e){} }
+function toggleTheme() { document.body.classList.toggle('light'); const isLight=document.body.classList.contains('light'); document.getElementById('theme-toggle').innerHTML=isLight?moonIcon:sunIcon; if(typeof applyHljsTheme==='function')applyHljsTheme(isLight); syncTitleBarOverlay(isLight); persist.set('rundock-theme',isLight?'light':'dark'); }
 // Restore saved theme on load
-try{if(localStorage.getItem('rundock-theme')==='light'){document.body.classList.add('light');document.getElementById('theme-toggle').innerHTML=moonIcon;}}catch(e){}
+if(persist.get('rundock-theme')==='light'){document.body.classList.add('light');document.getElementById('theme-toggle').innerHTML=moonIcon;}
 
 // The Windows caption buttons are drawn by the OS from colours we pass, so
 // they keep the old ones until re-sent. BOTH paths must call this: only

--- a/test/unit/renderer-storage.test.js
+++ b/test/unit/renderer-storage.test.js
@@ -1,0 +1,80 @@
+// Tests for renderer persistence (electron/renderer-storage.js).
+//
+// The desktop app loads http://localhost:<port> with an OS-assigned port, so
+// the web origin changes every launch and anything the renderer keeps in
+// localStorage silently vanishes between sessions. Durable state therefore
+// lives in a JSON file under userData, which no port ever touches.
+//
+// The test that matters here is survival across launches: a value written by
+// one load must be read back by a completely fresh load. The server port is
+// nowhere in this module's API, which is the point: persistence cannot
+// depend on a number that changes every launch.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { loadRendererStorage, setRendererStorageKey } = require('../../electron/renderer-storage.js');
+
+let dir;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-storage-test-'));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('a value survives to the next launch', () => {
+  test('written by one load, read by a fresh one', () => {
+    setRendererStorageKey(dir, 'rundock-theme', 'light');
+    // A fresh load stands in for the next app launch: nothing carried over
+    // in memory, only what the file holds.
+    const next = loadRendererStorage(dir);
+    assert.strictEqual(next['rundock-theme'], 'light');
+  });
+
+  test('multiple keys accumulate rather than replace', () => {
+    setRendererStorageKey(dir, 'a', '1');
+    setRendererStorageKey(dir, 'b', '2');
+    assert.deepStrictEqual(loadRendererStorage(dir), { a: '1', b: '2' });
+  });
+
+  test('writing a key again overwrites it', () => {
+    setRendererStorageKey(dir, 'a', '1');
+    setRendererStorageKey(dir, 'a', '2');
+    assert.strictEqual(loadRendererStorage(dir).a, '2');
+  });
+
+  test('values are stored as strings, mirroring localStorage', () => {
+    setRendererStorageKey(dir, 'n', 280);
+    assert.strictEqual(loadRendererStorage(dir).n, '280');
+  });
+});
+
+describe('storage loss never breaks boot', () => {
+  test('no file yet means empty storage', () => {
+    assert.deepStrictEqual(loadRendererStorage(dir), {});
+  });
+
+  test('a corrupt file means empty storage, not a throw', () => {
+    fs.writeFileSync(path.join(dir, 'renderer-storage.json'), '{not json');
+    assert.deepStrictEqual(loadRendererStorage(dir), {});
+  });
+
+  test('a file holding a non-object means empty storage', () => {
+    fs.writeFileSync(path.join(dir, 'renderer-storage.json'), '"just a string"');
+    assert.deepStrictEqual(loadRendererStorage(dir), {});
+  });
+
+  test('non-string stored values are dropped on load', () => {
+    fs.writeFileSync(path.join(dir, 'renderer-storage.json'), JSON.stringify({ ok: 'yes', bad: { nested: true } }));
+    assert.deepStrictEqual(loadRendererStorage(dir), { ok: 'yes' });
+  });
+
+  test('writing into a directory that does not exist yet creates it', () => {
+    const deeper = path.join(dir, 'not', 'yet', 'here');
+    setRendererStorageKey(deeper, 'k', 'v');
+    assert.strictEqual(loadRendererStorage(deeper).k, 'v');
+  });
+});


### PR DESCRIPTION
## What this changes

The desktop app loads `http://localhost:<port>` with an OS-assigned port, so the web origin changes every launch and localStorage silently loses everything between sessions. Theme, sidebar width, and one-time disclosures all reset on every launch.

Renderer persistence now lives in the main process:

- `electron/renderer-storage.js`: a JSON file under userData, localStorage semantics (string keys and values), atomic write-then-rename, and total tolerance of missing or corrupt files (storage loss must never break boot).
- Preload fetches a snapshot synchronously before the page loads, so the theme applies at boot with no flash; writes go through IPC.
- A small `persist` adapter in `public/app.js` chooses the backend at startup: main-process storage in the desktop app, plain localStorage in a browser. All persisted call sites go through it.

A custom URL scheme was the alternative and was rejected: it would put a reverse proxy on every request and still could not carry the WebSocket upgrade, so connection logic would stay port-aware while the storage problem it solves turned out to be three keys.

## Testing

- 9 new unit tests. The one that matters: a value written by one load is read back by a completely fresh load, with the server port nowhere in the module's API — persistence cannot depend on a number that changes every launch.
- Full suite 1205 passing; e2e 102 passing (the browser path is the fallback branch of the adapter and runs unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
