### PR TITLE
Show .md in search results so the tree and search agree on names

### DIFF
--- a/search.js
+++ b/search.js
@@ -96,34 +96,30 @@ function sanitizeFtsQuery(raw, { prefix = false } = {}) {
 /**
  * How a file's name is presented, in the index and in every result row.
  *
- * Markdown is the default format for notes, so `.md` appears on almost every
- * file and never distinguishes one from another. It is hidden. Every other
- * extension is shown, because when several files share a name it is the only
- * thing telling them apart: a report held as HTML, PDF, PNG, JPG and GIF is
- * ordinary, and stripping the extension collapsed all five into identical rows.
+ * THE NAMING RULE, in its single written form: every file, markdown
+ * included, is shown under its real filename, extension and all, exactly as
+ * the file tree shows it. The tree and search are usually visible at the
+ * same time, and one file must not carry two names on one screen. The tree
+ * side follows the same rule by rendering names untouched.
  *
- * This is deliberately the single definition of that rule. The stripping it
- * replaces was written out longhand in three separate places.
+ * This deliberately REVERSES an earlier rule that hid `.md` here ("almost
+ * every file is a note and its extension never told two of them apart").
+ * That reasoning is sound within a single pane and was overridden anyway:
+ * consistency between two simultaneously visible panes beats per-pane
+ * tidiness. Recorded as a reversal so the argument is not re-run from
+ * scratch; if this changes again, change it HERE and nowhere else.
  *
  * Note this feeds the indexed `title`, not just the rendering. That is
- * required, not incidental: query tokens are combined with implicit AND, so a
- * title shown as `report.pdf` but indexed as `report` would not be found by
- * someone typing exactly what they can see.
+ * required, not incidental: query tokens are combined with implicit AND, so
+ * the indexed title must be the string the user can see. It also means
+ * typing a full filename including its extension matches, as it always has.
  *
  * Total by design: it runs on every indexed row and every result, so junk in
  * yields a string out rather than taking down indexing or a result list.
  */
-const HIDDEN_EXTENSION = '.md';
 function displayTitle(relPath) {
   if (typeof relPath !== 'string' || relPath === '') return '';
-  const base = path.basename(relPath);
-  const ext = path.extname(base);
-  // path.extname('.gitignore') is '' by design, so dotfiles keep their name.
-  if (!ext) return base;
-  if (ext.toLowerCase() !== HIDDEN_EXTENSION) return base;
-  const stem = path.basename(base, ext);
-  // A file named exactly '.md' would strip to nothing; never blank a row.
-  return stem || base;
+  return path.basename(relPath);
 }
 
 // ── Fuzzy title matcher ──────────────────────────────────────────────────────

--- a/test/e2e/search.spec.js
+++ b/test/e2e/search.spec.js
@@ -334,9 +334,10 @@ test('files differing only by type are distinguishable in results', async ({ pag
   expect(trimmed).toContain('board-pack-q3.pdf');
   expect(trimmed).toContain('board-pack-q3.png');
   expect(trimmed).toContain('board-pack-q3.html');
-  // Markdown keeps a clean name: .md is on almost every file and never tells
-  // two of them apart.
-  expect(trimmed).toContain('board-pack-q3');
+  // Markdown shows its extension like everything else: the tree and search
+  // must give a file one name. The rule and its history live on
+  // displayTitle in search.js.
+  expect(trimmed).toContain('board-pack-q3.md');
 });
 
 test('each file type draws its own icon rather than one generic glyph', async ({ page }) => {

--- a/test/integration/search-fallback.test.js
+++ b/test/integration/search-fallback.test.js
@@ -102,7 +102,7 @@ describe('file type on the degraded path', () => {
     const files = (reply.groups && reply.groups.files) || [];
     const titles = files.map(f => f.title);
 
-    for (const want of ['quarter-pack.pdf', 'quarter-pack.png', 'quarter-pack']) {
+    for (const want of ['quarter-pack.pdf', 'quarter-pack.png', 'quarter-pack.md']) {
       assert.ok(titles.includes(want),
         `expected a row titled ${want} on the grep path; got ${JSON.stringify(titles)}`);
     }

--- a/test/integration/search-file-type.test.js
+++ b/test/integration/search-file-type.test.js
@@ -78,15 +78,15 @@ describe('telling files apart in search results', () => {
       + `got ${JSON.stringify(collisions)}`);
   });
 
-  test('the extension is shown for everything except markdown', async () => {
+  test('the extension is shown for every type, markdown included', async () => {
+    // Markdown used to be the one hidden extension here. That was reversed:
+    // the tree shows .md and both panes must give a file one name. The full
+    // rationale is recorded on displayTitle in search.js.
     const titles = titlesFor(await search('board-pack-q3'));
-    for (const ext of ['pdf', 'html', 'png', 'jpg', 'gif']) {
+    for (const ext of ['pdf', 'html', 'png', 'jpg', 'gif', 'md']) {
       assert.ok(titles.includes(`board-pack-q3.${ext}`),
         `expected a row titled board-pack-q3.${ext}; got ${JSON.stringify(titles)}`);
     }
-    assert.ok(titles.includes('board-pack-q3'),
-      'the markdown file keeps a clean title, because .md is on almost every file '
-      + `and never tells two of them apart; got ${JSON.stringify(titles)}`);
   });
 
   test('a title shown on screen can be found by typing it exactly', async () => {
@@ -101,9 +101,11 @@ describe('telling files apart in search results', () => {
   });
 
   test('searching a bare stem still finds a markdown note', async () => {
+    // The title now carries .md, but a user typing just the name they think
+    // of must still find the note.
     const titles = titlesFor(await search('pricing-strategy'));
-    assert.ok(titles.includes('pricing-strategy'),
-      `an ordinary note must be unaffected; got ${JSON.stringify(titles)}`);
+    assert.ok(titles.includes('pricing-strategy.md'),
+      `an ordinary note must be found by its stem; got ${JSON.stringify(titles)}`);
   });
 
   test('results carry a kind, so the row can show a per-type icon', async () => {
@@ -119,6 +121,6 @@ describe('telling files apart in search results', () => {
     const byTitle = Object.fromEntries(rows.map(r => [r.title, r.kind]));
     assert.strictEqual(byTitle['board-pack-q3.pdf'], 'pdf');
     assert.strictEqual(byTitle['board-pack-q3.png'], 'image');
-    assert.strictEqual(byTitle['board-pack-q3'], 'note');
+    assert.strictEqual(byTitle['board-pack-q3.md'], 'note');
   });
 });

--- a/test/unit/display-title.test.js
+++ b/test/unit/display-title.test.js
@@ -1,66 +1,46 @@
 'use strict';
 // Unit: how a file's name is presented in search results.
 //
-// Search used to strip the extension from every file, so a set of files that
-// differed only by type collapsed into identical rows: the same text, the same
-// generic icon, no type anywhere. Having a report as HTML, PDF, PNG, JPG and
-// GIF is ordinary, and the list gave no way to tell which row was which.
+// The rule: every file, markdown included, is shown under its real filename,
+// extension and all, exactly as the file tree shows it. The two panes are
+// usually visible at the same time, and the same file must not carry two
+// names on one screen.
 //
-// The rule: markdown is the default format for notes, so `.md` appears on
-// almost every file and never distinguishes one from another. It is hidden.
-// Every other extension is shown, because it is the only thing separating
-// those five files.
-//
-// This function is the single definition of that rule. It exists as one shared
-// function precisely because the old stripping logic was written in three
-// separate places, and they drifted.
+// This DELIBERATELY REVERSES an earlier rule that hid `.md` in search
+// ("almost every file is a note and its extension never told two of them
+// apart"). That reasoning is sound per-pane and was overridden anyway:
+// consistency between two simultaneously visible panes beats per-pane
+// tidiness. Recorded here as a reversal so the argument is not re-run from
+// scratch a fourth time; this function is the single written form of the
+// naming rule, and the tree side simply renders names untouched.
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 const { displayTitle } = require('../../search.js');
 
 describe('displayTitle', () => {
-  test('hides .md, because it appears on almost every file', () => {
-    assert.strictEqual(displayTitle('notes.md'), 'notes');
-    assert.strictEqual(displayTitle('pricing-strategy.md'), 'pricing-strategy');
+  test('shows .md, so the tree and search agree on one name per file', () => {
+    assert.strictEqual(displayTitle('notes.md'), 'notes.md');
+    assert.strictEqual(displayTitle('pricing-strategy.md'), 'pricing-strategy.md');
+    assert.strictEqual(displayTitle('REPORT.MD'), 'REPORT.MD');
   });
 
-  test('shows every other extension, because that is what tells files apart', () => {
-    // The exact case this change exists for: one name, five types.
-    assert.strictEqual(displayTitle('board-pack-q3.pdf'), 'board-pack-q3.pdf');
-    assert.strictEqual(displayTitle('board-pack-q3.html'), 'board-pack-q3.html');
-    assert.strictEqual(displayTitle('board-pack-q3.png'), 'board-pack-q3.png');
-    assert.strictEqual(displayTitle('board-pack-q3.jpg'), 'board-pack-q3.jpg');
-    assert.strictEqual(displayTitle('board-pack-q3.gif'), 'board-pack-q3.gif');
-
+  test('shows every other extension, unchanged from before', () => {
+    // One name, five types: the extension is what tells the rows apart.
     const titles = ['pdf', 'html', 'png', 'jpg', 'gif']
       .map(e => displayTitle(`board-pack-q3.${e}`));
     assert.strictEqual(new Set(titles).size, 5,
-      'five files sharing a name must produce five distinct titles; that is the whole point');
+      'five files sharing a name must produce five distinct titles');
+    assert.strictEqual(displayTitle('board-pack-q3.pdf'), 'board-pack-q3.pdf');
   });
 
   test('takes the basename, so a nested path does not leak into the title', () => {
     assert.strictEqual(displayTitle('notes/board-packs/report.pdf'), 'report.pdf');
-    assert.strictEqual(displayTitle('notes/board-packs/report.md'), 'report');
+    assert.strictEqual(displayTitle('notes/board-packs/report.md'), 'report.md');
   });
 
-  test('matches the extension case-insensitively', () => {
-    // A case-insensitive filesystem will hand us either spelling, and .MD is
-    // still markdown. Getting this wrong shows `REPORT.MD` to some users only.
-    assert.strictEqual(displayTitle('REPORT.MD'), 'REPORT');
-    assert.strictEqual(displayTitle('notes.Md'), 'notes');
-    assert.strictEqual(displayTitle('REPORT.PDF'), 'REPORT.PDF',
-      'a shown extension keeps its original case; only the comparison is insensitive');
-  });
-
-  test('leaves a file with no extension alone', () => {
+  test('leaves files with no extension and dotfiles alone', () => {
     assert.strictEqual(displayTitle('Makefile'), 'Makefile');
-    assert.strictEqual(displayTitle('LICENSE'), 'LICENSE');
-  });
-
-  test('treats a dotfile as a name, not as an extension', () => {
-    // path.extname('.gitignore') is '' by design. Stripping naively here would
-    // produce an empty title and an invisible row.
     assert.strictEqual(displayTitle('.gitignore'), '.gitignore');
     assert.strictEqual(displayTitle('.env'), '.env');
     assert.strictEqual(displayTitle('.md'), '.md');
@@ -68,13 +48,11 @@ describe('displayTitle', () => {
 
   test('handles multiple dots without eating part of the name', () => {
     assert.strictEqual(displayTitle('archive.tar.gz'), 'archive.tar.gz');
-    assert.strictEqual(displayTitle('notes.v2.md'), 'notes.v2');
-    assert.strictEqual(displayTitle('.env.md'), '.env');
+    assert.strictEqual(displayTitle('notes.v2.md'), 'notes.v2.md');
+    assert.strictEqual(displayTitle('.env.md'), '.env.md');
   });
 
-  test('never returns an empty title for any input', () => {
-    // An empty title renders as a blank, unclickable-looking row. No input
-    // that names a real file may produce one.
+  test('never returns an empty title for any input that names a file', () => {
     const inputs = [
       'notes.md', '.md', '.gitignore', 'Makefile', 'a.md', 'a.pdf',
       'x/y/z.md', 'x/y/.md', 'archive.tar.gz', 'REPORT.MD', '.env.md',
@@ -88,18 +66,10 @@ describe('displayTitle', () => {
 
   test('behaves identically under Windows path rules', () => {
     // Tree and index paths are built with explicit forward slashes on every
-    // platform, and Windows accepts both separators. This pins that, so the
-    // rule cannot quietly diverge on the one platform CI does not run the
-    // integration suite on.
+    // platform, and Windows accepts both separators. Pinned so the rule
+    // cannot quietly diverge on the platform CI does not integration-test.
     const path = require('node:path');
-    const HIDDEN = '.md';
-    const under = (P, rel) => {
-      const b = P.basename(rel);
-      const e = P.extname(b);
-      if (!e) return b;
-      if (e.toLowerCase() !== HIDDEN) return b;
-      return P.basename(b, e) || b;
-    };
+    const under = (P, rel) => P.basename(rel);
     const cases = [
       'packs/board-pack-q3.pdf', 'notes/sub/report.MD', 'Makefile',
       '.gitignore', 'archive.tar.gz', 'notes.v2.md', 'x/y/.md',


### PR DESCRIPTION
## What this changes

The file tree shows `Briefing.md`; search showed `Briefing`. Both panes are usually visible at the same time, so one file carried two names on one screen. Search results now show the real filename, extension included, for every type.

This deliberately reverses the earlier decision to hide `.md` in search. That decision's reasoning (markdown is on almost every file and never tells two apart) is sound within a single pane and is overridden anyway: consistency between two simultaneously visible panes beats per-pane tidiness. The rule now lives in exactly one written place, `displayTitle` in `search.js`, recorded as a reversal so the argument is not re-run a fourth time; the tree follows the same rule by rendering names untouched.

Matching is unchanged in both directions: a bare stem still finds the note, and typing the visible title with its extension still matches.

## Testing

Unit, integration (including the no-sqlite fallback path), and e2e expectations all moved to the new rule; suites green (1194 unit / 102 e2e).

The public documentation describes the old naming behaviour and will be updated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)