### PR TITLE
Agents explain missing connectors honestly

### DIFF
--- a/server.js
+++ b/server.js
@@ -796,6 +796,9 @@ function buildSystemPrompt(agentData) {
     'REVIEW ANNOTATIONS (HTML and other non-markdown files):',
     `Review feedback for a non-markdown file lives in a sidecar JSON under .rundock/reviews/, identified by its "path" field: find it with grep -l "\\"path\\": \\"<relative file path>\\"" .rundock/reviews/*.json. Root entries under "comments" are keyed c1, c2, ... and carry quote/prefix/suffix (the anchored passage), body, by, at. To act on a comment: locate the quoted passage in the file itself, make the change there, then set resolved: true and resolvedAt: <ISO timestamp> on the entry (keep body and quote intact: they are the audit trail). Reply with a NEW comments entry carrying body, re: <parent id>, by: ${annotationHandle}, at: <timestamp>. Never renumber, delete, or rewrite existing entries, and never edit the file's "path" field. The same quoting convention applies: discuss items by quoting their text, never by id.`,
     '',
+    'CONNECTORS (MCP tools):',
+    'Rundock has no connector settings. Connectors and their sign-ins are managed outside Rundock, in the user\'s claude.ai account or the runtime\'s own configuration. If a connector tool you expect is missing or unavailable, say so plainly and name the connector: its authorisation has usually lapsed or was never completed. The terminal-free fix is claude.ai, then Settings, then Connectors, where a connector needing attention shows a Connect button; after reconnecting, a fresh conversation picks the tools up. Never invent Rundock settings, panels, or menus as the fix.',
+    '',
     'TIMEZONE:',
     `The user's local timezone is ${Intl.DateTimeFormat().resolvedOptions().timeZone}. Always use this timezone when querying time-aware tools (Google Calendar, Todoist, etc.) and when displaying dates and times to the user.`,
   ].join('\n');

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -386,6 +386,20 @@ describe('rosters and system prompt', () => {
     assert.ok(!prompt.includes('Claude Code') && !prompt.includes('Codex'), 'no runtime named in the shared identity');
   });
 
+  test('buildSystemPrompt: agents are told the truth about missing connectors', () => {
+    // Live finding (issue #70): when a connector's authorisation lapses, its
+    // tools are silently absent and the agent improvises an explanation. One
+    // user was sent hunting for "Rundock connector settings", which do not
+    // exist. The base rules now state the honest cause and the terminal-free
+    // fix. Phrased runtime-neutrally: the neutrality test below must keep
+    // passing, and a Codex agent's connectors are not Claude Code's anyway.
+    useWorkspace({ agents: standardTeam() });
+    const prompt = srv.buildSystemPrompt(srv.discoverAgents().find(a => a.id === 'content-lead'));
+    assert.ok(prompt.includes('Rundock has no connector settings'), 'the non-existent settings are ruled out');
+    assert.ok(prompt.includes('claude.ai'), 'points at where connectors are actually managed');
+    assert.ok(prompt.includes('Never invent Rundock settings'), 'the hallucination is named and forbidden');
+  });
+
   test('buildSystemPrompt: injects the concrete review-annotation handle instead of a derivation rule', () => {
     // Live finding: "by: <your agent name, lowercase>" parsed differently on
     // GPT-5 (it wrote its ROLE). The concrete handle is now injected.


### PR DESCRIPTION
Adds a CONNECTORS block to the shared base rules: name the affected connector, state the auth cause, give the terminal-free fix, and never invent Rundock settings. Runtime-neutral phrasing, pinned by a test alongside the existing neutrality test. Full suite 1282/1282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)