### PR TITLE
Follow the OS light/dark setting until the user chooses

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3280,20 +3280,45 @@ function switchNav(nav) {
 function showView(v) { currentView=v; ['workspace','home','profile','chat','convo-empty','editor','skills','settings'].forEach(id=>{const e=document.getElementById(`view-${id}`);if(e){e.classList.add('hidden');e.style.display='none';e.classList.remove('main-view-transition');}}); const e=document.getElementById(`view-${v}`); if(e){e.classList.remove('hidden');e.style.display='flex';e.classList.add('main-view-transition');}  }
 function goHome() { discardIfEmpty(); activeConversation=null; switchNav('conversations'); }
 
-// Theme
-function toggleTheme() { document.body.classList.toggle('light'); const isLight=document.body.classList.contains('light'); document.getElementById('theme-toggle').innerHTML=isLight?moonIcon:sunIcon; if(typeof applyHljsTheme==='function')applyHljsTheme(isLight); syncTitleBarOverlay(isLight); persist.set('rundock-theme',isLight?'light':'dark'); }
-// Restore saved theme on load
-if(persist.get('rundock-theme')==='light'){document.body.classList.add('light');document.getElementById('theme-toggle').innerHTML=moonIcon;}
+// Theme. One function applies it everywhere it shows (body class, toggle
+// icon, code highlighting, Windows caption colours); which theme applies is
+// decided by chooseTheme (public/theme-choice.js): an explicit choice wins
+// forever, and until one exists the app follows the OS setting, live.
+function applyTheme(isLight) {
+  document.body.classList.toggle('light', isLight);
+  const t = document.getElementById('theme-toggle');
+  if (t) t.innerHTML = isLight ? moonIcon : sunIcon;
+  if (typeof applyHljsTheme === 'function') applyHljsTheme(isLight);
+  syncTitleBarOverlay(isLight);
+}
+function toggleTheme() {
+  const isLight = !document.body.classList.contains('light');
+  applyTheme(isLight);
+  // The toggle is the user choosing. From here on the OS setting no longer
+  // moves the theme (the media listener below checks storage before acting).
+  persist.set('rundock-theme', isLight ? 'light' : 'dark');
+}
+// Apply the right theme on load, and follow OS changes only while no
+// explicit choice exists.
+{
+  const osLight = window.matchMedia('(prefers-color-scheme: light)');
+  const choice = chooseTheme({ stored: persist.get('rundock-theme'), osPrefersLight: osLight.matches });
+  applyTheme(choice.light);
+  if (choice.followOs) {
+    osLight.addEventListener('change', (e) => {
+      const again = chooseTheme({ stored: persist.get('rundock-theme'), osPrefersLight: e.matches });
+      if (again.followOs) applyTheme(again.light);
+    });
+  }
+}
 
 // The Windows caption buttons are drawn by the OS from colours we pass, so
-// they keep the old ones until re-sent. BOTH paths must call this: only
-// hooking the toggle leaves them correct after a click and wrong after a
-// restart, because the restore-from-storage path above changes the theme
-// without going through it. A no-op off Windows and in a browser.
+// they keep the old ones until re-sent. Every theme change flows through
+// applyTheme above, which calls this, so boot, toggle, and OS-follow all
+// keep the buttons in step. A no-op off Windows and in a browser.
 function syncTitleBarOverlay(isLight) {
   try { window.electronAPI?.setTitleBarOverlay?.(!!isLight); } catch (e) {}
 }
-syncTitleBarOverlay(document.body.classList.contains('light'));
 
 // ===== 11. FILE TREE & EDITOR =====
 

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 <script src="/vendor/highlight/highlight.min.js"></script>
 <script src="/code-language.js"></script>
 <script src="/chrome-insets.js"></script>
+<script src="/theme-choice.js"></script>
 <script src="/empty-list.js"></script>
 <script src="/unread-state.js"></script>
 <script src="/markers.js"></script>

--- a/public/theme-choice.js
+++ b/public/theme-choice.js
@@ -1,0 +1,32 @@
+// Theme decision. Pure: no DOM, no storage, following the convention of
+// public/chrome-insets.js and public/code-language.js.
+//
+// The rule: an explicit choice the user once made wins forever; until they
+// make one, the app follows the OS. `followOs` tells the caller whether to
+// keep listening for OS changes (only while no explicit choice exists:
+// a chosen theme must not flip when the OS schedule does).
+//
+// Anything in storage that is not exactly 'light' or 'dark' counts as no
+// choice, so corrupt or legacy values degrade to following the OS rather
+// than pinning a theme the user never picked.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.chooseTheme = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  /**
+   * @param {object} input
+   * @param {string|null} [input.stored]        persisted 'light' | 'dark' | anything else
+   * @param {boolean} [input.osPrefersLight]    prefers-color-scheme: light
+   * @returns {{ light: boolean, followOs: boolean }}
+   */
+  function chooseTheme(input) {
+    const s = input || {};
+    if (s.stored === 'light') return { light: true, followOs: false };
+    if (s.stored === 'dark') return { light: false, followOs: false };
+    return { light: Boolean(s.osPrefersLight), followOs: true };
+  }
+
+  return chooseTheme;
+}));

--- a/test/unit/theme-choice.test.js
+++ b/test/unit/theme-choice.test.js
@@ -1,0 +1,42 @@
+// Tests for the theme decision (public/theme-choice.js).
+//
+// The app used to default to dark unconditionally; the OS setting was never
+// consulted. The rule now: an explicit choice the user once made wins
+// forever, and until they make one the app follows the OS. This only became
+// possible when renderer storage started surviving relaunches; before that,
+// "the user chose" was forgotten on every launch and following the OS would
+// have fought a phantom preference.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const chooseTheme = require('../../public/theme-choice.js');
+
+describe('an explicit choice wins over the OS', () => {
+  test('stored light beats an OS that prefers dark', () => {
+    assert.deepStrictEqual(chooseTheme({ stored: 'light', osPrefersLight: false }), { light: true, followOs: false });
+  });
+
+  test('stored dark beats an OS that prefers light', () => {
+    assert.deepStrictEqual(chooseTheme({ stored: 'dark', osPrefersLight: true }), { light: false, followOs: false });
+  });
+});
+
+describe('no choice yet means follow the OS, live', () => {
+  test('nothing stored, OS light', () => {
+    assert.deepStrictEqual(chooseTheme({ stored: null, osPrefersLight: true }), { light: true, followOs: true });
+  });
+
+  test('nothing stored, OS dark', () => {
+    assert.deepStrictEqual(chooseTheme({ stored: null, osPrefersLight: false }), { light: false, followOs: true });
+  });
+});
+
+describe('junk in storage is treated as no choice', () => {
+  test('an unrecognised stored value follows the OS', () => {
+    assert.deepStrictEqual(chooseTheme({ stored: 'blue', osPrefersLight: true }), { light: true, followOs: true });
+  });
+
+  test('missing input entirely follows a dark OS default', () => {
+    assert.deepStrictEqual(chooseTheme({}), { light: false, followOs: true });
+  });
+});


### PR DESCRIPTION
Recreates a change whose original pull request was auto-closed when its base branch was deleted mid-queue; the content is identical and was already reviewed there.

The app defaulted to dark and never consulted the OS. Now an explicit user choice wins forever, and until one exists the app follows the OS light/dark setting live. The decision is a pure module with unit tests; unrecognised stored values degrade to OS-following. One applyTheme path keeps the toggle icon, code highlighting, and Windows caption colours in step on every path.

Depends on the renderer-storage work, which is already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)