### PR TITLE
Setup completes when the team exists, however the files arrived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 **Name:** Foundations
 
+### Fixed
+
+- **Setup completes when your team exists, however it was created:** the workspace used to leave "setup pending" only when agents were created through the standard onboarding flow. A team created any other way (an agent writing the files directly, or you dropping agent files into place) now completes setup too, within a couple of seconds of the files appearing.
+
 ### Changed
 
 - **Releases are validated before they exist:** every release candidate now passes a full gauntlet (the complete test suite with coverage, end-to-end browser tests, the release smoke including a real-model run, scripted user journeys for first-run onboarding and vault imports, type checking, packaging, and internal-reference hygiene) before its version tag can be created, and publishing is a single verified command. You see this as fewer, better-tested releases rather than a new button, and it is the first piece of a release built on stronger foundations.

--- a/server.js
+++ b/server.js
@@ -664,6 +664,23 @@ function agentsDirSignature(dir) {
     return null; // directory missing: a later appearance counts as a change
   }
 }
+// Setup is complete the moment a real (non-platform) agent is on the team,
+// HOWEVER its file arrived: the save_agent marker path, an agent using the
+// Write tool, or a user dropping a file in place. This used to live only in
+// the save_agent handler, so a team created any other way left the workspace
+// "setup pending" forever, with the client offering "Set up your team" to a
+// user who already had one.
+function maybeCompleteSetup(agentList) {
+  try {
+    const state = readState();
+    if (state.setupComplete) return;
+    if ((agentList || []).some(a => a.status === 'onTeam' && a.type !== 'platform')) {
+      writeState({ ...state, setupComplete: true, setupCompletedAt: new Date().toISOString(), version: 1 });
+      console.log('[Setup] Marked complete');
+    }
+  } catch (e) { /* state write is best-effort; the next convergence retries */ }
+}
+
 function armAgentsDirWatcher() {
   if (_agentsWatchTimer) { clearInterval(_agentsWatchTimer); _agentsWatchTimer = null; }
   if (!WORKSPACE) return;
@@ -675,6 +692,7 @@ function armAgentsDirWatcher() {
     _agentsDirSig = sig;
     invalidateAgentCache();
     flagRosterRefresh();
+    maybeCompleteSetup(discoverAgents());
     console.log('[Roster] agents directory changed on disk; live orchestrators flagged');
   }, AGENTS_WATCH_POLL_MS);
   if (_agentsWatchTimer.unref) _agentsWatchTimer.unref();
@@ -5207,13 +5225,7 @@ wss.on('connection', (ws) => {
             ws.send(JSON.stringify({ type: 'agents', agents: updatedAgents }));
             ws.send(JSON.stringify({ type: 'skills', skills: discoverSkills(updatedAgents) }));
             flagRosterRefresh();
-            if (!existed) {
-              const state = readState();
-              if (!state.setupComplete && updatedAgents.some(a => a.status === 'onTeam' && a.type !== 'platform')) {
-                writeState({ ...state, setupComplete: true, setupCompletedAt: new Date().toISOString(), version: 1 });
-                console.log(`[Setup] Marked complete`);
-              }
-            }
+            if (!existed) maybeCompleteSetup(updatedAgents);
           }
         }
       }
@@ -7975,7 +7987,7 @@ module.exports._internal = {
   extractSelfDescription, buildSystemPrompt,
   // workspace analysis / scaffolding
   detectWorkspaceMode, isEmptyWorkspace, analyzeWorkspace,
-  scaffoldDefaults, scaffoldWorkspace, muteHooks, discoverWorkspaces,
+  scaffoldDefaults, scaffoldWorkspace, muteHooks, discoverWorkspaces, maybeCompleteSetup,
   readMcpServerNames, getFileTree, fileKind, validateAgentSlug, isInsideWorkspace, isSafeCreatePath,
   // persistence
   readConversations, writeConversations, readState, writeState,

--- a/test/integration/team-membership.test.js
+++ b/test/integration/team-membership.test.js
@@ -114,3 +114,46 @@ describe('one team-membership rule', () => {
     assert.ok(flagged, 'live orchestrator flagged for roster refresh after an external edit to .claude/agents');
   });
 });
+
+describe('setup completes when the team exists, however the files arrived', () => {
+  // The setupComplete flip lived only in the save_agent WS handler (the
+  // marker path). A Doc that creates the team with the Write tool, or a user
+  // who drops agent files in place, got a working team while the workspace
+  // stayed "setup pending" forever: the client kept offering "Set up your
+  // team" and onboarding routing never exited setup mode. Found by the live
+  // New User persona (a creation turn saying "Writing a file...") plus code
+  // reading, 2026-08-11.
+  const statePath = () => path.join(h.workspaceDir, '.rundock', 'state.json');
+  const readSetup = () => {
+    try { return JSON.parse(fs.readFileSync(statePath(), 'utf8')).setupComplete; }
+    catch { return undefined; }
+  };
+  const seedPending = () => {
+    const state = (() => { try { return JSON.parse(fs.readFileSync(statePath(), 'utf8')); } catch { return {}; } })();
+    fs.writeFileSync(statePath(), JSON.stringify({ ...state, setupComplete: false }));
+  };
+
+  test('an agent file written straight to disk flips setup within one watcher poll', async () => {
+    seedPending();
+    fs.writeFileSync(path.join(h.workspaceDir, '.claude', 'agents', 'dropped-in.md'),
+      '---\nname: dropped-in\ndisplayName: Dropped In\nrole: Hand-authored\ntype: specialist\norder: 6\nreportsTo: roo\n---\nYou are Dropped In.\n');
+    const flipped = await h.waitUntil(() => readSetup() === true, { timeout: 6000 });
+    assert.ok(flipped, 'setupComplete flips when the on-disk team gains a non-platform agent');
+  });
+
+  test('a platform-only roster never flips setup', () => {
+    seedPending();
+    const flip = h.internal.maybeCompleteSetup;
+    assert.strictEqual(typeof flip, 'function', 'the flip is one extracted helper');
+    flip([
+      { id: 'rundock-guide', status: 'onTeam', type: 'platform' },
+      { id: 'other-platform', status: 'onTeam', type: 'platform' },
+    ]);
+    assert.strictEqual(readSetup(), false, 'platform agents alone are not a team');
+    flip([
+      { id: 'rundock-guide', status: 'onTeam', type: 'platform' },
+      { id: 'cos', status: 'onTeam', type: 'orchestrator' },
+    ]);
+    assert.strictEqual(readSetup(), true, 'a real team member flips it');
+  });
+});


### PR DESCRIPTION
## What

The `setupComplete` flip lived only in the `save_agent` handler (the marker path). A Doc creating the team with the Write tool, or a user dropping agent files into place, got a working team while the workspace stayed "setup pending" forever — the client kept offering "Set up your team" and onboarding routing never exited setup mode.

The flip is now one extracted helper (a non-platform agent on the team while setup is pending completes it), called from both convergence points: the `save_agent` handler and the agents-directory watcher tick. Files that appear on disk by any route flip setup within one poll; a platform-only roster never flips it.

## Found by

The live new-user journey (a creation turn reading "Writing a file...") plus code reading — the first cashed-in finding from the journeys that merged in #93.

## Tests first

Two tests written red before the fix: the direct-to-disk flip through the real watcher (failed at 6s timeout on the old code), and the platform-only guard against the extracted helper (failed on the helper not existing).

## Evidence

Suite green with coverage floors holding, e2e 103, persona journeys 16/16, typecheck and hygiene clean. Changelog entry added under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)