### PR TITLE
Stop the tree rebuild opening unchanged files

### DIFF
--- a/server.js
+++ b/server.js
@@ -5256,6 +5256,32 @@ function fileKind(fullPath, name) {
   return 'file';
 }
 
+// Kind, but only opening files whose identity has changed. Classifying a
+// markdown file reads its frontmatter head, which OPENS it, and on a
+// cloud-synced vault (iCloud, OneDrive, Dropbox online-only files) an open
+// can force the provider to download content. A stat reads metadata only and
+// materialises nothing, so it is the cheap question ("same file as last
+// time?") that decides whether the expensive one ("what is in it?") is asked
+// at all. A rebuild over an unchanged vault opens zero files.
+//
+// Entries for deleted files linger until the process restarts; at three
+// small numbers per path that is noise, and pruning would cost a pass over
+// the map on every walk to save it.
+const _fileKindCache = new Map(); // absolute path -> { mtimeMs, size, kind }
+
+function fileKindCached(fullPath, name) {
+  // Only markdown classification reads content; everything else is decided
+  // by extension alone, with no I/O to save.
+  if (!/\.mdx?$/i.test(name)) return fileKind(fullPath, name);
+  let st;
+  try { st = fs.statSync(fullPath); } catch (e) { return fileKind(fullPath, name); }
+  const hit = _fileKindCache.get(fullPath);
+  if (hit && hit.mtimeMs === st.mtimeMs && hit.size === st.size) return hit.kind;
+  const kind = fileKind(fullPath, name);
+  _fileKindCache.set(fullPath, { mtimeMs: st.mtimeMs, size: st.size, kind });
+  return kind;
+}
+
 function getFileTree(dir, prefix = '') {
   const entries = [];
   try {
@@ -5271,7 +5297,7 @@ function getFileTree(dir, prefix = '') {
       if (item.isDirectory()) {
         entries.push({ type: 'folder', name: item.name, path: relativePath, children: getFileTree(path.join(dir, item.name), relativePath) });
       } else if (VIEWABLE_FILE_RE.test(item.name)) {
-        entries.push({ type: 'file', name: item.name, path: relativePath, kind: fileKind(path.join(dir, item.name), item.name) });
+        entries.push({ type: 'file', name: item.name, path: relativePath, kind: fileKindCached(path.join(dir, item.name), item.name) });
       }
     }
   } catch (e) {}

--- a/test/unit/file-kind-cache.test.js
+++ b/test/unit/file-kind-cache.test.js
@@ -1,0 +1,98 @@
+// The tree walk must not open files whose identity has not changed.
+//
+// Classifying a markdown file for its tree icon reads its frontmatter head,
+// which means opening the file. On a cloud-synced vault (iCloud, OneDrive,
+// Dropbox with online-only files) an open can force the provider to download
+// the file's content; a tree rebuild that opens every note turns into a
+// freeze that scales with vault size. A stat does not materialise content,
+// so the fix is an identity check: only a file whose mtime or size moved is
+// worth opening again.
+//
+// These tests count actual opens during walks by spying on fs.openSync,
+// which the head-read uses. The invariant: a walk over unchanged files opens
+// nothing, and a walk after one change opens exactly that one file.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { _internal } = require('../../server.js');
+
+const NOTE_COUNT = 24;
+
+let dir;
+let realOpenSync;
+let openCount;
+
+function countingOpenSync(...args) {
+  openCount += 1;
+  return realOpenSync.apply(fs, args);
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-kind-cache-'));
+  for (let i = 0; i < NOTE_COUNT; i++) {
+    const body = i % 5 === 0
+      ? '---\nkanban-plugin: board\n---\n\n## Doing\n'
+      : `# Note ${i}\n\nBody.\n`;
+    fs.writeFileSync(path.join(dir, `note-${String(i).padStart(2, '0')}.md`), body);
+  }
+  realOpenSync = fs.openSync;
+  openCount = 0;
+});
+
+afterEach(() => {
+  fs.openSync = realOpenSync;
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function walkCountingOpens() {
+  openCount = 0;
+  fs.openSync = countingOpenSync;
+  try {
+    return _internal.getFileTree(dir);
+  } finally {
+    fs.openSync = realOpenSync;
+  }
+}
+
+describe('file opens during a tree walk', () => {
+  test('a walk over unchanged files opens none of them', () => {
+    walkCountingOpens(); // cold: entitled to open everything once
+    const warmOpens = (walkCountingOpens(), openCount);
+    assert.strictEqual(
+      warmOpens, 0,
+      `expected an unchanged walk to open no files, but it opened ${warmOpens} of ${NOTE_COUNT}: the cost scales with note count`
+    );
+  });
+
+  test('after one file changes, only that file is opened', () => {
+    walkCountingOpens();
+    const changed = path.join(dir, 'note-03.md');
+    fs.writeFileSync(changed, '# Note 3, edited\n\nNew body.\n');
+    // File timestamps can be coarse; force a distinct mtime so the change
+    // is visible to an identity check regardless of filesystem granularity.
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(changed, future, future);
+    walkCountingOpens();
+    assert.strictEqual(openCount, 1, `expected exactly 1 open after 1 change, got ${openCount}`);
+  });
+
+  test('classification stays correct through the cache', () => {
+    const tree1 = walkCountingOpens();
+    const kinds1 = Object.fromEntries(tree1.map((n) => [n.name, n.kind]));
+    assert.strictEqual(kinds1['note-00.md'], 'board');
+    assert.strictEqual(kinds1['note-01.md'], 'note');
+
+    // Turning a note into a board must be picked up once its identity moves.
+    const target = path.join(dir, 'note-01.md');
+    fs.writeFileSync(target, '---\nkanban-plugin: board\n---\n\n## Doing\n');
+    const future = new Date(Date.now() + 5000);
+    fs.utimesSync(target, future, future);
+    const tree2 = walkCountingOpens();
+    const kinds2 = Object.fromEntries(tree2.map((n) => [n.name, n.kind]));
+    assert.strictEqual(kinds2['note-01.md'], 'board');
+  });
+});


### PR DESCRIPTION
## What this changes

The tree walk opened every markdown file on every rebuild to classify it (note vs board), because the classification reads the frontmatter head. On a cloud-synced vault with online-only files, each open can force the sync provider to download content, so a rebuild froze in proportion to vault size.

File kind is now cached per file, keyed on mtime + size. A stat materialises nothing, so it decides cheaply whether the file needs opening at all:

- A rebuild over an unchanged vault opens zero files (previously: all of them).
- After one edit, exactly one file is opened.
- Turning a note into a kanban board is still picked up the moment the file changes.

This composes with the existing tree cache: that cache avoids walks whose directory shape is unchanged; this one makes the walks that do happen stop touching file contents.

## Testing

The failing test came first, counting real opens through the walk via the head-read's `openSync`: 24 of 24 unchanged files opened before the fix, 0 after. Full suite 1199 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
