### PR TITLE
One membership rule, no rehydrate marker leaks, and a release-candidate smoke suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Agents the org chart shows on your team are now actually delegable:** an agent file without a `reportsTo` line was displayed under your orchestrator and listed in its own team roster, but the delegation engine refused the handoff and told the orchestrator to route through a leader that did not exist. One membership rule now governs the chart, the roster, and the delegation engine together.
+- **Editing agent files outside Rundock now reaches running agents:** hand edits (your editor, git, a sync client) update the sidebar and chart within seconds, and live agents now pick up the new roster on their next message instead of holding a stale one until they happened to restart.
+- **Reopening a conversation where Doc created agents no longer shows raw file internals:** the first paint of a reopened conversation rendered the agent file's frontmatter as message text; it now renders exactly like the live view did.
 - **A specialist's handback now carries everything it produced, not just its sign-off:** when a specialist worked across several messages and then handed back, the agent who delegated received only the final message, so a full analysis could arrive as a one-line goodbye and you ended up copying the real work across by hand. The handback now includes every message from the delegation, and if it is ever too long to pass whole, the receiving agent is told exactly what was trimmed and where to read the rest.
 - **Agents no longer claim to run work "in parallel" they cannot run:** delegation runs one specialist at a time, but team leads were never told, so they promised simultaneous work that quietly never happened. Leads now know the rule, and when one turn tries to hand work to several specialists at once, the extra handoffs are queued and named instead of silently vanishing: the lead is told exactly which ones still need sequencing.
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "release": "node scripts/release.js",
     "test:e2e": "playwright test",
     "check:refs": "node scripts/check-internal-refs.js",
