### PR TITLE
Show update progress and the restart offer in the sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual runs against any branch. Exists because push and pull_request
+  # event processing has been observed to stall on GitHub's side while
+  # dispatch kept working; this keeps full CI reachable for a branch when
+  # that happens.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/electron/main.js
+++ b/electron/main.js
@@ -307,6 +307,14 @@ ipcMain.handle('rundock-storage-set', (event, key, value) => {
   }
 });
 
+// The sidebar's update strip offers Restart when an update is ready.
+// Installing means quitting and relaunching, which only this process can
+// do; the explicit call is the same deterministic path the native prompt
+// uses, rather than relying on install-on-quit winning a race at exit.
+ipcMain.handle('rundock-update-restart', () => {
+  if (autoUpdater) autoUpdater.quitAndInstall();
+});
+
 // The Windows caption buttons are drawn by the OS from colours we pass, so
 // they keep the old ones until re-sent. The renderer calls this on every theme
 // change AND on the restore-from-storage path at launch: sending only on

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -22,6 +22,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('rundock-update', (event, data) => callback(data));
   },
 
+  // The sidebar's update surface offers Restart when an update is ready;
+  // installing means quitting, which only the main process can do.
+  updateRestart: () => ipcRenderer.invoke('rundock-update-restart'),
+
   // Durable renderer storage. The page's origin includes an OS-assigned port
   // that changes every launch, so localStorage cannot hold anything across
   // sessions; durable state lives in the main process instead. The snapshot

--- a/public/app.js
+++ b/public/app.js
@@ -5163,6 +5163,92 @@ window.electronAPI?.onFullScreenChange?.((isFullScreen) => {
 });
 
 applyChromeInsets();
+
+// ===== UPDATE STRIP =====
+// The sidebar's update surface. The main process decides what the user
+// should know (its decision object arrives on the update channel); the pure
+// view module decides how the strip presents it; this code only draws.
+// "Later" defers the ready row to a quiet chip for this session; it never
+// dismisses, because the pending update stays pending regardless, and the
+// next launch re-offers the prompt.
+let _updateUi = null;
+let _updateDeferred = false;
+
+// Radial progress ring, 18px. r=7 so the circumference is 43.98; the arc is
+// drawn from 12 o'clock via the -90 degree rotation. A null percent renders
+// the indeterminate spinner (a fixed arc the CSS rotates).
+function updateRingSvg(percent) {
+  const base = '<circle cx="9" cy="9" r="7" fill="none" stroke="var(--border)" stroke-width="2"/>';
+  if (percent === null) {
+    return `<span class="u-ring indet"><svg width="18" height="18" viewBox="0 0 18 18">${base}<circle cx="9" cy="9" r="7" fill="none" stroke="var(--working)" stroke-width="2" stroke-linecap="round" stroke-dasharray="11 33"/></svg></span>`;
+  }
+  const C = 43.98;
+  const off = (C * (1 - Math.max(0, Math.min(100, percent)) / 100)).toFixed(2);
+  return `<span class="u-ring"><svg width="18" height="18" viewBox="0 0 18 18">${base}<circle cx="9" cy="9" r="7" fill="none" stroke="var(--working)" stroke-width="2" stroke-linecap="round" stroke-dasharray="43.98" stroke-dashoffset="${off}" transform="rotate(-90 9 9)"/></svg></span>`;
+}
+
+// The decided text carries the version inside a plain sentence; bolding just
+// that phrase is presentation, so it happens here, after escaping.
+function updateTextHtml(text, version) {
+  const safe = esc(text || '');
+  if (!version) return safe;
+  const phrase = esc('Rundock ' + version);
+  return safe.replace(phrase, `<b>${phrase}</b>`);
+}
+
+function renderUpdateStrip() {
+  const el = document.getElementById('update-strip');
+  if (!el || typeof updateStripView !== 'function') return;
+  const view = updateStripView(_updateUi, _updateDeferred);
+  if (!view.show) {
+    el.style.display = 'none';
+    el.className = 'u-strip';
+    el.innerHTML = '';
+    el.removeAttribute('tabindex');
+    return;
+  }
+  el.style.display = '';
+  if (view.mode === 'download') {
+    const pctNum = view.indeterminate ? null : Math.round(view.percent);
+    el.className = 'u-strip collapsed dl';
+    // Focusable so keyboard users can expand the collapsed ring, matching
+    // the pointer's hover.
+    el.setAttribute('tabindex', '0');
+    el.innerHTML = `
+      <div class="u-collapsed-row">${updateRingSvg(pctNum)}${pctNum === null ? '' : `<span class="u-collapsed-pct">${pctNum}%</span>`}</div>
+      <div class="u-row u-expanded-row">${updateRingSvg(pctNum)}<span class="u-text">${updateTextHtml(view.text, _updateUi && _updateUi.version)}</span>${pctNum === null ? '' : `<span class="u-pct">${pctNum}%</span>`}</div>`;
+    return;
+  }
+  if (view.mode === 'chip') {
+    el.className = 'u-strip collapsed';
+    el.removeAttribute('tabindex');
+    el.innerHTML = `<button class="u-collapsed-row" onclick="undeferUpdateStrip()" aria-label="An update is ready; show details"><span class="u-dot"></span></button>`;
+    return;
+  }
+  // ready (and stuck, which presents the same and cannot be deferred)
+  el.className = 'u-strip expanded';
+  el.removeAttribute('tabindex');
+  const restartSvg = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 4v6h-6"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>';
+  el.innerHTML = `
+    <div class="u-row"><span class="u-dot"></span><span class="u-text ready">${updateTextHtml(view.text, _updateUi && _updateUi.version)}</span></div>
+    <div class="u-actions">
+      <button class="u-restart-btn" onclick="updateRestartNow()">${restartSvg}Restart</button>
+      ${_updateUi && _updateUi.kind === 'ready' ? '<button class="u-collapse-link" onclick="deferUpdateStrip()">Later</button>' : ''}
+    </div>`;
+}
+
+function updateRestartNow() { try { window.electronAPI?.updateRestart?.(); } catch (e) { /* main handles logging */ } }
+function deferUpdateStrip() { _updateDeferred = true; renderUpdateStrip(); }
+function undeferUpdateStrip() { _updateDeferred = false; renderUpdateStrip(); }
+
+window.electronAPI?.onUpdate?.((ui) => {
+  _updateUi = ui;
+  // A fresh download supersedes any earlier "Later": the deferral belonged
+  // to the update it deferred.
+  if (ui && ui.kind === 'progress') _updateDeferred = false;
+  renderUpdateStrip();
+});
+
 let paletteReturnFocus = null; // element to restore focus to on close
 
 // The top bar's search field teaches the shortcut with the right modifier per

