### PR TITLE
Stop tracking the node_modules symlink

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/liamdarmody/Documents/Projects/Rundock/node_modules


### PR DESCRIPTION
## What this changes

A repository-root symlink named `node_modules` slipped into a recent merge. It points at its own path, so checking it out replaces a real dependency directory with a self-resolving link, and a fresh clone fails with "too many levels of symbolic links" as soon as anything touches a dependency. Pulling latest main onto an existing working copy destroys the local `node_modules` the same way (observed first-hand; `npm ci` recovers it).

`git rm --cached node_modules` removes the tracked entry; the path was always gitignored and stays that way. Nothing else changes.

Worth merging ahead of everything else in the queue: every clone and pull of main is affected until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
