### PR TITLE
Characterize codex runtime edges before the glue moves

### DIFF
--- a/test/integration/codex-delegate-edges.test.js
+++ b/test/integration/codex-delegate-edges.test.js
@@ -1,0 +1,145 @@
+'use strict';
+// Characterization: codex delegate turn edges that had never been driven,
+// pinned ahead of the codex glue's own extraction. Covers the delegate
+// event stream (live deltas), the three error routings (transient willRetry,
+// busy-turn notice, terminal error), the done-status-failed surface, and
+// the turn-start failure path (thread/start retries exhausted). Every test
+// asserts BOTH the user-facing surface and that the parked parent is
+// restored: a dead delegate must never strand the conversation.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+
+let client;
+
+function team() {
+  return {
+    ...standardTeam(),
+    'researcher': agentFile({
+      name: 'researcher', displayName: 'Ida', role: 'Researcher',
+      description: 'Researches suppliers', type: 'specialist', order: 5,
+      reportsTo: 'chief-of-staff', runtime: 'codex',
+      body: 'You are Ida, the researcher.',
+    }),
+  };
+}
+
+before(async () => {
+  await h.boot({ agents: team() });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+async function startOrchestrator(convoId, keyword) {
+  h.writeScenario([
+    { match: { agent: 'chief-of-staff', promptIncludes: keyword }, turn: [{ text: `Orchestrator ready (${keyword}).` }] },
+  ]);
+  client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: keyword });
+  await client.waitForEvent('system', 'done', convoId);
+}
+
+async function waitForParentRestored(convoId) {
+  const ok = await h.waitUntil(() => {
+    const e = h.internal.chatProcesses.get(convoId);
+    return e && e.agentId === 'chief-of-staff';
+  });
+  assert.ok(ok, 'the parked parent was restored after the delegate turn ended');
+}
+
+test('a codex delegate streams live deltas to the browser, stamped with the delegate', async () => {
+  const convoId = h.freshConvoId('cdeltas');
+  await startOrchestrator(convoId, 'cdeltas-setup');
+  // The version override also exercises the untested-range warning on the
+  // app-server's first boot in this process.
+  h.writeCodexScenario([
+    { match: { promptIncludes: 'cdeltas task' }, deltas: ['chunk one ', 'chunk two'], text: 'chunk one chunk two' },
+  ], { version: '0.999.0' });
+
+  const since = client.messages.length;
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'researcher', context: 'cdeltas task' });
+
+  const { msg: delta } = await client.waitFor(
+    m => m.type === 'stream_event' && m.event?.type === 'content_block_delta'
+      && m._conversationId === convoId && m._agent === 'researcher',
+    { since, label: 'live delegate delta' });
+  assert.strictEqual(delta.event.delta.type, 'text_delta');
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'researcher',
+    { since, label: 'delegate result' });
+  await waitForParentRestored(convoId);
+});
+
+test('a transient (willRetry) error is never surfaced; the failed turn end is', async () => {
+  const convoId = h.freshConvoId('cretry');
+  await startOrchestrator(convoId, 'cretry-setup');
+  h.writeCodexScenario([
+    { match: { promptIncludes: 'cretry task' },
+      error: { message: 'stream disconnected, retrying', willRetry: true } },
+  ]);
+
+  const since = client.messages.length;
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'researcher', context: 'cretry task' });
+
+  // The turn ends failed WITHOUT a prior surfaced error, so the done handler
+  // owns the error surface (exactly once).
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'codex_error' && m._conversationId === convoId,
+    { since, label: 'error surfaced at turn end' });
+  const errors = client.messages.slice(since).filter(
+    m => m.type === 'system' && m.subtype === 'codex_error' && m._conversationId === convoId);
+  assert.strictEqual(errors.length, 1, 'the transient error itself was never surfaced');
+  await waitForParentRestored(convoId);
+});
+
+test('a busy-turn error becomes the retryable notice, never an error card', async () => {
+  const convoId = h.freshConvoId('cbusy');
+  await startOrchestrator(convoId, 'cbusy-setup');
+  h.writeCodexScenario([
+    { match: { promptIncludes: 'cbusy task' },
+      error: { message: 'a turn is already active on thread t_1' } },
+  ]);
+
+  const since = client.messages.length;
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'researcher', context: 'cbusy task' });
+
+  const { msg: notice } = await client.waitFor(
+    m => m.type === 'system' && m.subtype === 'notice' && m._conversationId === convoId,
+    { since, label: 'busy notice' });
+  assert.match(notice.content, /wrapping up the previous turn/);
+  await waitForParentRestored(convoId);
+  const errors = client.messages.slice(since).filter(
+    m => m.type === 'system' && m.subtype === 'codex_error' && m._conversationId === convoId);
+  assert.strictEqual(errors.length, 0, 'busy is not a failure: no error card');
+});
+
+test('a terminal delegate error is surfaced once and the parent still comes back', async () => {
+  const convoId = h.freshConvoId('cfail');
+  await startOrchestrator(convoId, 'cfail-setup');
+  h.writeCodexScenario([
+    { match: { promptIncludes: 'cfail task' },
+      error: { message: 'model exploded', codexErrorInfo: 'other' } },
+  ]);
+
+  const since = client.messages.length;
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'researcher', context: 'cfail task' });
+
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'codex_error' && m._conversationId === convoId,
+    { since, label: 'terminal error surfaced' });
+  await waitForParentRestored(convoId);
+  const errors = client.messages.slice(since).filter(
+    m => m.type === 'system' && m.subtype === 'codex_error' && m._conversationId === convoId);
+  assert.strictEqual(errors.length, 1, 'the done-failed path never doubles the surface');
+});
+
+test('a delegate whose thread cannot start surfaces the failure and restores the parent', async () => {
+  const convoId = h.freshConvoId('cnostart');
+  await startOrchestrator(convoId, 'cnostart-setup');
+  // Exhaust the protocol client's overload retries so thread/start rejects.
+  h.writeCodexScenario([], { overload: { method: 'thread/start', times: 10 } });
+
+  const since = client.messages.length;
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'researcher', context: 'cnostart task' });
+
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'codex_error' && m._conversationId === convoId,
+    { since, label: 'turn-start failure surfaced', timeout: 15000 });
+  await waitForParentRestored(convoId);
+});

