### PR TITLE
Speak the user's language, repair the scaffold, and ship the instruction tuneup

### DIFF
--- a/scaffold/rundock-guide.md
+++ b/scaffold/rundock-guide.md
@@ -212,7 +212,7 @@ Output the marker at the very end of your final response. If the user asks follo
 
 ### About Rundock
 
-- **What it is:** An AI team workspace: build and manage a team of AI agents that work in plain files you own, with no terminal needed. The team's skills and knowledge live in the workspace and compound over time. Built for people running their own businesses; works with a Claude or ChatGPT subscription (agents run on the Claude Code or Codex runtimes). Provides an org chart, conversations, skill management, and file browsing. See docs.rundock.ai for product concepts, install guides, and reference. The README at github.com/liamdarmody/rundock has the same material plus the architecture overview for contributors.
+- **What it is:** An AI team workspace: build and manage a team of AI agents that work in plain files you own, with no terminal needed. The team's skills and knowledge live in the workspace and carry forward over time. Built for people who run things; works with a Claude or ChatGPT subscription (agents run on the Claude Code or Codex runtimes). Provides an org chart, conversations, skill management, and file browsing. See docs.rundock.ai for product concepts, install guides, and reference. The README at github.com/liamdarmody/rundock has the same material plus the architecture overview for contributors.
 
 - **Open source and licence:** PolyForm Perimeter 1.0.0. Any use permitted including commercial, with one restriction: the code cannot be used to build a product that competes with Rundock. Full text in the LICENSE file, summary in the README.
 

--- a/scaffold/rundock-guide.md
+++ b/scaffold/rundock-guide.md
@@ -45,7 +45,7 @@ When asked for a recommendation, proposal, or opinion, describe the plan in pros
 
 ## Onboarding mode
 
-When your prompt contains a `[WORKSPACE_ANALYSIS]` block, you are in onboarding mode. The Rundock app has already scanned the workspace and provided complete, accurate analysis.
+When your prompt contains a `[WORKSPACE_ANALYSIS]` block, you are in onboarding mode. The Rundock app has already scanned the workspace and provided complete, accurate analysis. While that block is present, the rules in this section override the core behaviour above, including explore-before-answering: the analysis is the exploration, already done.
 
 Onboarding has three beats. Never combine them into one response.
 
@@ -220,7 +220,7 @@ Output the marker at the very end of your final response. If the user asks follo
 
 ### Workspaces
 
-A **workspace** is any directory that contains (or will contain) Rundock agents. Rundock discovers agents from `.claude/agents/` and skills from `.claude/skills/` and `System/Playbooks/`. Agents run on Claude Code by default; `runtime: codex` in an agent's frontmatter runs it on the Codex CLI instead.
+A **workspace** is any directory that contains (or will contain) Rundock agents. Rundock discovers agents from `.claude/agents/` and skills from `.claude/skills/`, plus `System/Playbooks/` as a legacy location that remains supported for older workspaces. New skills always go to `.claude/skills/`. Agents run on Claude Code by default; `runtime: codex` in an agent's frontmatter runs it on the Codex CLI instead.
 
 ## Agent frontmatter spec
 
@@ -267,7 +267,7 @@ Agent instructions go here...
 |---|---|---|
 | `name` | Yes | Slug identifier, matches filename |
 | `description` | Yes | What the agent does |
-| `model` | Recommended | `opus` (complex reasoning), `sonnet` (balanced, default), or `haiku` (fast/simple). Defaults to `sonnet` if omitted |
+| `model` | Required for Claude Code agents | `opus` (complex reasoning), `sonnet` (balanced), or `haiku` (fast/simple). OMIT for `runtime: codex`; Codex applies the account default |
 | `displayName` | No | Human-friendly name for UI (falls back to title-cased name) |
 | `role` | No | Short title on org chart (2-4 words) |
 | `type` | No | `orchestrator` (team lead), `specialist` (team member), `platform` (system agent) |
@@ -311,22 +311,7 @@ The orchestrator only sees its direct reports (Kit, Jules). Kit only sees their 
 
 ## Creating agents
 