-    "screenshots": "node scripts/screenshots/run.mjs"
+    "screenshots": "node scripts/screenshots/run.mjs",
+    "smoke": "node scripts/smoke/run.mjs"
   },
   "dependencies": {
     "electron-updater": "^6.8.9",
@@ -47,6 +48,7 @@
       "public/**/*",
       "scaffold/**/*",
       "scripts/**/*",
+      "!scripts/smoke/**",
       "!scripts/screenshots/**",
       "!scripts/update-harness/**",
       "node_modules/**/*",

--- a/public/app.js
+++ b/public/app.js
@@ -924,7 +924,8 @@ const EFFECT_EXECUTORS = {
     if (!convo) return;
     convo.messages.push({ role: 'agent', content: ef.text, agentId: ef.agentId, timestamp: new Date().toISOString() });
     convo.lastAgentId = ef.agentId;
-    convo.lastMessagePreview = stripMd(ef.text).substring(0, 80);
+    // Markers stripped first or a Doc turn's preview reads "<!-- RUNDOCK:SA...".
+    convo.lastMessagePreview = stripMd(stripRundockMarkers(ef.text || '')).trim().substring(0, 80);
   },
   'mark-unread': (convoId) => {
     unread.markMessage(convoId);
@@ -2869,7 +2870,11 @@ function renderSessionHistory(d) {
       const ht = msg.timestamp ? new Date(msg.timestamp) : null;
       const htStr = ht && !isNaN(ht.getTime()) ? ht.toLocaleTimeString([],{hour:'2-digit',minute:'2-digit'}) : '';
       const htSpan = htStr ? `<span class="msg-time">${htStr}</span>` : '';
-      div.innerHTML = `<div class="msg-sender" style="color:${msgAgent?.colour||'var(--accent)'}"><div class="avatar xs" style="background:${msgAgent?.colour||'var(--accent)'}">${msgAgent?.icon||'?'}</div> ${msgAgent?.displayName||'Agent'}${htSpan}</div><div class="msg-bubble">${formatMd(msg.content)}</div>`;
+      // Strip RUNDOCK markers before rendering: the stored copy below strips
+      // them (line ~2906), but this first-paint fragment rendered the raw
+      // wire text, so a rehydrated Doc turn leaked its SAVE_AGENT payload as
+      // visible frontmatter until the user navigated away and back.
+      div.innerHTML = `<div class="msg-sender" style="color:${msgAgent?.colour||'var(--accent)'}"><div class="avatar xs" style="background:${msgAgent?.colour||'var(--accent)'}">${msgAgent?.icon||'?'}</div> ${msgAgent?.displayName||'Agent'}${htSpan}</div><div class="msg-bubble">${formatMd(stripRundockMarkers(msg.content || '').trim())}</div>`;
     }
     frag.appendChild(div);
   }

--- a/scripts/check-internal-refs.js
+++ b/scripts/check-internal-refs.js
@@ -53,6 +53,10 @@ const RULES = [
   { label: 'private workspace content reference', re: /\b(vault|private workspace) (conversation|transcript|note|entry)\b/i },
   { label: 'workspace conversation id', re: /\bconversation 1[0-9]{12}\b/i },
   { label: 'internal process phrase', re: /adversarial (sweep|review round)|handoff file per run|completion report per run/i },
+  // Board vocabulary (priority/size markers) is planning language, not public
+  // language. Narrow by construction: parenthesised or hash-tagged forms only,
+  // never a bare token like p1, which appears legitimately in code.
+  { label: 'internal priority/size marker', re: /\((?:p[0-3])\)|#priority\/p[0-3]|#size\/(?:xs|s|m|l|xl)\b|\bsize `?(?:xs|m|l|xl)`?, priority\b/ },
   // An external tool named as the JUSTIFICATION for a design choice. Naming
   // formats we interoperate with describes the system and belongs in the code;
   // naming a tool as authority describes how the decision was reached, which is

--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+'use strict';
+// Release-candidate smoke: drive the REAL app (served client in a real
+// Chromium) against the REAL server from source, and verify every step from
+// disk artifacts (events log, created files), not from UI optimism.
+//
+// Why this exists: the stub harness can validate a bug. The 0.11.6 draft
+// shipped with delegation interception dead on real streams while 1,300
+// stub-shaped tests stayed green, because the stub modelled the stream
+// wrong. This smoke closes that class two ways: the stub scenarios here run
+// with realStream: true (the captured production end-of-message shape, so
+// breaking the message_stop decision point fails S2), and --live replaces
+// the stub with the real CLI and a real model for the delegation step.
+//
+// Usage:
+//   npm run smoke            # deterministic: stub runtime, all steps, no spend
+//   npm run smoke -- --live  # adds one real-model delegation turn (real CLI on PATH)
+//
+// Run it against a release candidate BEFORE tagging. Every step prints
+// PASS/FAIL; exit code is non-zero on any failure.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LIVE = process.argv.includes('--live');
+const PORT = Number(process.env.SMOKE_PORT || 3641);
+
+const results = [];
+function record(step, ok, detail) {
+  results.push({ step, ok });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${step}${detail ? `  (${detail})` : ''}`);
+}
+
+// ── Workspace: the common real shape. Roo is order 0 (so id `default`), Kit
+// deliberately has NO reportsTo (the membership rule must make him delegable
+// anyway), Vox reports explicitly.
+function buildWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-smoke-'));
+  const agents = path.join(dir, '.claude', 'agents');
+  fs.mkdirSync(agents, { recursive: true });
+  fs.writeFileSync(path.join(agents, 'roo.md'),
+    '---\nname: roo\ndisplayName: Roo\nrole: Chief of Staff\ntype: orchestrator\norder: 0\nmodel: sonnet\n---\nYou are Roo, the orchestrator. Route work to the team.\n');
+  fs.writeFileSync(path.join(agents, 'kit.md'),
+    '---\nname: kit\ndisplayName: Kit\nrole: Customer Support\ntype: specialist\norder: 2\nmodel: sonnet\n---\nYou are Kit, customer support.\n');
+  fs.writeFileSync(path.join(agents, 'vox.md'),
+    '---\nname: vox\ndisplayName: Vox\nrole: Content Writer\ntype: specialist\norder: 3\nreportsTo: roo\nmodel: sonnet\n---\nYou are Vox, the content writer. LinkedIn posts only.\n');
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# Smoke Workspace\n\nA disposable release-candidate smoke workspace.\n');
+  return dir;
+}
+
+function writeScenario(dir) {
+  // realStream: true on every turn that must intercept: the production
+  // end-of-message shape (message_delta + message_stop, no trailing
+  // assistant envelope) is the whole point of this suite.
+  fs.writeFileSync(path.join(dir, 'stub-scenario.json'), JSON.stringify({ rules: [
+    { match: { agent: 'roo', promptIncludes: 'SMOKE-S1 direct turn' },
+      turn: [{ text: 'SMOKE-S1-REPLY: direct turn works.' }] },
+    { match: { agent: 'roo', promptIncludes: 'SMOKE-S2 delegate to kit' },
+      realStream: true,
+      turn: [
+        { text: 'Handing to Kit.' },
+        { agentTool: { subagent_type: 'kit', prompt: 'SMOKE-S2 brief for kit' } },
+      ] },
+    { match: { agent: 'kit', promptIncludes: 'SMOKE-S2 brief for kit' },
+      turn: [{ text: 'SMOKE-S2-KIT-REPLY: Kit handled it.' }] },
+    { match: { agent: 'roo', promptIncludes: 'SMOKE-S3 ask doc' },
+      realStream: true,
+      turn: [
+        { text: 'Handing to Doc.' },
+        { agentTool: { subagent_type: 'rundock-guide', prompt: 'SMOKE-S3 create smokey' } },
+      ] },
+    { match: { agent: 'rundock-guide', promptIncludes: 'SMOKE-S3 create smokey' },
+      turn: [{ text: 'Created the agent. <!-- RUNDOCK:SAVE_AGENT name=smokey -->\n---\nname: smokey\ndisplayName: Smokey\nrole: Smoke Agent\ntype: specialist\norder: 9\nreportsTo: roo\n---\nYou are Smokey.<!-- /RUNDOCK:SAVE_AGENT --> <!-- RUNDOCK:COMPLETE -->' }] },
+    { match: { agent: 'vox', promptIncludes: 'SMOKE-S4 refund question' },
+      realStream: true,
+      turn: [{ text: 'Outside my lane, handing back. <!-- RUNDOCK:RETURN -->' }] },
+    { match: { promptIncludes: '[SYSTEM' },
+      turn: [{ text: '<silent>' }] },
+  ] }, null, 2));
+}
+
+function readEvents(workspace) {
+  const dir = path.join(workspace, '.rundock', 'state');
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const f of fs.readdirSync(dir)) {
+    if (!/^events-.*\.jsonl$/.test(f)) continue;
+    for (const line of fs.readFileSync(path.join(dir, f), 'utf8').split('\n')) {
+      if (line.trim()) { try { out.push(JSON.parse(line)); } catch { /* skip */ } }
+    }
+  }
+  return out;
+}
+
+async function waitFor(pred, timeout = 30000, interval = 200) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const v = await pred();
+    if (v) return v;
+    if (Date.now() >= deadline) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}
+
+// ── Boot ────────────────────────────────────────────────────────────────
+const workspace = buildWorkspace();
+if (!LIVE) writeScenario(workspace);
+const stubPath = LIVE ? '' : `${path.join(ROOT, 'test', 'helpers', 'stub-claude')}${path.delimiter}${path.join(ROOT, 'test', 'helpers', 'stub-codex')}${path.delimiter}`;
+const env = { ...process.env, WORKSPACE: workspace, PORT: String(PORT), PATH: `${stubPath}${process.env.PATH}` };
+if (!LIVE) env.HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-smoke-home-'));
+const server = spawn(process.execPath, [path.join(ROOT, 'server.js')], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+let serverLog = '';
+server.stdout.on('data', d => { serverLog += d; });
+server.stderr.on('data', d => { serverLog += d; });
+
+const up = await waitFor(async () => {
+  try { const r = await fetch(`http://127.0.0.1:${PORT}/`); return r.ok; } catch { return false; }
+}, 15000);
+record('S0 server boots from source', !!up);
+if (!up) { console.log(serverLog.slice(-2000)); process.exit(1); }
+
+const { chromium } = require('@playwright/test');
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.goto(`http://127.0.0.1:${PORT}/`);
+await page.waitForTimeout(1500);
+
+async function sendInNewConversation(text) {
+  await page.evaluate(() => window.newConversation());
+  await page.waitForTimeout(300);
+  await page.fill('#msg-input', text);
+  await page.click('#send-btn');
+}
+
+// ── S1: direct turn ─────────────────────────────────────────────────────
+await sendInNewConversation('SMOKE-S1 direct turn please');
+const s1 = await waitFor(() => page.locator('.msg-bubble', { hasText: 'SMOKE-S1-REPLY' }).count().then(c => c > 0));
+record('S1 direct orchestrator turn renders a reply', !!s1);
+const s1ev = await waitFor(() => readEvents(workspace).some(e => e.e === 'turn'));
+record('S1 turn event recorded', !!s1ev);
+
+// ── S2: intercepted delegation on the production stream shape ───────────
+await sendInNewConversation('SMOKE-S2 delegate to kit please');
+const s2 = await waitFor(() => page.locator('.msg-bubble', { hasText: 'SMOKE-S2-KIT-REPLY' }).count().then(c => c > 0), 45000);
+record('S2 delegation intercepts on realStream shape and the delegate answers', !!s2);
+const s2ev = readEvents(workspace).find(e => e.e === 'delegation_start' && e.d && e.d.to === 'kit' && e.d.intercepted === true);
+record('S2 delegation_start event (to kit, intercepted)', !!s2ev);
+const s2blocked = await page.locator('text=Blocked a handoff').count();
+record('S2 no off-roster block for the reportsTo-less specialist', s2blocked === 0);
+
+// ── S3: platform CRUD end to end (marker scan is CLIENT code) ───────────
+await sendInNewConversation('SMOKE-S3 ask doc to create smokey');
+const s3file = await waitFor(() => fs.existsSync(path.join(workspace, '.claude', 'agents', 'smokey.md')), 45000);
+record('S3 Doc SAVE_AGENT marker creates the file on disk', !!s3file);
+const s3pill = await waitFor(() => page.locator('text=Agent "smokey" created').count().then(c => c > 0), 10000);
+record('S3 created pill renders', !!s3pill);
+const s3leak = await page.locator('#messages >> text=displayName: Smokey').count();
+record('S3 marker payload never renders as message text', s3leak === 0);
+
+// ── S4: scope return restores the orchestrator ──────────────────────────
+await page.evaluate(() => window.startConversation('vox'));
+await page.waitForTimeout(300);
+await page.fill('#msg-input', 'SMOKE-S4 refund question for you');
+await page.click('#send-btn');
+const s4 = await waitFor(() => readEvents(workspace).some(e => e.e === 'handback' && e.d && e.d.kind === 'return' && e.agent === 'vox'), 45000);
+record('S4 specialist scope return hands back (handback event, kind return)', !!s4);
+
+// ── S5: both permission paths, as designed ──────────────────────────────
+// Low-risk read-only commands are AUTO-APPROVED by the client's risk policy
+// (permissions.js): no card, silent allow. High-risk commands must card and
+// wait for a click. Both behaviours are product contract; both are checked.
+const lowP = fetch(`http://127.0.0.1:${PORT}/api/permission-request`, {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'echo smoke' }, conversation_id: '', session_id: '' }),
+}).then(r => r.json()).catch(() => null);
+const lowResult = await Promise.race([lowP, new Promise(r => setTimeout(() => r(null), 15000))]);
+record('S5 low-risk command auto-approves without a card', !!(lowResult && lowResult.allow === true));
+
+const highP = fetch(`http://127.0.0.1:${PORT}/api/permission-request`, {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'rm -rf build && git push --force' }, conversation_id: '', session_id: '' }),
+}).then(r => r.json()).catch(() => null);
+const allowBtn = await waitFor(() => page.locator('.permission-card .btn-allow').first().isVisible().catch(() => false), 15000);
+record('S5 high-risk command shows the permission card', !!allowBtn);
+if (allowBtn) await page.locator('.permission-card .btn-allow').first().click();
+const highResult = await Promise.race([highP, new Promise(r => setTimeout(() => r(null), 15000))]);
+record('S5 clicking Allow resolves the hook request', !!(highResult && highResult.allow === true));
+const s5ev = readEvents(workspace).some(e => e.e === 'permission' && e.d && e.d.decision === 'allow');
+record('S5 permission event recorded', s5ev);
+
+// ── S6: the events log is skinny ────────────────────────────────────────
+const leak = readEvents(workspace).some(e => JSON.stringify(e).includes('SMOKE-S1 direct turn'));
+record('S6 events log carries structure, never message content', !leak);
+
+// ── LIVE (optional): one real-model delegation turn ─────────────────────
+if (LIVE) {
+  await sendInNewConversation('Ask Kit to draft a one-line reply to a customer asking about refunds. Delegate to Kit now.');
+  const liveOk = await waitFor(() => readEvents(workspace).some(e => e.e === 'delegation_start' && e.d && e.d.intercepted === true), 180000, 1000);
+  record('LIVE real-model delegation intercepts end to end', !!liveOk);
+}
+
+await browser.close();
+server.kill();
+const failed = results.filter(r => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed${LIVE ? ' (live mode)' : ''}`);
+if (failed.length) { console.log('Server log tail:\n' + serverLog.slice(-1500)); process.exit(1); }

--- a/server.js
+++ b/server.js
@@ -599,29 +599,45 @@ function validateAgentSlug(name) {
 // reach live processes the same way in-app CRUD does. Without this, a hand
 // edit updates discovery (2s cache TTL: chart, sidebar, matcher) but a
 // long-lived agent process keeps its stale prompt roster until it happens to
-// respawn. Debounced because editors fire multiple fs events per save; the
-// in-app CRUD paths still call flagRosterRefresh directly (the watcher
-// firing again behind them is idempotent).
-let _agentsDirWatcher = null;
-let _agentsWatchDebounce = null;
+// respawn.
+//
+// A self-owned POLLER, not fs.watch: event-based watching is exactly the
+// seam where the live-refresh data-loss bug lived (0.11.5: fs.watchFile's
+// async baseline could swallow a change forever) and fs.watch delivery
+// differs across platforms and Node versions (its event form failed on CI
+// Node 22 while passing on 24). A 2s signature poll over a directory of a
+// dozen small files is deterministic everywhere and matches the agent
+// cache's own TTL. In-app CRUD still flags directly; the poller firing
+// behind it is idempotent.
+const AGENTS_WATCH_POLL_MS = 2000;
+let _agentsWatchTimer = null;
+let _agentsDirSig = null;
+function agentsDirSignature(dir) {
+  try {
+    let sig = '';
+    for (const f of fs.readdirSync(dir).sort()) {
+      if (!f.endsWith('.md')) continue;
+      try { sig += f + ':' + fs.statSync(path.join(dir, f)).mtimeMs + ';'; } catch (e) { /* file vanished mid-scan */ }
+    }
+    return sig;
+  } catch (e) {
+    return null; // directory missing: a later appearance counts as a change
+  }
+}
 function armAgentsDirWatcher() {
-  if (_agentsDirWatcher) { try { _agentsDirWatcher.close(); } catch (e) {} _agentsDirWatcher = null; }
+  if (_agentsWatchTimer) { clearInterval(_agentsWatchTimer); _agentsWatchTimer = null; }
   if (!WORKSPACE) return;
   const dir = path.join(WORKSPACE, '.claude', 'agents');
-  if (!fs.existsSync(dir)) return; // re-armed on the next workspace set; in-app CRUD flags directly regardless
-  try {
-    _agentsDirWatcher = fs.watch(dir, { persistent: false }, () => {
-      clearTimeout(_agentsWatchDebounce);
-      _agentsWatchDebounce = setTimeout(() => {
-        invalidateAgentCache();
-        flagRosterRefresh();
-        console.log('[Roster] agents directory changed on disk; live orchestrators flagged');
-      }, 250);
-      if (_agentsWatchDebounce.unref) _agentsWatchDebounce.unref();
-    });
-  } catch (e) {
-    console.warn(`[Roster] could not watch agents directory: ${e.message}`);
-  }
+  _agentsDirSig = agentsDirSignature(dir);
+  _agentsWatchTimer = setInterval(() => {
+    const sig = agentsDirSignature(dir);
+    if (sig === _agentsDirSig) return;
+    _agentsDirSig = sig;
+    invalidateAgentCache();
+    flagRosterRefresh();
+    console.log('[Roster] agents directory changed on disk; live orchestrators flagged');
+  }, AGENTS_WATCH_POLL_MS);
+  if (_agentsWatchTimer.unref) _agentsWatchTimer.unref();
 }
 
 function flagRosterRefresh() {

--- a/server.js
+++ b/server.js
@@ -595,6 +595,35 @@ function validateAgentSlug(name) {
 // Flag all active orchestrator processes for roster refresh on next message.
 // Called after agent/skill CRUD so the orchestrator respawns with an updated team roster.
 // Uses chatProcesses (global Map declared later) via late binding.
+// Watch .claude/agents so EXTERNAL edits (an editor, git, a sync client)
+// reach live processes the same way in-app CRUD does. Without this, a hand
+// edit updates discovery (2s cache TTL: chart, sidebar, matcher) but a
+// long-lived agent process keeps its stale prompt roster until it happens to
+// respawn. Debounced because editors fire multiple fs events per save; the
+// in-app CRUD paths still call flagRosterRefresh directly (the watcher
+// firing again behind them is idempotent).
+let _agentsDirWatcher = null;
+let _agentsWatchDebounce = null;
+function armAgentsDirWatcher() {
+  if (_agentsDirWatcher) { try { _agentsDirWatcher.close(); } catch (e) {} _agentsDirWatcher = null; }
+  if (!WORKSPACE) return;
+  const dir = path.join(WORKSPACE, '.claude', 'agents');
+  if (!fs.existsSync(dir)) return; // re-armed on the next workspace set; in-app CRUD flags directly regardless
+  try {
+    _agentsDirWatcher = fs.watch(dir, { persistent: false }, () => {
+      clearTimeout(_agentsWatchDebounce);
+      _agentsWatchDebounce = setTimeout(() => {
+        invalidateAgentCache();
+        flagRosterRefresh();
+        console.log('[Roster] agents directory changed on disk; live orchestrators flagged');
+      }, 250);
+      if (_agentsWatchDebounce.unref) _agentsWatchDebounce.unref();
+    });
+  } catch (e) {
+    console.warn(`[Roster] could not watch agents directory: ${e.message}`);
+  }
+}
+
 function flagRosterRefresh() {
   if (typeof chatProcesses === 'undefined') return;
   const agentList = discoverAgents();
@@ -694,7 +723,15 @@ function findDirectReportMatch(agentId, toolInput) {
     a.status === 'onTeam' && a.id !== agentId && (
       a.reportsTo === agentId ||
       a.reportsTo === leader?.name ||
-      (isOrchestrator && a.type === 'platform')
+      (isOrchestrator && a.type === 'platform') ||
+      // One membership rule: an onTeam, non-platform agent with NO reportsTo
+      // belongs to the orchestrator. The org chart and buildTeamRoster have
+      // always applied this fallback; the matcher lacking it meant the
+      // orchestrator's own prompt roster offered agents this function then
+      // refused, and the off-roster guard blocked the delegation the system
+      // prompt instructed (live incident, 2026-08-12: the user was told to
+      // route through a leader that does not exist).
+      (isOrchestrator && !a.reportsTo && a.type !== 'platform')
     )
   );
   if (directReports.length === 0) return null;
@@ -766,7 +803,10 @@ function findOffRosterWorkspaceMatch(agentId, toolInput) {
   const isDirectReport =
     match.reportsTo === agentId ||
     match.reportsTo === leader?.name ||
-    (isOrchestrator && match.type === 'platform');
+    (isOrchestrator && match.type === 'platform') ||
+    // Keep this mirror in lockstep with findDirectReportMatch: the guard must
+    // never block an agent the roster offered.
+    (isOrchestrator && !match.reportsTo && match.type !== 'platform');
   return isDirectReport ? null : match;
 }
 
@@ -4603,6 +4643,7 @@ wss.on('connection', (ws) => {
           const startup = phaseTimer();
           killAllChildren();
           WORKSPACE = dir;
+          armAgentsDirWatcher();
           // Before anything reads state that may have come from another path.
           healWorkspaceIfMoved(dir);
           // A workspace switch (including re-selecting the same one) is the
@@ -4701,6 +4742,7 @@ wss.on('connection', (ws) => {
             // Kill all running processes when creating/switching workspace
             killAllChildren();
             WORKSPACE = dir;
+            armAgentsDirWatcher();
             loadRoutineState();
             saveRecentWorkspace(dir);
 
@@ -7761,6 +7803,7 @@ async function runUniversalSearch(msg) {
 // ===== START =====
 
 function startServer(options = {}) {
+  armAgentsDirWatcher();
   const port = options.port != null ? options.port : PORT;
   return new Promise((resolve) => {
     server.listen(port, () => {
@@ -7820,7 +7863,7 @@ module.exports = { startServer };
 // tests can point the module-level WORKSPACE at a temp fixture directory.
 module.exports._internal = {
   // workspace pointer (test fixture wiring only)
-  setWorkspace(dir) { WORKSPACE = dir; invalidateAgentCache(); },
+  setWorkspace(dir) { WORKSPACE = dir; invalidateAgentCache(); armAgentsDirWatcher(); },
   getWorkspace() { return WORKSPACE; },
   // scheduler
   getNextRun, executeRoutine, routineState,

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -208,10 +208,19 @@ function buildFixture() {
     jsonlUser('Where did the export land?', '2026-06-20T09:00:00.000Z')
     + jsonlAssistant('Saved the render to [[chart.png]] and the summary to [[report.pdf]].', '2026-06-20T09:00:30.000Z'));
 
+  // s4: a platform-delegate turn carrying a SAVE_AGENT block. The payload
+  // must NEVER render as message text: live rendering strips it (and shows
+  // the created pill), and the rehydrate first-paint fragment must strip it
+  // identically (it leaked the raw frontmatter until 0.11.6).
+  fs.writeFileSync(path.join(sessions, 's4.jsonl'),
+    jsonlUser('Create the research agent please', '2026-07-03T09:00:00.000Z')
+    + jsonlAssistant('Created the agent as requested. <!-- RUNDOCK:SAVE_AGENT name=ren -->\n---\nname: ren\ndisplayName: RenSecret\nrole: Research Lead\n---\nYou are Ren.<!-- /RUNDOCK:SAVE_AGENT --> <!-- RUNDOCK:COMPLETE -->', '2026-07-03T09:00:30.000Z'));
+
   // Conversation metadata: one pinned + one unpinned, deliberately ordered so
   // pinned-first grouping is observable (the pinned one is LESS recent).
   fs.mkdirSync(path.join(workspace, '.rundock'), { recursive: true });
   fs.writeFileSync(path.join(workspace, '.rundock', 'conversations.json'), JSON.stringify([
+    { id: 'c4', agentId: 'rundock-guide', sessionId: 's4', sessionIds: [], title: 'Doc created an agent', status: 'active', createdAt: '2026-07-03T08:59:00.000Z', lastActiveAt: '2026-07-03T10:00:00.000Z' },
     { id: 'c3', agentId: 'penn', sessionId: 's3', sessionIds: [], title: 'Export handoff', status: 'active', createdAt: '2026-06-20T08:59:00.000Z', lastActiveAt: '2026-06-20T10:00:00.000Z' },
     { id: 'c2', agentId: 'penn', sessionId: 's2', sessionIds: [], title: 'July content calendar', status: 'active', createdAt: '2026-07-02T08:59:00.000Z', lastActiveAt: '2026-07-10T10:00:00.000Z' },
     { id: 'c1', agentId: 'default', sessionId: 's1', sessionIds: [], title: 'Board prep planning', status: 'active', pinned: true, pinnedAt: '2026-07-05T09:00:00.000Z', createdAt: '2026-07-01T09:59:00.000Z', lastActiveAt: '2026-07-08T10:00:00.000Z' },

--- a/test/e2e/history-marker-strip.spec.js
+++ b/test/e2e/history-marker-strip.spec.js
@@ -1,0 +1,21 @@
+'use strict';
+// Rehydrated conversations must not leak RUNDOCK marker payloads.
+//
+// Live rendering of a platform-delegate turn strips SAVE_AGENT blocks and
+// shows the created pill. The rehydrate FIRST PAINT rendered the raw wire
+// text, so reopening a Doc conversation showed the agent file's frontmatter
+// as visible message text (found in synthetic user testing, 2026-08-12).
+// The stored copy was stripped, so navigating away and back hid the leak,
+// which is exactly why it survived: the bug only existed on first paint.
+const { test, expect } = require('@playwright/test');
+
+test('reopening a conversation with a SAVE_AGENT turn renders no payload on first paint', async ({ page }) => {
+  await page.goto('/');
+  await page.click('.convo-item:has-text("Doc created an agent")');
+  const bubble = page.locator('.msg-bubble', { hasText: 'Created the agent as requested.' });
+  await expect(bubble).toBeVisible();
+  // The payload must be absent from the ENTIRE messages pane, first paint
+  // included: RenSecret only exists inside the marker block.
+  await expect(page.locator('#messages')).not.toContainText('RenSecret');
+  await expect(page.locator('#messages')).not.toContainText('RUNDOCK:SAVE_AGENT');
+});

--- a/test/integration/team-membership.test.js
+++ b/test/integration/team-membership.test.js
@@ -1,0 +1,116 @@
+'use strict';
+// One team-membership rule: the org chart, the prompt roster, and the
+// delegation matcher must agree about who is on the orchestrator's team.
+//
+// Live incident (2026-08-12, synthetic user testing with a real model): a
+// hand-authored specialist with no reportsTo was shown under the orchestrator
+// on the org chart AND listed in the orchestrator's prompt roster ("Only
+// delegate to agents in YOUR TEAM below"), but findDirectReportMatch had no
+// fallback for it, so the delegation the system prompt instructed was refused
+// and the off-roster guard then BLOCKED it with a corrective message. The
+// user was told to route through "Kit's leader": a leader that does not
+// exist. One missing frontmatter line produced a dead end, with the chart
+// visually promising the opposite.
+//
+// The workspace here mirrors the incident exactly: an order-0 orchestrator
+// (which therefore becomes agent id `default`) and a specialist with no
+// reportsTo line.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+
+const ROO = `---
+name: roo
+displayName: Roo
+role: Chief of Staff
+type: orchestrator
+order: 0
+model: sonnet
+---
+You are Roo, the orchestrator.
+`;
+const KIT = `---
+name: kit
+displayName: Kit
+role: Customer Support
+type: specialist
+order: 2
+model: sonnet
+---
+You are Kit, customer support. No reportsTo line, exactly like a hand-authored file.
+`;
+
+let client;
+before(async () => {
+  await h.boot({ agents: { roo: ROO, kit: KIT } });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+describe('one team-membership rule', () => {
+  test('roster, matcher, and off-roster guard agree: a reportsTo-less onTeam specialist belongs to the orchestrator', () => {
+    const srv = h.internal;
+    const roster = srv.buildTeamRoster('default');
+    assert.ok(roster && roster.includes('Kit'), 'prompt roster lists the specialist (backward-compat fallback)');
+    const match = srv.findDirectReportMatch('default', { subagent_type: 'kit' });
+    assert.ok(match && match.name === 'kit', 'the matcher must agree with the roster it instructed');
+    const off = srv.findOffRosterWorkspaceMatch('default', { subagent_type: 'kit' });
+    assert.strictEqual(off, null, 'the off-roster guard must not block an agent the roster offered');
+  });
+
+  test('the orchestrator can actually delegate to a reportsTo-less specialist (the observed dead end, replayed)', async () => {
+    const convoId = h.freshConvoId('membership');
+    h.clearInvocations();
+    h.writeScenario([
+      { match: { agent: 'roo', promptIncludes: 'route this to kit please' },
+        realStream: true,
+        turn: [
+          { text: 'Handing to Kit.' },
+          { agentTool: { subagent_type: 'kit', prompt: 'membership brief for kit' } },
+        ] },
+      { match: { agent: 'kit', promptIncludes: 'membership brief for kit' },
+        turn: [{ text: 'Kit here, handling the refund question.' }] },
+    ]);
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'default', content: 'route this to kit please' });
+    try {
+      await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+        && m._conversationId === convoId && m.toAgent === 'kit',
+        { since, label: 'delegation to the reportsTo-less specialist fires' });
+      const { msg } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId
+        && m._agent === 'kit', { since, label: 'Kit result' });
+      assert.ok(msg.result.includes('Kit here'), 'Kit actually ran');
+      const blocked = client.messages.slice(since).find(m => m.subtype === 'info' && /Blocked a handoff/.test(m.content || ''));
+      assert.strictEqual(blocked, undefined, 'no block message: the guard and the roster agree');
+    } finally {
+      h.reapConvo(convoId);
+    }
+  });
+
+  test('an external edit to .claude/agents flags live orchestrators for roster refresh', async () => {
+    // Today only in-app CRUD calls flagRosterRefresh, so a hand edit outside
+    // Rundock leaves a long-lived process on a stale prompt roster. The
+    // agents directory is now watched; this pins it.
+    const convoId = h.freshConvoId('watcher');
+    h.writeScenario([
+      { match: { agent: 'roo', promptIncludes: 'idle turn please' },
+        turn: [{ text: 'Idling.' }] },
+    ]);
+    const since = client.messages.length;
+    client.send({ type: 'chat', conversationId: convoId, agent: 'default', content: 'idle turn please' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { since, label: 'idle turn result' });
+    const entry = h.internal.chatProcesses.get(convoId);
+    assert.ok(entry && !entry.needsRosterRefresh, 'no refresh flag before the edit');
+
+    // The external edit: a new agent file written straight to disk.
+    fs.writeFileSync(path.join(h.workspaceDir, '.claude', 'agents', 'newbie.md'),
+      '---\nname: newbie\ndisplayName: Newbie\nrole: New Agent\ntype: specialist\norder: 5\nreportsTo: roo\n---\nYou are Newbie.\n');
+
+    const flagged = await h.waitUntil(() => entry.needsRosterRefresh === true, { timeout: 5000 });
+    h.reapConvo(convoId);
+    assert.ok(flagged, 'live orchestrator flagged for roster refresh after an external edit to .claude/agents');
+  });
+});


### PR DESCRIPTION
## What

Three deliveries folded into 0.11.6 before publish, all found by synthetic user testing (Chrome, from source, real-model evals).

**1. One team-membership rule.** An onTeam specialist without `reportsTo` rendered under the orchestrator on the org chart and appeared in the orchestrator's own prompt roster, but `findDirectReportMatch` refused it and the off-roster guard then blocked the delegation the system prompt instructed — observed live as the orchestrator telling the user to route through a leader that does not exist. The matcher and guard now apply the same fallback the chart and roster always applied. Pinned by a three-surfaces-agree unit test and an integration replay of the observed flow on the production stream shape. Second half: `.claude/agents/` is now watched, so external edits flag live orchestrators for roster refresh the same way in-app CRUD does.

**2. Rehydrate marker leak.** The reopened-conversation first paint rendered raw wire text, leaking SAVE_AGENT payloads as visible frontmatter (the stored copy was stripped, so navigating away hid it — which is why it survived). The fragment now strips identically; the sidebar preview strips too. Pinned by an e2e spec over a seeded sentinel payload: red on the unfixed client, green now.

**3. Release-candidate smoke suite (`npm run smoke`).** Real client in real Chromium against the real server from source; every step disk-verified; `realStream` scenarios keep the interception regression class caught by construction; `--live` adds a real-model delegation turn. 15/15 green on this branch.

Also: the hygiene gate now flags internal board vocabulary in public surfaces.

Full suite 1321 pass, e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)