### PR TITLE
Release gate: one command validates the candidate, the tag refuses to move without it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ playwright-report/
 screenshots-out/
 # Local, private banned-token overrides for the sanitization gate (never committed)
 scripts/screenshots/.banned-tokens.json
+
+# Release gate record (per-machine, references a local SHA)
+.release-gate.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
+## Unreleased
+
+**Name:** Foundations
+
+### Changed
+
+- **Releases are validated before they exist:** every release candidate now passes a full gauntlet (the complete test suite with coverage, end-to-end browser tests, the release smoke including a real-model run, packaging, and internal-reference hygiene) before its version tag can be created, and publishing is a single verified command. You see this as fewer, better-tested releases rather than a new button, and it is the first piece of a release built on stronger foundations.
+
 ## 0.11.6: Team Integrity (2026-08-11)
 
 > **Updating from 0.11.5:** this is the first release delivered by the new updater. Rundock shows the download with real progress in the sidebar, then asks before restarting: Restart now installs immediately, Later keeps a quiet reminder.

--- a/electron/main.js
+++ b/electron/main.js
@@ -18,6 +18,18 @@ try {
 let mainWindow = null;
 let serverPort = null;
 
+// ===== SMOKE MODE ISOLATION =====
+
+// The packaged-boot check (scripts/smoke-packaged.mjs) must not contend with
+// a real running Rundock: the single-instance lock is keyed on userData, so
+// without this a smoke run on a machine where Rundock is open loses the lock
+// and exits 0 silently, before any boot code runs. A disposable userData,
+// set BEFORE the lock is requested, gives smoke runs their own lock scope
+// and keeps them from ever touching the user's real state.
+if (process.env.RUNDOCK_SMOKE_TEST === '1') {
+  app.setPath('userData', path.join(require('os').tmpdir(), 'rundock-smoke-userdata'));
+}
+
 // ===== SINGLE INSTANCE =====
 
 const gotLock = app.requestSingleInstanceLock();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "electron": "electron .",
     "build:mac": "electron-builder --mac",
     "dist": "node scripts/build.js",
+    "release:gate": "node scripts/release-gate.js",
     "release": "node scripts/release.js",
     "test:e2e": "playwright test",
     "check:refs": "node scripts/check-internal-refs.js",

--- a/scripts/release-gate.js
+++ b/scripts/release-gate.js
@@ -97,9 +97,11 @@ function buildSteps(live) {
   if (live) {
     steps.push({ name: 'smoke (live)', cmd: ['npm', ['run', 'smoke', '--', '--live']] });
   }
-  // Unpacked build: exercises electron-builder config and the afterPack
-  // require-guard without producing installers.
-  steps.push({ name: 'packaging (unpacked)', cmd: ['node', ['scripts/build.js', '--dir']] });
+  // Unsigned unpacked build + real boot check: exercises electron-builder
+  // config, the afterPack require-guard, and the packaged binary actually
+  // starting. Signing stays the publish jobs' concern (and local codesign
+  // fails on xattr detritus anyway; proven 2026-08-11).
+  steps.push({ name: 'packaging (unpacked+boot)', cmd: ['node', ['scripts/smoke-packaged.mjs']] });
   return steps;
 }
 
@@ -150,7 +152,10 @@ async function runGate({ root = ROOT, live = true, exec = defaultExec, log = con
     try {
       exec(step.cmd[0], step.cmd[1]);
     } catch (err) {
-      return finish(false, `step "${step.name}" failed: ${err.message}`);
+      // execFileSync attaches the captured stdout; surface its tail so a
+      // failing step diagnoses itself instead of saying "Command failed".
+      const tail = err.stdout ? `\n--- last output ---\n${String(err.stdout).split('\n').slice(-25).join('\n')}` : '';
+      return finish(false, `step "${step.name}" failed: ${err.message}${tail}`);
     }
     const seconds = Math.round((Date.now() - stepStart) / 100) / 10;
     timings.push({ name: step.name, seconds });

--- a/scripts/release-gate.js
+++ b/scripts/release-gate.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Release gate: one command validates the release candidate against HEAD.
+ *
+ * Why: 0.11.6 took six cuts because candidate testing happened AFTER tagging.
+ * The gate inverts the train. It runs the full gauntlet (suite with coverage,
+ * e2e, smoke stub + live, hygiene, packaging, changelog readiness, version
+ * sanity) and, only if everything passes on a clean tree, writes
+ * `.release-gate.json` recording the SHA it passed on, the wall clock, and
+ * per-step timings. `scripts/release.js` refuses to tag unless that record
+ * exists for the exact current HEAD with live smoke included.
+ *
+ * The release commit that follows (version bump + changelog promotion) is the
+ * only thing allowed on top of a gated SHA, by construction: release.js
+ * checks the gate BEFORE creating it, and that commit touches only
+ * package.json and CHANGELOG.md.
+ *
+ * Usage:
+ *   npm run release:gate              # full gauntlet including live smoke
+ *   npm run release:gate -- --no-live # development of the gate itself only;
+ *                                     # release.js refuses a no-live record
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const GATE_FILE_NAME = '.release-gate.json';
+
+// ---------------------------------------------------------------------------
+// Preconditions (pure, unit-tested)
+// ---------------------------------------------------------------------------
+
+// package.json must be valid semver AND match the latest tag: a version that
+// is already ahead of the tags means a half-done bump is sitting in the tree.
+function versionSanity(pkgVersion, latestTag) {
+  if (!/^\d+\.\d+\.\d+$/.test(pkgVersion || '')) {
+    throw new Error(`package.json version "${pkgVersion}" is not plain semver MAJOR.MINOR.PATCH.`);
+  }
+  const tagVersion = String(latestTag || '').replace(/^v/, '').trim();
+  if (pkgVersion !== tagVersion) {
+    throw new Error(
+      `package.json version ${pkgVersion} does not match the latest tag ${latestTag}. ` +
+      `The bump belongs to scripts/release.js; a mismatch means a half-done release is in the tree.`
+    );
+  }
+}
+
+// CHANGELOG.md must carry a real `## Unreleased` section: present, named, and
+// with content beyond the name line. A release with no notes is not a release.
+function changelogReady(changelogText) {
+  const lines = String(changelogText).split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^## Unreleased\s*$/.test(lines[i])) { start = i; break; }
+  }
+  if (start === -1) {
+    throw new Error('CHANGELOG.md has no "## Unreleased" section. Add release notes before gating.');
+  }
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('## ')) { end = i; break; }
+  }
+  const body = lines.slice(start + 1, end).join('\n');
+  if (!/^\s*\*\*Name:\*\*\s*.+$/m.test(body)) {
+    throw new Error('The Unreleased section has no "**Name:**" line. Every release is named.');
+  }
+  const withoutName = body.replace(/^\s*\*\*Name:\*\*\s*.+$/m, '').trim();
+  if (!withoutName) {
+    throw new Error('The Unreleased section is empty beyond its name. Release notes are content, not a heading.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The gauntlet
+// ---------------------------------------------------------------------------
+
+function defaultExec(cmd, args = []) {
+  return execFileSync(cmd, args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function buildSteps(live) {
+  const steps = [
+    { name: 'hygiene', cmd: ['npm', ['run', 'check:refs']] },
+    { name: 'suite+coverage', cmd: ['npm', ['run', 'test:coverage']] },
+    { name: 'e2e', cmd: ['npm', ['run', 'test:e2e']] },
+    { name: 'smoke (stub)', cmd: ['npm', ['run', 'smoke']] },
+  ];
+  if (live) {
+    steps.push({ name: 'smoke (live)', cmd: ['npm', ['run', 'smoke', '--', '--live']] });
+  }
+  // Unpacked build: exercises electron-builder config and the afterPack
+  // require-guard without producing installers.
+  steps.push({ name: 'packaging (unpacked)', cmd: ['node', ['scripts/build.js', '--dir']] });
+  return steps;
+}
+
+function readGateRecord(root = ROOT) {
+  const file = path.join(root, GATE_FILE_NAME);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+async function runGate({ root = ROOT, live = true, exec = defaultExec, log = console.log } = {}) {
+  const startedAt = Date.now();
+  const finish = (ok, error) => {
+    if (!ok) log(`[gate] FAIL: ${error}`);
+    return { ok, error };
+  };
+
+  // A gate pass must describe a reproducible SHA: refuse dirty trees.
+  let sha;
+  try {
+    const dirty = String(exec('git', ['status', '--porcelain'])).trim();
+    if (dirty) {
+      return finish(false, `working tree is not clean; a gate pass must describe a committed SHA:\n${dirty}`);
+    }
+    sha = String(exec('git', ['rev-parse', 'HEAD'])).trim();
+  } catch (err) {
+    return finish(false, `git preflight failed: ${err.message}`);
+  }
+
+  // Preconditions before any expensive step.
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+    const latestTag = String(exec('git', ['describe', '--tags', '--abbrev=0'])).trim();
+    versionSanity(pkg.version, latestTag);
+    changelogReady(fs.readFileSync(path.join(root, 'CHANGELOG.md'), 'utf8'));
+  } catch (err) {
+    return finish(false, err.message);
+  }
+
+  const steps = buildSteps(live);
+  const timings = [];
+  for (const step of steps) {
+    const stepStart = Date.now();
+    log(`[gate] ${step.name}...`);
+    try {
+      exec(step.cmd[0], step.cmd[1]);
+    } catch (err) {
+      return finish(false, `step "${step.name}" failed: ${err.message}`);
+    }
+    const seconds = Math.round((Date.now() - stepStart) / 100) / 10;
+    timings.push({ name: step.name, seconds });
+    log(`[gate] ${step.name} passed (${seconds}s)`);
+  }
+
+  const record = {
+    sha,
+    live,
+    passedAt: new Date().toISOString(),
+    wallClockSeconds: Math.round((Date.now() - startedAt) / 100) / 10,
+    steps: timings,
+  };
+  fs.writeFileSync(path.join(root, GATE_FILE_NAME), JSON.stringify(record, null, 2) + '\n');
+  log(`[gate] PASS on ${sha.slice(0, 9)} in ${record.wallClockSeconds}s${live ? '' : ' (NO LIVE SMOKE: release will refuse this record)'}`);
+  return { ok: true, record };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const live = !process.argv.includes('--no-live');
+  runGate({ live }).then(result => {
+    process.exit(result.ok ? 0 : 1);
+  });
+}
+
+module.exports = { GATE_FILE_NAME, versionSanity, changelogReady, buildSteps, readGateRecord, runGate };

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -27,6 +27,8 @@ const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+const { GATE_FILE_NAME, readGateRecord } = require('./release-gate.js');
+
 const ROOT = path.join(__dirname, '..');
 const REPO = 'liamdarmody/rundock';
 
@@ -95,6 +97,83 @@ function preflight(version) {
   if (git(['tag', '-l', tag]).trim()) {
     fail('preflight', `Tag ${tag} already exists locally. Choose a new version or delete the tag.`);
   }
+}
+
+// The tag refuses to move without a gate pass on the exact current SHA.
+// The gate record (`.release-gate.json`) is written only by a fully green
+// `npm run release:gate` on a clean tree; a record for any other SHA, or one
+// gated without live smoke, is refused. Throws so it is unit-testable; the
+// main flow converts to fail().
+function requireGatePass(headSha, { root = ROOT } = {}) {
+  const record = readGateRecord(root);
+  if (!record || !record.sha) {
+    throw new Error(
+      `No release gate pass found (${GATE_FILE_NAME} missing or unreadable). ` +
+      `Run "npm run release:gate" on this candidate first; the tag refuses to move without it.`
+    );
+  }
+  if (record.sha !== headSha) {
+    throw new Error(
+      `The release gate passed on ${record.sha} but HEAD is ${headSha}. ` +
+      `Every commit invalidates the gate. Re-run "npm run release:gate" on the current candidate.`
+    );
+  }
+  if (!record.live) {
+    throw new Error(
+      `The gate on ${record.sha} ran without live smoke (--no-live). ` +
+      `Releases require the full gauntlet: re-run "npm run release:gate" without flags.`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Publish subcommand
+// ---------------------------------------------------------------------------
+
+// Default GitHub API transport via the gh CLI. `api(method, path, body)`.
+function ghApi(method, apiPath, body) {
+  const args = ['api', '-X', method, apiPath];
+  if (body) {
+    for (const [key, value] of Object.entries(body)) {
+      // -F preserves JSON types (booleans stay booleans); -f would send strings.
+      args.push('-F', `${key}=${JSON.stringify(value)}`);
+    }
+  }
+  const out = execFileSync('gh', args, { cwd: ROOT, encoding: 'utf8' });
+  return out ? JSON.parse(out) : {};
+}
+
+// Publish the draft release for `version`, binding the tag BEFORE flipping
+// the draft flag. The 0.11.6 lesson mechanised: after a recut deletes a tag,
+// the draft's tag_name falls back to `untagged-*`, and publishing in that
+// state binds the release to the junk tag permanently. Order is the fix:
+// PATCH tag_name, VERIFY it stuck, only then PATCH draft=false.
+function publishRelease(version, { api = ghApi, log = (msg) => console.log(`[release:publish] ${msg}`) } = {}) {
+  const tag = `v${version}`;
+  const releases = api('GET', `repos/${REPO}/releases`);
+  const draft = (releases || []).find(r => r.draft && (
+    r.tag_name === tag || (r.name && r.name.startsWith(`${version}:`))
+  ));
+  if (!draft) {
+    throw new Error(
+      `No draft release found for ${version} (looked for tag_name ${tag} or a name starting "${version}:"). ` +
+      `Has the CI build finished and produced its draft?`
+    );
+  }
+
+  log(`Found draft ${draft.id} "${draft.name}" (tag_name currently "${draft.tag_name}")`);
+  const bound = api('PATCH', `repos/${REPO}/releases/${draft.id}`, { tag_name: tag });
+  if (!bound || bound.tag_name !== tag) {
+    throw new Error(
+      `Binding the tag failed: asked for tag_name ${tag}, release reports "${bound && bound.tag_name}". ` +
+      `Draft left untouched (still a draft); nothing was published.`
+    );
+  }
+  log(`Tag bound: ${tag}`);
+
+  const published = api('PATCH', `repos/${REPO}/releases/${draft.id}`, { draft: false });
+  log(`Published: ${published.html_url || `release ${draft.id}`}`);
+  return { id: draft.id, tag, url: published.html_url };
 }
 
 function setVersion(version) {
@@ -202,18 +281,43 @@ function commitTagPush(version) {
 // Guarded so the changelog helpers are requireable (by tests and by
 // scripts/release-notes.js) without starting a release.
 if (require.main === module) {
-  const version = getVersion();
-  preflight(version);
-  setVersion(version);
-  promoteUnreleasedChangelog(version);
-  commitTagPush(version);
+  if (process.argv[2] === 'publish') {
+    // npm run release -- publish <version>
+    // Publishes the reviewed draft, binding the tag before the draft flip.
+    const version = process.argv[3];
+    if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+      fail('publish', 'Usage: npm run release -- publish <version> (e.g. npm run release -- publish 0.11.7)');
+    }
+    try {
+      const result = publishRelease(version);
+      console.log('');
+      log('done', `v${version} is live: ${result.url || `https://github.com/${REPO}/releases`}`);
+      log('done', 'Site download links resolve via /releases/latest; no bump needed.');
+    } catch (err) {
+      fail('publish', err.message);
+    }
+  } else {
+    const version = getVersion();
+    preflight(version);
+    // The gate governs the SHA being tagged: check it BEFORE the version-bump
+    // commit is created (that commit only adds package.json + CHANGELOG.md on
+    // top of the gated code).
+    try {
+      requireGatePass(git(['rev-parse', 'HEAD']).trim());
+    } catch (err) {
+      fail('gate', err.message);
+    }
+    setVersion(version);
+    promoteUnreleasedChangelog(version);
+    commitTagPush(version);
 
-  console.log('');
-  log('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
-  log('done', `Watch the build:   https://github.com/${REPO}/actions`);
-  log('done', `Review + publish:  https://github.com/${REPO}/releases`);
-  log('done', `Then bump the Rundock Site download links to v${version}.`);
-  log('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+    console.log('');
+    log('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
+    log('done', `Watch the build:   https://github.com/${REPO}/actions`);
+    log('done', `Review the draft:  https://github.com/${REPO}/releases`);
+    log('done', `Then publish with: npm run release -- publish ${version}  (binds the tag before flipping the draft flag)`);
+    log('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+  }
 }
 
-module.exports = { extractChangelogEntry, promoteUnreleasedChangelog };
+module.exports = { extractChangelogEntry, promoteUnreleasedChangelog, requireGatePass, publishRelease };

--- a/scripts/smoke-packaged.mjs
+++ b/scripts/smoke-packaged.mjs
@@ -18,11 +18,17 @@
 
 import { spawn, execFileSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
-const DIST = join(ROOT, 'dist');
+// The throwaway build lands OUTSIDE the repo tree on purpose: a repo under a
+// file-provider-synced folder (iCloud Documents) gets extended attributes
+// re-applied by the sync daemon faster than afterPack can strip them, and
+// codesign then fails on "detritus not allowed". A temp path is out of the
+// provider's reach, and this build is disposable by definition.
+const DIST = join(tmpdir(), 'rundock-smoke-packaged');
 const MARKER = '[Electron] Smoke test OK';
 const BOOT_TIMEOUT_MS = 120000;
 
@@ -53,12 +59,33 @@ function findBinary() {
 
 if (!skipBuild) {
   const target = process.platform === 'win32' ? '--win' : process.platform === 'darwin' ? '--mac' : '--linux';
-  console.log(`smoke-packaged: building unpacked app (electron-builder ${target} --dir)`);
-  execFileSync('npx', ['electron-builder', target, '--dir'], { cwd: ROOT, stdio: 'inherit' });
+  console.log(`smoke-packaged: building unpacked app (electron-builder ${target} --dir, unsigned)`);
+  // Signing is the publish jobs' concern, explicitly: on a dev Mac with a
+  // Developer ID cert in the keychain, electron-builder's identity
+  // auto-discovery would try to codesign this throwaway build (and fails on
+  // local xattr detritus). This gate answers one question only: does the app
+  // that packaging produces actually start?
+  execFileSync('npx', ['electron-builder', target, '--dir', `-c.directories.output=${DIST}`], {
+    cwd: ROOT,
+    stdio: 'inherit',
+    env: { ...process.env, CSC_IDENTITY_AUTO_DISCOVERY: 'false' },
+  });
 }
 
 const bin = findBinary();
 if (!bin) fail(`no packaged binary found under ${DIST}. Build first or drop --skip-build.`);
+
+// Apple Silicon refuses to map a framework whose Team ID differs from the
+// process. electron-builder's unsigned fallback signs the outer app ad-hoc
+// but leaves the Electron Framework on its upstream signature, so the boot
+// dies in dyld before main() runs. One deep ad-hoc pass makes every Mach-O
+// in the throwaway bundle consistent; the real releases never hit this
+// because CI deep-signs with the Developer ID.
+if (process.platform === 'darwin') {
+  const app = resolve(bin, '..', '..', '..');
+  console.log('smoke-packaged: deep ad-hoc re-sign for a consistent throwaway bundle');
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', app], { stdio: 'inherit' });
+}
 
 console.log(`smoke-packaged: launching ${bin}`);
 const child = spawn(bin, [], {

--- a/test/unit/release-gate.test.js
+++ b/test/unit/release-gate.test.js
@@ -135,7 +135,7 @@ describe('release gate: the run', () => {
     assert.match(joined, /smoke/, 'stub smoke runs');
     assert.match(joined, /--live/, 'live smoke runs');
     assert.match(joined, /check:refs/, 'hygiene gate runs');
-    assert.match(joined, /--dir/, 'packaging runs (unpacked build exercises afterPack)');
+    assert.match(joined, /smoke-packaged/, 'packaging runs (unsigned unpacked build + boot check)');
   });
 
   test('a dirty tree refuses to gate: the record must describe a reproducible SHA', async () => {

--- a/test/unit/release-gate.test.js
+++ b/test/unit/release-gate.test.js
@@ -1,0 +1,285 @@
+'use strict';
+// The release gate: one command validates the candidate, and the tag refuses
+// to move without it.
+//
+// Why this exists: 0.11.6 took SIX cuts because candidate testing happened
+// after tagging; the draft build was the convenient test vehicle, so
+// cut-test-recut became the loop. The gate inverts the train: the full
+// gauntlet runs against HEAD, records the SHA it passed on, and
+// scripts/release.js refuses to tag any other SHA. The publish subcommand
+// additionally mechanises the 0.11.6 publish quirk: a draft can sit on an
+// `untagged-*` tag_name after a recut, and flipping draft=false in that state
+// binds the release to the junk tag forever. Publishing must bind tag_name
+// FIRST, verify it stuck, and only then flip the draft flag.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  runGate,
+  readGateRecord,
+  versionSanity,
+  changelogReady,
+  GATE_FILE_NAME,
+} = require('../../scripts/release-gate.js');
+const { requireGatePass, publishRelease } = require('../../scripts/release.js');
+
+let root;
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-gate-'));
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+// A fake exec that records every invocation and serves canned results.
+// Commands are matched on their joined form; unmatched commands succeed
+// with empty output so step lists can grow without breaking older tests.
+function fakeExec(canned = {}) {
+  const calls = [];
+  const exec = (cmd, args = []) => {
+    const key = [cmd, ...args].join(' ');
+    calls.push(key);
+    for (const [pattern, result] of Object.entries(canned)) {
+      if (key.includes(pattern)) {
+        if (result instanceof Error) throw result;
+        return result;
+      }
+    }
+    return '';
+  };
+  exec.calls = calls;
+  return exec;
+}
+
+const GOOD_CHANGELOG = `# Changelog
+
+## Unreleased
+
+**Name:** Foundations
+
+### Changed
+
+- Something user visible.
+
+## 0.11.6: Team Integrity (2026-08-11)
+
+- Older notes.
+`;
+
+function seedWorkspace({ version = '0.11.6', changelog = GOOD_CHANGELOG } = {}) {
+  fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ version }, null, 2));
+  fs.writeFileSync(path.join(root, 'CHANGELOG.md'), changelog);
+}
+
+describe('release gate: preconditions', () => {
+  test('version sanity: package.json must match the latest tag (no half-done bump)', () => {
+    assert.doesNotThrow(() => versionSanity('0.11.6', 'v0.11.6'));
+    assert.throws(() => versionSanity('0.11.7', 'v0.11.6'), /0\.11\.7[\s\S]*v0\.11\.6/);
+    assert.throws(() => versionSanity('not-semver', 'v0.11.6'), /semver/i);
+  });
+
+  test('changelog readiness: an Unreleased section with a Name line and real content', () => {
+    assert.doesNotThrow(() => changelogReady(GOOD_CHANGELOG));
+    assert.throws(
+      () => changelogReady('# Changelog\n\n## 0.11.6: Team Integrity (2026-08-11)\n\n- Old.\n'),
+      /Unreleased/
+    );
+    assert.throws(
+      () => changelogReady('# Changelog\n\n## Unreleased\n\n### Changed\n\n- A thing.\n\n## 0.11.6: X (2026-08-11)\n'),
+      /Name/
+    );
+    assert.throws(
+      () => changelogReady('# Changelog\n\n## Unreleased\n\n**Name:** Foundations\n\n## 0.11.6: X (2026-08-11)\n'),
+      /empty|content/i
+    );
+  });
+});
+
+describe('release gate: the run', () => {
+  test('a green run writes the record: SHA, wall clock, per-step timings, live flag', async () => {
+    seedWorkspace();
+    const exec = fakeExec({
+      'rev-parse HEAD': 'abc123def\n',
+      'describe --tags': 'v0.11.6\n',
+    });
+    const result = await runGate({ root, live: true, exec });
+    assert.strictEqual(result.ok, true);
+
+    const record = readGateRecord(root);
+    assert.ok(record, 'gate record written');
+    assert.strictEqual(record.sha, 'abc123def');
+    assert.strictEqual(record.live, true);
+    assert.strictEqual(typeof record.wallClockSeconds, 'number');
+    assert.ok(Array.isArray(record.steps) && record.steps.length > 0, 'steps recorded');
+    for (const step of record.steps) {
+      assert.strictEqual(typeof step.name, 'string');
+      assert.strictEqual(typeof step.seconds, 'number');
+    }
+    assert.ok(!Number.isNaN(Date.parse(record.passedAt)), 'passedAt is a real timestamp');
+  });
+
+  test('the gauntlet is complete: suite+coverage, e2e, smoke stub, smoke live, hygiene, packaging', async () => {
+    seedWorkspace();
+    const exec = fakeExec({
+      'rev-parse HEAD': 'abc123def\n',
+      'describe --tags': 'v0.11.6\n',
+    });
+    await runGate({ root, live: true, exec });
+    const joined = exec.calls.join('\n');
+    assert.match(joined, /test:coverage/, 'suite runs WITH coverage');
+    assert.match(joined, /test:e2e/, 'e2e runs');
+    assert.match(joined, /smoke/, 'stub smoke runs');
+    assert.match(joined, /--live/, 'live smoke runs');
+    assert.match(joined, /check:refs/, 'hygiene gate runs');
+    assert.match(joined, /--dir/, 'packaging runs (unpacked build exercises afterPack)');
+  });
+
+  test('a dirty tree refuses to gate: the record must describe a reproducible SHA', async () => {
+    seedWorkspace();
+    const exec = fakeExec({
+      'status --porcelain': ' M server.js\n',
+      'rev-parse HEAD': 'abc123def\n',
+      'describe --tags': 'v0.11.6\n',
+    });
+    const result = await runGate({ root, live: true, exec });
+    assert.strictEqual(result.ok, false);
+    assert.match(result.error, /clean|dirty|uncommitted/i);
+    assert.strictEqual(readGateRecord(root), null, 'no record for an ungateable state');
+  });
+
+  test('a failing step means no record', async () => {
+    seedWorkspace();
+    const exec = fakeExec({
+      'rev-parse HEAD': 'abc123def\n',
+      'describe --tags': 'v0.11.6\n',
+      'test:coverage': new Error('suite failed'),
+    });
+    const result = await runGate({ root, live: true, exec });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(readGateRecord(root), null);
+  });
+
+  test('--no-live is recorded honestly so the release step can refuse it', async () => {
+    seedWorkspace();
+    const exec = fakeExec({
+      'rev-parse HEAD': 'abc123def\n',
+      'describe --tags': 'v0.11.6\n',
+    });
+    await runGate({ root, live: false, exec });
+    const record = readGateRecord(root);
+    assert.strictEqual(record.live, false);
+    assert.ok(!exec.calls.join('\n').includes('--live'), 'live smoke not run');
+  });
+});
+
+describe('release refuses to tag without a gate pass on HEAD', () => {
+  test('no gate record: fails naming the command to run', () => {
+    seedWorkspace();
+    assert.throws(
+      () => requireGatePass('abc123def', { root }),
+      /release:gate/
+    );
+  });
+
+  test('gate passed on a different SHA: fails naming both SHAs', () => {
+    seedWorkspace();
+    fs.writeFileSync(path.join(root, GATE_FILE_NAME), JSON.stringify({
+      sha: 'oldsha111', live: true, passedAt: '2026-08-11T09:00:00Z', wallClockSeconds: 900, steps: [],
+    }));
+    assert.throws(
+      () => requireGatePass('newsha222', { root }),
+      /oldsha111[\s\S]*newsha222|newsha222[\s\S]*oldsha111/
+    );
+  });
+
+  test('gate passed without live smoke: refused', () => {
+    seedWorkspace();
+    fs.writeFileSync(path.join(root, GATE_FILE_NAME), JSON.stringify({
+      sha: 'abc123def', live: false, passedAt: '2026-08-11T09:00:00Z', wallClockSeconds: 900, steps: [],
+    }));
+    assert.throws(
+      () => requireGatePass('abc123def', { root }),
+      /live/i
+    );
+  });
+
+  test('gate passed on HEAD with live smoke: proceeds', () => {
+    seedWorkspace();
+    fs.writeFileSync(path.join(root, GATE_FILE_NAME), JSON.stringify({
+      sha: 'abc123def', live: true, passedAt: '2026-08-11T09:00:00Z', wallClockSeconds: 900, steps: [],
+    }));
+    assert.doesNotThrow(() => requireGatePass('abc123def', { root }));
+  });
+});
+
+describe('publish binds the tag before flipping the draft flag', () => {
+  // A fake GitHub API that records calls in order and serves canned pages.
+  function fakeApi({ releases, patchTagResponds } = {}) {
+    const calls = [];
+    const api = (method, apiPath, body) => {
+      calls.push({ method, path: apiPath, body });
+      if (method === 'GET') return releases;
+      if (method === 'PATCH' && body && body.tag_name) {
+        return { id: 42, tag_name: patchTagResponds || body.tag_name };
+      }
+      if (method === 'PATCH' && body && body.draft === false) {
+        return { id: 42, draft: false, html_url: 'https://github.com/liamdarmody/rundock/releases/tag/v0.11.7' };
+      }
+      return {};
+    };
+    api.calls = calls;
+    return api;
+  }
+
+  const DRAFT_ON_JUNK_TAG = {
+    id: 42, draft: true, name: '0.11.7: Foundations', tag_name: 'untagged-9f2a',
+  };
+  const OLD_PUBLISHED = {
+    id: 7, draft: false, name: '0.11.6: Team Integrity', tag_name: 'v0.11.6',
+  };
+
+  test('the 0.11.6 quirk, mechanised away: tag_name is patched and verified BEFORE draft=false', () => {
+    const api = fakeApi({ releases: [OLD_PUBLISHED, DRAFT_ON_JUNK_TAG] });
+    const result = publishRelease('0.11.7', { api });
+
+    const tagPatch = api.calls.findIndex(c => c.method === 'PATCH' && c.body && c.body.tag_name === 'v0.11.7');
+    const draftFlip = api.calls.findIndex(c => c.method === 'PATCH' && c.body && c.body.draft === false);
+    assert.ok(tagPatch !== -1, 'tag_name was patched');
+    assert.ok(draftFlip !== -1, 'draft was flipped');
+    assert.ok(tagPatch < draftFlip, 'tag binding happens strictly before the draft flip');
+    assert.ok(api.calls[draftFlip].path.includes('/releases/42'), 'the draft, not the old release');
+    assert.strictEqual(result.tag, 'v0.11.7');
+  });
+
+  test('if the tag does not stick, the draft flag is never flipped', () => {
+    const api = fakeApi({ releases: [DRAFT_ON_JUNK_TAG], patchTagResponds: 'untagged-9f2a' });
+    assert.throws(() => publishRelease('0.11.7', { api }), /tag/i);
+    assert.ok(
+      !api.calls.some(c => c.method === 'PATCH' && c.body && c.body.draft === false),
+      'no draft flip after a failed tag bind'
+    );
+  });
+
+  test('the right draft is found even when its tag_name is junk (matched by name)', () => {
+    const api = fakeApi({ releases: [OLD_PUBLISHED, DRAFT_ON_JUNK_TAG] });
+    publishRelease('0.11.7', { api });
+    const tagPatch = api.calls.find(c => c.method === 'PATCH' && c.body && c.body.tag_name);
+    assert.ok(tagPatch.path.includes('/releases/42'));
+  });
+
+  test('no matching draft is an error naming the version', () => {
+    const api = fakeApi({ releases: [OLD_PUBLISHED] });
+    assert.throws(() => publishRelease('0.11.7', { api }), /0\.11\.7/);
+  });
+
+  test('a draft already on the right tag still publishes (idempotent bind)', () => {
+    const api = fakeApi({ releases: [{ id: 42, draft: true, name: '0.11.7: Foundations', tag_name: 'v0.11.7' }] });
+    const result = publishRelease('0.11.7', { api });
+    assert.strictEqual(result.tag, 'v0.11.7');
+    assert.ok(api.calls.some(c => c.method === 'PATCH' && c.body && c.body.draft === false));
+  });
+});


### PR DESCRIPTION
## What

- **`npm run release:gate`**: one command runs the full gauntlet against HEAD — hygiene (`check:refs`), the suite with coverage, e2e, release smoke (stub + live), and an unsigned unpacked packaging build with a real boot check. A green run on a clean tree writes `.release-gate.json` (gitignored) recording the SHA, wall clock, and per-step timings.
- **`scripts/release.js` refuses to tag** unless the gate record matches the exact current HEAD and includes live smoke. The version-bump commit is the only thing allowed on top of a gated SHA, by construction.
- **`npm run release -- publish <version>`**: publishing finds the draft, binds `tag_name`, verifies it stuck, and only then flips `draft=false`. A recut can leave a draft on an `untagged-*` name, and flipping the draft flag in that state permanently binds the release to the junk tag; the ordering is now enforced and pinned by a dry-run test with an injected API.

## Why

The last release took six cuts because candidate validation happened after tagging: the draft build was the convenient test vehicle, so cut, test, recut became the loop. The gate inverts the train: validate the candidate, then tag once.

## Found by running the gate for real

The first full run failed honestly at packaging and surfaced four real faults, all fixed here:

- local signing-identity discovery has no business signing a throwaway boot-check build (signing belongs to the publish jobs);
- a repo under a file-provider-synced folder gets extended attributes re-applied faster than afterPack strips them, so the throwaway build now lands in a temp directory out of the provider's reach;
- the unsigned fallback left the Electron Framework on its upstream Team ID while the outer app was ad-hoc, which Apple Silicon dyld refuses; one deep ad-hoc pass makes the bundle consistent;
- a product fix: the packaged smoke boot on a machine with Rundock already open lost the single-instance lock and exited 0 silently before any boot code ran. Smoke runs now take a disposable userData before requesting the lock, so they never contend with the user's real app or state.

## Evidence

- 16 new tests (`test/unit/release-gate.test.js`), full suite 1350, e2e 103, hygiene clean.
- Real full-gauntlet run on this branch: PASS in 187.1s including live smoke and the packaged boot check.

## Tests first

All gate/refusal/publish-ordering behaviour was written as failing tests before implementation; the packaging fixes were driven by the real failing gate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)