-**Important:** Do NOT use the Write or Edit tool for `.claude/agents/` files. Claude Code blocks writes to `.claude/` directories. Instead, use the RUNDOCK:SAVE_AGENT marker pattern so the Rundock client creates the file through the server.
-
-When a user asks you to create an agent:
-
-1. Ask what the agent should do (role, responsibilities)
-2. Suggest a name, displayName, role, type, icon, and colour
-3. Output the complete agent file wrapped in the marker block:
-
-<!-- RUNDOCK:SAVE_AGENT name={slug} -->
-```
-{full agent file content with frontmatter and instructions}
-```
-<!-- /RUNDOCK:SAVE_AGENT -->
-
-4. The Rundock client detects this marker and creates the file automatically
-5. The org chart and skills panel update automatically
+**Important:** Do NOT use the Write or Edit tool for `.claude/agents/` files. Claude Code blocks writes to `.claude/` directories. The `rundock-agents` skill carries the full lifecycle (create, edit, upgrade, delete, audit) including the exact marker format; follow it for every agent operation.
 
 **After creating agents, always give next steps.** Tell the user:
 - Which agent to try first (usually the orchestrator)
@@ -348,55 +333,11 @@ Skills live in `.claude/skills/{skill-slug}/SKILL.md`. A skill is assigned to an
 
 ### Creating and editing skills
 
-**Important:** Do NOT use the Write or Edit tool for `.claude/skills/` files. Claude Code blocks writes to `.claude/` directories. Instead, use the RUNDOCK:SAVE_SKILL marker so the Rundock client saves the file through the server. This works for both creating new skills and updating existing ones.
-
-When a user asks you to create or edit a skill, use the `rundock-skill-creator` skill for the full guided flow. For quick creation, output the marker directly:
-
-<!-- RUNDOCK:SAVE_SKILL name={slug} -->
-```
----
-name: Skill Display Name
-description: One-line description of what this skill does
----
-
-Instructions here...
-```
-<!-- /RUNDOCK:SAVE_SKILL -->
-
-To delete a skill:
-
-<!-- RUNDOCK:DELETE_SKILL name={slug} -->
-
-The skill will be saved to `.claude/skills/{slug}/SKILL.md`. The skills panel updates automatically.
-
-**Always emit the SAVE_SKILL marker** when creating a skill, whether through the guided flow or quick creation. Writing a SKILL.md file in prose without the marker wrapper will not register the skill. The marker is what triggers the Rundock client to save the file.
-
-**Quality rules for skill creation:**
-
-- **Clear trigger:** Every skill needs an obvious "when to use this" statement at the top
-- **Step-by-step structure:** Instructions should be numbered steps, not prose paragraphs
-- **Specific file paths:** Reference real workspace paths, not placeholders. Run `ls` if unsure
-- **Agent assignment:** After creating a skill, update the owning agent's instructions to reference the skill slug. Without this, the skill won't appear on the agent's profile in the UI
-- **One skill, one purpose:** Don't combine unrelated capabilities into a single skill. If it does two distinct things, make two skills
-- **Slug convention:** Lowercase, hyphens, no spaces (e.g. `my-skill-name`)
+**Important:** Do NOT use the Write or Edit tool for `.claude/skills/` files. Claude Code blocks writes to `.claude/` directories. When a user asks you to create or edit a skill, follow the `rundock-skills` skill for the full guided flow, including the marker format and quality rules it specifies. Writing a SKILL.md file in prose without the marker wrapper will not register the skill.
 
 ## Auditing agents and skills
 
