### PR TITLE
Gate releases on the packaged app actually booting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,15 @@ jobs:
       - name: Run E2E suite
         run: npx playwright test
 
+  # The packaged app must BOOT before anything publishes. Source-level suites
+  # cannot catch packaging mistakes; this is the gate that does.
+  smoke:
+    name: Packaged-app smoke test
+    uses: ./.github/workflows/smoke.yml
+
   macos:
     name: Build macOS (arm64 + x64)
-    needs: [test, e2e]
+    needs: [test, e2e, smoke]
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -116,7 +122,7 @@ jobs:
   # ---------------------------------------------------------------------------
   windows:
     name: Build Windows (x64)
-    needs: [test, e2e]
+    needs: [test, e2e, smoke]
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,14 +13,6 @@ name: Packaged-app smoke test
 on:
   workflow_call:
   workflow_dispatch:
-  # TEMPORARY, removed before merge: dispatch-by-name only works once the
-  # workflow exists on the default branch, so the gate's own verification
-  # (green on a healthy branch, red on a deliberately broken one) runs via
-  # push triggers on the two verification branches.
-  push:
-    branches:
-      - fix/packaged-smoke-gate
-      - smoke-gate-break-check
 
 jobs:
   smoke:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,6 +13,14 @@ name: Packaged-app smoke test
 on:
   workflow_call:
   workflow_dispatch:
+  # TEMPORARY, removed before merge: dispatch-by-name only works once the
+  # workflow exists on the default branch, so the gate's own verification
+  # (green on a healthy branch, red on a deliberately broken one) runs via
+  # push triggers on the two verification branches.
+  push:
+    branches:
+      - fix/packaged-smoke-gate
+      - smoke-gate-break-check
 
 jobs:
   smoke:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,37 @@
+name: Packaged-app smoke test
+
+# Boots the PACKAGED app once and requires a clean start. The unit and e2e
+# suites run against source; nothing they prove survives a packaging mistake
+# (a module missing from the build whitelist, a broken main entry, a
+# dependency absent from the asar). One shipped release died on its first
+# require, after install, where no test had ever looked.
+#
+# workflow_call: the release pipeline runs this as a gate before publishing.
+# workflow_dispatch: runnable against any branch, which is also how the gate
+# itself is verified (break the packaging on a branch, dispatch, expect red).
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Boot the packaged app
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build unpacked, launch, and require a clean boot
+        # Unsigned --dir build: signing and notarisation are the publish
+        # jobs' concern. This gate answers one question only: does the app
+        # that packaging produces actually start?
+        run: node scripts/smoke-packaged.mjs

