### PR TITLE
A structured vault is not an empty workspace

### DIFF
--- a/server.js
+++ b/server.js
@@ -1848,6 +1848,22 @@ function isEmptyWorkspace(dir, agentList) {
     } catch (e) { /* ignore */ }
   }
 
+  // Check for user file structure. A workspace can lack CLAUDE.md, agents,
+  // and skills and still be someone's organised vault (beta incident,
+  // 2026-04-30: an existing Obsidian vault was scaffolded with the default
+  // folders during onboarding). Hidden entries never count: they are tool
+  // state (.obsidian, .claude, .rundock, .git, .DS_Store), not structure.
+  // One or two stray root files are tolerated so a folder holding a lone
+  // readme still gets the full scaffold; any visible directory, or three
+  // or more visible files, means the user has structure we must not
+  // scaffold over.
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+      .filter(e => !e.name.startsWith('.'));
+    if (entries.some(e => e.isDirectory())) return false;
+    if (entries.filter(e => e.isFile()).length >= 3) return false;
+  } catch (e) { /* unreadable dir: treat as empty, matching prior behaviour */ }
+
   return true;
 }
 

--- a/test/unit/workspace-modes.test.js
+++ b/test/unit/workspace-modes.test.js
@@ -80,6 +80,47 @@ describe('isEmptyWorkspace', () => {
     const withUserSkill = makeWorkspace({ skills: { 'my-skill': 'x' } });
     assert.strictEqual(srv.isEmptyWorkspace(withUserSkill, []), false);
   });
+
+  // The Lucas Simonian incident (2026-04-30): an existing, well-organised
+  // Obsidian vault with no CLAUDE.md passed as "empty" and had the default
+  // folder scaffold written into it. A workspace with real user structure
+  // is not empty, whatever its CLAUDE.md status.
+  test('a structured vault without CLAUDE.md is not empty', () => {
+    const dir = makeWorkspace({ files: {
+      'Notes/2026-04-30.md': '# meeting',
+      'Projects/launch.md': 'plan',
+      'Archive/old.md': 'x',
+    } });
+    assert.strictEqual(srv.isEmptyWorkspace(dir, []), false);
+  });
+
+  test('a single user folder is enough to be non-empty', () => {
+    const dir = makeWorkspace({ files: { 'Notes/hello.md': 'x' } });
+    assert.strictEqual(srv.isEmptyWorkspace(dir, []), false);
+  });
+
+  test('one or two stray root files still count as empty', () => {
+    const one = makeWorkspace({ files: { 'readme.md': 'x' } });
+    assert.strictEqual(srv.isEmptyWorkspace(one, []), true);
+    const two = makeWorkspace({ files: { 'readme.md': 'x', 'notes.md': 'y' } });
+    assert.strictEqual(srv.isEmptyWorkspace(two, []), true);
+  });
+
+  test('three or more root files count as non-empty', () => {
+    const dir = makeWorkspace({ files: { 'a.md': 'x', 'b.md': 'y', 'c.md': 'z' } });
+    assert.strictEqual(srv.isEmptyWorkspace(dir, []), false);
+  });
+
+  test('hidden and tool-managed entries never count toward structure', () => {
+    const dir = makeWorkspace({ files: {
+      '.obsidian/app.json': '{}',
+      '.claude/settings.local.json': '{}',
+      '.rundock/state.json': '{}',
+      '.DS_Store': '',
+      '.git/config': '',
+    } });
+    assert.strictEqual(srv.isEmptyWorkspace(dir, []), true);
+  });
 });
 
 describe('scaffoldDefaults', () => {


### PR DESCRIPTION
Fixes the onboarding scaffold writing default folders into an existing organised vault. The emptiness check now considers the user's visible file structure (any directory, or three or more root files) alongside the existing CLAUDE.md/agents/skills checks. Hidden tool state never counts; a folder holding one or two stray files still scaffolds as before. Doc's folder presentation is downstream of the same gate, so the onboarding conversation stops proposing folders in structured vaults too. TDD: the incident is reproduced by tests that fail on the old predicate, and the tolerance cases are pinned. Full suite green (1278/1278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)