-When asked to audit agents or skills, check frontmatter completeness and fix any problems.
-
-**Skill audit checklist:**
-
-- Every `.claude/skills/{slug}/SKILL.md` must have YAML frontmatter with `name:` and `description:` fields
-- Missing frontmatter means the skill detail view won't show a description, and instructions may not render for older files
-- Check by reading each SKILL.md and verifying the `---` block contains both fields
-
-**Agent audit checklist:**
-
-- Every `.claude/agents/{slug}.md` must have YAML frontmatter with at minimum `name:` and `description:` (required by Claude Code)
-- Rundock-specific fields to check: `displayName`, `role`, `type`, `order`, `icon`, `colour`. Flag any that are missing
-- Optional but recommended: `reportsTo` (every specialist should have this), `prompts`, `model`
-
-**Fixing problems:** Read the existing file, construct the complete version with proper frontmatter added (preserving the existing instructions body), and re-save via `RUNDOCK:SAVE_SKILL` or `RUNDOCK:SAVE_AGENT`. Do not use the Write or Edit tool for files in `.claude/`.
+When asked to audit, use the audit modes the platform skills carry: `rundock-agents` for agent files, `rundock-skills` for skills, and `rundock-workspace` for workspace health. Each states its own checklist; do not maintain a separate one here. Fix problems by re-saving complete files through the markers those skills specify, never with the Write or Edit tool in `.claude/`.
 
 ## Making a workspace Rundock-ready
 

--- a/scaffold/rundock-guide.md
+++ b/scaffold/rundock-guide.md
@@ -328,6 +328,7 @@ Skills live in `.claude/skills/{skill-slug}/SKILL.md`. A skill is assigned to an
 - `rundock-workspace`: set up, configure, and audit the workspace (CLAUDE.md, folders, health check)
 - `rundock-agents`: create, edit, upgrade, delete, and audit agents (full lifecycle)
 - `rundock-skills`: create, edit, delete, and audit skills (full lifecycle)
+- `rundock-tuneup`: audit the team's instructions against current model guidance and propose updates, applied only with per-item approval
 
 **Discovering workspace skills:** Do not rely on a hardcoded list of the workspace's skills. Always discover them dynamically by running `ls .claude/skills/` and reading the SKILL.md files in each subdirectory. The workspace may have many more skills than what's documented here. Directories prefixed with `_` (like `_available/`) contain inactive or optional skills.
 

--- a/scaffold/rundock-guide.md
+++ b/scaffold/rundock-guide.md
@@ -212,7 +212,7 @@ Output the marker at the very end of your final response. If the user asks follo
 
 ### About Rundock
 
-- **What it is:** A visual workspace for your AI agent team. Built for people running their own businesses; works with a Claude or ChatGPT subscription (agents run on the Claude Code or Codex runtimes). Provides an org chart, conversations, skill management, and file browsing. See docs.rundock.ai for product concepts, install guides, and reference. The README at github.com/liamdarmody/rundock has the same material plus the architecture overview for contributors.
+- **What it is:** An AI team workspace: build and manage a team of AI agents that work in plain files you own, with no terminal needed. The team's skills and knowledge live in the workspace and compound over time. Built for people running their own businesses; works with a Claude or ChatGPT subscription (agents run on the Claude Code or Codex runtimes). Provides an org chart, conversations, skill management, and file browsing. See docs.rundock.ai for product concepts, install guides, and reference. The README at github.com/liamdarmody/rundock has the same material plus the architecture overview for contributors.
 
 - **Open source and licence:** PolyForm Perimeter 1.0.0. Any use permitted including commercial, with one restriction: the code cannot be used to build a product that competes with Rundock. Full text in the LICENSE file, summary in the README.
 

--- a/scaffold/rundock-skills.md
+++ b/scaffold/rundock-skills.md
@@ -27,8 +27,9 @@ A good skill file has:
 - **File references:** Specific paths the skill reads from or writes to. Run `ls` if unsure what exists.
 - **Output format:** What the result should look like (structure, length, tone).
 - **Boundaries:** What the skill does NOT cover. Which other skill or agent handles adjacent requests.
+- **House style:** UK spelling throughout, and never any em dashes or en dashes.
 
-**Naming:** Slugs are lowercase with hyphens: `meeting-prep`, `weekly-digest`, `code-review`.
+**Naming:** Slugs are lowercase with hyphens: `meeting-prep`, `weekly-digest`, `code-review`. The slug in the marker must match this convention exactly.
 
 ### 3. Save the skill
 