--- a/test/integration/codex-spawn-error.test.js
+++ b/test/integration/codex-spawn-error.test.js
@@ -1,0 +1,89 @@
+'use strict';
+// Characterization: the codex spawn-failure surface, pinned ahead of the
+// codex glue's extraction. A machine without the Codex CLI gets the
+// codex-specific install guidance (NOT the Claude-install message), a clean
+// done so the client unblocks, and a 30s per-conversation dedupe so retries
+// against a missing binary never stack pills.
+//
+// Own file, own process: after boot, PATH is REPLACED with a minimal
+// whitelist (claude stub + node's own dir + system dirs) that contains no
+// codex anywhere. Filtering only the stub's directory out is NOT enough: a
+// developer machine with the real CLI installed would resolve and spawn it,
+// which is exactly what the harness boot assertion exists to prevent. With
+// the whitelist, `which codex` finds nothing, the resolver falls back to
+// the bare name, and the spawn fails with ENOENT exactly as on a machine
+// without the CLI.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const h = require('../helpers/harness.js');
+const { agentFile, standardTeam } = require('../helpers/workspace.js');
+
+let client;
+let originalPath;
+
+before(async () => {
+  await h.boot({
+    agents: {
+      ...standardTeam(),
+      'researcher': agentFile({
+        name: 'researcher', displayName: 'Ida', role: 'Researcher',
+        description: 'Researches suppliers', type: 'specialist', order: 5,
+        reportsTo: 'chief-of-staff', runtime: 'codex',
+        body: 'You are Ida, the researcher.',
+      }),
+    },
+  });
+  client = await h.connect();
+  originalPath = process.env.PATH;
+  const claudeStubDir = path.join(__dirname, '..', 'helpers', 'stub-claude');
+  process.env.PATH = [
+    claudeStubDir,
+    path.dirname(process.execPath), // node itself, for the stub's shebang
+    '/usr/bin', '/bin', '/usr/sbin', '/sbin',
+  ].join(path.delimiter);
+});
+after(async () => {
+  if (originalPath) process.env.PATH = originalPath;
+  await h.shutdown();
+});
+
+const INSTALL_GUIDANCE = /Codex CLI was not found/;
+
+test('a missing codex binary surfaces install guidance and a clean done', async () => {
+  const convoId = h.freshConvoId('cnobin');
+  const since = client.messages.length;
+  client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'hello codex' });
+
+  const { msg: info } = await client.waitFor(
+    m => m.type === 'system' && m.subtype === 'info' && m._conversationId === convoId,
+    { since, label: 'install guidance' });
+  assert.match(info.content, INSTALL_GUIDANCE, 'codex-specific guidance, never the Claude-install message');
+  const { msg: done } = await client.waitFor(
+    m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId,
+    { since, label: 'done after spawn failure' });
+  assert.strictEqual(done.code, -1);
+});
+
+test('a retry within 30s is deduped: done arrives, the guidance does not stack', async () => {
+  // SAME conversation as the previous attempt would be ideal, but each test
+  // owns its convo; the dedupe window is per conversation, so drive both
+  // attempts here.
+  const convoId = h.freshConvoId('cdedupe');
+  const since = client.messages.length;
+  client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'first try' });
+  await client.waitFor(
+    m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId,
+    { since, label: 'first failure done' });
+
+  const sinceRetry = client.messages.length;
+  client.send({ type: 'chat', conversationId: convoId, agent: 'researcher', content: 'second try' });
+  await client.waitFor(
+    m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId,
+    { since: sinceRetry, label: 'deduped failure done' });
+
+  const guidance = client.messages.slice(since).filter(
+    m => m.type === 'system' && m.subtype === 'info' && m._conversationId === convoId
+      && INSTALL_GUIDANCE.test(m.content || ''));
+  assert.strictEqual(guidance.length, 1, 'the second failure inside the window sends done only');
+});

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -1,11 +1,11 @@
 {
-  "generatedAt": "2026-08-11T23:20:38.769Z",
-  "commit": "28759565162d5ca8bcb1da807f9a276347152c78",
+  "generatedAt": "2026-08-12T08:42:58.546Z",
+  "commit": "6a8ac6670257e9d633b0603ca4084a9ba8427dfe",
   "tolerance": 0.25,
   "floors": {
-    "OVERALL server.js": 95.1,
+    "OVERALL server.js": 96.3,
     "OVERALL codex.js": 100,
-    "OVERALL codex-appserver.js": 94.2,
+    "OVERALL codex-appserver.js": 95,
     "OVERALL search.js": 98.4,
     "OVERALL lib/delegation/markers.js": 100,
     "OVERALL lib/delegation/handback.js": 100,
@@ -38,6 +38,6 @@
     "HTTP request router (incl. permission bridge)": 98,
     "WebSocket message handlers": 96.3,
     "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 98.1,
-    "Codex runtime (status, turns, delegate wiring)": 89
+    "Codex runtime (status, turns, delegate wiring)": 96.4
   }
 }


