### PR TITLE
The watcher never mistakes the server's own boot writes for external edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Opening a workspace no longer risks a spurious agent restart moments later:** when Rundock updates its own built-in agent or skill files during workspace open, that write was briefly mistaken for an external edit, which could restart a busy agent mid-conversation about two seconds in. The server's own writes are now recognised as its own.
 - **Setup completes when your team exists, however it was created:** the workspace used to leave "setup pending" only when agents were created through the standard onboarding flow. A team created any other way (an agent writing the files directly, or you dropping agent files into place) now completes setup too, within a couple of seconds of the files appearing.
 
 ### Changed

--- a/server.js
+++ b/server.js
@@ -681,6 +681,18 @@ function maybeCompleteSetup(agentList) {
   } catch (e) { /* state write is best-effort; the next convergence retries */ }
 }
 
+// The server's own writers (the boot/switch scaffold sync of managed files)
+// call this after finishing, so the poller never mistakes a boot write for an
+// external edit. Without it, the arm-then-scaffold order at every workspace
+// entry point produced one guaranteed tick ~2s in that flagged every live
+// orchestrator for roster refresh; whichever conversation's follow-up landed
+// next was killed-and-respawned instead of reused (the CI spawn-count flake
+// on main, 2026-08-11).
+function rebaselineAgentsWatcher() {
+  if (!WORKSPACE) return;
+  _agentsDirSig = agentsDirSignature(path.join(WORKSPACE, '.claude', 'agents'));
+}
+
 function armAgentsDirWatcher() {
   if (_agentsWatchTimer) { clearInterval(_agentsWatchTimer); _agentsWatchTimer = null; }
   if (!WORKSPACE) return;
@@ -2182,7 +2194,12 @@ function scaffoldWorkspace(dir, opts = {}) {
     // a caller that primed the cache before this sync (the workspace-open path
     // does exactly that) would keep reading stale agents and the platform
     // skills would show as unassigned until a reload.
-    if (wroteManagedFile) invalidateAgentCache();
+    if (wroteManagedFile) {
+      invalidateAgentCache();
+      // These writes are the server's own, not external edits: refresh the
+      // watcher baseline so the next poll stays quiet.
+      if (dir === WORKSPACE) rebaselineAgentsWatcher();
+    }
 
     // Create .rundock/ directory for session persistence
     const rundockPath = path.join(dir, '.rundock');

--- a/test/integration/watcher-baseline.test.js
+++ b/test/integration/watcher-baseline.test.js
@@ -1,0 +1,61 @@
+'use strict';
+// The agents-dir watcher must not treat the server's OWN boot writes as
+// external edits.
+//
+// The sequence that flaked CI (delegation.test.js spawn-count pin, main run
+// after #94): startServer arms the watcher (baseline captured), then the
+// listen callback runs scaffoldWorkspace, which writes the managed
+// rundock-guide.md into .claude/agents. The first 2s tick sees the changed
+// signature, flags every live orchestrator for roster refresh, and whichever
+// conversation's follow-up lands next kills-and-respawns instead of reusing
+// its process. The workspace-switch paths had the same arm-then-scaffold
+// order. Deterministic trigger, timing-dependent victim: the worst kind.
+//
+// The invariant: the watcher's baseline is captured AFTER all boot-time
+// writers finish, so a quiet workspace produces zero ticks and no live entry
+// is ever flagged without a real external edit.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+
+let client;
+let convoId;
+let entry;
+before(async () => {
+  // The default harness workspace reproduces the bug by construction: it
+  // seeds the team agents but NOT the managed platform files, so the boot
+  // scaffold sync writes rundock-guide.md after the watcher armed. The
+  // conversation must be LIVE inside the first watcher poll (2s), which is
+  // exactly the state every early test in a suite is in, so the turn starts
+  // here, immediately after boot.
+  await h.boot();
+  client = await h.connect();
+  h.writeScenario([
+    { match: { agent: 'chief-of-staff', promptIncludes: 'baseline idle turn' },
+      turn: [{ text: 'Idling.' }] },
+  ]);
+  convoId = h.freshConvoId('baseline');
+  client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'baseline idle turn' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'idle turn' });
+  entry = h.internal.chatProcesses.get(convoId);
+});
+after(async () => h.shutdown());
+
+describe('watcher baseline vs boot writes', () => {
+  test('a quiet workspace stays quiet: no roster-refresh flag without a real external edit', async () => {
+    assert.ok(entry, 'entry exists');
+    assert.notStrictEqual(entry.needsRosterRefresh, true, 'not flagged at turn completion');
+
+    // Cover two full watcher polls from boot: if the boot scaffold write is
+    // being mistaken for an external edit, the tick fires in this window and
+    // flags the entry.
+    await h.delay(4500);
+    const flagged = entry.needsRosterRefresh === true;
+    h.reapConvo(convoId);
+    assert.strictEqual(flagged, false,
+      'the boot-time scaffold sync must not read as an external edit (it killed resumed parents mid-test on CI)');
+  });
+});


### PR DESCRIPTION
## What

Every workspace entry point armed the agents-dir watcher and *then* ran the scaffold sync, which writes managed files (`rundock-guide.md`) into `.claude/agents`. The first 2s poll saw the changed signature, flagged every live orchestrator for roster refresh, and whichever conversation's follow-up landed next was **killed-and-respawned instead of reused**.

The scaffold sync now refreshes the watcher baseline after writing managed files, healing every arm-then-scaffold call site at once. Real external edits still flag — the existing team-membership watcher pin covers that path.

## Why now

This is the diagnosis and fix for the `Test (Node 22)` failure on main's latest push run: the delegation spawn-count pin failed `3 !== 2`. Deterministic trigger (the tick fired on **every** suite run, confirmed by instrumentation showing `rundock-guide.md` appearing in the signature 42ms after the seeds), timing-dependent victim (which conversation the flag lands on depends on runner speed) — which is why it stayed green locally and through many CI runs before striking.

It is also a real product bug, not just test noise: any Rundock update that changes scaffold-managed files caused the next workspace open to flag live orchestrators ~2s in, restarting a busy agent mid-conversation.

## Tests first

New pin written red before the fix: a conversation live inside the first watcher poll, in a workspace whose managed files need syncing (the exact state every early test in a suite is in), must never be flagged without a real external edit. Red showed the guaranteed tick; green after.

## Evidence

- Five consecutive delegation-suite runs after the fix: **zero watcher ticks**, 25/25 each (before: one guaranteed tick per run).
- Full battery: suite with floors holding, e2e 103, smoke 20/20, personas 16/16, typecheck and hygiene clean.
- Changelog entry under Unreleased → Fixed. No CI retries added, no waits lengthened: the trigger is eliminated, not hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)