### PR TITLE
Characterise the WebSocket handlers and spawn plumbing before their move

### DIFF
--- a/server.js
+++ b/server.js
@@ -8014,7 +8014,7 @@ module.exports._internal = {
   parseSessionHistory, getSessionJsonlPath,
   // spawn plumbing
   wireProcessHandlers, handleDelegation, handleScopeReturn,
-  handleChatSpawnError, resolveClaudeBin, spawnClaude,
+  handleChatSpawnError, resolveClaudeBin, spawnClaude, killProcessTree,
   getBareArgs, getSpawnEnv, getDisallowedTools, getPermissionMode,
   getAllowedToolsInteractive, getAllowedToolsLegacy, modelArgs,
   killAllChildren, cleanOrphanedProcesses, loadPidFile, savePidFile, pidRecordAlive, processCommand,

--- a/test/helpers/stub-claude/claude
+++ b/test/helpers/stub-claude/claude
@@ -17,13 +17,17 @@
 // workspace). Scenario format:
 //   { "rules": [ { "match": { "agent": "chief-of-staff",
 //                             "promptIncludes": "hooks" | ["a","b"],
-//                             "promptExcludes": "x" },
+//                             "promptExcludes": "x",
+//                             "resume": true },  // gate on --resume presence
 //                  "delayMs": 0,
 //                  "singleChunk": false,
 //                  "isError": false,
 //                  "crash": 1,   // exit with this code WITHOUT emitting a result
 //                                // envelope: simulates an abnormal mid-turn death
 //                                // (CLI crash / OOM / auth expiry). No `turn` runs.
+//                  "stderr": "...",     // written to stderr before a crash exit
+//                  "crashTail": "...",  // final stdout fragment, no newline,
+//                                       // left in the server's line buffer
 //                  "turn": [ { "text": "..." },
 //                            { "agentTool": { "subagent_type": "penn", "prompt": "..." } },
 //                            { "tool": { "name": "Read", "input": {...} } },
@@ -103,6 +107,9 @@ function loadRules() {
 function matches(rule, prompt) {
   const m = rule.match || {};
   if (m.agent !== undefined && m.agent !== AGENT) return false;
+  // Gate a rule on whether this spawn is a --resume: lets a scenario crash
+  // the resumed process while answering its fresh retry normally.
+  if (m.resume !== undefined && m.resume !== (RESUME != null)) return false;
   const includes = m.promptIncludes == null ? [] : [].concat(m.promptIncludes);
   for (const s of includes) if (!prompt.includes(s)) return false;
   const excludes = m.promptExcludes == null ? [] : [].concat(m.promptExcludes);
@@ -204,11 +211,20 @@ function handleUserMessage(content) {
   };
   if (rule.spawnChild) spawnGrandchild();
   if (rule.crash != null) {
-    // Abnormal death: exit non-zero without emitting a result envelope, so the
+    // Abnormal death: exit without emitting a result envelope, so the
     // server's close handler runs with no result for this turn.
+    // `stderr` models CLI error output (e.g. a failed --resume complaining
+    // about the session); `crashTail` writes a final stdout fragment WITHOUT
+    // a trailing newline, so it is still sitting in the server's line buffer
+    // when the process dies.
     const code = typeof rule.crash === 'number' ? rule.crash : 1;
-    if (rule.delayMs) setTimeout(() => process.exit(code), rule.delayMs);
-    else process.exit(code);
+    const die = () => {
+      if (rule.stderr) process.stderr.write(String(rule.stderr));
+      if (rule.crashTail) process.stdout.write(String(rule.crashTail));
+      process.exit(code);
+    };
+    if (rule.delayMs) setTimeout(die, rule.delayMs);
+    else die();
     return;
   }
   const delay = rule.delayMs || 0;

--- a/test/integration/chat-close-paths.test.js
+++ b/test/integration/chat-close-paths.test.js
@@ -1,0 +1,128 @@
+'use strict';
+// Characterisation: the chat process-close paths, pinned as they behave today,
+// before the WS handlers move out of server.js.
+//
+// Three behaviours live only in the close handler and had no coverage:
+//   1. A failed --resume (non-zero exit, stderr naming the session) retries
+//      fresh exactly once, invisibly to the user beyond one info line.
+//   2. A final stdout fragment still sitting in the line buffer when the
+//      process dies is flushed: parseable JSON as itself, anything else as a
+//      raw message.
+//   3. A client connecting mid-turn is told about the live process so it can
+//      restore the thinking indicator.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+
+const h = require('../helpers/harness.js');
+
+let client;
+
+before(async () => {
+  await h.boot();
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+describe('resume failure recovery', () => {
+  test('an expired session retries fresh once: info line, new spawn without --resume, normal answer', async () => {
+    const convoId = h.freshConvoId('resume');
+    h.clearInvocations();
+    h.writeScenario([
+      // The resumed spawn dies the way the real CLI does when a session is
+      // gone. No agent gate: resume spawns carry no --agent flag.
+      { match: { promptIncludes: 'retry me please', resume: true },
+        crash: 1, stderr: 'No conversation found with session ID: sess-expired-1' },
+      // The fresh retry (no --resume) answers normally.
+      { match: { agent: 'chief-of-staff', promptIncludes: 'retry me please' },
+        turn: [{ text: 'Fresh start answer' }] },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'retry me please', sessionId: 'sess-expired-1' });
+
+    const info = (await client.waitFor(
+      m => m.type === 'system' && m.subtype === 'info' && m._conversationId === convoId,
+      { label: 'session-expired info' })).msg;
+    assert.strictEqual(info.content, 'Previous session expired. Starting fresh.');
+
+    const result = (await client.waitFor(
+      m => m.type === 'result' && m._conversationId === convoId,
+      { label: 'fresh result' })).msg;
+    assert.match(result.result, /Fresh start answer/);
+
+    // Exactly two spawns: the failed resume, then the fresh retry.
+    const spawns = h.readInvocations().filter(i => i.resume !== undefined);
+    assert.strictEqual(spawns.length, 2);
+    assert.strictEqual(spawns[0].resume, 'sess-expired-1');
+    assert.strictEqual(spawns[1].resume, null, 'retry drops the dead session');
+
+    h.reapConvo(convoId);
+  });
+});
+
+describe('line-buffer flush at process exit', () => {
+  test('a parseable JSON tail is delivered as itself, stamped with the conversation', async () => {
+    const convoId = h.freshConvoId('tailjson');
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'tail json' },
+        crash: 0, crashTail: '{"type":"system","subtype":"stub_tail"}' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'tail json' });
+
+    const tail = (await client.waitFor(
+      m => m.type === 'system' && m.subtype === 'stub_tail',
+      { label: 'flushed JSON tail' })).msg;
+    assert.strictEqual(tail._conversationId, convoId);
+    assert.strictEqual(tail._agent, 'chief-of-staff');
+
+    // No result envelope ever arrived, so the close handler still unblocks
+    // the client with done.
+    const done = (await client.waitForEvent('system', 'done', convoId, { label: 'done after tail' })).msg;
+    assert.strictEqual(done.code, 0);
+    assert.ok(!h.internal.chatProcesses.has(convoId), 'entry cleaned up');
+  });
+
+  test('an unparseable tail is delivered as a raw message rather than dropped', async () => {
+    const convoId = h.freshConvoId('tailraw');
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'tail raw' },
+        crash: 0, crashTail: 'partial-line-without-newline' },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'tail raw' });
+
+    const raw = (await client.waitFor(
+      m => m.type === 'raw' && m._conversationId === convoId,
+      { label: 'flushed raw tail' })).msg;
+    assert.strictEqual(raw.content, 'partial-line-without-newline');
+
+    await client.waitForEvent('system', 'done', convoId, { label: 'done after raw tail' });
+  });
+});
+
+describe('connect during a live turn', () => {
+  test('a fresh client is told about active processes so it can restore the thinking indicator', async () => {
+    const convoId = h.freshConvoId('midturn');
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'think slowly' },
+        delayMs: 1500, turn: [{ text: 'Done thinking' }] },
+    ]);
+
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'think slowly' });
+    await client.waitForEvent('system', 'process_started', convoId, { label: 'turn started' });
+
+    const latecomer = await h.connect();
+    const announce = (await latecomer.waitFor(m => m.type === 'active_processes', { label: 'active_processes' })).msg;
+    const entry = announce.processes.find(p => p.conversationId === convoId);
+    assert.ok(entry, 'live turn announced to the new client');
+    assert.strictEqual(typeof entry.processId, 'string');
+    assert.strictEqual(entry.agentId, 'chief-of-staff');
+    assert.strictEqual(entry.idle, false);
+    assert.strictEqual(entry.responseText, '');
+    assert.strictEqual(entry.delegation, null);
+
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'turn finished' });
+    latecomer.close();
+    h.reapConvo(convoId);
+  });
+});