### PR DESCRIPTION
## Summary

Characterization only: pins the codex runtime edges that had never been driven, ahead of extracting the codex glue out of server.js. The area sat at 89.0%, below the 95% characterize-before-move threshold, so the pins land first and the move follows in its own PR against pinned main.

## What is now pinned

**Delegate turn edges** (`codex-delegate-edges.test.js`) — each test asserts both the user-facing surface AND that the parked parent is restored (a dead delegate must never strand the conversation):
- live deltas stream to the browser stamped with the delegate, not the parent
- a transient `willRetry` error is never surfaced; the failed turn end owns the error surface, exactly once
- a busy-turn error becomes the retryable notice, never an error card, and suppresses any later error surface for the turn
- a terminal error surfaces once; the done-failed path never doubles it
- thread/start retries exhausted (stub overload) surfaces the failure and restores the parent

**Spawn failure** (`codex-spawn-error.test.js`, own process): a machine without the Codex CLI gets the codex-specific install guidance (never the Claude-install message) plus a clean done, and a retry within 30s is deduped to done-only.

## Method note

The spawn-failure file REPLACES PATH with a codex-free whitelist (claude stub + node's dir + system dirs) after boot. The first attempt filtered out only the stub's directory, which resolved and spawned the real Codex CLI on a developer machine — exactly what the harness boot assertion exists to prevent. The whitelist makes the failure deterministic on any machine and is documented in the file header.

## Deliberately still uncovered (~36 lines)

Version-warning parse branches, ready-wait timeout, EACCES/generic spawn-error wordings (ENOENT and the dedupe are pinned), approval-on-cancelled respond, keepalive terminal-flag sweep, delegate-event catch, and the ENOENT/busy branches of the delegate turn-start catch (the generic branch is pinned). Enumerated so the move PR inherits an honest baseline.

## Numbers

- Codex runtime area 89.0 -> 96.4 (floor ratcheted)
- server.js overall 95.1 -> 96.3 (floor ratcheted)
- codex-appserver.js 94.2 -> 95 (floor ratcheted)
- Suite: 1450 pass / 0 fail; E2E: 103 pass; all 36 floors hold

No production code changed; no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