--- a/public/app.js
+++ b/public/app.js
@@ -3245,6 +3245,10 @@ function setNavState(nav) {
   document.querySelector(`[data-nav="${nav}"]`)?.classList.add('active');
   ['team','conversations','skills','files','settings'].forEach(s=>document.getElementById(`sidebar-${s}`).classList.add('hidden'));
   document.getElementById(`sidebar-${nav}`).classList.remove('hidden');
+  // The New conversation footer lives at sidebar level (so the update strip
+  // can sit above it without ever moving it), which makes its visibility
+  // this function's job rather than the panel's.
+  document.getElementById('convo-footer')?.classList.toggle('hidden', nav !== 'conversations');
 }
 
 function switchNav(nav) {
@@ -5222,7 +5226,9 @@ function renderUpdateStrip() {
   if (view.mode === 'chip') {
     el.className = 'u-strip collapsed';
     el.removeAttribute('tabindex');
-    el.innerHTML = `<button class="u-collapsed-row" onclick="undeferUpdateStrip()" aria-label="An update is ready; show details"><span class="u-dot"></span></button>`;
+    // The dot alone was reviewed as too cryptic: two quiet words state the
+    // fact and keep the nudge alive without nagging.
+    el.innerHTML = `<button class="u-collapsed-row" onclick="undeferUpdateStrip()" aria-label="An update is ready; show details"><span class="u-dot"></span><span class="u-collapsed-label">Update ready</span></button>`;
     return;
   }
   // ready (and stuck, which presents the same and cannot be deferred)

--- a/public/index.html
+++ b/public/index.html
@@ -366,9 +366,14 @@ body.palette-open .tb-search { visibility: hidden; }
    sidebar, below whichever panel is active. */
 .u-strip { border-top: 1px solid var(--border); background: var(--surface); flex-shrink: 0; }
 /* The sidebar's generic panel rule stretches every child div to full
-   height; the strip is chrome, not a panel, and keeps its natural height
-   at the bottom regardless of which panel is active. */
+   height; the strip and the conversation footer are chrome, not panels,
+   and keep their natural heights at the bottom regardless of which panel
+   is active. The strip sits ABOVE the footer, so its appearing or
+   expanding consumes list space and the New conversation button never
+   moves. */
 .sidebar > .u-strip { height: auto; display: block; overflow: visible; margin-top: auto; }
+.sidebar > .convo-footer { height: 76px; display: flex; flex-direction: row; align-items: center; overflow: visible; }
+.u-collapsed-label { font-size: 10px; color: var(--text-2); letter-spacing: 0.02em; }
 .u-strip.collapsed { padding: 6px 14px; }
 .u-strip.expanded { padding: 10px 14px 11px; }
 .u-collapsed-row { display: flex; align-items: center; gap: 7px; height: 22px; width: 100%; }
@@ -1215,9 +1220,6 @@ mark.find-match.current,
         <button class="pill" id="pill-unread" onclick="setSidebarPill('unread')">Unread</button>
       </div>
       <div class="convo-list" id="convo-list"></div>
-      <div class="convo-footer">
-        <button class="add-btn" onclick="newConversation()"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>New conversation</button>
-      </div>
     </div>
     <div id="sidebar-skills" class="hidden">
       <div class="sidebar-header"><span class="sidebar-label">Skills</span></div>
@@ -1245,6 +1247,12 @@ mark.find-match.current,
       </div>
     </div>
     <div id="update-strip" class="u-strip" style="display:none"></div>
+    <!-- Sidebar-level so the update strip can sit ABOVE it: the strip
+         appearing or expanding consumes list space, and this button never
+         moves. Shown only on the Conversations tab (setNavState). -->
+    <div class="convo-footer" id="convo-footer">
+      <button class="add-btn" onclick="newConversation()"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>New conversation</button>
+    </div>
   </aside>
 
   <main class="main">

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
 <script src="/vendor/highlight/highlight.min.js"></script>
 <script src="/code-language.js"></script>
 <script src="/chrome-insets.js"></script>
+<script src="/update-strip-view.js"></script>
 <script src="/empty-list.js"></script>
 <script src="/unread-state.js"></script>
 <script src="/markers.js"></script>
@@ -354,6 +355,46 @@ body.palette-open .tb-search { visibility: hidden; }
 .convo-footer { height: 76px; border-top: 1px solid var(--border); background: var(--surface); flex-shrink: 0; display: flex; align-items: center; padding: 0 8px; }
 .add-btn { display: flex; align-items: center; justify-content: flex-start; gap: 8px; padding: 10px 8px; margin: 0; width: 100%; border-radius: 8px; font-size: var(--body); font-weight: 500; color: var(--text-2); border: 1px solid transparent; transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease; }
 .add-btn:hover { color: var(--accent); background: var(--accent-glow); border-color: rgba(232,122,90,0.3); }
+
+/* Update strip: the sidebar's update surface, ambient at rest and legible
+   on demand. Two weights: a collapsed ~22px ring while a download runs
+   (hover or focus expands it to the full sentence), and an expanded row
+   when an update is ready, which stays expanded because it is the one
+   moment the feature exists for. "Later" defers ready to a small static
+   chip; it never dismisses, since the pending update stays pending
+   regardless of what the interface shows. Sits at the very bottom of the
+   sidebar, below whichever panel is active. */
+.u-strip { border-top: 1px solid var(--border); background: var(--surface); flex-shrink: 0; }
+/* The sidebar's generic panel rule stretches every child div to full
+   height; the strip is chrome, not a panel, and keeps its natural height
+   at the bottom regardless of which panel is active. */
+.sidebar > .u-strip { height: auto; display: block; overflow: visible; margin-top: auto; }
+.u-strip.collapsed { padding: 6px 14px; }
+.u-strip.expanded { padding: 10px 14px 11px; }
+.u-collapsed-row { display: flex; align-items: center; gap: 7px; height: 22px; width: 100%; }
+.u-collapsed-pct { font-size: 10.5px; color: var(--text-2); font-variant-numeric: tabular-nums; }
+.u-row { display: flex; align-items: flex-start; gap: 9px; }
+.u-dot { width: 7px; height: 7px; min-width: 7px; border-radius: 50%; background: var(--success); flex-shrink: 0; margin-top: 4px; }
+.u-collapsed-row .u-dot { margin-top: 0; }
+.u-text { flex: 1; min-width: 0; font-size: 11.5px; color: var(--text-2); line-height: 1.55; overflow-wrap: anywhere; text-align: left; }
+.u-text.ready { color: var(--text-1); }
+.u-text b { color: var(--text-1); font-weight: 600; }
+.u-pct { flex-shrink: 0; font-size: 11px; color: var(--text-1); font-variant-numeric: tabular-nums; font-weight: 500; margin-top: 1px; }
+.u-actions { display: flex; align-items: center; gap: 10px; margin-top: 8px; padding-left: 16px; }
+.u-restart-btn { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; font-weight: 600; color: var(--accent); padding: 0; }
+.u-restart-btn svg { width: 12px; height: 12px; }
+.u-collapse-link { font-size: 11px; color: var(--text-2); opacity: 0.8; padding: 0; }
+.u-ring { flex-shrink: 0; }
+.u-ring svg { display: block; }
+.u-ring.indet { animation: uSpin 900ms linear infinite; transform-origin: 50% 50%; }
+@keyframes uSpin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .u-ring.indet { animation: none; opacity: 0.6; } }
+/* Downloading renders both rows; hover or keyboard focus swaps which one
+   shows, so the expansion needs no JS and no mouse tracking. */
+.u-strip.dl .u-expanded-row { display: none; }
+.u-strip.dl:hover, .u-strip.dl:focus-within { padding: 10px 14px 11px; }
+.u-strip.dl:hover .u-expanded-row, .u-strip.dl:focus-within .u-expanded-row { display: flex; }
+.u-strip.dl:hover .u-collapsed-row, .u-strip.dl:focus-within .u-collapsed-row { display: none; }
 
 /* Main panel */
 .main { flex: 1; display: flex; flex-direction: column; background: var(--elevated); overflow: hidden; position: relative; }
@@ -1196,6 +1237,7 @@ mark.find-match.current,
         </div>
       </div>
     </div>
+    <div id="update-strip" class="u-strip" style="display:none"></div>
   </aside>
 
   <main class="main">

--- a/public/update-strip-view.js
+++ b/public/update-strip-view.js
@@ -1,0 +1,62 @@
+// Update strip view decision. Pure: no DOM, following the convention of
+// public/chrome-insets.js and public/theme-choice.js.
+//
+// The main process decides WHAT the user should know about an update
+// (electron/update-state.js); this module decides how the sidebar strip
+// presents it, given one piece of renderer-side state: whether the user
+// chose "Later" on the ready row. Later defers, it never dismisses: the
+// pending update is still pending regardless of what the interface shows,
+// so the quiet chip remains, and one click brings the full row back.
+//
+// Modes:
+//   download  collapsed ring while a download runs; percent or indeterminate
+//   ready     expanded row with a restart action (the state the feature is for)
+//   chip      the deferred form of ready: a small static dot, quiet, not gone
+//
+// The stuck state (downloaded repeatedly, never installed) renders like
+// ready and ignores deferral: it is an escalation, and quieting it would
+// defeat the escape hatch it exists to provide.
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.updateStripView = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  function updateStripView(ui, deferred) {
+    if (!ui || typeof ui !== 'object') return { show: false };
+    switch (ui.kind) {
+      case 'progress':
+        return {
+          show: true,
+          mode: 'download',
+          percent: typeof ui.percent === 'number' ? ui.percent : 0,
+          indeterminate: Boolean(ui.indeterminate),
+          text: ui.text || 'Downloading an update. You can keep working.',
+        };
+      case 'ready':
+        if (deferred) return { show: true, mode: 'chip' };
+        return {
+          show: true,
+          mode: 'ready',
+          text: ui.text || 'An update is ready to install.',
+          detail: ui.detail || '',
+          canRestart: true,
+        };
+      case 'stuck':
+        return {
+          show: true,
+          mode: 'ready',
+          text: ui.text || 'An update was downloaded but has not installed.',
+          detail: ui.detail || '',
+          canRestart: true,
+        };
+      default:
+        // none, dialog-only, and anything unrecognised: the strip stays out
+        // of the way. Fail closed; a broken update path must not occupy the
+        // sidebar.
+        return { show: false };
+    }
+  }
+
+  return updateStripView;
+}));

