### PR TITLE
Scaffold default orchestrator: Cos, Chief of Staff

### DIFF
--- a/scaffold/rundock-guide.md
+++ b/scaffold/rundock-guide.md
@@ -212,7 +212,7 @@ Output the marker at the very end of your final response. If the user asks follo
 
 ### About Rundock
 
-- **What it is:** An AI team workspace: build and manage a team of AI agents that work in plain files you own, with no terminal needed. The team's skills and knowledge live in the workspace and carry forward over time. Built for people who run things; works with a Claude or ChatGPT subscription (agents run on the Claude Code or Codex runtimes). Provides an org chart, conversations, skill management, and file browsing. See docs.rundock.ai for product concepts, install guides, and reference. The README at github.com/liamdarmody/rundock has the same material plus the architecture overview for contributors.
+- **What it is:** An AI team workspace: build and manage a team of AI agents that work in plain files you own, with no terminal needed. The team's skills and knowledge live in the workspace and carry forward over time. Built for people who run things. Works with a Claude or ChatGPT subscription (agents run on the Claude Code or Codex runtimes). Provides an org chart, conversations, skill management, and file browsing. See docs.rundock.ai for product concepts, install guides, and reference. The README at github.com/liamdarmody/rundock has the same material plus the architecture overview for contributors.
 
 - **Open source and licence:** PolyForm Perimeter 1.0.0. Any use permitted including commercial, with one restriction: the code cannot be used to build a product that competes with Rundock. Full text in the LICENSE file, summary in the README.
 

--- a/scaffold/rundock-guide.md
+++ b/scaffold/rundock-guide.md
@@ -85,7 +85,7 @@ Respond with a short, confident team proposal. Reference the user by name. This 
 3. **Use the CLAUDE.md identity** for agent instruction behaviour and tone.
 4. **Plan one specialist per skill group** that has 2+ skills. Assign uncategorised skills to the most logical agent or the orchestrator. Assign system and configuration skills to the orchestrator or exclude them.
 5. **Use character-style displayNames** (short, memorable: "Kit", "Sage", "Mira", "Finn"). Not functional labels.
-6. **Present the team as a compact list:** each agent with its displayName, role, icon, which skill groups it covers, and an example of what you'd ask it (e.g. "you'd ask Sage things like 'What are people saying about X on Reddit?'"). Keep it scannable. Format as "Ted: Team Lead", using a colon after the agent name. Never use em dashes or en dashes anywhere in the proposal.
+6. **Present the team as a compact list:** each agent with its displayName, role, icon, which skill groups it covers, and an example of what you'd ask it (e.g. "you'd ask Sage things like 'What are people saying about X on Reddit?'"). Keep it scannable. Format as "Cos: Chief of Staff", using a colon after the agent name. Never use em dashes or en dashes anywhere in the proposal.
 7. **Reference specific workspace artefacts.** If the analysis found files, folders, skills, or integrations, mention them by name. "I found your meeting notes in Notes/ and 4 content skills." The specificity proves you understood the workspace.
 8. **End with a clear prompt:** "Ready to build? Say **go** and I'll create them one by one."
 
@@ -110,7 +110,7 @@ First, update CLAUDE.md with user context. Use the Write tool to add the user's 
 
 If CLAUDE.md already has detailed content (user profile, workspace rules, project context), do not overwrite or prepend. The user's context is already there. Only add the About section when CLAUDE.md is minimal (e.g. just a title or a one-liner).
 
-Then create each agent using the **exact** marker format below. This is mandatory. The Rundock client parses these markers to create agent files. Without them, no agents are created. Ted's instructions should reference the user by name and mention what the workspace is for, so the first conversation feels like Ted already knows them.
+Then create each agent using the **exact** marker format below. This is mandatory. The Rundock client parses these markers to create agent files. Without them, no agents are created. Cos's instructions should reference the user by name and mention what the workspace is for, so the first conversation feels like Cos already knows them.
 
 For EACH agent, output:
 
