### PR TITLE
The tuneup skill is named for what it does: Instruction Tuneup

### DIFF
--- a/scaffold/rundock-tuneup.md
+++ b/scaffold/rundock-tuneup.md
@@ -1,5 +1,5 @@
 ---
-name: Rundock Tuneup
+name: Instruction Tuneup
 description: Audit the team's instructions against current model guidance and propose updates, item by item, with the user approving every change.
 ---
 


### PR DESCRIPTION
One-line scaffold rename: the skill's display name follows the plain-language convention of the other platform skills and the existing product copy. Slug unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)