--- a/test/integration/conversation-metadata.test.js
+++ b/test/integration/conversation-metadata.test.js
@@ -165,12 +165,19 @@ describe('add_to_team', () => {
     // invalidation (in production, the agents-dir watcher's next poll).
     h.internal.invalidateAgentCache();
 
+    // The recruit joins at max(existing orders) + 1 across the WHOLE roster,
+    // platform agent included (the scaffolded guide holds a deliberately high
+    // order so it sits last, and recruits land after it).
+    const roster = await request({ type: 'get_agents' }, m => m.type === 'agents', 'roster before add');
+    const expectedOrder = Math.max(0, ...roster.agents.filter(a => a.order !== null).map(a => a.order)) + 1;
+
     const res = await request({ type: 'add_to_team', agentId: 'doc' }, m => m.type === 'agents', 'agents after add');
 
-    // Disk is the source of truth and is correct immediately: standardTeam
-    // occupies orders 1-4, so the recruit takes 5, written after `type:`.
+    // Disk is the source of truth and is correct immediately, written after
+    // the `type:` field.
     const content = fs.readFileSync(path.join(agentsDir, 'doc.md'), 'utf-8');
-    assert.match(content, /^type: specialist\norder: 5$/m, 'order written directly after the type field');
+    assert.match(content, new RegExp(`^type: specialist\\norder: ${expectedOrder}$`, 'm'),
+      'order written directly after the type field');
 
     // CHARACTERISED GAP (carded): the agents message answered here is built
     // from the roster cache populated at the top of the same handler, so it

--- a/test/integration/conversation-metadata.test.js
+++ b/test/integration/conversation-metadata.test.js
@@ -1,0 +1,230 @@
+'use strict';
+// Characterisation: the conversation-metadata WS handlers, pinned as they
+// behave today, before they move out of server.js. Covers the
+// get_conversations load pipeline (cleanup, activeAgentId reconciliation,
+// enrichment), set_last_active_conversation, the conversation lists CRUD,
+// create_path, add_to_team, the reveal_in_finder guard, and the
+// disconnect-buffer flush.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
+
+let client;
+let sessionsDir;
+
+function request(msg, pred, label) {
+  const since = client.messages.length;
+  client.send(msg);
+  return client.waitFor(pred, { since, label }).then(r => r.msg);
+}
+
+function getConversations(label) {
+  return request({ type: 'get_conversations' }, m => m.type === 'conversations', label || 'conversations');
+}
+
+function writeSession(sessionId, entries) {
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  fs.writeFileSync(path.join(sessionsDir, `${sessionId}.jsonl`),
+    entries.map(e => JSON.stringify(e)).join('\n') + '\n');
+}
+
+before(async () => {
+  await h.boot();
+  client = await h.connect();
+  sessionsDir = path.join(process.env.HOME, '.claude', 'projects', h.workspaceDir.replace(/\//g, '-'));
+});
+after(async () => h.shutdown());
+
+describe('get_conversations: load pipeline', () => {
+  test('cleans stale empties and reconciles activeAgentId, persisting once', async () => {
+    const oldStamp = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    const convosFile = path.join(h.workspaceDir, '.rundock', 'conversations.json');
+    fs.mkdirSync(path.dirname(convosFile), { recursive: true });
+    fs.writeFileSync(convosFile, JSON.stringify([
+      // Never got a sessionId and is older than the 5-minute grace: dropped.
+      { id: 'stale-empty', agentId: 'chief-of-staff', title: 'Abandoned', lastActiveAt: oldStamp },
+      // Points at a delegatee with no live process: reset to the owner.
+      { id: 'reconcile-1', agentId: 'chief-of-staff', activeAgentId: 'penn', sessionId: 's-r1', title: 'Reconciled', lastActiveAt: oldStamp },
+    ]));
+
+    const res = await getConversations();
+    assert.ok(!res.conversations.some(c => c.id === 'stale-empty'), 'stale empty conversation dropped');
+    const reconciled = res.conversations.find(c => c.id === 'reconcile-1');
+    assert.strictEqual(reconciled.activeAgentId, 'chief-of-staff', 'stale delegatee pointer reset to the owner');
+
+    const persisted = JSON.parse(fs.readFileSync(convosFile, 'utf-8'));
+    assert.ok(!persisted.some(c => c.id === 'stale-empty'), 'cleanup persisted to disk');
+    assert.strictEqual(persisted.find(c => c.id === 'reconcile-1').activeAgentId, 'chief-of-staff');
+  });
+
+  test('enriches each conversation with messageCount and a stripped last-message preview', async () => {
+    const convoId = 'enrich-1';
+    writeSession('sess-enrich-1', [
+      { type: 'user', message: { role: 'user', content: 'Real question' } },
+      { message: { role: 'assistant', content: [{ type: 'text', text: 'Real answer' }] } },
+      // None of these are user-visible bubbles: excluded from the count.
+      { type: 'user', message: { role: 'user', content: '[DELEGATION BRIEF] internal' } },
+      { message: { role: 'assistant', content: [{ type: 'text', text: 'No response requested.' }] } },
+    ]);
+    client.send({
+      type: 'save_conversation',
+      conversation: { id: convoId, agentId: 'chief-of-staff', title: 'Enrichment pin', sessionId: 'sess-enrich-1', sessionIds: [{ sessionId: 'sess-enrich-1' }] },
+    });
+    // The preview comes from the transcript's last agent entry: markers,
+    // markdown, and leading tool summaries all stripped.
+    const dir = path.join(h.workspaceDir, '.rundock', 'transcripts');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${convoId}.json`), JSON.stringify([
+      { role: 'user', text: 'Real question' },
+      {
+        role: 'agent', agent: 'penn',
+        text: '<!-- RUNDOCK:SAVE_AGENT name=doc -->\nhidden payload\n<!-- /RUNDOCK:SAVE_AGENT -->[Read: notes.md] **Bold** update with a [link](https://example.com) and [[Page|alias]] inside',
+      },
+    ]));
+
+    const res = await getConversations('conversations with enrichment');
+    const convo = res.conversations.find(c => c.id === convoId);
+    assert.ok(convo, 'saved conversation listed');
+    assert.strictEqual(convo.messageCount, 2, 'only user-visible bubbles counted');
+    assert.strictEqual(convo.lastAgentId, 'penn');
+    assert.strictEqual(convo.lastMessagePreview, 'Bold update with a link and alias inside');
+  });
+});
+
+describe('set_last_active_conversation', () => {
+  test('sets and clears the pointer served with the conversation list', async () => {
+    client.send({ type: 'set_last_active_conversation', id: 'enrich-1' });
+    let res = await getConversations('conversations after set');
+    assert.strictEqual(res.lastActiveConversationId, 'enrich-1');
+
+    client.send({ type: 'set_last_active_conversation' });
+    res = await getConversations('conversations after clear');
+    assert.strictEqual(res.lastActiveConversationId, null);
+  });
+});
+
+describe('conversation lists', () => {
+  test('create trims the name, duplicates are a no-op, delete removes everywhere', async () => {
+    let res = await request({ type: 'get_lists' }, m => m.type === 'lists', 'initial lists');
+    assert.deepStrictEqual(res.lists, []);
+
+    res = await request({ type: 'create_list', name: '  Client Work  ' }, m => m.type === 'lists', 'created list');
+    assert.strictEqual(res.lists.length, 1);
+    assert.strictEqual(res.lists[0].name, 'Client Work');
+    assert.match(res.lists[0].id, /^list-/);
+
+    // Same name, different case: no duplicate pill.
+    res = await request({ type: 'create_list', name: 'client work' }, m => m.type === 'lists', 'duplicate list');
+    assert.strictEqual(res.lists.length, 1);
+
+    res = await request({ type: 'delete_list', id: res.lists[0].id }, m => m.type === 'lists', 'deleted list');
+    assert.deepStrictEqual(res.lists, []);
+  });
+});
+
+describe('create_path', () => {
+  test('notes are created (never clobbered); folders are idempotent; dot-paths are refused', async () => {
+    const since = client.messages.length;
+    client.send({ type: 'create_path', path: '/notes/new-note.md', kind: 'note', content: '# Hi' });
+    const created = (await client.waitFor(m => m.type === 'path_created', { since, label: 'path_created' })).msg;
+    // The leading slash is stripped: the path is workspace-relative.
+    assert.strictEqual(created.path, 'notes/new-note.md');
+    assert.strictEqual(created.kind, 'note');
+    await client.waitFor(m => m.type === 'file_tree', { since, label: 'file_tree after create' });
+    assert.strictEqual(fs.readFileSync(path.join(h.workspaceDir, 'notes', 'new-note.md'), 'utf-8'), '# Hi');
+
+    let err = await request({ type: 'create_path', path: 'notes/new-note.md', kind: 'note' },
+      m => m.type === 'create_error', 'clobber refused');
+    assert.strictEqual(err.reason, 'already exists');
+
+    const folder = await request({ type: 'create_path', path: 'boards/q3', kind: 'folder' },
+      m => m.type === 'path_created', 'folder created');
+    assert.strictEqual(folder.kind, 'folder');
+    const again = await request({ type: 'create_path', path: 'boards/q3', kind: 'folder' },
+      m => m.type === 'path_created', 'folder idempotent');
+    assert.strictEqual(again.path, 'boards/q3');
+
+    err = await request({ type: 'create_path', path: '.hidden/x.md', kind: 'note' },
+      m => m.type === 'create_error', 'dot path refused');
+    assert.strictEqual(err.reason, 'invalid path');
+  });
+});
+
+describe('add_to_team', () => {
+  test('assigns the next order number and writes it into the agent file frontmatter', async () => {
+    const agentsDir = path.join(h.workspaceDir, '.claude', 'agents');
+    fs.writeFileSync(path.join(agentsDir, 'doc.md'), agentFile({
+      name: 'doc', displayName: 'Doc', role: 'Recruiter', type: 'specialist',
+      description: 'Available agent with no order',
+    }));
+    // The roster is signature-cached; an external write is only visible after
+    // invalidation (in production, the agents-dir watcher's next poll).
+    h.internal.invalidateAgentCache();
+
+    const res = await request({ type: 'add_to_team', agentId: 'doc' }, m => m.type === 'agents', 'agents after add');
+
+    // Disk is the source of truth and is correct immediately: standardTeam
+    // occupies orders 1-4, so the recruit takes 5, written after `type:`.
+    const content = fs.readFileSync(path.join(agentsDir, 'doc.md'), 'utf-8');
+    assert.match(content, /^type: specialist\norder: 5$/m, 'order written directly after the type field');
+
+    // CHARACTERISED GAP (carded): the agents message answered here is built
+    // from the roster cache populated at the top of the same handler, so it
+    // still reports the recruit as order-less. The client only sees the real
+    // order on a later roster refresh. Pinned as-is; the fix flips this
+    // assertion to `5`.
+    const doc = res.agents.find(a => a.id === 'doc');
+    assert.strictEqual(doc.order, null);
+  });
+});
+
+describe('reveal_in_finder', () => {
+  test('a path outside the workspace is guarded to a no-op, not an error', async () => {
+    client.send({ type: 'reveal_in_finder', path: '../../outside' });
+    // The handler answers nothing; prove the connection survived it.
+    const res = await request({ type: 'get_lists' }, m => m.type === 'lists', 'alive after reveal');
+    assert.ok(Array.isArray(res.lists));
+  });
+});
+
+// Last on purpose: this closes every connected client to force buffering.
+describe('flush_buffer', () => {
+  test('messages emitted while no client is connected replay on request, minus stream noise', async () => {
+    const convoId = h.freshConvoId('flush');
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'answer into the void' },
+        delayMs: 400, turn: [{ text: 'Buffered answer' }] },
+    ]);
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'answer into the void' });
+    await client.waitForEvent('system', 'process_started', convoId, { label: 'turn started' });
+    client.close();
+
+    // The turn completes with nobody connected: its output buffers. In
+    // interactive mode the process entry stays alive as idle after the
+    // result, so completion is resultSent, not entry removal.
+    const finished = await h.waitUntil(() => {
+      const e = h.internal.chatProcesses.get(convoId);
+      return !!(e && e.resultSent);
+    }, { timeout: 8000 });
+    assert.ok(finished, 'turn completed while disconnected');
+    assert.ok(h.internal.disconnectBuffer.length > 0, 'messages buffered during the disconnect');
+
+    client = await h.connect();
+    const since = client.messages.length;
+    client.send({ type: 'flush_buffer' });
+    const result = (await client.waitFor(
+      m => m.type === 'result' && m._conversationId === convoId,
+      { since, label: 'buffered result' })).msg;
+    assert.ok(result, 'terminal result survived the disconnect');
+    // The stream-level noise is filtered: the responseText snapshot covers it.
+    assert.ok(!client.messages.slice(since).some(m =>
+      (m.type === 'stream_event' || m.type === 'assistant') && m._conversationId === convoId),
+    'stream_event and assistant messages are not replayed');
+    assert.strictEqual(h.internal.disconnectBuffer.length, 0, 'buffer fully drained');
+    h.reapConvo(convoId);
+  });
+});

--- a/test/integration/session-history.test.js
+++ b/test/integration/session-history.test.js
@@ -1,0 +1,232 @@
+'use strict';
+// Characterisation: the get_session_history WS handler, pinned as it behaves
+// today, before it moves out of server.js.
+//
+// The handler has two modes. With `sessionIds`, it merges JSONL content from
+// every session the conversation touched, using the Rundock transcript as the
+// ordering and attribution authority (JSONL sessions group messages
+// per-process and reorder across agents). Without `sessionIds`, it falls back
+// to reading a single session directly. These tests seed both sources on disk
+// exactly where production reads them: session JSONL under
+// $HOME/.claude/projects/<workspace-hash>/, transcripts under
+// .rundock/transcripts/.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+
+let client;
+let sessionsDir;
+
+function writeSession(sessionId, entries) {
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  const lines = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
+  fs.writeFileSync(path.join(sessionsDir, `${sessionId}.jsonl`), lines);
+}
+
+function userLine(content, timestamp) {
+  return { type: 'user', message: { role: 'user', content }, timestamp: timestamp || null };
+}
+
+function assistantLine(text, timestamp) {
+  return { message: { role: 'assistant', content: [{ type: 'text', text }] }, timestamp: timestamp || null };
+}
+
+function writeTranscript(convoId, entries) {
+  const dir = path.join(h.workspaceDir, '.rundock', 'transcripts');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${convoId}.json`), JSON.stringify(entries, null, 2));
+}
+
+function getHistory(msg, label) {
+  const since = client.messages.length;
+  client.send({ type: 'get_session_history', ...msg });
+  return client.waitFor(
+    m => m.type === 'session_history' && m.conversationId === msg.conversationId,
+    { since, label: label || `session_history for ${msg.conversationId}` }
+  ).then(r => r.msg);
+}
+
+before(async () => {
+  await h.boot();
+  client = await h.connect();
+  // Production derives the JSONL directory name from the workspace path with
+  // slashes turned into dashes. Pin that derivation by using it.
+  sessionsDir = path.join(process.env.HOME, '.claude', 'projects', h.workspaceDir.replace(/\//g, '-'));
+});
+after(async () => h.shutdown());
+
+describe('get_session_history: multi-session merge', () => {
+  test('the transcript orders and attributes; JSONL supplies full content', async () => {
+    const convoId = 'sh-merge-1';
+    // Orchestrator session: greeted, then routed.
+    writeSession('sess-orch-1', [
+      userLine('Hello there team', '2026-08-11T10:00:00Z'),
+      assistantLine('Routing you to the specialist for this request', '2026-08-11T10:00:05Z'),
+    ]);
+    // Specialist session: the transcript stores only a prefix of this reply;
+    // the JSONL carries the full text, and the merge must prefer it.
+    const fullReply = 'Here is the draft you asked for, complete with the long tail of content that the transcript truncated away.';
+    writeSession('sess-spec-1', [
+      assistantLine(fullReply, '2026-08-11T10:01:00Z'),
+    ]);
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Hello there team', timestamp: '2026-08-11T10:00:00Z' },
+      { role: 'agent', agent: 'chief-of-staff', text: 'Routing you to the specialist for this request', timestamp: '2026-08-11T10:00:05Z' },
+      { role: 'agent', agent: 'penn', text: 'Here is the draft you asked for, complete with the long', timestamp: '2026-08-11T10:01:00Z' },
+    ]);
+
+    const res = await getHistory({
+      conversationId: convoId,
+      sessionIds: [{ sessionId: 'sess-orch-1' }, { sessionId: 'sess-spec-1' }],
+    });
+
+    assert.strictEqual(res.totalCount, 3);
+    assert.strictEqual(res.hasMore, false);
+    assert.deepStrictEqual(res.messages.map(m => [m.role, m.agentId]), [
+      ['user', null],
+      ['assistant', 'chief-of-staff'],
+      ['assistant', 'penn'],
+    ]);
+    // Full JSONL content won over the transcript's truncated prefix.
+    assert.strictEqual(res.messages[2].content, fullReply);
+  });
+
+  test('routing entries pass through typed, so the client can draw the divider without a bubble', async () => {
+    const convoId = 'sh-routing-1';
+    writeSession('sess-routing-1', [userLine('Route this please', null)]);
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Route this please' },
+      { role: 'agent', agent: 'chief-of-staff', text: '', type: 'routing', timestamp: '2026-08-11T11:00:00Z' },
+      { role: 'agent', agent: 'penn', text: 'Specialist reporting in' },
+    ]);
+
+    const res = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-routing-1' }] });
+
+    const routing = res.messages.find(m => m.type === 'routing');
+    assert.ok(routing, 'routing entry present in merged history');
+    assert.strictEqual(routing.role, 'assistant');
+    assert.strictEqual(routing.agentId, 'chief-of-staff');
+    // The specialist turn had no JSONL match: transcript text is used rather
+    // than the turn being dropped.
+    assert.strictEqual(res.messages.at(-1).content, 'Specialist reporting in');
+  });
+
+  test('a JSONL reply shorter than its transcript entry still matches (prefix containment runs both ways)', async () => {
+    const convoId = 'sh-shortmatch-1';
+    // The transcript entry carries trailing text the JSONL does not (e.g. the
+    // transcript writer appended tool summaries after the prose).
+    writeSession('sess-shortmatch-1', [assistantLine('Short answer', null)]);
+    writeTranscript(convoId, [
+      { role: 'agent', agent: 'chief-of-staff', text: 'Short answer with trailing transcript-only text appended after the prose' },
+    ]);
+
+    const res = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-shortmatch-1' }] });
+
+    assert.strictEqual(res.messages.length, 1);
+    assert.strictEqual(res.messages[0].content, 'Short answer');
+    assert.strictEqual(res.messages[0].agentId, 'chief-of-staff');
+  });
+
+  test('repeated user messages in the transcript collapse to one bubble', async () => {
+    const convoId = 'sh-dedup-1';
+    writeSession('sess-dedup-1', [userLine('Say that again', null)]);
+    // A resume replays the user message into the transcript twice.
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Say that again' },
+      { role: 'user', text: 'Say that again' },
+      { role: 'agent', agent: 'chief-of-staff', text: 'Only once, though' },
+    ]);
+
+    const res = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-dedup-1' }] });
+
+    assert.strictEqual(res.messages.filter(m => m.role === 'user').length, 1);
+    assert.strictEqual(res.totalCount, 2);
+  });
+
+  test('internal injection messages never become bubbles: briefs, system markers, resume ghosts', async () => {
+    const convoId = 'sh-filter-1';
+    writeSession('sess-filter-1', [
+      userLine('[DELEGATION BRIEF] internal handoff payload', null),
+      userLine('[SYSTEM: scope return] internal marker', null),
+      userLine('CONVERSATION SO FAR: transcript replay', null),
+      assistantLine('No response requested.', null),
+      userLine('The one real user message', null),
+      assistantLine('The one real reply', null),
+    ]);
+
+    // No transcript: the JSONL pool IS the history, so the pool filters are
+    // observable directly.
+    const res = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-filter-1' }] });
+
+    assert.deepStrictEqual(res.messages.map(m => m.content), [
+      'The one real user message',
+      'The one real reply',
+    ]);
+    assert.strictEqual(res.totalCount, 2);
+  });
+
+  test('pagination slices from the end: limit and offset window the merged history', async () => {
+    const convoId = 'sh-page-1';
+    const entries = [];
+    for (let i = 1; i <= 6; i++) entries.push(userLine(`Message number ${i}`, null));
+    writeSession('sess-page-1', entries);
+
+    const page1 = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-page-1' }], limit: 2 });
+    assert.deepStrictEqual(page1.messages.map(m => m.content), ['Message number 5', 'Message number 6']);
+    assert.strictEqual(page1.totalCount, 6);
+    assert.strictEqual(page1.hasMore, true);
+
+    const page2 = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-page-1' }], limit: 2, offset: 2 });
+    assert.deepStrictEqual(page2.messages.map(m => m.content), ['Message number 3', 'Message number 4']);
+
+    const lastPage = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-page-1' }], limit: 2, offset: 4 });
+    assert.deepStrictEqual(lastPage.messages.map(m => m.content), ['Message number 1', 'Message number 2']);
+    assert.strictEqual(lastPage.hasMore, false);
+  });
+
+  test('a missing session file degrades to the transcript, not an error', async () => {
+    const convoId = 'sh-missing-1';
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Anyone home' },
+      { role: 'agent', agent: 'chief-of-staff', text: 'Recovered from the transcript alone' },
+    ]);
+
+    const res = await getHistory({ conversationId: convoId, sessionIds: [{ sessionId: 'sess-does-not-exist' }] });
+
+    assert.deepStrictEqual(res.messages.map(m => m.content), [
+      'Anyone home',
+      'Recovered from the transcript alone',
+    ]);
+  });
+});
+
+describe('get_session_history: single-session fallback', () => {
+  test('without sessionIds, the named session is read directly with limit and offset', async () => {
+    const convoId = 'sh-single-1';
+    writeSession('sess-single-1', [
+      userLine('First', null),
+      assistantLine('Second', null),
+      userLine('Third', null),
+    ]);
+
+    const res = await getHistory({ conversationId: convoId, sessionId: 'sess-single-1', limit: 2 });
+
+    assert.deepStrictEqual(res.messages.map(m => [m.role, m.content]), [
+      ['assistant', 'Second'],
+      ['user', 'Third'],
+    ]);
+    assert.strictEqual(res.totalCount, 3);
+    assert.strictEqual(res.hasMore, true);
+  });
+
+  test('an unknown session answers empty, so the client renders a blank history rather than hanging', async () => {
+    const convoId = 'sh-single-missing-1';
+    const res = await getHistory({ conversationId: convoId, sessionId: 'sess-never-existed' });
+    assert.deepStrictEqual(res, {
+      type: 'session_history', conversationId: convoId, messages: [], totalCount: 0, hasMore: false,
+    });
+  });
+});

