### PR TITLE
The default agent's profile shows its own instructions, not CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Your orchestrator's profile now shows the instructions it was actually given:** an orchestrator that doubles as the workspace default agent had its authored instructions replaced by the workspace's CLAUDE.md in the profile and in team rosters, so a freshly created Chief of Staff appeared to have almost no instructions at all. The agent file's own body now wins; CLAUDE.md fills in only for agents that genuinely have none.
 - **Agents the org chart shows on your team are now actually delegable:** an agent file without a `reportsTo` line was displayed under your orchestrator and listed in its own team roster, but the delegation engine refused the handoff and told the orchestrator to route through a leader that did not exist. One membership rule now governs the chart, the roster, and the delegation engine together.
 - **Editing agent files outside Rundock now reaches running agents:** hand edits (your editor, git, a sync client) update the sidebar and chart within seconds, and live agents now pick up the new roster on their next message instead of holding a stale one until they happened to restart.
 - **Reopening a conversation where Doc created agents no longer shows raw file internals:** the first paint of a reopened conversation rendered the agent file's frontmatter as message text; it now renders exactly like the live view did.

--- a/server.js
+++ b/server.js
@@ -1110,8 +1110,15 @@ function discoverAgents() {
         const bodyMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)/);
         let instructions = bodyMatch ? bodyMatch[1].trim() : '';
 
-        // If this is the default agent, merge instructions from CLAUDE.md
-        if (isDefault && fs.existsSync(claudeMdPath)) {
+        // Default agent: CLAUDE.md fills in ONLY when the agent file has no
+        // body of its own. The old code REPLACED the authored body outright,
+        // so every scaffolded order-0 orchestrator showed workspace
+        // boilerplate as its instructions and none of the file Doc wrote
+        // (found in 0.11.6 pre-publish testing: the profile appeared "cut
+        // off" exactly at CLAUDE.md's last line). The runtime is unaffected
+        // either way: it loads the agent file and CLAUDE.md separately; this
+        // field feeds the profile and the roster self-descriptions.
+        if (isDefault && !instructions.trim() && fs.existsSync(claudeMdPath)) {
           instructions = readNormalisedFile(claudeMdPath).substring(0, AGENT_INSTRUCTIONS_MAX);
         }
 

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -167,17 +167,35 @@ describe('discoverAgents', () => {
     assert.deepStrictEqual(statuses, ['onTeam', 'available', 'raw']);
   });
 
-  test('order: 0 marks the default agent and CLAUDE.md instructions are merged', () => {
+  test('order: 0 marks the default agent; CLAUDE.md fills in ONLY when the file has no body', () => {
+    // Live incident (0.11.6 pre-publish testing): the old code REPLACED the
+    // default agent's authored body with CLAUDE.md, so a freshly scaffolded
+    // Cos showed 279 bytes of workspace boilerplate as its instructions and
+    // none of the file Doc actually wrote. The file's body wins when it
+    // exists; CLAUDE.md remains the source for body-less stubs (and the
+    // synthesised no-file default below), which was the merge's original
+    // purpose. The runtime is unaffected either way: it loads the agent file
+    // and CLAUDE.md separately.
+    // Raw file: agentFile() always writes a default body, and this arm needs
+    // a genuinely body-less stub.
     useWorkspace({
-      agents: { lead: agentFile({ name: 'team-lead', displayName: 'Lead', type: 'orchestrator', order: 0 }) },
+      agents: { lead: '---\nname: team-lead\ndisplayName: Lead\ntype: orchestrator\norder: 0\n---\n' },
       claudeMd: '# My Workspace\n\nWorkspace instructions here.',
     });
-    const agents = srv.discoverAgents();
-    const def = agents.find(a => a.isDefault);
+    let def = srv.discoverAgents().find(a => a.isDefault);
     assert.ok(def, 'order 0 agent is the default');
     assert.strictEqual(def.id, 'default');
     assert.strictEqual(def.name, 'team-lead');
-    assert.ok(def.instructions.includes('Workspace instructions here'));
+    assert.ok(def.instructions.includes('Workspace instructions here'), 'body-less stub: CLAUDE.md fills in');
+
+    useWorkspace({
+      agents: { lead: agentFile({ name: 'team-lead', displayName: 'Lead', type: 'orchestrator', order: 0,
+        body: 'You are Lead.\n\n## Responsibilities\n\nRun the whole team end to end.' }) },
+      claudeMd: '# My Workspace\n\nWorkspace instructions here.',
+    });
+    def = srv.discoverAgents().find(a => a.isDefault);
+    assert.ok(def.instructions.includes('Run the whole team end to end'), 'authored body is the instructions');
+    assert.ok(!def.instructions.includes('Workspace instructions here'), 'CLAUDE.md must not replace an authored body');
   });
 
   test('no agent files: default agent synthesised from CLAUDE.md heading', () => {


### PR DESCRIPTION
## What

Fresh-workspace testing of the release candidate surfaced this within minutes: a newly scaffolded Cos appeared to have its instructions cut off. The file on disk was complete — discovery was REPLACING the default agent's authored body with CLAUDE.md (279 bytes of workspace boilerplate), so the profile and roster self-descriptions showed none of what Doc actually wrote. Every order-0 orchestrator (the standard scaffold shape) was affected.

**Fix:** the agent file's body wins whenever it is non-empty; CLAUDE.md fills in only for body-less stubs and the synthesised no-file default — the fallback's original purpose. Runtime behaviour was never affected (the runtime loads both files separately); this is the profile and roster surface.

The characterisation pin now asserts both arms, authored-body arm proven red on the old code. Suite 1321 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)