### PR TITLE
Adding an agent to the team answers with the fresh roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Adding an agent to your team shows their place immediately:** the roster sent back after "Add to team" was built from a snapshot taken just before the join, so the new member could appear still off-team until a later refresh. The response now reflects the join at once.
 - **Opening a workspace no longer risks a spurious agent restart moments later:** when Rundock updates its own built-in agent or skill files during workspace open, that write was briefly mistaken for an external edit, which could restart a busy agent mid-conversation about two seconds in. The server's own writes are now recognised as its own.
 - **Setup completes when your team exists, however it was created:** the workspace used to leave "setup pending" only when agents were created through the standard onboarding flow. A team created any other way (an agent writing the files directly, or you dropping agent files into place) now completes setup too, within a couple of seconds of the files appearing.
 

--- a/server.js
+++ b/server.js
@@ -5176,7 +5176,11 @@ wss.on('connection', (ws) => {
             }
           }
           fs.writeFileSync(filePath, content, 'utf-8');
-          // Send updated agent list
+          // Invalidate before rediscovering: the roster cache was populated
+          // at the top of this handler, so without this the agents message
+          // would answer with the recruit still order-less and the client
+          // would not show the join until a later refresh.
+          invalidateAgentCache();
           ws.send(JSON.stringify({ type: 'agents', agents: discoverAgents() }));
         }
       }

--- a/test/integration/conversation-metadata.test.js
+++ b/test/integration/conversation-metadata.test.js
@@ -179,13 +179,10 @@ describe('add_to_team', () => {
     assert.match(content, new RegExp(`^type: specialist\\norder: ${expectedOrder}$`, 'm'),
       'order written directly after the type field');
 
-    // CHARACTERISED GAP (carded): the agents message answered here is built
-    // from the roster cache populated at the top of the same handler, so it
-    // still reports the recruit as order-less. The client only sees the real
-    // order on a later roster refresh. Pinned as-is; the fix flips this
-    // assertion to `5`.
+    // The agents message answers with the FRESH roster: the recruit's new
+    // order is on the wire immediately, not deferred to a later refresh.
     const doc = res.agents.find(a => a.id === 'doc');
-    assert.strictEqual(doc.order, null);
+    assert.strictEqual(doc.order, expectedOrder);
   });
 });
 


### PR DESCRIPTION
## What

Fixes the gap found while characterising the WS handlers (#96): `add_to_team` wrote the recruit's order number to disk correctly, but answered its `agents` message from the roster cache populated at the top of the same handler. The wire reported the recruit as still order-less, so the client did not show the join until a later roster refresh.

## Fix

Invalidate the roster cache after the frontmatter write and before rediscovery, so the response reflects the join immediately. One line plus the comment explaining it.

## Proof

Red-first: the characterisation pin from #96 documented the stale answer as-is; this PR flips that assertion from `null` to the recruit's real order and it fails against the old handler, passes against the fixed one. This is the enumerated behavioural change of this PR; no other assertion moves.

## Changelog

User-facing Fixed entry added: adding an agent to your team shows their place immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
