### PR TITLE
parseSkills: accept inline flow arrays and any block indent

### DIFF
--- a/server.js
+++ b/server.js
@@ -1338,13 +1338,26 @@ function parsePrompts(fmText) {
   return prompts;
 }
 
+// Reads the `skills:` list from frontmatter text. Accepts both YAML list
+// forms authors actually write: the block sequence at any indent (two-space,
+// four-space, tabs) and the inline flow form `skills: [a, b]`. The inline
+// form silently parsed to [] for as long as this function existed, masked by
+// the body-text fallback scan, so an agent could look correctly configured
+// while Rundock saw no skills at all. Anchored to the top-level key so
+// `other-skills:` and nested `skills:` keys never match.
 function parseSkills(fmText) {
-  const match = fmText.match(/skills:\n((?:  - [^\n]*(?:\n|$))+)/);
+  const inline = fmText.match(/^skills:[ \t]*\[([^\]]*)\][ \t]*$/m);
+  if (inline) {
+    return inline[1].split(',')
+      .map(s => s.trim().replace(/^["']|["']$/g, '').trim())
+      .filter(Boolean);
+  }
+  const match = fmText.match(/^skills:[ \t]*\n((?:[ \t]+-[ \t]*[^\n]*(?:\n|$))+)/m);
   if (!match) return [];
   const skills = [];
   for (const line of match[1].split('\n')) {
     if (!line.trim()) continue;
-    const item = line.match(/^\s+-\s*"?(.*?)"?\s*$/);
+    const item = line.match(/^[ \t]+-[ \t]*["']?(.*?)["']?[ \t]*$/);
     if (item && item[1].trim()) skills.push(item[1].trim());
   }
   return skills;

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -101,6 +101,27 @@ describe('nested frontmatter block parsers', () => {
   test('parseSkills extracts skill slugs', () => {
     assert.deepStrictEqual(srv.parseSkills(fm), ['linkedin-hook-generator', 'content-linter']);
   });
+
+  // The inline flow form is valid YAML that authors legitimately write, and
+  // it silently parsed to [] for as long as the parser existed: the agent
+  // looked correct to its author while Rundock saw no skills at all. The
+  // failure was masked by the body-text fallback scan, so nothing ever
+  // surfaced it. Same class: block lists indented with four spaces or tabs.
+  test('parseSkills reads the inline flow form', () => {
+    assert.deepStrictEqual(srv.parseSkills('skills: [alpha, beta]'), ['alpha', 'beta']);
+    assert.deepStrictEqual(srv.parseSkills('skills: ["alpha", \'beta-two\']'), ['alpha', 'beta-two']);
+    assert.deepStrictEqual(srv.parseSkills('skills: []'), []);
+  });
+
+  test('parseSkills reads block lists at any indent', () => {
+    assert.deepStrictEqual(srv.parseSkills('skills:\n    - four-space\n    - indent'), ['four-space', 'indent']);
+    assert.deepStrictEqual(srv.parseSkills('skills:\n\t- tab\n\t- indent'), ['tab', 'indent']);
+  });
+
+  test('parseSkills only matches the top-level skills key', () => {
+    assert.deepStrictEqual(srv.parseSkills('other-skills:\n  - nope'), []);
+    assert.deepStrictEqual(srv.parseSkills('meta:\n  skills: [nested]'), []);
+  });
 });
 
 describe('discoverAgents', () => {


### PR DESCRIPTION
Fixes the silently-empty parse of skills: [a, b] and of block lists indented with anything other than exactly two spaces, and anchors the match to the top-level key. TDD: three failing tests first, including one proving the old regex matched other-skills:. Full suite 1281/1281. Audit of real agent files found no inline declarations in the wild, so nothing shipped broken; this prevents the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)