### PR TITLE
Coverage floors enforce, areas carry their file, afterPack sees lib/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,32 @@ jobs:
       - name: Run tests
         run: npm test
 
+  # Coverage floors: the suite runs WITH coverage and the per-area floors in
+  # test/tools/coverage-floors.json are enforced. Deleting a covered test, or
+  # moving code without carrying its area definition, fails here. Floors
+  # ratchet up, never down (--write-floors refuses to lower one).
+  coverage:
+    name: Coverage floors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install runtime dependencies
+        run: npm ci --omit=dev
+
+      - name: Install test-only DOM dependency
+        run: npm install --no-save jsdom@29.1.1
+
+      - name: Run suite with coverage and enforce floors
+        run: npm run test:coverage
+
   # E2E smoke suite (browser-driven, Playwright). Protects the client layer
   # the Node suite cannot observe: named regression tests for the two
   # escaped bugs (anchor re-flash, nav-state desync) plus palette golden

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -9,6 +9,16 @@
 
 const { execSync } = require('child_process');
 
+// Every local module the server requires, as repo-relative paths. The
+// character class includes `/`: until it did, `require('./lib/...')` paths
+// were invisible to the packaged-contents gate, so the lib/ modules the
+// decomposition programme creates were silently unprotected.
+function extractLocalRequires(src) {
+  return [...src.matchAll(/require\('\.\/([\w/-]+\.js)'\)/g)].map(m => m[1]);
+}
+
+exports.extractLocalRequires = extractLocalRequires;
+
 exports.default = async function afterPack(context) {
   // Packaged-contents gate (all platforms). The 0.10.0 macOS build shipped
   // without codex.js because the build.files whitelist was never updated
@@ -20,7 +30,7 @@ exports.default = async function afterPack(context) {
   const path = require('path');
   const asar = require(require.resolve('@electron/asar', { paths: [require.resolve('electron-builder')] }));
   const serverSrc = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf-8');
-  const required = [...serverSrc.matchAll(/require\('\.\/([\w-]+\.js)'\)/g)].map(m => m[1]);
+  const required = extractLocalRequires(serverSrc);
   const resourcesDir = process.platform === 'darwin'
     ? `${context.appOutDir}/${context.packager.appInfo.productFilename}.app/Contents/Resources`
     : `${context.appOutDir}/resources`;

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -1,70 +1,112 @@
 #!/usr/bin/env node
 'use strict';
-// Per-functional-area line coverage for server.js.
+// Per-functional-area line coverage, with committed floors. The suite's
+// enforcement instrument for the decomposition programme.
 //
-// node --experimental-test-coverage reports a single file-level % for
-// server.js, which is misleading: the file is a 4,200-line monolith mixing
-// the high-risk delegation engine with static-file serving and Electron shell
-// glue that the suite deliberately does NOT exercise. This tool reads the lcov
-// report (DA:<line>,<hits> records) and computes covered/total executable
-// lines for the functional ranges that matter, so coverage can be reported
-// HONESTLY per area instead of as one vanity number.
+// node --experimental-test-coverage reports a single file-level % per file,
+// which is misleading for a monolith: server.js mixes the high-risk
+// delegation engine with static-file serving and Electron shell glue that
+// the suite deliberately does NOT exercise. This tool reads the lcov report
+// (DA:<line>,<hits> records) and computes covered/total executable lines for
+// the functional ranges that matter, so coverage is reported HONESTLY per
+// area instead of as one vanity number.
 //
-// Usage: node test/tools/coverage-areas.js [coverage.lcov]
+// Three properties make it an instrument rather than a report:
+//   1. Area definitions carry their FILE, so an area keeps its number when
+//      its code moves to lib/ during decomposition.
+//   2. An anchor that fails to resolve is a HARD FAILURE. A moved function
+//      whose area definition was not updated must stop the build, not print
+//      a warning that scrolls past.
+//   3. Committed floors (coverage-floors.json) are enforced: any area or
+//      file measuring below its floor (beyond a small timing tolerance)
+//      exits non-zero. Floors ratchet up, never down.
+//
+// Usage:
+//   node test/tools/coverage-areas.js [coverage.lcov]                # report + enforce
+//   node test/tools/coverage-areas.js [coverage.lcov] --write-floors # ratchet floors up
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
-const lcovPath = process.argv[2] || 'coverage.lcov';
-const targetFile = 'server.js';
-const serverSrcPath = path.join(__dirname, '..', '..', 'server.js');
+const ROOT = path.join(__dirname, '..', '..');
+const FLOORS_PATH = path.join(__dirname, 'coverage-floors.json');
 
-// Functional areas, located by ANCHOR PATTERNS rather than hardcoded line
-// numbers, so edits elsewhere in server.js cannot silently shift an area onto
-// unrelated code. Each area runs from the line matching `start` to the line
-// BEFORE the one matching `end` (both regexes, matched against whole lines).
+// Coverage measurements jitter slightly on timing-dependent paths
+// (scheduler ticks, reaper sweeps). The tolerance absorbs that noise; a
+// deleted test drops an area far past it.
+const FLOOR_TOLERANCE = 0.25;
+
+// Functional areas: [file, label, startRe, endRe]. Located by ANCHOR
+// PATTERNS rather than line numbers, so edits cannot silently shift an area
+// onto unrelated code. Each area runs from the line matching `start` to the
+// line BEFORE the one matching `end`. When decomposition moves an area to
+// lib/, the SAME slice PR updates its file here, and the area keeps its
+// floor.
 const AREA_DEFS = [
-  ['Delegation / orchestration engine', /^function wireProcessHandlers\(/, /^wss\.on\('connection'/],
-  ['  - wireProcessHandlers (stream-json + interception)', /^function wireProcessHandlers\(/, /^function handleScopeReturn/],
-  ['  - handleScopeReturn', /^function handleScopeReturn/, /^function handleDelegation/],
-  ['  - handleDelegation', /^function handleDelegation/, /^wss\.on\('connection'/],
-  ['Scheduler (getNextRun + startScheduler + executeRoutine)', /^function startScheduler\(/, /^function analyzeWorkspace/],
-  ['Agent discovery + frontmatter parsing', /^\/\/ ===== AGENT DISCOVERY =====/, /^function startScheduler\(/],
-  ['Skill discovery', /^function discoverSkills\(/, /^function getFileTree\(/],
-  ['System prompt + roster builders', /^function buildSystemPrompt\(/, /^\/\/ ===== AGENT DISCOVERY =====/],
-  ['Workspace analysis (Seven Signals)', /^function analyzeWorkspace\(/, /^function muteHooks\(/],
-  ['Workspace mode detection + scaffolding', /^function muteHooks\(/, /^const server = http\.createServer/],
-  ['Transcripts + persistence helpers', /^function loadTranscript\(/, /^function safeSend\(/],
-  ['Conversation / state persistence', /^function readConversations\(/, /^function readState\(/],
-  ['HTTP request router (incl. permission bridge)', /^const server = http\.createServer/, /^function loadTranscript\(/],
-  ['WebSocket message handlers', /^wss\.on\('connection'/, /^function discoverSkills\(/],
-  ['Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', /^function resolveClaudeBin\(/, /^\/\/ ===== CODEX RUNTIME =====/],
-  ['Codex runtime (status, turns, delegate wiring)', /^\/\/ ===== CODEX RUNTIME =====/, /^\/\/ Graceful shutdown/],
+  ['server.js', 'Delegation / orchestration engine', /^function wireProcessHandlers\(/, /^wss\.on\('connection'/],
+  ['server.js', '  - wireProcessHandlers (stream-json + interception)', /^function wireProcessHandlers\(/, /^function handleScopeReturn/],
+  ['server.js', '  - handleScopeReturn', /^function handleScopeReturn/, /^function handleDelegation/],
+  ['server.js', '  - handleDelegation', /^function handleDelegation/, /^wss\.on\('connection'/],
+  ['server.js', 'Scheduler (getNextRun + startScheduler + executeRoutine)', /^function startScheduler\(/, /^function analyzeWorkspace/],
+  ['server.js', 'Agent discovery + frontmatter parsing', /^\/\/ ===== AGENT DISCOVERY =====/, /^function startScheduler\(/],
+  ['server.js', 'Skill discovery', /^function discoverSkills\(/, /^function getFileTree\(/],
+  ['server.js', 'System prompt + roster builders', /^function buildSystemPrompt\(/, /^\/\/ ===== AGENT DISCOVERY =====/],
+  ['server.js', 'Workspace analysis (Seven Signals)', /^function analyzeWorkspace\(/, /^function muteHooks\(/],
+  ['server.js', 'Workspace mode detection + scaffolding', /^function muteHooks\(/, /^const server = http\.createServer/],
+  ['server.js', 'Transcripts + persistence helpers', /^function loadTranscript\(/, /^function safeSend\(/],
+  ['server.js', 'Conversation / state persistence', /^function readConversations\(/, /^function readState\(/],
+  ['server.js', 'HTTP request router (incl. permission bridge)', /^const server = http\.createServer/, /^function loadTranscript\(/],
+  ['server.js', 'WebSocket message handlers', /^wss\.on\('connection'/, /^function discoverSkills\(/],
+  ['server.js', 'Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', /^function resolveClaudeBin\(/, /^\/\/ ===== CODEX RUNTIME =====/],
+  ['server.js', 'Codex runtime (status, turns, delegate wiring)', /^\/\/ ===== CODEX RUNTIME =====/, /^\/\/ Graceful shutdown/],
 ];
 
-// Resolve anchor patterns to line ranges against the current source.
-function resolveAreas() {
-  const lines = fs.readFileSync(serverSrcPath, 'utf-8').split('\n');
-  const findLine = (re) => {
-    for (let i = 0; i < lines.length; i++) if (re.test(lines[i])) return i + 1;
-    return null;
+// Whole files reported (and floored) as OVERALL lines.
+const OVERALL_FILES = [
+  'server.js', 'codex.js', 'codex-appserver.js', 'search.js',
+  'lib/delegation/markers.js', 'lib/delegation/handback.js', 'lib/delegation/state.js',
+];
+
+// ---------------------------------------------------------------------------
+// Resolution and measurement (pure; injected reader for tests)
+// ---------------------------------------------------------------------------
+
+function defaultReadFile(file) {
+  return fs.readFileSync(path.join(ROOT, file), 'utf-8');
+}
+
+// Resolve [file, label, startRe, endRe] definitions to [file, label, start,
+// end] line ranges. Unresolvable anchors THROW: the caller decides exit.
+function resolveAreas(defs = AREA_DEFS, readFile = defaultReadFile) {
+  const fileLines = new Map();
+  const linesOf = (file) => {
+    if (!fileLines.has(file)) fileLines.set(file, readFile(file).split('\n'));
+    return fileLines.get(file);
   };
   const areas = [];
-  for (const [label, startRe, endRe] of AREA_DEFS) {
+  for (const [file, label, startRe, endRe] of defs) {
+    const lines = linesOf(file);
+    const findLine = (re) => {
+      for (let i = 0; i < lines.length; i++) if (re.test(lines[i])) return i + 1;
+      return null;
+    };
     const start = findLine(startRe);
     const end = findLine(endRe);
     if (start == null || end == null || end <= start) {
-      console.warn(`coverage-areas: could not resolve "${label}" (start=${start}, end=${end}); anchors need updating`);
-      continue;
+      throw new Error(
+        `coverage-areas: could not resolve area "${label}" in ${file} ` +
+        `(start=${start}, end=${end}). If this code moved, update the area's ` +
+        `file/anchors in AREA_DEFS in the SAME PR as the move.`
+      );
     }
-    areas.push([label, start, end - 1]);
+    areas.push([file, label, start, end - 1]);
   }
   return areas;
 }
 
-function parseLcov(file, wantedFile) {
-  const text = fs.readFileSync(file, 'utf-8');
-  const records = text.split('end_of_record');
+function parseLcov(lcovText, wantedFile) {
+  const records = lcovText.split('end_of_record');
   for (const rec of records) {
     const sfMatch = rec.match(/SF:(.*)/);
     if (!sfMatch) continue;
@@ -93,41 +135,125 @@ function areaCoverage(hits, start, end) {
   return { total, covered };
 }
 
-function pct(c, t) { return t === 0 ? 'n/a' : ((c / t) * 100).toFixed(1) + '%'; }
+// ---------------------------------------------------------------------------
+// Floors (pure)
+// ---------------------------------------------------------------------------
+
+// measured/floors: { label -> pct }. Returns human-readable violations.
+function checkFloors(measured, floors) {
+  const violations = [];
+  for (const [key, floor] of Object.entries(floors)) {
+    const current = measured[key];
+    if (current == null) {
+      violations.push(`"${key}" has a floor (${floor}) but was not measured. An area cannot disappear to silence its floor; update AREA_DEFS and floors deliberately, in the same PR.`);
+      continue;
+    }
+    if (current + FLOOR_TOLERANCE < floor) {
+      violations.push(`"${key}" measured ${current}%, below its floor of ${floor}%. Coverage floors never ratchet down; add tests to restore it.`);
+    }
+  }
+  return violations;
+}
+
+// Ratchet: an existing floor never lowers; fresh areas enter at measurement.
+function mergeFloors(existing, fresh) {
+  const merged = { ...fresh };
+  for (const [key, oldFloor] of Object.entries(existing)) {
+    if (merged[key] != null && merged[key] < oldFloor) merged[key] = oldFloor;
+    if (merged[key] == null) merged[key] = oldFloor;
+  }
+  return merged;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function pctNum(c, t) { return t === 0 ? 0 : Math.round((c / t) * 1000) / 10; }
+function pctStr(c, t) { return t === 0 ? 'n/a' : pctNum(c, t).toFixed(1) + '%'; }
 
 function main() {
+  const args = process.argv.slice(2).filter(a => !a.startsWith('--'));
+  const writeFloors = process.argv.includes('--write-floors');
+  const lcovPath = args[0] || 'coverage.lcov';
+
   if (!fs.existsSync(lcovPath)) {
     console.error(`coverage-areas: ${lcovPath} not found. Run npm run test:coverage.`);
     process.exit(1);
   }
-  const hits = parseLcov(lcovPath, targetFile);
-  if (!hits) {
-    console.error(`coverage-areas: no ${targetFile} record in ${lcovPath}`);
+  const lcovText = fs.readFileSync(lcovPath, 'utf-8');
+
+  let areas;
+  try {
+    areas = resolveAreas();
+  } catch (err) {
+    console.error(err.message);
     process.exit(1);
   }
-  let fileTotal = 0, fileCovered = 0;
-  for (const [, c] of hits) { fileTotal++; if (c > 0) fileCovered++; }
 
-  console.log('\n===== server.js coverage by functional area =====\n');
-  console.log(`OVERALL server.js: ${pct(fileCovered, fileTotal)}  (${fileCovered}/${fileTotal} executable lines)`);
-  // Sibling modules included in coverage get their own overall line.
-  for (const extra of ['codex.js', 'codex-appserver.js', 'search.js', 'lib/delegation/markers.js', 'lib/delegation/handback.js', 'lib/delegation/state.js']) {
-    const extraHits = parseLcov(lcovPath, extra);
-    if (extraHits) {
-      let t = 0, c2 = 0;
-      for (const [, c] of extraHits) { t++; if (c > 0) c2++; }
-      console.log(`OVERALL ${extra}: ${pct(c2, t)}  (${c2}/${t} executable lines)`);
+  const measured = {};
+
+  console.log('\n===== coverage by file and functional area =====\n');
+  for (const file of OVERALL_FILES) {
+    const hits = parseLcov(lcovText, file);
+    if (!hits) {
+      console.error(`coverage-areas: no ${file} record in ${lcovPath}. Is it in test:coverage's include list?`);
+      process.exit(1);
     }
+    let t = 0, c = 0;
+    for (const [, count] of hits) { t++; if (count > 0) c++; }
+    measured[`OVERALL ${file}`] = pctNum(c, t);
+    console.log(`OVERALL ${file}: ${pctStr(c, t)}  (${c}/${t} executable lines)`);
   }
+
   console.log('');
   const pad = (s, n) => (s + ' '.repeat(n)).slice(0, n);
-  console.log(pad('Area', 58) + pad('Lines', 10) + pad('Covered', 10) + 'Coverage');
-  console.log('-'.repeat(88));
-  for (const [label, start, end] of resolveAreas()) {
+  console.log(pad('Area', 58) + pad('Lines', 12) + pad('Covered', 10) + 'Coverage');
+  console.log('-'.repeat(90));
+  for (const [file, label, start, end] of areas) {
+    const hits = parseLcov(lcovText, file);
+    if (!hits) {
+      console.error(`coverage-areas: no ${file} record in ${lcovPath} (needed by area "${label}")`);
+      process.exit(1);
+    }
     const { total, covered } = areaCoverage(hits, start, end);
-    console.log(pad(label, 58) + pad(`${start}-${end}`, 10) + pad(`${covered}/${total}`, 10) + pct(covered, total));
+    measured[label.trim()] = pctNum(covered, total);
+    console.log(pad(label, 58) + pad(`${start}-${end}`, 12) + pad(`${covered}/${total}`, 10) + pctStr(covered, total));
   }
   console.log('');
+
+  if (writeFloors) {
+    let existing = {};
+    if (fs.existsSync(FLOORS_PATH)) {
+      existing = JSON.parse(fs.readFileSync(FLOORS_PATH, 'utf-8')).floors || {};
+    }
+    const merged = mergeFloors(existing, measured);
+    let commit = 'unknown';
+    try { commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf-8' }).trim(); } catch { /* fine */ }
+    fs.writeFileSync(FLOORS_PATH, JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      commit,
+      tolerance: FLOOR_TOLERANCE,
+      floors: merged,
+    }, null, 2) + '\n');
+    console.log(`coverage-areas: floors written to ${path.relative(ROOT, FLOORS_PATH)} (ratcheted: never lower than before)`);
+    return;
+  }
+
+  if (!fs.existsSync(FLOORS_PATH)) {
+    console.error('coverage-areas: no coverage-floors.json. Generate with: npm run test:coverage -- (then) node test/tools/coverage-areas.js coverage.lcov --write-floors');
+    process.exit(1);
+  }
+  const floors = JSON.parse(fs.readFileSync(FLOORS_PATH, 'utf-8')).floors;
+  const violations = checkFloors(measured, floors);
+  if (violations.length) {
+    console.error('coverage-areas: FLOOR VIOLATIONS:');
+    for (const v of violations) console.error(`  - ${v}`);
+    process.exit(1);
+  }
+  console.log(`coverage-areas: all ${Object.keys(floors).length} floors hold (tolerance ${FLOOR_TOLERANCE})`);
 }
 
-main();
+if (require.main === module) main();
+
+module.exports = { AREA_DEFS, OVERALL_FILES, FLOOR_TOLERANCE, resolveAreas, parseLcov, areaCoverage, checkFloors, mergeFloors };

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -1,0 +1,30 @@
+{
+  "generatedAt": "2026-08-11T14:33:06.952Z",
+  "commit": "975317db49f412aaf6b3c15cf668432df142d01c",
+  "tolerance": 0.25,
+  "floors": {
+    "OVERALL server.js": 88.9,
+    "OVERALL codex.js": 100,
+    "OVERALL codex-appserver.js": 94.2,
+    "OVERALL search.js": 98.4,
+    "OVERALL lib/delegation/markers.js": 100,
+    "OVERALL lib/delegation/handback.js": 100,
+    "OVERALL lib/delegation/state.js": 100,
+    "Delegation / orchestration engine": 90.5,
+    "- wireProcessHandlers (stream-json + interception)": 100,
+    "- handleScopeReturn": 87.3,
+    "- handleDelegation": 86.7,
+    "Scheduler (getNextRun + startScheduler + executeRoutine)": 89.9,
+    "Agent discovery + frontmatter parsing": 98.9,
+    "Skill discovery": 98.5,
+    "System prompt + roster builders": 98.9,
+    "Workspace analysis (Seven Signals)": 97.3,
+    "Workspace mode detection + scaffolding": 96.9,
+    "Transcripts + persistence helpers": 99,
+    "Conversation / state persistence": 100,
+    "HTTP request router (incl. permission bridge)": 97,
+    "WebSocket message handlers": 70.9,
+    "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 74.3,
+    "Codex runtime (status, turns, delegate wiring)": 89
+  }
+}

--- a/test/unit/coverage-instruments.test.js
+++ b/test/unit/coverage-instruments.test.js
@@ -1,0 +1,167 @@
+'use strict';
+// Phase 0 instruments: the coverage tool becomes an enforcement gate, and the
+// packaged-contents gate learns to see nested requires.
+//
+// Why: the decomposition programme moves code out of server.js into lib/.
+// Three instruments must hold through every move or the programme flies
+// blind: (1) per-AREA coverage keeps its number when code moves file (area
+// definitions carry their file, and an anchor that fails to resolve is a
+// HARD failure, not a warning that scrolls past); (2) committed floors make
+// coverage regression a CI failure, not a vibe (floors ratchet up, never
+// down); (3) the afterPack require-scan sees `require('./lib/...')` paths,
+// which its character class excluded until now: server.js already requires
+// three lib/ modules that the packaged gate silently never checked.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  resolveAreas,
+  parseLcov,
+  areaCoverage,
+  checkFloors,
+  mergeFloors,
+  FLOOR_TOLERANCE,
+} = require('../tools/coverage-areas.js');
+const { extractLocalRequires } = require('../../scripts/afterPack.js');
+
+// ---------------------------------------------------------------------------
+// Per-file area definitions with hard anchor failure
+// ---------------------------------------------------------------------------
+
+describe('per-file area resolution', () => {
+  const SOURCES = {
+    'server.js': [
+      '// prologue',
+      'function alpha() {',
+      '}',
+      'function beta() {',
+      '}',
+    ].join('\n'),
+    'lib/things/alpha.js': [
+      'function alpha() {',
+      '  return 1;',
+      '}',
+      'module.exports = { alpha };',
+    ].join('\n'),
+  };
+  const readFile = (file) => {
+    if (!(file in SOURCES)) throw new Error(`no such file ${file}`);
+    return SOURCES[file];
+  };
+
+  test('areas resolve against the file each definition names', () => {
+    const defs = [
+      ['server.js', 'alpha (still in the monolith)', /^function alpha\(/, /^function beta\(/],
+      ['lib/things/alpha.js', 'alpha (moved)', /^function alpha\(/, /^module\.exports/],
+    ];
+    const areas = resolveAreas(defs, readFile);
+    assert.deepStrictEqual(areas, [
+      ['server.js', 'alpha (still in the monolith)', 2, 3],
+      ['lib/things/alpha.js', 'alpha (moved)', 1, 3],
+    ]);
+  });
+
+  test('an anchor that fails to resolve is a HARD failure naming the area', () => {
+    const defs = [
+      ['server.js', 'gone area', /^function vanished\(/, /^function beta\(/],
+    ];
+    assert.throws(() => resolveAreas(defs, readFile), /gone area/);
+  });
+
+  test('an end anchor before the start anchor is a hard failure too', () => {
+    const defs = [
+      ['server.js', 'inverted area', /^function beta\(/, /^function alpha\(/],
+    ];
+    assert.throws(() => resolveAreas(defs, readFile), /inverted area/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Floors: enforce and ratchet
+// ---------------------------------------------------------------------------
+
+describe('coverage floors', () => {
+  test('measured below floor (beyond tolerance) is a violation naming area, floor, and measured', () => {
+    const floors = { 'Delegation engine': 90.0, 'OVERALL server.js': 80.0 };
+    const measured = { 'Delegation engine': 84.2, 'OVERALL server.js': 80.1 };
+    const violations = checkFloors(measured, floors);
+    assert.strictEqual(violations.length, 1);
+    assert.match(violations[0], /Delegation engine/);
+    assert.match(violations[0], /90/);
+    assert.match(violations[0], /84\.2/);
+  });
+
+  test('within tolerance passes: floors gate regressions, not timing noise', () => {
+    const floors = { 'Area X': 90.0 };
+    const measured = { 'Area X': 90.0 - FLOOR_TOLERANCE + 0.01 };
+    assert.deepStrictEqual(checkFloors(measured, floors), []);
+  });
+
+  test('an area in the floors file but missing from the measurement is a violation (deleting the area does not silence its floor)', () => {
+    const floors = { 'Area X': 90.0 };
+    const violations = checkFloors({}, floors);
+    assert.strictEqual(violations.length, 1);
+    assert.match(violations[0], /Area X/);
+  });
+
+  test('ratchet: merging floors never lowers one', () => {
+    const existing = { 'Area X': 92.0, 'Area Y': 70.0 };
+    const fresh = { 'Area X': 89.5, 'Area Y': 75.3, 'Area Z': 100.0 };
+    assert.deepStrictEqual(mergeFloors(existing, fresh), {
+      'Area X': 92.0,   // never down
+      'Area Y': 75.3,   // up is fine
+      'Area Z': 100.0,  // new areas enter at their measurement
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The committed floors file is real and enforced against the real tool
+// ---------------------------------------------------------------------------
+
+describe('the committed floors file', () => {
+  const FLOORS_PATH = path.join(__dirname, '..', 'tools', 'coverage-floors.json');
+
+  test('exists, is stamped with a commit, and floors every defined area', () => {
+    assert.ok(fs.existsSync(FLOORS_PATH), 'test/tools/coverage-floors.json is committed');
+    const floors = JSON.parse(fs.readFileSync(FLOORS_PATH, 'utf8'));
+    assert.match(floors.commit, /^[0-9a-f]{7,40}$/);
+    assert.ok(!Number.isNaN(Date.parse(floors.generatedAt)));
+    assert.ok(Object.keys(floors.floors).length >= 10, 'floors cover the area set');
+    for (const [key, value] of Object.entries(floors.floors)) {
+      assert.strictEqual(typeof value, 'number', `${key} floor is a number`);
+      assert.ok(value >= 0 && value <= 100);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// afterPack: nested requires are seen
+// ---------------------------------------------------------------------------
+
+describe('packaged-contents gate require extraction', () => {
+  test('sees root-level and nested local requires, ignores package requires', () => {
+    const src = [
+      "const { markers } = require('./lib/delegation/markers.js');",
+      "const search = require('./search.js');",
+      "const ws = require('ws');",
+      "const path = require('path');",
+      "const handback = require('./lib/delegation/handback.js');",
+    ].join('\n');
+    assert.deepStrictEqual(extractLocalRequires(src).sort(), [
+      'lib/delegation/handback.js',
+      'lib/delegation/markers.js',
+      'search.js',
+    ]);
+  });
+
+  test('the live blind spot, closed: server.js lib requires are in the gate set', () => {
+    const serverSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'server.js'), 'utf8');
+    const required = extractLocalRequires(serverSrc);
+    assert.ok(required.includes('lib/delegation/markers.js'), `lib requires visible, got: ${required.join(', ')}`);
+    assert.ok(required.includes('search.js'), 'root requires still visible');
+  });
+});


### PR DESCRIPTION
## What

Instrumentation before decomposition: the three instruments that must hold through every code move.

- **Per-file area definitions**: `test/tools/coverage-areas.js` definitions are now `[file, label, startRe, endRe]`, so an area keeps its coverage number when its code moves into `lib/`. An anchor that fails to resolve is a **hard failure naming the area** — a moved function whose definition was not updated stops the build instead of printing a warning that scrolls past.
- **Committed, enforced floors**: `test/tools/coverage-floors.json` (stamped with its generating commit) floors every area and file. Below floor beyond a 0.25 timing tolerance → non-zero exit. An area disappearing from measurement is itself a violation. `--write-floors` ratchets — a floor never lowers. New blocking CI job (**Coverage floors**) runs the suite with coverage and enforces on every push and PR.
- **afterPack sees nested requires**: the require-extraction character class excluded `/`, so `require('./lib/...')` paths were invisible to the packaged-contents gate — the three `lib/delegation` modules the app ships were silently unprotected. Closed, with the extraction exported and pinned by tests (including a regression test against the real `server.js`).

## Proofs run

- Deleting a covered test file: coverage run exits 1 with `"OVERALL lib/delegation/handback.js" measured 85.2%, below its floor of 100%`.
- A probe area defined against a `lib/` file resolves and measures with the real tool against real lcov output.
- 10 new tests; full coverage-enforced suite green (23 floors hold), e2e 103, hygiene clean.

## Baseline

Re-measured for the decomposition slice ordering: WebSocket handlers 70.9% and spawn plumbing 74.3% are the weakest areas — confirming the characterise-first order already planned for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)