--- a/electron/main.js
+++ b/electron/main.js
@@ -617,7 +617,13 @@ app.whenReady().then(async () => {
 
   const setupMarker = path.join(app.getPath('userData'), '.claude-setup-verified');
   const setupVerified = fs.existsSync(setupMarker);
-  const needsWizard = !claudeBin || (!setupVerified && !isClaudeAuthenticated());
+  // RUNDOCK_SMOKE_TEST: boot verification for the packaged app (see
+  // scripts/smoke-packaged.mjs). The machine running it has no CLI and no
+  // sign-in, so the wizard gate is skipped; everything else about startup
+  // (module loading, embedded server, window creation) runs for real, which
+  // is the point: a packaging mistake that breaks any of it must fail here.
+  const isSmokeTest = process.env.RUNDOCK_SMOKE_TEST === '1';
+  const needsWizard = !isSmokeTest && (!claudeBin || (!setupVerified && !isClaudeAuthenticated()));
 
   if (needsWizard) {
     console.log('[Electron] Showing first-run wizard (Claude missing or not signed in)');
@@ -631,7 +637,11 @@ app.whenReady().then(async () => {
 
   // Setup confirmed (installed + signed in): remember it so future launches
   // skip the auth API call. The 401 recovery card covers later expiry.
-  try { fs.writeFileSync(setupMarker, new Date().toISOString()); } catch { /* non-fatal */ }
+  // Never written during a smoke test: on a developer machine that would
+  // fake the verification the wizard exists to perform.
+  if (!isSmokeTest) {
+    try { fs.writeFileSync(setupMarker, new Date().toISOString()); } catch { /* non-fatal */ }
+  }
 
   // Start the embedded server on an OS-assigned port
   console.log('[Electron] Starting server...');
@@ -643,8 +653,18 @@ app.whenReady().then(async () => {
   // Open the main window
   createMainWindow(serverPort);
   setupMenu();
-  setupAutoUpdate();
+  // The updater talks to the release feed over the network; a boot check
+  // must not depend on that being reachable, so smoke runs skip it.
+  if (!isSmokeTest) setupAutoUpdate();
   console.log('[Electron] Ready');
+
+  if (isSmokeTest) {
+    // Full boot succeeded: modules loaded, server up, window created. The
+    // marker line is what scripts/smoke-packaged.mjs waits for; quitting
+    // with code 0 is the pass signal.
+    console.log('[Electron] Smoke test OK');
+    app.quit();
+  }
 });
 
 // macOS: re-show window when dock icon is clicked

--- a/scripts/smoke-packaged.mjs
+++ b/scripts/smoke-packaged.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Boot the PACKAGED app once and require it to come up cleanly.
+//
+// The unit and e2e suites run against source. Nothing they prove survives a
+// packaging mistake: a module missing from the build whitelist, a broken
+// main entry, a dependency that did not make it into the asar. One shipped
+// release died exactly that way, on its first require, after install, where
+// no test had ever looked.
+//
+// This script builds an unpacked app (electron-builder --dir), launches the
+// real packaged binary with RUNDOCK_SMOKE_TEST=1, and waits for the boot
+// marker that electron/main.js prints after modules load, the embedded
+// server starts, and the window is created. No marker, or a non-zero exit,
+// fails the run. The release workflow runs this before anything publishes.
+//
+// Usage:
+//   node scripts/smoke-packaged.mjs [--skip-build]
+
+import { spawn, execFileSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const DIST = join(ROOT, 'dist');
+const MARKER = '[Electron] Smoke test OK';
+const BOOT_TIMEOUT_MS = 120000;
+
+const skipBuild = process.argv.includes('--skip-build');
+
+function fail(msg) {
+  console.error(`smoke-packaged: FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// Locate the packaged binary for the current platform under dist/.
+function findBinary() {
+  if (process.platform === 'darwin') {
+    const dirs = existsSync(DIST) ? readdirSync(DIST).filter((d) => d.startsWith('mac')) : [];
+    for (const d of dirs) {
+      const bin = join(DIST, d, 'Rundock.app', 'Contents', 'MacOS', 'Rundock');
+      if (existsSync(bin)) return bin;
+    }
+    return null;
+  }
+  if (process.platform === 'win32') {
+    const bin = join(DIST, 'win-unpacked', 'Rundock.exe');
+    return existsSync(bin) ? bin : null;
+  }
+  const bin = join(DIST, 'linux-unpacked', 'rundock');
+  return existsSync(bin) ? bin : null;
+}
+
+if (!skipBuild) {
+  const target = process.platform === 'win32' ? '--win' : process.platform === 'darwin' ? '--mac' : '--linux';
+  console.log(`smoke-packaged: building unpacked app (electron-builder ${target} --dir)`);
+  execFileSync('npx', ['electron-builder', target, '--dir'], { cwd: ROOT, stdio: 'inherit' });
+}
+
+const bin = findBinary();
+if (!bin) fail(`no packaged binary found under ${DIST}. Build first or drop --skip-build.`);
+
+console.log(`smoke-packaged: launching ${bin}`);
+const child = spawn(bin, [], {
+  env: { ...process.env, RUNDOCK_SMOKE_TEST: '1' },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let output = '';
+let sawMarker = false;
+const onData = (chunk) => {
+  const text = chunk.toString();
+  output += text;
+  process.stdout.write(text);
+  if (text.includes(MARKER)) sawMarker = true;
+};
+child.stdout.on('data', onData);
+child.stderr.on('data', onData);
+
+const timer = setTimeout(() => {
+  // Kill only the child this script spawned, by its own PID.
+  child.kill('SIGKILL');
+  fail(`no "${MARKER}" within ${BOOT_TIMEOUT_MS / 1000}s. The packaged app did not finish booting.`);
+}, BOOT_TIMEOUT_MS);
+
+child.on('exit', (code) => {
+  clearTimeout(timer);
+  if (!sawMarker) {
+    fail(`the app exited (code ${code}) without printing "${MARKER}". Boot did not complete.`);
+  }
+  if (code !== 0) {
+    fail(`boot marker seen but the app exited with code ${code}.`);
+  }
+  console.log('smoke-packaged: PASS: packaged app booted, served, and shut down cleanly.');
+});
+
+child.on('error', (err) => {
+  clearTimeout(timer);
+  fail(`could not launch the packaged binary: ${err.message}`);
+});


### PR DESCRIPTION
## What this changes

The release pipeline had no post-pack verification of any kind: the unit and e2e suites run against source, so nothing they prove survives a packaging mistake (a module missing from the build whitelist, a broken main entry, a dependency absent from the asar). One shipped release died on its first require, after install, where no test had ever looked.

- `scripts/smoke-packaged.mjs` builds an unpacked app, launches the real packaged binary, and requires the boot marker the main process prints only after modules load, the embedded server starts, and the window is created. No marker or a non-zero exit fails the run.
- `.github/workflows/smoke.yml` runs it on a macOS runner; the release workflow calls it as a gate, so neither publish job starts until the packaged app has actually booted.
- In smoke mode (`RUNDOCK_SMOKE_TEST=1`) the app skips the first-run wizard (a CI machine has no CLI or sign-in), never writes the setup-verified marker, and skips the network update check so the gate cannot flake on reachability. Everything else about startup runs for real.

## Verification

The gate was proven in both directions before the temporary triggers were removed:

- Healthy branch: built, launched, `[Electron] Smoke test OK`, pass ([run](https://github.com/liamdarmody/rundock/actions/runs/31194057318)).
- Branch with a deliberately broken entry point: red ([run](https://github.com/liamdarmody/rundock/actions/runs/31194062073)).

Full suite 1196 passing; the smoke hook adds no behaviour outside `RUNDOCK_SMOKE_TEST=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
