### PR TITLE
Extract session persistence and transcripts to lib/store

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,26 @@
+'use strict';
+/**
+ * Workspace root, owned here so extracted lib/ modules can read it at USE
+ * time. The root is LIVE state: it changes when the user switches workspace,
+ * and every consumer (113 call sites at extraction start) depends on seeing
+ * the change immediately. Modules must therefore call getWorkspace() inside
+ * each operation, never capture the value at require time.
+ *
+ * During the server.js decomposition the root's own `WORKSPACE` variable
+ * mirrors this value (server.js still has unconverted read sites); every
+ * assignment there goes through a single helper that writes both. Once the
+ * last root read site is converted, the mirror goes away and this module is
+ * the only owner.
+ */
+
+let workspaceRoot = process.env.WORKSPACE || null;
+
+function getWorkspace() {
+  return workspaceRoot;
+}
+
+function setWorkspace(dir) {
+  workspaceRoot = dir;
+}
+
+module.exports = { getWorkspace, setWorkspace };

--- a/lib/store/persistence.js
+++ b/lib/store/persistence.js
@@ -1,0 +1,109 @@
+'use strict';
+/**
+ * Rundock session persistence: the .rundock/ directory in the workspace root.
+ * Conversations, conversation lists, and UI state live here as JSON files,
+ * read and written wholesale (they are small and the server is the only
+ * writer). Extracted from server.js verbatim; the only change is that the
+ * workspace root is read from lib/config at use time, because the root is
+ * live state that changes when the user switches workspace.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { getWorkspace } = require('../config.js');
+
+function rundockDir() { return path.join(getWorkspace(), '.rundock'); }
+
+function readConversations() {
+  try {
+    const file = path.join(rundockDir(), 'conversations.json');
+    const list = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    // One-time migration: status: 'done' -> status: 'archived'. The UI renamed
+    // Done to Archive; the data model follows so the rest of the code can
+    // assume 'archived' without a backwards-compat fallback. Idempotent:
+    // already-migrated workspaces hit no writes and no log lines.
+    let migrated = 0;
+    for (const c of list) {
+      if (c.status === 'done') {
+        c.status = 'archived';
+        migrated++;
+      }
+    }
+    if (migrated > 0) {
+      try {
+        // Snapshot the pre-migration file once before the first write so a
+        // manual recovery path exists if anything later goes wrong. Skips on
+        // every subsequent migration attempt since the backup is preserved.
+        const backupPath = file + '.pre-archive-backup';
+        if (!fs.existsSync(backupPath)) {
+          fs.copyFileSync(file, backupPath);
+        }
+        writeConversations(list);
+        console.log(`[migrate] conversations.json: ${migrated} done -> archived`);
+      } catch (err) {
+        // Migration is safe to retry: the in-memory list is already migrated
+        // for this session, and the next workspace open will attempt the
+        // write again. Do not throw; the rest of read should still return.
+        console.error('[migrate] persist failed:', err && err.message ? err.message : err);
+      }
+    }
+    return list;
+  } catch (e) { return []; }
+}
+
+function writeConversations(list) {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'conversations.json'), JSON.stringify(list, null, 2));
+}
+
+// Conversation lists (user-named, many-to-many groupings shown as sidebar
+// pills). The registry lives in .rundock/lists.json; membership lives on each
+// conversation entry (listIds) so it rides the existing conversation
+// persistence. Deleting a list removes the registry entry and strips the id
+// from every conversation, never touching the conversations themselves.
+function readLists() {
+  try {
+    const list = JSON.parse(fs.readFileSync(path.join(rundockDir(), 'lists.json'), 'utf-8'));
+    return Array.isArray(list) ? list.filter(l => l && typeof l.id === 'string' && typeof l.name === 'string') : [];
+  } catch (e) { return []; }
+}
+
+function writeLists(lists) {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'lists.json'), JSON.stringify(lists, null, 2));
+}
+
+function deleteListEverywhere(listId) {
+  writeLists(readLists().filter(l => l.id !== listId));
+  const convos = readConversations();
+  let changed = false;
+  for (const c of convos) {
+    if (Array.isArray(c.listIds) && c.listIds.includes(listId)) {
+      c.listIds = c.listIds.filter(id => id !== listId);
+      changed = true;
+    }
+  }
+  if (changed) writeConversations(convos);
+}
+
+function readState() {
+  try {
+    const file = path.join(rundockDir(), 'state.json');
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  } catch (e) { return {}; }
+}
+
+function writeState(state) {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'state.json'), JSON.stringify(state, null, 2));
+}
+
+module.exports = {
+  rundockDir,
+  readConversations, writeConversations,
+  readLists, writeLists, deleteListEverywhere,
+  readState, writeState,
+};

--- a/lib/store/transcripts.js
+++ b/lib/store/transcripts.js
@@ -1,0 +1,120 @@
+'use strict';
+/**
+ * Conversation transcripts: the in-memory cache and its on-disk mirror at
+ * .rundock/transcripts/<convoId>.json. This module OWNS convoTranscripts;
+ * server.js re-exports the module's own Map through _internal BY IDENTITY
+ * (tests mutate it live), so object identity is part of the public test
+ * contract. Extracted from server.js verbatim; the only change is that the
+ * workspace root is read from lib/config at use time.
+ *
+ * appendTranscript stays in the composition root for now: its body is the
+ * convergence point for the signal layer and the live search reconcile,
+ * which belong to later extraction slices. It builds on the primitives here.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { getWorkspace } = require('../config.js');
+const { rundockDir } = require('./persistence.js');
+
+const convoTranscripts = new Map(); // conversationId -> [{ role: 'user'|'agent', agent: string, text: string }]
+
+function transcriptDir() { return path.join(rundockDir(), 'transcripts'); }
+
+// Best-effort recovery of a corrupt (e.g. truncated) transcript JSON array.
+// A transcript file is normally overwritten wholesale on the next append, so a
+// mid-write truncation that JSON.parse rejects must NOT be masked as an empty
+// array: doing so lets the next append clobber the file and silently wipe all
+// prior history. This salvages as much history as possible instead.
+// Attempt 1 balances any string/brackets left open by the truncation; attempt
+// 2 keeps only the complete leading objects. Returns [] only if nothing at all
+// can be recovered.
+function recoverTranscriptData(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') return [];
+  const stack = [];
+  let inString = false, escaped = false, lastCompleteObjEnd = -1;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{' || ch === '[') stack.push(ch);
+    else if (ch === '}' || ch === ']') {
+      stack.pop();
+      // A complete top-level object just closed (only the outer array remains).
+      if (ch === '}' && stack.length === 1 && stack[0] === '[') lastCompleteObjEnd = i;
+    }
+  }
+  let patched = raw;
+  if (inString) patched += '"';
+  for (let i = stack.length - 1; i >= 0; i--) patched += stack[i] === '{' ? '}' : ']';
+  try {
+    const data = JSON.parse(patched);
+    if (Array.isArray(data)) return data;
+  } catch { /* fall through to complete-object salvage */ }
+  if (lastCompleteObjEnd >= 0) {
+    try {
+      const data = JSON.parse(raw.slice(0, lastCompleteObjEnd + 1) + ']');
+      if (Array.isArray(data)) return data;
+    } catch { /* nothing recoverable */ }
+  }
+  return [];
+}
+
+function loadTranscript(convoId) {
+  if (convoTranscripts.has(convoId)) return convoTranscripts.get(convoId);
+  const file = path.join(transcriptDir(), `${convoId}.json`);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf-8');
+  } catch (e) {
+    // File absent (or otherwise unreadable): legitimately empty history.
+    const empty = [];
+    convoTranscripts.set(convoId, empty);
+    return empty;
+  }
+  try {
+    const data = JSON.parse(raw);
+    convoTranscripts.set(convoId, data);
+    return data;
+  } catch (e) {
+    // File exists but is corrupt. Salvage rather than mask as empty, so the
+    // next append does not overwrite recoverable history.
+    const recovered = recoverTranscriptData(raw);
+    convoTranscripts.set(convoId, recovered);
+    return recovered;
+  }
+}
+
+function saveTranscript(convoId) {
+  if (!getWorkspace()) return;
+  const transcript = convoTranscripts.get(convoId);
+  if (!transcript) return;
+  const dir = transcriptDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${convoId}.json`), JSON.stringify(transcript, null, 2));
+}
+
+function buildToolSummary(toolCalls) {
+  if (!toolCalls || toolCalls.length === 0) return '';
+  const seen = new Set();
+  const parts = [];
+  for (const tc of toolCalls) {
+    const key = tc.arg ? `${tc.tool}: ${tc.arg}` : tc.tool;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parts.push(tc.arg ? `[${tc.tool} ${tc.arg}]` : `[${tc.tool}]`);
+    if (parts.length >= 10) break;
+  }
+  return parts.join(' ');
+}
+
+module.exports = {
+  convoTranscripts,
+  transcriptDir, recoverTranscriptData,
+  loadTranscript, saveTranscript, buildToolSummary,
+};

--- a/server.js
+++ b/server.js
@@ -22,6 +22,15 @@ const { resolveMarkers } = require('./lib/delegation/markers.js');
 const { createHandbackBuilder } = require('./lib/delegation/handback.js');
 const { createDelegationRecord, attachDelegationRecord } = require('./lib/delegation/state.js');
 const config = require('./lib/config.js');
+const {
+  rundockDir, readConversations, writeConversations,
+  readLists, writeLists, deleteListEverywhere,
+  readState, writeState,
+} = require('./lib/store/persistence.js');
+const {
+  convoTranscripts, transcriptDir,
+  loadTranscript, saveTranscript, buildToolSummary,
+} = require('./lib/store/transcripts.js');
 
 const PORT = process.env.PORT || 3000;
 let ACTUAL_PORT = PORT; // Updated after server.listen() with the real listening port
@@ -235,95 +244,8 @@ function saveRecentWorkspace(dir) {
   fs.writeFileSync(RECENT_FILE, JSON.stringify(recent.slice(0, 10), null, 2));
 }
 
-// Rundock session persistence (.rundock/ in workspace root)
-function rundockDir() { return path.join(WORKSPACE, '.rundock'); }
-
-function readConversations() {
-  try {
-    const file = path.join(rundockDir(), 'conversations.json');
-    const list = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    // One-time migration: status: 'done' -> status: 'archived'. The UI renamed
-    // Done to Archive; the data model follows so the rest of the code can
-    // assume 'archived' without a backwards-compat fallback. Idempotent:
-    // already-migrated workspaces hit no writes and no log lines.
-    let migrated = 0;
-    for (const c of list) {
-      if (c.status === 'done') {
-        c.status = 'archived';
-        migrated++;
-      }
-    }
-    if (migrated > 0) {
-      try {
-        // Snapshot the pre-migration file once before the first write so a
-        // manual recovery path exists if anything later goes wrong. Skips on
-        // every subsequent migration attempt since the backup is preserved.
-        const backupPath = file + '.pre-archive-backup';
-        if (!fs.existsSync(backupPath)) {
-          fs.copyFileSync(file, backupPath);
-        }
-        writeConversations(list);
-        console.log(`[migrate] conversations.json: ${migrated} done -> archived`);
-      } catch (err) {
-        // Migration is safe to retry: the in-memory list is already migrated
-        // for this session, and the next workspace open will attempt the
-        // write again. Do not throw; the rest of read should still return.
-        console.error('[migrate] persist failed:', err && err.message ? err.message : err);
-      }
-    }
-    return list;
-  } catch (e) { return []; }
-}
-
-function writeConversations(list) {
-  const dir = rundockDir();
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'conversations.json'), JSON.stringify(list, null, 2));
-}
-
-// Conversation lists (user-named, many-to-many groupings shown as sidebar
-// pills). The registry lives in .rundock/lists.json; membership lives on each
-// conversation entry (listIds) so it rides the existing conversation
-// persistence. Deleting a list removes the registry entry and strips the id
-// from every conversation, never touching the conversations themselves.
-function readLists() {
-  try {
-    const list = JSON.parse(fs.readFileSync(path.join(rundockDir(), 'lists.json'), 'utf-8'));
-    return Array.isArray(list) ? list.filter(l => l && typeof l.id === 'string' && typeof l.name === 'string') : [];
-  } catch (e) { return []; }
-}
-
-function writeLists(lists) {
-  const dir = rundockDir();
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'lists.json'), JSON.stringify(lists, null, 2));
-}
-
-function deleteListEverywhere(listId) {
-  writeLists(readLists().filter(l => l.id !== listId));
-  const convos = readConversations();
-  let changed = false;
-  for (const c of convos) {
-    if (Array.isArray(c.listIds) && c.listIds.includes(listId)) {
-      c.listIds = c.listIds.filter(id => id !== listId);
-      changed = true;
-    }
-  }
-  if (changed) writeConversations(convos);
-}
-
-function readState() {
-  try {
-    const file = path.join(rundockDir(), 'state.json');
-    return JSON.parse(fs.readFileSync(file, 'utf-8'));
-  } catch (e) { return {}; }
-}
-
-function writeState(state) {
-  const dir = rundockDir();
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'state.json'), JSON.stringify(state, null, 2));
-}
+// Session persistence (.rundock/ conversations, lists, state) lives in
+// lib/store/persistence.js.
 
 // Search helper: extract a snippet around the query match
 function extractSnippet(text, query, contextChars = 60) {
@@ -2606,7 +2528,6 @@ const wss = new WebSocketServer({
 
 // Module-level process tracking: survives WebSocket reconnects
 const chatProcesses = new Map(); // conversationId -> { process, buffer, processId, agentId, responseText }
-const convoTranscripts = new Map(); // conversationId -> [{ role: 'user'|'agent', agent: string, text: string }]
 
 // Circuit breaker: consecutive agent auto-resume events with no user message.
 // Prevents infinite delegation loops (e.g. orchestrator -> specialist -> orchestrator -> specialist ...).
@@ -2625,100 +2546,9 @@ function resetAutoResume(convoId) {
 const connectedClients = new Set(); // All active WebSocket connections
 const disconnectBuffer = []; // Messages queued while no clients are connected
 
-// Conversation transcript helpers
-function transcriptDir() { return path.join(rundockDir(), 'transcripts'); }
-
-// Best-effort recovery of a corrupt (e.g. truncated) transcript JSON array.
-// A transcript file is normally overwritten wholesale on the next append, so a
-// mid-write truncation that JSON.parse rejects must NOT be masked as an empty
-// array: doing so lets the next append clobber the file and silently wipe all
-// prior history. This salvages as much history as possible instead.
-// Attempt 1 balances any string/brackets left open by the truncation; attempt
-// 2 keeps only the complete leading objects. Returns [] only if nothing at all
-// can be recovered.
-function recoverTranscriptData(raw) {
-  if (typeof raw !== 'string' || raw.trim() === '') return [];
-  const stack = [];
-  let inString = false, escaped = false, lastCompleteObjEnd = -1;
-  for (let i = 0; i < raw.length; i++) {
-    const ch = raw[i];
-    if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === '\\') escaped = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') inString = true;
-    else if (ch === '{' || ch === '[') stack.push(ch);
-    else if (ch === '}' || ch === ']') {
-      stack.pop();
-      // A complete top-level object just closed (only the outer array remains).
-      if (ch === '}' && stack.length === 1 && stack[0] === '[') lastCompleteObjEnd = i;
-    }
-  }
-  let patched = raw;
-  if (inString) patched += '"';
-  for (let i = stack.length - 1; i >= 0; i--) patched += stack[i] === '{' ? '}' : ']';
-  try {
-    const data = JSON.parse(patched);
-    if (Array.isArray(data)) return data;
-  } catch { /* fall through to complete-object salvage */ }
-  if (lastCompleteObjEnd >= 0) {
-    try {
-      const data = JSON.parse(raw.slice(0, lastCompleteObjEnd + 1) + ']');
-      if (Array.isArray(data)) return data;
-    } catch { /* nothing recoverable */ }
-  }
-  return [];
-}
-
-function loadTranscript(convoId) {
-  if (convoTranscripts.has(convoId)) return convoTranscripts.get(convoId);
-  const file = path.join(transcriptDir(), `${convoId}.json`);
-  let raw;
-  try {
-    raw = fs.readFileSync(file, 'utf-8');
-  } catch (e) {
-    // File absent (or otherwise unreadable): legitimately empty history.
-    const empty = [];
-    convoTranscripts.set(convoId, empty);
-    return empty;
-  }
-  try {
-    const data = JSON.parse(raw);
-    convoTranscripts.set(convoId, data);
-    return data;
-  } catch (e) {
-    // File exists but is corrupt. Salvage rather than mask as empty, so the
-    // next append does not overwrite recoverable history.
-    const recovered = recoverTranscriptData(raw);
-    convoTranscripts.set(convoId, recovered);
-    return recovered;
-  }
-}
-
-function saveTranscript(convoId) {
-  if (!WORKSPACE) return;
-  const transcript = convoTranscripts.get(convoId);
-  if (!transcript) return;
-  const dir = transcriptDir();
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, `${convoId}.json`), JSON.stringify(transcript, null, 2));
-}
-
-function buildToolSummary(toolCalls) {
-  if (!toolCalls || toolCalls.length === 0) return '';
-  const seen = new Set();
-  const parts = [];
-  for (const tc of toolCalls) {
-    const key = tc.arg ? `${tc.tool}: ${tc.arg}` : tc.tool;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    parts.push(tc.arg ? `[${tc.tool} ${tc.arg}]` : `[${tc.tool}]`);
-    if (parts.length >= 10) break;
-  }
-  return parts.join(' ');
-}
+// Transcript primitives (convoTranscripts cache, load/save/salvage,
+// buildToolSummary) live in lib/store/transcripts.js. appendTranscript
+// below composes them with the signal layer and the search reconcile.
 
 // ── Signal layer (Build A) ─────────────────────────────────────────────────
 // Local, append-only, skinny events at server-layer convergence points, so

--- a/server.js
+++ b/server.js
@@ -21,10 +21,19 @@ const { resolvePermissionConvoId } = require('./permission-routing.js');
 const { resolveMarkers } = require('./lib/delegation/markers.js');
 const { createHandbackBuilder } = require('./lib/delegation/handback.js');
 const { createDelegationRecord, attachDelegationRecord } = require('./lib/delegation/state.js');
+const config = require('./lib/config.js');
 
 const PORT = process.env.PORT || 3000;
 let ACTUAL_PORT = PORT; // Updated after server.listen() with the real listening port
-let WORKSPACE = process.env.WORKSPACE || null;
+// WORKSPACE mirrors lib/config's workspace root during the decomposition:
+// this file's remaining read sites use the local variable, while extracted
+// lib/ modules read config.getWorkspace() at use time. EVERY assignment must
+// go through setWorkspaceRoot so the two can never drift.
+let WORKSPACE = config.getWorkspace();
+function setWorkspaceRoot(dir) {
+  WORKSPACE = dir;
+  config.setWorkspace(dir);
+}
 
 // Workspace boundary check. A bare `startsWith(resolve(WORKSPACE))`
 // lets a SIBLING directory sharing the name prefix pass (e.g. `<ws>-backup`
@@ -4732,7 +4741,7 @@ wss.on('connection', (ws) => {
         // Clear stale workspace pointer if the directory no longer exists
         if (WORKSPACE && !fs.existsSync(WORKSPACE)) {
           console.log(`[Workspace] Current workspace no longer exists: ${WORKSPACE}`);
-          WORKSPACE = null;
+          setWorkspaceRoot(null);
         }
         const wsData = {
           type: 'workspaces',
@@ -4769,7 +4778,7 @@ wss.on('connection', (ws) => {
           // Kill all running processes when switching workspace
           const startup = phaseTimer();
           killAllChildren();
-          WORKSPACE = dir;
+          setWorkspaceRoot(dir);
           armAgentsDirWatcher();
           // Before anything reads state that may have come from another path.
           healWorkspaceIfMoved(dir);
@@ -4868,7 +4877,7 @@ wss.on('connection', (ws) => {
             fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
             // Kill all running processes when creating/switching workspace
             killAllChildren();
-            WORKSPACE = dir;
+            setWorkspaceRoot(dir);
             armAgentsDirWatcher();
             loadRoutineState();
             saveRecentWorkspace(dir);
@@ -7951,7 +7960,7 @@ function startServer(options = {}) {
       console.log(`\n  Rundock running at http://localhost:${actualPort}`);
       if (WORKSPACE && !fs.existsSync(WORKSPACE)) {
         console.log(`  Workspace no longer exists: ${WORKSPACE}`);
-        WORKSPACE = null;
+        setWorkspaceRoot(null);
       }
       if (WORKSPACE) {
         loadRoutineState();
@@ -7988,7 +7997,7 @@ module.exports = { startServer };
 // tests can point the module-level WORKSPACE at a temp fixture directory.
 module.exports._internal = {
   // workspace pointer (test fixture wiring only)
-  setWorkspace(dir) { WORKSPACE = dir; invalidateAgentCache(); armAgentsDirWatcher(); },
+  setWorkspace(dir) { setWorkspaceRoot(dir); invalidateAgentCache(); armAgentsDirWatcher(); },
   getWorkspace() { return WORKSPACE; },
   // scheduler
   getNextRun, executeRoutine, routineState,

--- a/test/integration/http-api.test.js
+++ b/test/integration/http-api.test.js
@@ -86,6 +86,13 @@ describe('static + JSON endpoints', () => {
     assert.ok(tree.find(e => e.name === 'notes.md'));
   });
 
+  test('/favicon.svg is served as svg', async () => {
+    const res = await get('/favicon.svg');
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'image/svg+xml');
+    assert.ok(res.body.includes('<svg'), 'svg body served');
+  });
+
   test('unknown route is 404', async () => {
     const res = await get('/definitely-not-a-route');
     assert.strictEqual(res.status, 404);
@@ -199,6 +206,22 @@ describe('permission bridge', () => {
     const res = await pending;
     assert.strictEqual(res.status, 200);
     assert.deepStrictEqual(JSON.parse(res.body), { allow: true });
+  });
+
+  test('an unattributable request (no conversation_id, unmatched session) still raises a card', async () => {
+    // L10: a request with no conversation_id and a session id no live process
+    // owns cannot be attributed. It must NOT be pinned to whatever
+    // conversation is on screen; it is logged, and the card goes out with an
+    // empty conversation so the user can still answer it.
+    const since = client.messages.length;
+    const pending = postJson('/api/permission-request', {
+      tool_name: 'Bash', tool_input: { command: 'true' }, session_id: 'sess-nobody-owns',
+    });
+    const { msg: card } = await client.waitFor(m => m.type === 'control_request', { since, label: 'unattributed card' });
+    assert.strictEqual(card._conversationId, '', 'never misattributed to an open conversation');
+    client.send({ type: 'permission_response', requestId: card.request_id, allow: false, conversationId: '' });
+    const res = await pending;
+    assert.deepStrictEqual(JSON.parse(res.body), { allow: false });
   });
 
   test('deny resolves with {allow:false}', async () => {

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -54,9 +54,14 @@ const AREA_DEFS = [
   ['server.js', 'System prompt + roster builders', /^function buildSystemPrompt\(/, /^\/\/ ===== AGENT DISCOVERY =====/],
   ['server.js', 'Workspace analysis (Seven Signals)', /^function analyzeWorkspace\(/, /^function muteHooks\(/],
   ['server.js', 'Workspace mode detection + scaffolding', /^function muteHooks\(/, /^const server = http\.createServer/],
-  ['server.js', 'Transcripts + persistence helpers', /^function loadTranscript\(/, /^function safeSend\(/],
-  ['server.js', 'Conversation / state persistence', /^function readConversations\(/, /^function readState\(/],
-  ['server.js', 'HTTP request router (incl. permission bridge)', /^const server = http\.createServer/, /^function loadTranscript\(/],
+  // Slice 1 migrations: these two areas moved to lib/store/ and keep their
+  // floors under the same labels; the interim root area covers what the move
+  // left behind (signal layer + the appendTranscript/formatTranscript
+  // composition) until the signals slice gives it a permanent home.
+  ['lib/store/transcripts.js', 'Transcripts + persistence helpers', /^function transcriptDir\(/, /^module\.exports/],
+  ['lib/store/persistence.js', 'Conversation / state persistence', /^function rundockDir\(/, /^module\.exports/],
+  ['server.js', 'Signals + transcript composition (root remainder)', /^const EVENTS_RETENTION_MONTHS/, /^function safeSend\(/],
+  ['server.js', 'HTTP request router (incl. permission bridge)', /^const server = http\.createServer/, /^\/\/ Transcript primitives \(convoTranscripts cache/],
   ['server.js', 'WebSocket message handlers', /^wss\.on\('connection'/, /^function discoverSkills\(/],
   ['server.js', 'Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', /^function resolveClaudeBin\(/, /^\/\/ ===== CODEX RUNTIME =====/],
   ['server.js', 'Codex runtime (status, turns, delegate wiring)', /^\/\/ ===== CODEX RUNTIME =====/, /^\/\/ Graceful shutdown/],
@@ -66,6 +71,7 @@ const AREA_DEFS = [
 const OVERALL_FILES = [
   'server.js', 'codex.js', 'codex-appserver.js', 'search.js',
   'lib/delegation/markers.js', 'lib/delegation/handback.js', 'lib/delegation/state.js',
+  'lib/config.js', 'lib/store/persistence.js', 'lib/store/transcripts.js',
 ];
 
 // ---------------------------------------------------------------------------

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-11T20:50:14.527Z",
-  "commit": "42c456d2b44947c4bb721d6b21d4cbb9c380ee70",
+  "generatedAt": "2026-08-11T21:23:32.011Z",
+  "commit": "bcb5cb86ea0fad2637174a64e52867e97e8f6037",
   "tolerance": 0.25,
   "floors": {
     "OVERALL server.js": 94.4,
@@ -10,6 +10,9 @@
     "OVERALL lib/delegation/markers.js": 100,
     "OVERALL lib/delegation/handback.js": 100,
     "OVERALL lib/delegation/state.js": 100,
+    "OVERALL lib/config.js": 100,
+    "OVERALL lib/store/persistence.js": 100,
+    "OVERALL lib/store/transcripts.js": 100,
     "Delegation / orchestration engine": 90.5,
     "- wireProcessHandlers (stream-json + interception)": 100,
     "- handleScopeReturn": 87.3,
@@ -20,10 +23,11 @@
     "System prompt + roster builders": 98.9,
     "Workspace analysis (Seven Signals)": 97.3,
     "Workspace mode detection + scaffolding": 96.9,
-    "Transcripts + persistence helpers": 99,
+    "Transcripts + persistence helpers": 100,
     "Conversation / state persistence": 100,
-    "HTTP request router (incl. permission bridge)": 97,
-    "WebSocket message handlers": 95.6,
+    "Signals + transcript composition (root remainder)": 98.7,
+    "HTTP request router (incl. permission bridge)": 98,
+    "WebSocket message handlers": 95.7,
     "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 98.1,
     "Codex runtime (status, turns, delegate wiring)": 89
   }

--- a/test/unit/config.test.js
+++ b/test/unit/config.test.js
@@ -1,0 +1,46 @@
+'use strict';
+// lib/config.js owns the workspace root for extracted lib/ modules. Two
+// contracts matter: reads see writes immediately (live state, read at use
+// time), and server.js's mirror variable can never drift because every
+// assignment there goes through the one helper that writes both.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const config = require('../../lib/config.js');
+
+describe('lib/config workspace root', () => {
+  test('setWorkspace is visible to the next getWorkspace call', () => {
+    const prev = config.getWorkspace();
+    config.setWorkspace('/tmp/rundock-config-test');
+    assert.strictEqual(config.getWorkspace(), '/tmp/rundock-config-test');
+    config.setWorkspace(null);
+    assert.strictEqual(config.getWorkspace(), null);
+    config.setWorkspace(prev);
+  });
+
+  test('seeds from process.env.WORKSPACE at load', () => {
+    // Fresh process so the env is read at require time, not inherited state.
+    const out = execFileSync(process.execPath, [
+      '-e', "process.stdout.write(String(require('./lib/config.js').getWorkspace()))",
+    ], { cwd: ROOT, env: { ...process.env, WORKSPACE: '/tmp/rundock-config-seed' } });
+    assert.strictEqual(out.toString(), '/tmp/rundock-config-seed');
+  });
+
+  test('server.js mirror cannot drift: every assignment goes through setWorkspaceRoot', () => {
+    // The root keeps a local WORKSPACE mirror while its read sites are
+    // converted slice by slice. A bare assignment anywhere else would update
+    // one copy and not the other; extracted modules would then operate on a
+    // stale workspace. Allowed assignments: the declaration (seeded FROM
+    // config) and the single helper body.
+    const src = fs.readFileSync(path.join(ROOT, 'server.js'), 'utf-8');
+    const assignments = src.match(/^\s*(?:let )?WORKSPACE = .*$/gm) || [];
+    assert.deepStrictEqual(assignments.map(s => s.trim()), [
+      'let WORKSPACE = config.getWorkspace();',
+      'WORKSPACE = dir;',
+    ], 'assign the workspace root via setWorkspaceRoot(), never directly');
+  });
+});


### PR DESCRIPTION
## What

First extraction slice of the server.js decomposition: session persistence and the transcript primitives move to `lib/store/`, and the workspace root gets a module home extracted code can read live.

- `lib/config.js` owns the workspace root (`getWorkspace()`/`setWorkspace()`). Extracted modules read it at use time, never at require time: the root is live state with 113 read sites depending on seeing a workspace switch immediately. server.js keeps its local mirror while its own read sites convert slice by slice, but every assignment now flows through one helper that writes both, and a unit test fails on any bare assignment so the copies cannot drift.
- `lib/store/persistence.js`: the `.rundock/` octet, verbatim (conversations with the done→archived migration and pre-migration backup, lists, state, `rundockDir`).
- `lib/store/transcripts.js`: `convoTranscripts` cache, load/save, corrupt-file salvage, `buildToolSummary`, verbatim. The module OWNS the Map; server.js re-exports the module's own object through `_internal`, so tests keep mutating the live state (object identity is part of the test contract).
- `appendTranscript` and `formatTranscript` stay in the composition root deliberately: they weave the store primitives together with the signal layer and the live search reconcile, which belong to later slices. Recorded in a pointer comment at the site.

## Commit structure

Move commit separated from edit commits: (1) config + mirror, (2) the verbatim move, (3) the coverage-instrument migration.

## Class B retargets (enumerated)

- The two moved coverage areas keep their labels and floors with new file columns (`lib/store/transcripts.js`, `lib/store/persistence.js`), both at 100%.
- The HTTP router area's end anchor retargeted: its old anchor was the moved `loadTranscript` declaration, and an unresolvable anchor is a hard build failure by design.
- A new interim area floors what the move left behind in the root (signal layer + transcript composition, 98.7%) so nothing leaves the instrument's sight between slices.
- No test-file pins needed retargeting: the `get_conversations` source scan anchors on handler text that did not move, and all `_internal` API uses are preserved by identity.

## Floors

All ratchets upward: transcripts area 99→100, HTTP router 97→98, WS handlers 95.6→95.7, three new files join OVERALL at 100%. One honest wobble worth recording: the router's ratio dropped from 97.0 to 96.5 when the always-covered transcript helpers left its span — no coverage actually lost. Restored above the floor with two pins the router wanted anyway: the favicon route, and an unattributable permission request (no conversation_id, unmatched session) raising a card with an EMPTY conversation instead of being pinned to whatever conversation is on screen.

## Proof

- Full suite: 1421 pass, 0 fail (was 1419; +2 router pins, +3 config tests, net of restructure).
- All 23 coverage floors hold; `lib/config.js` and both store modules at 100%.
- Packaging: `lib/**/*` is already in `build.files`, and the afterPack packaged-contents gate sees the three new requires (they are root-level `./lib/...js` requires in server.js, the exact form its extractor matches).
- E2E: full Playwright suite green before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