@@ -106,14 +107,3 @@ Review all skills for quality and consistency.
 Present findings as **Issues** (must fix), **Warnings** (should fix), **Good** (working well).
 
 Offer to fix each issue. Output corrected skill files using the SAVE_SKILL marker, one at a time. For assignment issues, also update the relevant agent file using the SAVE_AGENT marker.
-
-## Quality checklist (for all operations)
-
-Before outputting any SAVE_SKILL marker, verify:
-- [ ] Skill has a clear, specific purpose
-- [ ] Instructions are step-by-step
-- [ ] File paths reference real workspace locations
-- [ ] Slug matches naming convention
-- [ ] No em dashes or en dashes
-- [ ] UK spelling throughout
-- [ ] Frontmatter includes name and description

--- a/scaffold/rundock-tuneup.md
+++ b/scaffold/rundock-tuneup.md
@@ -1,0 +1,81 @@
+---
+name: Rundock Tuneup
+description: Audit the team's instructions against current model guidance and propose updates, item by item, with the user approving every change.
+---
+
+Keep a team's instructions current with the model generation it runs on. Prompts and skills written for earlier models are often too prescriptive for current ones and can actively degrade output quality; the guidance changes with each model generation, and a workspace with no currency mechanism silently rots on every release. This skill is the currency mechanism.
+
+## When to use
+
+- The user asks to tune up, modernise, or health-check the team's instructions ("tune up my team", "are my agents up to date?").
+- After a model-generation change: when the criteria version below is newer than the last tuneup this workspace has seen (look for a previous tuneup report in the workspace, or ask; when unsure, mention it once and move on, never nag).
+- Not for structural problems (broken reportsTo, missing frontmatter: that is `rundock-agents` and `rundock-skills` audit territory) and not for behavioural issues like misroutes.
+
+## Scope, stated plainly
+
+- Version 1 audits **Claude agents only**. Say so in the report. Codex agents are listed as "not audited (Codex criteria not yet shipped)".
+- Audit the user's agent files (`.claude/agents/`), skills (`.claude/skills/`), and `CLAUDE.md`.
+- **Rundock-owned files are the exception:** anything the scaffold manages (the `rundock-*` agent and skills) is reported as "update Rundock to refresh this file", never proposed as a local edit. The next release would overwrite it.
+
+## The flow
+
+1. Read every agent file, every SKILL.md, and CLAUDE.md.
+2. Match each file against the criteria catalogue below.
+3. Produce findings, one per match: **file, line, the quoted text, verdict, rationale, confidence (high or medium)**.
+4. A clean result is a real result. Report "clean against criteria version {version}" and stop; do not invent findings to seem useful.
+5. Present findings in chat, grouped by verdict. Ask for approval **per item, or per named group** ("apply all DELETEs", "let's review the REWRITEs one by one"). Never modify anything without that explicit approval.
+6. Apply approved changes: agents and skills through the `RUNDOCK:SAVE_AGENT` and `RUNDOCK:SAVE_SKILL` markers (never the Write or Edit tool in `.claude/`), CLAUDE.md with the Write tool.
+7. End by naming the criteria version the workspace is now current with.
+
+## Verdicts
+
+- **DELETE:** the passage matches a dated pattern and removing it is safe. Quote exactly what goes.
+- **REWRITE:** the intent is worth keeping, the form is dated. Show before and after.
+- **FLAG:** looks like a match but context matters, or confidence is medium. Explain what would decide it.
+- **When uncertain, the verdict is FLAG, never DELETE.** Overzealous deletion is the failure mode that loses the user's trust in one run.
+
+## Criteria
+
+**Criteria version: 2026-08. Target model generation: Claude Fable 5 (Claude Code runtime).** Updated criteria ship with Rundock releases, the same channel as this skill.
+
+Dated patterns to find:
+
+1. **Forced self-verification.** Instructions demanding the agent re-check, re-verify, or double-check its own output as a mandatory step. Current models over-verify when ordered to; verification belongs in deterministic gates (scripts, linters), not repeated LLM passes. Verdict: REWRITE to a deterministic check where one exists, DELETE otherwise.
+2. **Severity filters in review contexts.** Rules like "only report critical issues" in review or audit skills. They suppress genuine findings. Verdict: REWRITE so everything is reported and ranked instead of filtered.
+3. **Aggressive triggering language.** ALWAYS/NEVER/MANDATORY stacked as emphasis rather than as a real invariant. Current models follow calm instructions; shouting costs compliance elsewhere. Verdict: REWRITE to plain statements, keep the true invariants.
+4. **Reasoning-echo and think-step scaffolds.** "Think step by step", "show your reasoning", "explain your thought process before answering" as blanket rules. Current models reason internally; forced echoes bloat output and can conflict with the runtime's own reasoning handling. Verdict: DELETE, unless the user genuinely wants visible working for that task.
+5. **Forced interim summaries.** "Summarise progress after each step" style rules that made older models coherent and make current ones repetitive. Verdict: DELETE.
+6. **API and model fossils.** References to retired model names, old API parameters, or capabilities framed as missing that now exist. Verdict: REWRITE to current names or DELETE.
+7. **Don't-overthink rules.** "Keep it simple, don't overanalyse" instructions added to curb older models' rambling; on current models they suppress legitimate depth. Verdict: FLAG (sometimes the user really does want brevity).
+8. **Anti-laziness padding.** "Do not be lazy", "write the full code, no placeholders", "do not truncate". Current models do not need the goad, and the padding dilutes real instructions. Verdict: DELETE.
+
+**The keep-list. Never propose removing:**
+
+- Context about the business, the user, or the domain (that is the workspace's value)
+- Rubrics and quality bars that define what good looks like
+- Exact steps for fragile operations (deployment sequences, data-safety rules, marker formats)
+- Truth and grounding rules ("never fabricate", "cite the file")
+- Human gates ("ask before sending", "propose then approve")
+- Loop bounds and budgets ("at most three attempts")
+
+These look like candidates to an over-eager audit and are load-bearing. When a passage mixes a dated pattern with keep-list material, the verdict is REWRITE preserving the keep-list half, or FLAG.
+
+## Report format
+
+```
+Tuneup report: criteria 2026-08 (Claude Fable 5)
+Scope: 6 Claude agents, 14 skills, CLAUDE.md. 2 Codex agents not audited (Codex criteria not yet shipped).
+
+DELETE (3)
+1. content-lead.md:41 "Think step by step before every reply." Reasoning-echo scaffold; current models reason internally. Confidence: high.
+...
+
+REWRITE (1)
+...
+
+FLAG (2)
+...
+
+Clean files: 11 of 21.
+Apply all DELETEs, review REWRITEs one by one, or pick items by number.
+```

--- a/scaffold/rundock-workspace.md
+++ b/scaffold/rundock-workspace.md
@@ -33,7 +33,7 @@ Keep it concise. CLAUDE.md should be a quick reference, not a manual.
 
 Suggest the best-fit structure based on the workspace purpose:
 
-**PARA** (personal productivity, knowledge management):
+**PARA** (personal productivity, knowledge management; note the scaffold's default folders are a simple starting structure, not PARA, so offer this only when the user wants a named methodology):
 - `0 Inbox/`, `1 Projects/`, `2 Areas/`, `3 Resources/`, `4 Archive/`
 
 **Functional** (business or team workspaces):

--- a/server.js
+++ b/server.js
@@ -766,7 +766,7 @@ function buildSystemPrompt(agentData) {
   const annotationHandle = String(agentData?.displayName || agentData?.name || 'agent').toLowerCase();
 
   const baseRules = [
-    'You are inside Rundock, an AI team workspace where the user builds and manages a team of AI agents with no terminal needed (docs.rundock.ai). The team works in plain files the user owns, and its skills and knowledge live in the workspace and compound over time. Answer "what is Rundock" questions directly using that description, even if Rundock is outside your usual domain. Every agent should know this. For deeper meta questions (creator, licence, runtimes, features, feedback), route the user to Doc or point at the docs.',
+    'You are inside Rundock, an AI team workspace where the user builds and manages a team of AI agents with no terminal needed (docs.rundock.ai). The team works in plain files the user owns, and its skills and knowledge live in the workspace and carry forward over time. Answer "what is Rundock" questions directly using that description, even if Rundock is outside your usual domain. Every agent should know this. For deeper meta questions (creator, licence, runtimes, features, feedback), route the user to Doc or point at the docs.',
     '',
     'FORMATTING RULES (mandatory, apply to all output):',
     '- NEVER use em dashes (\u2014) or en dashes (\u2013) anywhere. This includes lists, headers, separators, and inline text. Wrong: "AI \u2014 your assistant". Right: "AI: your assistant". Use colons, full stops, commas, or restructure instead.',

--- a/server.js
+++ b/server.js
@@ -1955,6 +1955,7 @@ const RUNDOCK_MANAGED_FILES = [
   { source: 'rundock-workspace.md',  target: '.claude/skills/rundock-workspace/SKILL.md' },
   { source: 'rundock-agents.md',    target: '.claude/skills/rundock-agents/SKILL.md' },
   { source: 'rundock-skills.md',    target: '.claude/skills/rundock-skills/SKILL.md' },
+  { source: 'rundock-tuneup.md',    target: '.claude/skills/rundock-tuneup/SKILL.md' },
 ];
 
 function scaffoldWorkspace(dir, opts = {}) {

--- a/server.js
+++ b/server.js
@@ -766,7 +766,7 @@ function buildSystemPrompt(agentData) {
   const annotationHandle = String(agentData?.displayName || agentData?.name || 'agent').toLowerCase();
 
   const baseRules = [
-    'You are inside Rundock, a visual interface for AI agent teams (docs.rundock.ai). Rundock runs agents on the Claude Code and Codex runtimes. Answer "what is Rundock" questions directly using that description, even if Rundock is outside your usual domain. Every agent should know this. For deeper meta questions (creator, licence, features, feedback), route the user to Doc or point at the docs.',
+    'You are inside Rundock, an AI team workspace where the user builds and manages a team of AI agents with no terminal needed (docs.rundock.ai). The team works in plain files the user owns, and its skills and knowledge live in the workspace and compound over time. Answer "what is Rundock" questions directly using that description, even if Rundock is outside your usual domain. Every agent should know this. For deeper meta questions (creator, licence, runtimes, features, feedback), route the user to Doc or point at the docs.',
     '',
     'FORMATTING RULES (mandatory, apply to all output):',
     '- NEVER use em dashes (\u2014) or en dashes (\u2013) anywhere. This includes lists, headers, separators, and inline text. Wrong: "AI \u2014 your assistant". Right: "AI: your assistant". Use colons, full stops, commas, or restructure instead.',

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -353,12 +353,16 @@ describe('rosters and system prompt', () => {
 
   test('buildSystemPrompt: self-description is runtime-neutral (a Codex agent must not say "powered by Claude Code")', () => {
     // Live finding: the base rules described Rundock as "powered by Claude
-    // Code" and a Codex agent said it verbatim. The identity line now names
-    // both runtimes and no agent claims a single one.
+    // Code" and a Codex agent said it verbatim. The identity line then named
+    // both runtimes as the first fix; the decided positioning goes further
+    // and names neither, so no agent can claim a single one and the
+    // description stays in the user's language. Runtime detail routes to
+    // Doc and the docs.
     useWorkspace({ agents: standardTeam() });
     const prompt = srv.buildSystemPrompt(srv.discoverAgents().find(a => a.id === 'content-lead'));
     assert.ok(!prompt.includes('powered by Claude Code'), 'single-runtime claim removed');
-    assert.ok(prompt.includes('Claude Code') && prompt.includes('Codex'), 'both runtimes named');
+    assert.ok(prompt.includes('AI team workspace'), 'the decided self-description is present');
+    assert.ok(!prompt.includes('Claude Code') && !prompt.includes('Codex'), 'no runtime named in the shared identity');
   });
 
   test('buildSystemPrompt: injects the concrete review-annotation handle instead of a derivation rule', () => {

--- a/test/unit/scaffold-integrity.test.js
+++ b/test/unit/scaffold-integrity.test.js
@@ -1,0 +1,37 @@
+// Every reference inside the scaffolded platform files must resolve.
+//
+// The scaffold ships into every new workspace, and a reference to a skill
+// that does not exist sends Doc confidently down a dead end (a live audit
+// found exactly that: a guided flow pointing at a skill that was never
+// shipped). Structural audits of USER workspaces cannot catch it, because
+// the defect is in what Rundock itself ships.
+//
+// The check is deliberately mechanical: any backtick-quoted `rundock-*`
+// name mentioned in any scaffolded file must exist as a scaffold file.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCAFFOLD = path.join(__dirname, '..', '..', 'scaffold');
+
+describe('scaffolded platform files', () => {
+  test('every referenced rundock-* skill exists in the scaffold', () => {
+    const files = fs.readdirSync(SCAFFOLD).filter((f) => f.endsWith('.md'));
+    const shipped = new Set(files.map((f) => f.replace(/\.md$/, '')));
+    const failures = [];
+    for (const f of files) {
+      const text = fs.readFileSync(path.join(SCAFFOLD, f), 'utf-8');
+      const lines = text.split('\n');
+      lines.forEach((line, i) => {
+        for (const m of line.matchAll(/`(rundock-[a-z][a-z-]*)`/g)) {
+          if (!shipped.has(m[1])) {
+            failures.push(`${f}:${i + 1} references \`${m[1]}\`, which is not a scaffolded file`);
+          }
+        }
+      });
+    }
+    assert.deepStrictEqual(failures, [], failures.join('\n'));
+  });
+});


### PR DESCRIPTION
## What this delivers

Two related pieces of work sharing the same files: the in-product positioning rewrite, and the scaffold quality repairs plus the new instruction-currency capability.

**The product describes itself in the user's language.** The definition injected into every agent's system prompt, and the scaffold guide's what-it-is line, described Rundock in runtime terms. Both now carry the decided framing: an AI team workspace where you build and manage a team of AI agents, working in plain files you own, with skills and knowledge that carry forward over time. The runtime-neutrality test evolves with it: the shared identity now names no runtime at all, the stronger form of the protection, with runtime detail available through the guide agent and the docs.

**Scaffold repair (eight fixes from a live audit of a mature workspace).** A phantom skill reference; a self-contradicting model-field rule (now stated once: required for Claude Code agents, omitted for Codex); onboarding-mode precedence made explicit; a forced re-verification gate folded into drafting rules; lifecycle sections that had drifted from the platform skills replaced with pointers to them; the PARA offer contextualised; the legacy playbooks path labelled as legacy; and the runtime-section injection verified safe on every install path. A new unit test scans every scaffolded file for references that do not resolve, so the phantom class cannot ship again.

**rundock-tuneup, the instruction currency skill.** Prompting patterns written for earlier model generations degrade current ones, invisibly to structural checks. The new fourth platform skill carries a versioned criteria catalogue (2026-08, naming its target model generation, updated through releases), audits the user's agents, skills, and CLAUDE.md, and proposes changes item by item with per-item or per-group approval through the existing markers. A keep-list protects load-bearing material, uncertainty resolves to FLAG rather than DELETE, clean is reported as clean, and scaffold-managed files are never edited locally.

## Verification

- Full suite green (1273) including the new scaffold reference-integrity test.
- Live behavioural acceptance, both directions: on a scratch workspace seeded with all eight catalogued patterns plus three keep-list decoys, the audit found all eight with correct verdicts (including FLAG where the criteria demand it) and explicitly preserved every decoy; on a clean workspace containing deliberately keep-list-shaped material, it reported clean with per-item reasoning and proposed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)