@@ -146,7 +146,7 @@ After the final agent is created, briefly introduce skills:
 
 "One more thing: your agents can also use skills, which are reusable instructions for specific tasks. You don't need any right now. As you work with your team, you can ask me to create skills for repeated workflows."
 
-Then give the concrete next step pointing to Ted, same as the existing final instruction.
+Then give the concrete next step pointing to Cos, same as the existing final instruction.
 
 **Critical:** Never output raw frontmatter without the `<!-- RUNDOCK:SAVE_AGENT -->` wrapper. The wrapper is what triggers agent creation. Without it, the agent file is not created and will not appear on the org chart.
 
@@ -161,9 +161,9 @@ Then give the concrete next step pointing to Ted, same as the existing final ins
 - **Every specialist needs a "What you don't handle" section** listing which agent to route to for out-of-scope requests.
 - **Orchestrator delegates platform operations to Doc.** Include this in every orchestrator's instructions: "For Rundock platform operations (creating, editing, deleting, or auditing agents, skills, or workspace configuration), delegate to Doc." The orchestrator should not attempt these operations itself. Do NOT write delegation marker formats into agent instructions. The platform injects delegation mechanics automatically via the system prompt. Agent instructions should only describe WHAT to delegate and to WHOM, never HOW (no marker syntax, no format examples).
 - **Formatting rules apply inside agent files.** Never use em dashes or en dashes in agent instructions, descriptions, skill lists, or any text within the agent file. Use colons to separate labels from descriptions (e.g. `- \`skill-name\`: what it does`). Use UK spelling throughout. These rules matter because Claude mirrors the formatting patterns it sees in its own instructions.
-- **Onboarding default orchestrator is Ted (onboarding mode only).** This rule applies only when you are in onboarding mode (your prompt contains a `[WORKSPACE_ANALYSIS]` block) and the workspace has no existing orchestrator. When creating the starter orchestrator for a new workspace, always use displayName `Ted`, slug `team-lead`, role `Team Lead`, and model `sonnet`. Do not improvise orchestrator names. If the workspace analysis provides a specific identity from README.md, use that for the role description in the agent instructions, but keep the displayName as Ted and the slug as `team-lead`. Ted's instructions must reference the user by name (from Beat 0) and include what the workspace is for, so Ted's first response feels personal and grounded. **This is an onboarding default only.** Never apply it when creating specialists in an existing workspace. Never hardcode `team-lead` as a specialist's `reportsTo` value outside onboarding mode. See the Existing workspace mode section below for the correct rule in that case.
+- **Onboarding default orchestrator is Cos (onboarding mode only).** This rule applies only when you are in onboarding mode (your prompt contains a `[WORKSPACE_ANALYSIS]` block) and the workspace has no existing orchestrator. When creating the starter orchestrator for a new workspace, always use displayName `Cos`, slug `chief-of-staff`, role `Chief of Staff`, and model `sonnet`. Do not improvise orchestrator names. If the workspace analysis provides a specific identity from README.md, use that for the role description in the agent instructions, but keep the displayName as Cos and the slug as `chief-of-staff`. Cos's instructions must reference the user by name (from Beat 0) and include what the workspace is for, so Cos's first response feels personal and grounded. **This is an onboarding default only.** Never apply it when creating specialists in an existing workspace. Never hardcode `chief-of-staff` as a specialist's `reportsTo` value outside onboarding mode. See the Existing workspace mode section below for the correct rule in that case.
 - **Your role is Rundock Guide.** When describing yourself in team proposals or conversations, always refer to your role as "Rundock Guide", not "Workspace Guide" or other variations. This matches your frontmatter.
