### PR TITLE
Delegation interception fires on real streams: decide at message_stop, never the mid-message assistant envelope

### DIFF
--- a/server.js
+++ b/server.js
@@ -3054,11 +3054,29 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
         }
 
         // ── Agent tool interception: decision ──
-        // Runs at the end-of-message `assistant` envelope with every Agent
-        // block of the turn collected (see the collection block above), and
-        // AFTER text accumulation so the transcript entry written below
-        // carries the turn's full prose.
-        if (enableInterception && parsed.type === 'assistant' && entry.pendingAgentTools && entry.pendingAgentTools.length) {
+        // Runs at end of message with every Agent block of the turn
+        // collected (see the collection block above), and AFTER text
+        // accumulation so the transcript entry written below carries the
+        // turn's full prose.
+        //
+        // The trigger is the message_stop stream event, with the result
+        // envelope as a belt-and-braces fallback for any stream shape that
+        // ends a turn without one. It is NEVER the consolidated `assistant`
+        // envelope: the real interactive stream emits that envelope PER
+        // BLOCK, mid-message, BEFORE the block's content_block_stop
+        // (captured from a live CLI stream, v2.1.226, 2026-08-12). The
+        // 0.11.6 regression anchored the decision there: on real streams it
+        // fired while the Agent block was still incomplete, skipped it,
+        // cleared the collection, and every real delegation fell through to
+        // the runtime's native subagent, which then did teammate-shaped
+        // work invisibly while the caller narrated an invented success. The
+        // stub-shaped suite stayed green throughout because the stub only
+        // emitted the envelope at end of message. The stub now emits the
+        // real end-of-message events (message_delta + message_stop) and a
+        // realStream rule mode pins the exact production shape.
+        const messageEnded = (parsed.type === 'stream_event' && parsed.event?.type === 'message_stop')
+          || parsed.type === 'result';
+        if (enableInterception && messageEnded && entry.pendingAgentTools && entry.pendingAgentTools.length) {
           const agentCalls = [];
           for (const block of entry.pendingAgentTools) {
             if (!block.complete) continue; // never closed: stream ended mid-block
@@ -3127,7 +3145,7 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
               _deferredTargets: deferredTargets.length ? deferredTargets : null
             }, chatProcesses);
             safeSend(JSON.stringify({ type: 'system', subtype: 'done', code: 0, _agent: entry.agentId, _conversationId: convoId, _processId: entry.processId }));
-            continue; // suppress the assistant envelope: agent_switch owns the client handoff
+            continue; // suppress this end-of-message envelope: agent_switch owns the client handoff
           }
 
           // Impersonation guard: an explicit subagent_type naming a

--- a/test/fixtures/stream-json.js
+++ b/test/fixtures/stream-json.js
@@ -36,6 +36,20 @@ function inputJsonDelta(partialJson, index = 1) {
   return { type: 'stream_event', event: { type: 'content_block_delta', index, delta: { type: 'input_json_delta', partial_json: partialJson } } };
 }
 