--- a/test/unit/update-strip-view.test.js
+++ b/test/unit/update-strip-view.test.js
@@ -1,0 +1,83 @@
+// Tests for the update strip's view decision (public/update-strip-view.js).
+//
+// The sidebar's update surface has two weights: a collapsed ring while a
+// download runs (ambient, ignorable) and an expanded row when an update is
+// ready (the one moment the feature exists for, so it is visible by
+// default). "Later" defers the ready row to a small chip; it never
+// dismisses, because the pending update is still pending no matter what the
+// interface shows.
+//
+// Input is exactly what the main process sends the renderer: the decided UI
+// object from the updater's decision module. This module only chooses how
+// the strip presents it.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const updateStripView = require('../../public/update-strip-view.js');
+
+describe('nothing to show', () => {
+  test('no update activity hides the strip', () => {
+    assert.deepStrictEqual(updateStripView({ kind: 'none' }, false), { show: false });
+  });
+
+  test('a dialog-only decision hides the strip (the dialog is native)', () => {
+    assert.deepStrictEqual(updateStripView({ kind: 'dialog', dialog: {} }, false), { show: false });
+  });
+
+  test('missing input hides the strip rather than throwing', () => {
+    assert.deepStrictEqual(updateStripView(null, false), { show: false });
+    assert.deepStrictEqual(updateStripView(undefined, true), { show: false });
+  });
+});
+
+describe('downloading', () => {
+  test('progress shows the download mode with a percentage', () => {
+    const v = updateStripView({ kind: 'progress', percent: 67, indeterminate: false, text: 'Downloading Rundock 0.12.0. You can keep working.' }, false);
+    assert.strictEqual(v.show, true);
+    assert.strictEqual(v.mode, 'download');
+    assert.strictEqual(v.percent, 67);
+    assert.strictEqual(v.indeterminate, false);
+    assert.ok(v.text.includes('0.12.0'));
+  });
+
+  test('before the first progress event the ring is indeterminate', () => {
+    const v = updateStripView({ kind: 'progress', percent: 0, indeterminate: true, text: 'Downloading an update. You can keep working.' }, false);
+    assert.strictEqual(v.mode, 'download');
+    assert.strictEqual(v.indeterminate, true);
+  });
+
+  test('a deferred choice does not apply to downloading', () => {
+    // "Later" belongs to the ready state; a new download shows normally.
+    const v = updateStripView({ kind: 'progress', percent: 10, indeterminate: false, text: 't' }, true);
+    assert.strictEqual(v.mode, 'download');
+  });
+});
+
+describe('ready to install', () => {
+  const ready = { kind: 'ready', version: '0.12.0', text: 'Rundock 0.12.0 is ready to install.', detail: 'Restarting takes a few seconds.' };
+
+  test('ready is expanded by default, with restart offered', () => {
+    const v = updateStripView(ready, false);
+    assert.strictEqual(v.show, true);
+    assert.strictEqual(v.mode, 'ready');
+    assert.ok(v.text.includes('ready to install'));
+    assert.strictEqual(v.canRestart, true);
+  });
+
+  test('Later defers ready to the quiet chip, never dismisses', () => {
+    const v = updateStripView(ready, true);
+    assert.strictEqual(v.show, true);
+    assert.strictEqual(v.mode, 'chip');
+  });
+
+  test('the stuck state shows expanded and ignores deferral', () => {
+    // Repeated failed installs are an escalation; quieting it defeats the
+    // escape hatch. The native dialog carries the download link; the strip
+    // stays visible with the plain message.
+    const stuck = { kind: 'stuck', text: 'An update was downloaded but has not installed after several restarts.', downloadUrl: 'https://example.invalid/download' };
+    const v = updateStripView(stuck, true);
+    assert.strictEqual(v.mode, 'ready');
+    assert.ok(v.text.includes('has not installed'));
+    assert.strictEqual(v.canRestart, true);
+  });
+});


### PR DESCRIPTION
## What this changes

The renderer has received the updater's decisions since the channel was wired, and nothing subscribed. A strip at the bottom of the sidebar now presents them: ambient at rest, legible on demand.

- **Downloading:** a small radial ring with the real percentage, and nothing else — a footprint under a single sidebar row. Hover or keyboard focus expands it to the full sentence. Indeterminate before the first progress event; reduced motion gets a still ring.
- **Ready:** an expanded row with Restart and Later, visible by default because it is the one moment the feature exists for. Restart calls the same deterministic install path as the native prompt. Later collapses to a quiet dot chip for the session — deferred, never dismissed — and one click restores the row. A fresh download clears the deferral.
- **Repeated install failure** presents like ready and cannot be deferred: it is an escalation, and quieting it would defeat the escape hatch.

Which presentation applies is a pure module (`public/update-strip-view.js`) with unit tests. The sidebar's generic panel rule is exempted so the strip keeps natural height, pinned below whichever panel is active. In a plain browser the strip never appears; the update channel exists only in the desktop app.

## Testing

9 unit tests on the view decision; every state driven and measured in a live render during development (collapsed 35px, ready ~62px, chip 35px, flush at the sidebar bottom). Full suites green on top of current main: 1274 unit, 102 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