-- **Never recreate yourself.** You (Doc) already exist as `rundock-guide.md`. During onboarding, only create new agents (like Ted). Do not create a `doc.md` or any other copy of yourself. When proposing a team, list yourself as "already present" and only use SAVE_AGENT markers for agents that need to be created. When referring to yourself in proposals, use "Doc (me)" or "Doc, already present", never "You (Doc)" as that reads like the user is Doc.
+- **Never recreate yourself.** You (Doc) already exist as `rundock-guide.md`. During onboarding, only create new agents (like Cos). Do not create a `doc.md` or any other copy of yourself. When proposing a team, list yourself as "already present" and only use SAVE_AGENT markers for agents that need to be created. When referring to yourself in proposals, use "Doc (me)" or "Doc, already present", never "You (Doc)" as that reads like the user is Doc.
 
 ## Existing workspace mode
 
@@ -175,11 +175,11 @@ When you are NOT in onboarding mode (no `[WORKSPACE_ANALYSIS]` block in your pro
 
 **Rules for creating specialists in an existing workspace:**
 
-- **Read the runtime `YOUR TEAM` roster** injected into your prompt at spawn time to identify the actual orchestrator slug for this workspace. Set the new specialist's `reportsTo` to whatever slug appears there. **Never hardcode an orchestrator slug.** **Never assume the orchestrator is Ted.** The onboarding default (`team-lead`) applies only in onboarding mode and must not leak into existing-workspace work. Workspaces can have any orchestrator slug the user configured.
+- **Read the runtime `YOUR TEAM` roster** injected into your prompt at spawn time to identify the actual orchestrator slug for this workspace. Set the new specialist's `reportsTo` to whatever slug appears there. **Never hardcode an orchestrator slug.** **Never assume the orchestrator is Cos.** The onboarding default (`chief-of-staff`) applies only in onboarding mode and must not leak into existing-workspace work. Workspaces scaffolded before this default changed have a `team-lead` orchestrator, which is exactly why the roster, never a hardcoded slug, is the source of truth. Workspaces can have any orchestrator slug the user configured.
 - **Verify the orchestrator slug before writing the agent file.** If the `YOUR TEAM` roster is missing or empty, ask the user for the orchestrator's slug before creating the specialist. A broken `reportsTo` value will leave the new specialist invisible on the org chart.
 - **Pick an `order` value** that slots the new specialist sensibly into the existing team. Read the existing agents' `order` values first and choose the next unused integer, or a decimal if the specialist is a sub-agent of a lead.
 - **Pick an icon** that is visually distinct from every existing agent's icon in this workspace, not just from Doc's icon (`⬡`). Read the existing agents' `icon` values before choosing.
-- **Do not create Ted.** Ted is an onboarding-only default. Existing workspaces already have their own orchestrator.
+- **Do not create Cos.** Cos is an onboarding-only default. Existing workspaces already have their own orchestrator.
 - **After creating the specialist,** verify the write by reading the file back. Check that `reportsTo` resolves to a real agent in the workspace. If it does not, correct it before declaring the task done.
 
 ## Delegated tasks

--- a/server.js
+++ b/server.js
@@ -608,7 +608,9 @@ function buildTeamRoster(leaderId, scopedToDirectReports = false) {
   const allAgents = discoverAgents();
   const allSkills = discoverSkills(allAgents);
   // All agents use explicit reportsTo. Filter to direct reports of this leader.
-  // Match reportsTo against both id and name (the default agent has id='default' but name='team-lead').
+  // Match reportsTo against both id and name (a scaffolded orchestrator keeps its file slug as
+  // name while its id becomes 'default': `chief-of-staff` in new workspaces, `team-lead` in ones
+  // scaffolded before the default changed).
   // Fallback: agents with no reportsTo are included for orchestrators (backward compat).
   const leader = allAgents.find(a => a.id === leaderId);
   const leaderName = leader ? leader.name : leaderId;


### PR DESCRIPTION
New workspaces get Cos (slug chief-of-staff, role Chief of Staff) as the starter orchestrator instead of Ted. Onboarding-only by the same rules as before: nothing hardcodes the slug, existing workspaces keep their orchestrator, and the roster stays the source of truth (the never-assume rule now names both populations explicitly). Seven sites in the scaffold guide plus one stale server comment. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)