+// End-of-message events. The REAL interactive stream closes every assistant
+// message with message_delta (stop_reason) then message_stop, and does NOT
+// reliably emit a consolidated `assistant` envelope before tool execution
+// begins. The 0.11.6 interception regression shipped because these events
+// were missing here: the stub's stream shape diverged from production, so
+// a decision point anchored on the assistant envelope passed every test and
+// never fired in real use.
+function messageDelta(stopReason = 'end_turn') {
+  return { type: 'stream_event', event: { type: 'message_delta', delta: { stop_reason: stopReason, stop_sequence: null }, usage: {} } };
+}
+function messageStop() {
+  return { type: 'stream_event', event: { type: 'message_stop' } };
+}
+
 // Full tool_use flow with the input JSON split into two deltas.
 function toolUseFlow(name, input, index = 1) {
   const json = JSON.stringify(input);
@@ -92,6 +106,6 @@ const MARKERS = {
 
 module.exports = {
   init, contentBlockStartText, textDelta, contentBlockStop,
-  toolUseStart, inputJsonDelta, toolUseFlow,
+  toolUseStart, inputJsonDelta, toolUseFlow, messageDelta, messageStop,
   assistantMessage, result, textTurn, toLines, MARKERS,
 };

--- a/test/helpers/stub-claude/claude
+++ b/test/helpers/stub-claude/claude
@@ -115,6 +115,7 @@ function buildEnvelopes(rule) {
   if (!initSent) { events.push(fx.init(SESSION_ID)); initSent = true; }
   let fullText = '';
   let toolIndex = 1;
+  let hadTool = false;
   for (const block of rule.turn || []) {
     if (block.text != null) {
       events.push(fx.contentBlockStartText());
@@ -125,14 +126,23 @@ function buildEnvelopes(rule) {
       events.push(fx.contentBlockStop());
       fullText += (fullText ? '\n' : '') + text;
     } else if (block.agentTool) {
+      hadTool = true;
       events.push(...fx.toolUseFlow('Agent', block.agentTool, toolIndex++));
     } else if (block.tool) {
+      hadTool = true;
       events.push(...fx.toolUseFlow(block.tool.name, block.tool.input || {}, toolIndex++));
     } else if (block.raw) {
       events.push(block.raw);
     }
   }
-  events.push(fx.assistantMessage(fullText));
+  // Faithful end-of-message shape: the real stream closes the message with
+  // message_delta + message_stop BEFORE any consolidated assistant envelope,
+  // and interactive turns may omit the assistant envelope entirely. A rule
+  // sets realStream: true to model that omission and pin code paths against
+  // the production shape.
+  events.push(fx.messageDelta(hadTool ? 'tool_use' : 'end_turn'));
+  events.push(fx.messageStop());
+  if (!rule.realStream) events.push(fx.assistantMessage(fullText));
   events.push(fx.result({ text: fullText, isError: !!rule.isError, sessionId: SESSION_ID }));
   return events;
 }

--- a/test/integration/delegation.test.js
+++ b/test/integration/delegation.test.js
@@ -802,6 +802,82 @@ describe('roster refresh', () => {
 // expectation in a scenario rule's promptIncludes: a rule that fails to match
 // dies as an unrelated waitFor timeout with no expected-vs-actual, which is
 // precisely why this class of bug went unnoticed for three releases.
+describe('real-stream interception (0.11.6 regression)', () => {
+  test('interception fires on the real interactive stream shape: no consolidated assistant envelope', async () => {
+    // THE 0.11.6 LIVE INCIDENT, reproduced against a real model 2026-08-12:
+    // the interception decision was anchored on the consolidated `assistant`
+    // envelope, which the stub emitted but the real interactive stream does
+    // not (it closes messages with message_delta + message_stop and runs the
+    // tool). Result in production: every Agent tool call fell through to the
+    // runtime's native subagent, the caller narrated a fabricated success,
+    // and no delegation machinery ran, while 1,300 stub-shaped tests stayed
+    // green. realStream: true pins the production shape forever.
+    const convoId = h.freshConvoId('realstream-intercept');
+    h.clearInvocations();
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'realstream delegation please' },
+        realStream: true,
+        turn: [
+          { text: 'Handing to Penn.' },
+          { agentTool: { subagent_type: 'content-lead', prompt: 'realstream brief for penn' } },
+        ] },
+      { match: { agent: 'content-lead', promptIncludes: 'realstream brief for penn' },
+        turn: [{ text: `Penn did the work. ${MARKERS.COMPLETE}` }] },
+    ]);
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'realstream delegation please' });
+    try {
+      await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+        && m._conversationId === convoId && m.toAgent === 'content-lead',
+        { since, label: 'interception fires without an assistant envelope' });
+      const { msg } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId
+        && m._agent === 'content-lead', { since, label: 'Penn result' });
+      assert.ok(msg.result.includes('Penn did the work'), 'the delegate actually ran');
+    } finally {
+      h.reapConvo(convoId);
+    }
+  });
+
+  test('a mid-message assistant envelope before the block closes does not destroy the collection', async () => {
+    // The exact captured production sequence (CLI v2.1.226): the consolidated
+    // assistant envelope for a block arrives BETWEEN its input deltas and its
+    // content_block_stop. The 0.11.6 code treated that envelope as
+    // end-of-message, found the Agent block incomplete, and cleared the
+    // collection, so the real message_stop that followed had nothing to
+    // decide on. This test replays that sequence verbatim via raw events.
+    const convoId = h.freshConvoId('midmsg-envelope');
+    h.clearInvocations();
+    const input = JSON.stringify({ subagent_type: 'content-lead', prompt: 'midmsg brief for penn' });
+    const mid = Math.floor(input.length / 2);
+    const fx = require('../fixtures/stream-json.js');
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'midmsg delegation please' },
+        realStream: true,
+        turn: [
+          { text: 'Handing to Penn.' },
+          { raw: fx.toolUseStart('Agent', 2) },
+          { raw: fx.inputJsonDelta(input.slice(0, mid), 2) },
+          { raw: fx.inputJsonDelta(input.slice(mid), 2) },
+          // The mid-message consolidated envelope, exactly where the real
+          // stream puts it: before the block's stop event.
+          { raw: fx.assistantMessage('Handing to Penn.') },
+          { raw: fx.contentBlockStop(2) },
+        ] },
+      { match: { agent: 'content-lead', promptIncludes: 'midmsg brief for penn' },
+        turn: [{ text: `Penn on it. ${MARKERS.COMPLETE}` }] },
+    ]);
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'midmsg delegation please' });
+    try {
+      await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+        && m._conversationId === convoId && m.toAgent === 'content-lead',
+        { since, label: 'interception survives the mid-message envelope' });
+    } finally {
+      h.reapConvo(convoId);
+    }
+  });
+});
+
 describe('handback payload integrity', () => {
   test('a multi-turn delegate hands back every substantive turn, not just its sign-off', async () => {
     const convoId = h.freshConvoId('handback-multiturn');


### PR DESCRIPTION
## What

Release-blocking regression in the unpublished v0.11.6 draft: delegation interception never fired on real streams. Every Agent tool call fell through to the runtime's native subagent, which ran invisibly inside the caller's turn while the caller narrated an invented success — no handoff, no delegate bubble, no files written.

**Root cause:** the draft anchored the interception decision on the consolidated `assistant` envelope. Captured from a live CLI stream (v2.1.226): that envelope arrives per block, mid-message, before the block's `content_block_stop`. The decision fired early, found the Agent block incomplete, cleared the collection, and the real end-of-message event (`message_stop`) had nothing left to decide on.

**Why 1,300 tests were green:** the stub emitted the assistant envelope only at end of message and never emitted `message_delta`/`message_stop` at all. The harness modelled the stream wrong, so the suite validated the bug.

**Fix:** decide at `message_stop` (with the `result` envelope as fallback), never at the assistant envelope. The stub now emits the real end-of-message events on every turn, plus a `realStream` rule mode that omits the trailing assistant envelope. Two new integration tests pin the production shapes — the captured mid-message sequence replayed verbatim, and the envelope-free interactive shape. Both fail on the draft code.

**Verification:** full suite 1317 pass; e2e green (one unrelated editor flake under load, green in isolation); and a live end-to-end run against a real model: interception fires, the delegate joins as itself, works, hands back, files and delegation events land.

## Release consequence

The v0.11.6 draft is unshippable. Plan: delete the unpublished draft and tag, merge this, re-tag v0.11.6 from fixed main so the pipeline rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)