--- a/test/integration/spawn-plumbing.test.js
+++ b/test/integration/spawn-plumbing.test.js
@@ -1,0 +1,126 @@
+'use strict';
+// Characterisation: spawn plumbing (resolveClaudeBin, spawnClaude,
+// killProcessTree), pinned as it behaves today, before it moves out of
+// server.js.
+//
+// resolveClaudeBin memoises its first answer for the life of the process, and
+// the harness boot gate already forces that first call (asserting the stub
+// resolved). Its unexercised branches therefore run in CHILD process probes:
+// each probe requires server.js fresh, patches process.platform, points PATH
+// at a fake windows shell, and prints what resolved. The Windows selection
+// logic itself is pure string work, so the probes pin it on any platform.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { makeTempDir } = require('../helpers/workspace.js');
+
+const SERVER_PATH = path.join(__dirname, '..', '..', 'server.js');
+
+before(async () => {
+  await h.boot();
+  await h.connect();
+});
+after(async () => h.shutdown());
+
+// Run resolveClaudeBin in a fresh node process: require server.js on the real
+// platform first (so module init is undisturbed), then patch the platform,
+// then resolve. `pathPrefix` is prepended to PATH; `breakPath` empties PATH
+// before the call so the lookup itself fails.
+function probeResolve({ pathPrefix, breakPath = false } = {}) {
+  const script = [
+    `const srv = require(${JSON.stringify(SERVER_PATH)});`,
+    `Object.defineProperty(process, 'platform', { value: 'win32' });`,
+    breakPath ? `process.env.PATH = ${JSON.stringify(path.join(path.sep, 'nonexistent-dir'))};` : '',
+    `console.log('RESOLVED:' + srv._internal.resolveClaudeBin());`,
+  ].join('\n');
+  const env = { ...process.env };
+  if (pathPrefix) env.PATH = pathPrefix + path.delimiter + env.PATH;
+  const res = spawnSync(process.execPath, ['-e', script], { env, encoding: 'utf-8', timeout: 30000 });
+  const line = String(res.stdout).split('\n').find(l => l.startsWith('RESOLVED:'));
+  assert.ok(line, `probe printed a resolution (stderr: ${String(res.stderr).slice(0, 300)})`);
+  return line.slice('RESOLVED:'.length);
+}
+
+// With the platform patched to win32, node shells the lookup through
+// cmd.exe, so the fake that answers on this machine is a `cmd.exe` on PATH
+// printing what `where.exe claude` would have.
+function fakeWinShell(lines) {
+  const dir = makeTempDir('rundock-test-winshell-');
+  const file = path.join(dir, 'cmd.exe');
+  fs.writeFileSync(file, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(lines.join('\n'))});\n`);
+  fs.chmodSync(file, 0o755);
+  return dir;
+}
+
+describe('resolveClaudeBin on Windows', () => {
+  test('prefers the .exe among where.exe candidates', () => {
+    const dir = fakeWinShell([
+      'C:\\Users\\liam\\claude',
+      'C:\\Users\\liam\\claude.cmd',
+      'C:\\Users\\liam\\claude.exe',
+    ]);
+    assert.strictEqual(probeResolve({ pathPrefix: dir }), 'C:\\Users\\liam\\claude.exe');
+  });
+
+  test('falls back to the .cmd shim when no .exe is listed', () => {
+    const dir = fakeWinShell(['C:\\Users\\liam\\claude', 'C:\\Users\\liam\\claude.cmd']);
+    assert.strictEqual(probeResolve({ pathPrefix: dir }), 'C:\\Users\\liam\\claude.cmd');
+  });
+
+  test('empty lookup output resolves to the bare command', () => {
+    const dir = fakeWinShell([]);
+    assert.strictEqual(probeResolve({ pathPrefix: dir }), 'claude');
+  });
+
+  test('a failed lookup resolves to the bare command instead of throwing', () => {
+    assert.strictEqual(probeResolve({ breakPath: true }), 'claude');
+  });
+});
+
+describe('spawnClaude error handling', () => {
+  test('a spawn failure reaches the caller\'s onError instead of tearing anything down', async () => {
+    // A nonexistent cwd makes the spawn itself fail with an error EVENT.
+    const seen = [];
+    h.internal.spawnClaude(['--model', 'stub', '--print'], {
+      cwd: path.join(h.workspaceDir, 'no-such-dir-anywhere'),
+      stdio: 'ignore',
+    }, (err) => seen.push(err));
+    const surfaced = await h.waitUntil(() => seen.length === 1);
+    assert.ok(surfaced, 'onError callback ran');
+    assert.strictEqual(seen[0].code, 'ENOENT');
+  });
+
+  test('a throwing onError is contained by the wrapper', async () => {
+    let ran = false;
+    h.internal.spawnClaude(['--model', 'stub', '--print'], {
+      cwd: path.join(h.workspaceDir, 'still-no-such-dir'),
+      stdio: 'ignore',
+    }, () => { ran = true; throw new Error('handler blew up'); });
+    const surfaced = await h.waitUntil(() => ran);
+    assert.ok(surfaced, 'throwing handler still ran, and nothing propagated');
+  });
+});
+
+describe('killProcessTree on Windows', () => {
+  test('when taskkill cannot run, the single-pid floor still signals the target', async () => {
+    // Patch the platform for this call only: killProcessTree reads it at call
+    // time. On this machine `taskkill` does not exist, so the spawned killer
+    // fires its error event and the floor path must run.
+    const signals = [];
+    const fakeTarget = { pid: 999999901, kill: (sig) => signals.push(sig) };
+    const realPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      h.internal.killProcessTree(fakeTarget, 'SIGTERM');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: realPlatform });
+    }
+    const fellBack = await h.waitUntil(() => signals.length === 1);
+    assert.ok(fellBack, 'floor kill ran after the taskkill error event');
+    assert.deepStrictEqual(signals, ['SIGTERM']);
+  });
+});

--- a/test/integration/workspace-picker.test.js
+++ b/test/integration/workspace-picker.test.js
@@ -1,0 +1,144 @@
+'use strict';
+// Characterisation: the workspace lifecycle WS handlers (get_workspaces,
+// list_workspaces, pick_folder, create_workspace), pinned as they behave
+// today, before they move out of server.js.
+//
+// pick_folder shells out to `osascript` for the native macOS folder dialog.
+// These tests put a fake `osascript` first on PATH (the same injection trick
+// the harness uses for the claude stub): it prints the contents of a control
+// file, or exits non-zero when the file is absent, so both the picked and the
+// cancelled paths run without any real dialog on any platform.
+//
+// Ordering matters in this file: create_workspace and the stale-pointer test
+// SWITCH the live workspace, so each restores the harness workspace before
+// the next test runs.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { makeTempDir } = require('../helpers/workspace.js');
+
+let client;
+let controlFile;
+
+before(async () => {
+  // Fake osascript, injected ahead of everything else on PATH. The harness
+  // prepends the claude/codex stub dirs inside boot(); passing PATH via
+  // opts.env overwrites that, so this value re-includes them explicitly and
+  // boot()'s stub-resolution safety gate still holds.
+  const fakeBin = makeTempDir('rundock-test-osascript-');
+  controlFile = path.join(fakeBin, 'picked-folder.txt');
+  const script = path.join(fakeBin, 'osascript');
+  fs.writeFileSync(script, [
+    '#!/usr/bin/env node',
+    `const fs = require('fs');`,
+    `try { process.stdout.write(fs.readFileSync(${JSON.stringify(controlFile)}, 'utf-8')); }`,
+    'catch (e) { process.exit(1); }',
+  ].join('\n'));
+  fs.chmodSync(script, 0o755);
+
+  await h.boot({
+    env: {
+      PATH: [fakeBin, h.STUB_DIR, h.CODEX_STUB_DIR, process.env.PATH].join(path.delimiter),
+    },
+  });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+function request(msg, pred, label) {
+  const since = client.messages.length;
+  client.send(msg);
+  return client.waitFor(pred, { since, label }).then(r => r.msg);
+}
+
+describe('get_workspaces', () => {
+  test('answers current workspace, recents, discovered, analysis, and setup state in one message', async () => {
+    const res = await request({ type: 'get_workspaces' }, m => m.type === 'workspaces', 'workspaces');
+    assert.strictEqual(res.current, h.workspaceDir);
+    assert.ok(Array.isArray(res.recent), 'recent is a list');
+    assert.ok(Array.isArray(res.discovered), 'discovered is a list');
+    assert.ok(res.analysis && typeof res.analysis === 'object', 'workspace analysis included');
+    assert.ok(typeof res.workspaceMode === 'string', 'workspace mode included');
+    assert.strictEqual(typeof res.setupComplete, 'boolean');
+  });
+
+  test('a workspace pointer whose directory vanished is cleared, not served stale', async () => {
+    const doomed = makeTempDir('rundock-test-doomed-');
+    h.internal.setWorkspace(doomed);
+    fs.rmSync(doomed, { recursive: true, force: true });
+
+    const res = await request({ type: 'get_workspaces' }, m => m.type === 'workspaces', 'workspaces after vanish');
+    assert.strictEqual(res.current, null, 'vanished workspace reported as no workspace');
+    assert.ok(!('analysis' in res), 'no analysis without a workspace');
+
+    h.internal.setWorkspace(h.workspaceDir);
+  });
+});
+
+describe('list_workspaces', () => {
+  test('answers recents and discovered only: no current, no analysis', async () => {
+    const res = await request({ type: 'list_workspaces' }, m => m.type === 'workspaces', 'list_workspaces');
+    assert.ok(Array.isArray(res.recent));
+    assert.ok(Array.isArray(res.discovered));
+    assert.ok(!('current' in res), 'list variant does not report current');
+    assert.ok(!('analysis' in res), 'list variant does not analyse');
+  });
+});
+
+describe('pick_folder', () => {
+  test('a picked folder comes back with its trailing slash stripped', async () => {
+    // osascript's POSIX path output ends in a slash; the handler strips it.
+    fs.writeFileSync(controlFile, '/tmp/rundock-picked-folder/\n');
+    const res = await request({ type: 'pick_folder' }, m => m.type === 'folder_picked', 'folder_picked');
+    assert.strictEqual(res.path, '/tmp/rundock-picked-folder');
+  });
+
+  test('cancelling the dialog answers null instead of erroring', async () => {
+    fs.rmSync(controlFile, { force: true });
+    const res = await request({ type: 'pick_folder' }, m => m.type === 'folder_picked', 'folder_picked cancel');
+    assert.strictEqual(res.path, null);
+  });
+
+  test('empty dialog output also answers null', async () => {
+    fs.writeFileSync(controlFile, '');
+    const res = await request({ type: 'pick_folder' }, m => m.type === 'folder_picked', 'folder_picked empty');
+    assert.strictEqual(res.path, null);
+  });
+});
+
+describe('create_workspace', () => {
+  test('an empty or fully-sanitised-away name is refused with a user-facing error', async () => {
+    const res = await request({ type: 'create_workspace', name: '  /\\:*?"<>|  ' },
+      m => m.type === 'workspace_error', 'workspace_error');
+    assert.strictEqual(res.message, 'Please enter a workspace name');
+  });
+
+  test('creates under HOME/Documents/Rundock, sanitises the name, scaffolds, and announces the full boot set', async () => {
+    const since = client.messages.length;
+    client.send({ type: 'create_workspace', name: 'My/Test:Space?' });
+
+    const wsSet = (await client.waitFor(m => m.type === 'workspace_set', { since, label: 'workspace_set' })).msg;
+    const expectedDir = path.join(os.homedir(), 'Documents', 'Rundock', 'MyTestSpace');
+    assert.strictEqual(wsSet.path, expectedDir, 'forbidden filename characters stripped from the name');
+    assert.strictEqual(wsSet.isEmpty, true);
+    assert.strictEqual(wsSet.setupComplete, false);
+    assert.strictEqual(wsSet.scaffoldError, null);
+    assert.ok(typeof wsSet.workspaceMode === 'string');
+
+    // The client also receives the agent roster and file tree without asking.
+    await client.waitFor(m => m.type === 'agents', { since, label: 'agents after create' });
+    const tree = (await client.waitFor(m => m.type === 'file_tree', { since, label: 'file_tree after create' })).msg;
+    assert.ok(Array.isArray(tree.tree));
+
+    // On disk: the workspace, its .claude dir, and the scaffold defaults.
+    assert.ok(fs.existsSync(expectedDir), 'workspace directory created');
+    assert.ok(fs.existsSync(path.join(expectedDir, '.claude')), '.claude directory created');
+    assert.ok(fs.existsSync(path.join(expectedDir, 'CLAUDE.md')), 'scaffold defaults written');
+
+    h.internal.setWorkspace(h.workspaceDir);
+  });
+});

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -1,9 +1,9 @@
 {
-  "generatedAt": "2026-08-11T14:33:06.952Z",
-  "commit": "975317db49f412aaf6b3c15cf668432df142d01c",
+  "generatedAt": "2026-08-11T20:50:14.527Z",
+  "commit": "42c456d2b44947c4bb721d6b21d4cbb9c380ee70",
   "tolerance": 0.25,
   "floors": {
-    "OVERALL server.js": 88.9,
+    "OVERALL server.js": 94.4,
     "OVERALL codex.js": 100,
     "OVERALL codex-appserver.js": 94.2,
     "OVERALL search.js": 98.4,
@@ -23,8 +23,8 @@
     "Transcripts + persistence helpers": 99,
     "Conversation / state persistence": 100,
     "HTTP request router (incl. permission bridge)": 97,
-    "WebSocket message handlers": 70.9,
-    "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 74.3,
+    "WebSocket message handlers": 95.6,
+    "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 98.1,
     "Codex runtime (status, turns, delegate wiring)": 89
   }
 }


### PR DESCRIPTION
## What

Characterisation tests for the two weakest-covered areas of `server.js`, written before any of their code moves: the WebSocket message handlers (70.9% → 95.6%) and the spawn plumbing (74.3% → 98.1%). `server.js` overall rises 88.9% → 94.4%. Coverage floors are ratcheted to the new numbers.

Every test pins behaviour exactly as it is today. No production behaviour changes ride along; the only `server.js` edit is adding `killProcessTree` to the `_internal` facade beside the rest of the spawn plumbing.

## New pins

- **`get_session_history`** (was entirely untested, 133 lines): the multi-session merge with the transcript as ordering/attribution authority and JSONL as content authority, routing passthrough, user dedup, injection filtering, both prefix-match directions, end-anchored pagination, missing-session degradation, and the single-session fallback.
- **Workspace lifecycle**: `get_workspaces` (including the vanished-directory pointer clear), `list_workspaces`, `pick_folder` via a fake `osascript` on PATH (picked, cancelled, and empty-output paths on any platform), `create_workspace` (name sanitisation, refusal, scaffold, announce set).
- **Conversation metadata**: the `get_conversations` load pipeline (stale-empty cleanup, activeAgentId reconciliation, messageCount and preview enrichment with marker/markdown stripping), `set_last_active_conversation`, lists CRUD, `create_path`, `add_to_team`, the `reveal_in_finder` guard, and the disconnect-buffer flush with its stream-noise filter.
- **Chat close paths**: a failed `--resume` retries fresh exactly once; a stdout fragment left in the line buffer at process death is flushed (JSON as itself, otherwise raw); a client connecting mid-turn is told about live processes.
- **Spawn plumbing**: `resolveClaudeBin`'s Windows candidate selection and failure fallback (child-process probes, since the resolver memoises per process), `spawnClaude`'s error containment including a throwing `onError`, and `killProcessTree`'s Windows single-pid floor.

## Test-asset additions (all additive)

Stub claude: `match.resume` gates a rule on `--resume` presence; `stderr` models CLI error output on a crash exit; `crashTail` leaves a final unterminated stdout fragment in the server's line buffer.

## Found while characterising

`add_to_team` writes the recruit's order number to disk correctly, but the `agents` message it answers with is built from the roster cache populated at the top of the same handler, so the wire still reports the recruit as order-less until a later refresh. Pinned as-is with the gap documented; fix follows separately, red-first, by flipping that pin.

## Deliberately left uncovered

The legacy spawn close handler (env-gated fallback path), the cancel handler's parked-ancestor walk, the defensive catch backstops in the search and session-history handlers, and `killProcessTree`'s synchronous-throw fallback. Enumerated here so the remaining gap is a decision, not an accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
