### PR TITLE
Extract the scheduler to lib/scheduler.js

### DIFF
--- a/lib/agents/discovery.js
+++ b/lib/agents/discovery.js
@@ -8,12 +8,11 @@
 // The workspace root is LIVE state: read getWorkspace() inside each
 // operation, never capture it at require time.
 //
-// Root-owned state this module needs arrives through named wiring:
-// setRoutineState(obj) hands over the scheduler's routineState object BY
-// IDENTITY (the scheduler mutates it in place, never reassigns), so routine
-// runs recorded by the root are visible here without a callback. When the
-// scheduler moves to lib/scheduler.js, this module requires it directly and
-// the wiring goes away.
+// Routine state comes straight from lib/scheduler.js, which owns it and
+// mutates it in place (never reassigns). The require happens at USE time
+// inside discoverAgents: the scheduler top-requires the codex glue, which
+// top-requires this module, so a top-level require here would close that
+// cycle and hand one of the three a partially-built module.
 const fs = require('fs');
 const path = require('path');
 const { getWorkspace, DEFAULT_MODEL } = require('../config.js');
@@ -27,10 +26,6 @@ const AGENT_CACHE_TTL = 2000; // 2 seconds
 const AGENT_INSTRUCTIONS_MAX = 20000;
 
 function invalidateAgentCache() { _agentCache = null; _agentCacheTime = 0; }
-
-// The scheduler's routineState, wired in by the root at boot (see header).
-let _routineState = {};
-function setRoutineState(state) { _routineState = state; }
 
 function discoverAgents() {
   // No workspace selected yet: nothing to discover. Guards path.join(null,…),
@@ -211,12 +206,14 @@ function discoverAgents() {
     });
   }
 
-  // Attach routine state
+  // Attach routine state, required at USE time to stay off the require
+  // cycle (see the module header).
+  const { routineState } = require('../scheduler.js');
   for (const agent of agents) {
     if (agent.routines) {
       for (const r of agent.routines) {
         const key = `${agent.id}:${r.name}`;
-        r.state = _routineState[key] || null;
+        r.state = routineState[key] || null;
       }
     }
   }
@@ -352,7 +349,7 @@ function parseSkills(fmText) {
 }
 
 module.exports = {
-  discoverAgents, invalidateAgentCache, setRoutineState,
+  discoverAgents, invalidateAgentCache,
   readNormalisedFile, extractFrontmatterText, titleCase,
   parseAgentFrontmatter, parseCapabilities, parseRoutines, parsePrompts, parseSkills,
   AGENT_CACHE_TTL, AGENT_INSTRUCTIONS_MAX,

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -1,0 +1,238 @@
+'use strict';
+// The routine scheduler: the 60-second tick (startScheduler), the schedule
+// grammar (getNextRun: exactly two shapes, daily and weekly), routine
+// execution on both runtimes (executeRoutine), and the persisted routine
+// state that stops a restart re-firing a run that already happened
+// (routineState + loadRoutineState/saveRoutineState/recordRoutineRun).
+//
+// routineState is module-owned and exported BY IDENTITY: the scheduler
+// mutates it in place and never reassigns, so the root's test re-exports
+// and lib/agents/discovery.js (which stamps run state onto rosters) all
+// observe the same live object. The workspace root is read at USE time via
+// lib/config.js (through rundockDir() for persistence and getWorkspace()
+// for routine cwd), so a workspace switch immediately redirects where
+// state persists and where routines run.
+//
+// Root-owned capabilities arrive through wireSchedulerDeps: the Claude
+// spawn plumbing (spawnClaude/getBareArgs/modelArgs/getSpawnEnv) until its
+// own extraction, and the WebSocket client set as an accessor (the wss is
+// created later at boot). Unwired deps throw at first use.
+const fs = require('fs');
+const path = require('path');
+const { getWorkspace } = require('./config.js');
+const { rundockDir } = require('./store/persistence.js');
+const { recordEvent } = require('./signals.js');
+const { buildSystemPrompt } = require('./agents/prompt.js');
+const { getCodexAppServer, waitForCodexReady, readAgentInstructions } = require('./runtime/codex-glue.js');
+const { discoverAgents } = require('./agents/discovery.js');
+
+const unwired = (name) => () => {
+  throw new Error(`lib/scheduler: ${name} not wired (call wireSchedulerDeps at boot)`);
+};
+const deps = {
+  spawnClaude: unwired('spawnClaude'),
+  getBareArgs: unwired('getBareArgs'),
+  modelArgs: unwired('modelArgs'),
+  getSpawnEnv: unwired('getSpawnEnv'),
+  getWssClients: unwired('getWssClients'),  // () => wss.clients (created at boot)
+};
+function wireSchedulerDeps(next) {
+  const prev = { ...deps };
+  Object.assign(deps, next);
+  return prev;
+}
+
+// ===== ROUTINE STATE =====
+// In-memory view of routine run state, persisted to .rundock/routine-state.json
+// so a server restart cannot re-fire a routine that already ran in its window
+// (the desktop quit-and-reopen pattern). The file is workspace-scoped like the
+// other .rundock stores; loadRoutineState() runs at startup and on every
+// workspace switch.
+
+const routineState = {}; // { routineKey: { lastRun, status, duration } }
+
+function loadRoutineState() {
+  for (const key of Object.keys(routineState)) delete routineState[key];
+  try {
+    const file = path.join(rundockDir(), 'routine-state.json');
+    const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    for (const [key, state] of Object.entries(saved)) {
+      if (!state || typeof state.lastRun !== 'string') continue;
+      // A run that was 'running' when the server died never finished; surface
+      // that honestly. lastRun stays, so the run still suppresses a re-fire
+      // (the work was started; firing it again is the bug this file prevents).
+      if (state.status === 'running') state.status = 'interrupted';
+      routineState[key] = state;
+    }
+  } catch (e) { /* missing or unreadable file: start empty */ }
+}
+
+function saveRoutineState() {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'routine-state.json'), JSON.stringify(routineState, null, 2));
+}
+
+function recordRoutineRun(key, state) {
+  routineState[key] = state;
+  try {
+    saveRoutineState();
+  } catch (e) {
+    // Persistence is protection for the NEXT process; this one already has
+    // the in-memory state. An unwritable .rundock must not kill the scheduler.
+    console.error('[Scheduler] Failed to persist routine state:', e && e.message ? e.message : e);
+  }
+}
+
+// ===== SCHEDULER =====
+
+function startScheduler() {
+  const checkInterval = 60 * 1000; // Check every 60 seconds
+
+  setInterval(() => {
+    const agents = discoverAgents();
+    const now = new Date();
+
+    for (const agent of agents) {
+      if (!agent.routines) continue;
+      for (const routine of agent.routines) {
+        const key = `${agent.id}:${routine.name}`;
+        const nextRun = getNextRun(routine.schedule, routineState[key]?.lastRun);
+        if (nextRun && now >= nextRun) {
+          console.log(`[Scheduler] Running routine: ${routine.name} (${agent.name})`);
+          executeRoutine(agent, routine, key);
+        }
+      }
+    }
+  }, checkInterval).unref(); // see heartbeat unref note: listener keeps process alive in production
+}
+
+function getNextRun(schedule, lastRunISO) {
+  if (!schedule) return null;
+  const now = new Date();
+  const s = schedule.toLowerCase();
+
+  // Parse "every day at HH:MM"
+  const dailyMatch = s.match(/every day at (\d{2}):(\d{2})/);
+  if (dailyMatch) {
+    // Don't re-run if already ran today. This suppression (fed by the
+    // persisted routine state) is the ONLY thing standing between a due
+    // routine and a duplicate fire, which is why it is checked first.
+    if (lastRunISO) {
+      const lastRun = new Date(lastRunISO);
+      if (lastRun.toDateString() === now.toDateString() && lastRun.getHours() >= parseInt(dailyMatch[1])) return null;
+    }
+    const target = new Date(now);
+    target.setHours(parseInt(dailyMatch[1]), parseInt(dailyMatch[2]), 0, 0);
+    // A target already past today stays TODAY: the scheduler's `now >= nextRun`
+    // check fires it on the next tick (same-day catch-up). The previous code
+    // rolled it to tomorrow, which meant the fire condition was only
+    // satisfiable in the single millisecond HH:MM:00.000 - routines whose
+    // tick did not land exactly on that instant never fired at all.
+    return target;
+  }
+
+  // Parse "every [weekday] at HH:MM"
+  const weeklyMatch = s.match(/every (\w+) at (\d{2}):(\d{2})/);
+  if (weeklyMatch) {
+    const days = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
+    const targetDay = days[weeklyMatch[1]];
+    if (targetDay === undefined) return null;
+    // Suppression first, same reasoning as the daily branch.
+    if (lastRunISO) {
+      const lastRun = new Date(lastRunISO);
+      const daysSinceLastRun = (now - lastRun) / (1000 * 60 * 60 * 24);
+      if (daysSinceLastRun < 1 && lastRun.getDay() === targetDay) return null;
+    }
+    const target = new Date(now);
+    target.setHours(parseInt(weeklyMatch[2]), parseInt(weeklyMatch[3]), 0, 0);
+    const daysUntil = (targetDay - now.getDay() + 7) % 7;
+    target.setDate(target.getDate() + daysUntil);
+    // On the target weekday a past-due target stays TODAY so the scheduler
+    // fires it (same-day catch-up); the suppression above prevents re-fires.
+    // See the daily branch for why the old roll-forward meant never firing.
+    return target;
+  }
+
+  return null;
+}
+
+function executeRoutine(agent, routine, key) {
+  const startTime = Date.now();
+  // Persisted immediately: if the server dies mid-run, the restarted process
+  // still knows the run started and will not fire it again in the same window.
+  recordRoutineRun(key, { lastRun: new Date().toISOString(), status: 'running', duration: null });
+
+  // Notify connected clients
+  broadcastRoutineUpdate();
+
+  const recordOutcome = (ok) => {
+    const duration = Math.round((Date.now() - startTime) / 1000);
+    recordRoutineRun(key, {
+      lastRun: new Date().toISOString(),
+      status: ok ? 'completed' : 'failed',
+      duration
+    });
+    console.log(`[Scheduler] Routine "${routine.name}" ${ok ? 'completed' : 'failed'} (${duration}s)`);
+    recordEvent('routine_run', { agent: agent.id, runtime: agent.runtime || 'claude', d: { routine: routine.name, status: ok ? 'completed' : 'failed', duration } });
+    broadcastRoutineUpdate();
+  };
+
+  if (agent.runtime === 'codex') {
+    // Codex agents run their routines on the shared Codex app-server: one
+    // fresh thread per run, the routine prompt travelling with the agent's
+    // instructions (Codex has no --agent equivalent). Routines run
+    // unattended with nobody to approve escalations, so approvalPolicy is
+    // an EXPLICIT 'never' (the client refuses to default to it):
+    // sandbox-blocked actions fail instead of hanging on an approval,
+    // matching the retired exec mode. The agent's plan choice is honoured
+    // even for unattended work.
+    const routinePrompt = [readAgentInstructions(agent), buildSystemPrompt(agent), routine.prompt].filter(Boolean).join('\n\n');
+    (async () => {
+      const server = await getCodexAppServer();
+      await waitForCodexReady(server);
+      const { threadId } = await server.startThread({
+        cwd: getWorkspace(),
+        model: agent.model || undefined,
+        sandbox: 'workspace-write',
+        approvalPolicy: 'never',
+      });
+      const sub = server.startTurn(threadId, routinePrompt);
+      const status = await new Promise((resolve) => {
+        sub.on('event', (ev) => { if (ev.type === 'done') resolve(ev.status); });
+      });
+      return status === 'completed';
+    })().then(recordOutcome, (err) => {
+      console.error(`[Scheduler] Codex routine "${routine.name}" failed to run: ${err.message}`);
+      recordOutcome(false);
+    });
+    return;
+  }
+
+  // Routines run unattended (no user to approve), so bypass permissions.
+  const args = [...deps.getBareArgs(), ...deps.modelArgs(agent), '--print', '--output-format', 'stream-json', '--verbose', '--dangerously-skip-permissions'];
+  if (agent.id !== 'default') args.push('--agent', agent.id);
+  args.push(routine.prompt);
+
+  const proc = deps.spawnClaude(args, {
+    cwd: getWorkspace(),
+    env: deps.getSpawnEnv(null),
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  proc.on('close', (code) => recordOutcome(code === 0));
+}
+
+function broadcastRoutineUpdate() {
+  const agents = discoverAgents();
+  const msg = JSON.stringify({ type: 'agents', agents });
+  deps.getWssClients().forEach(client => {
+    if (client.readyState === 1) client.send(msg);
+  });
+}
+
+module.exports = {
+  wireSchedulerDeps,
+  routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
+  startScheduler, getNextRun, executeRoutine,
+};

--- a/server.js
+++ b/server.js
@@ -488,14 +488,15 @@ function discoverWorkspaces() {
   return candidates;
 }
 
-// ===== ROUTINE STATE =====
-// In-memory view of routine run state, persisted to .rundock/routine-state.json
-// so a server restart cannot re-fire a routine that already ran in its window
-// (the desktop quit-and-reopen pattern). The file is workspace-scoped like the
-// other .rundock stores; loadRoutineState() runs at startup and on every
-// workspace switch.
-
-const routineState = {}; // { routineKey: { lastRun, status, duration } }
+// ===== ROUTINE STATE + SCHEDULER =====
+// Routine state, its persistence, and the scheduler (startScheduler,
+// getNextRun, executeRoutine) live in lib/scheduler.js. routineState comes
+// back BY IDENTITY for the test re-exports below.
+const schedulerLib = require('./lib/scheduler.js');
+const {
+  routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
+  startScheduler, getNextRun, executeRoutine,
+} = schedulerLib;
 // Hand lib/agents its root-owned dependencies (see the module headers).
 // routineState goes over BY IDENTITY: the scheduler mutates it in place.
 agentsDiscovery.setRoutineState(routineState);
@@ -504,7 +505,7 @@ workspaceAnalysis.wireAnalysisDeps({ parseSkillFile });
 workspaceScaffold.wireScaffoldDeps({ invalidateAgentCache, rebaselineAgentsWatcher });
 const codexGlue = require('./lib/runtime/codex-glue.js');
 const {
-  getCodexAppServer, waitForCodexReady, shutdownCodexAppServer,
+  shutdownCodexAppServer,
   readAgentInstructions, wireCodexDelegate, startCodexTurn,
 } = codexGlue;
 codexGlue.wireCodexGlueDeps({
@@ -519,38 +520,12 @@ codexGlue.wireCodexGlueDeps({
   getPermissionTimeoutMs: () => PERMISSION_TIMEOUT_MS,
 });
 
-function loadRoutineState() {
-  for (const key of Object.keys(routineState)) delete routineState[key];
-  try {
-    const file = path.join(rundockDir(), 'routine-state.json');
-    const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
-    for (const [key, state] of Object.entries(saved)) {
-      if (!state || typeof state.lastRun !== 'string') continue;
-      // A run that was 'running' when the server died never finished; surface
-      // that honestly. lastRun stays, so the run still suppresses a re-fire
-      // (the work was started; firing it again is the bug this file prevents).
-      if (state.status === 'running') state.status = 'interrupted';
-      routineState[key] = state;
-    }
-  } catch (e) { /* missing or unreadable file: start empty */ }
-}
-
-function saveRoutineState() {
-  const dir = rundockDir();
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'routine-state.json'), JSON.stringify(routineState, null, 2));
-}
-
-function recordRoutineRun(key, state) {
-  routineState[key] = state;
-  try {
-    saveRoutineState();
-  } catch (e) {
-    // Persistence is protection for the NEXT process; this one already has
-    // the in-memory state. An unwritable .rundock must not kill the scheduler.
-    console.error('[Scheduler] Failed to persist routine state:', e && e.message ? e.message : e);
-  }
-}
+schedulerLib.wireSchedulerDeps({
+  // Root spawn plumbing until its own extraction slice; the client set is
+  // read through an accessor because wss is created later at boot.
+  spawnClaude, getBareArgs, modelArgs, getSpawnEnv,
+  getWssClients: () => wss.clients,
+});
 
 // ===== AGENT HELPERS =====
 
@@ -796,152 +771,8 @@ function watchOpenFile(ws, relPath, fullPath) {
 // parseCapabilities, parseRoutines, parsePrompts, parseSkills) and titleCase
 // live in lib/agents/discovery.js.
 
-// ===== SCHEDULER =====
-
-function startScheduler() {
-  const checkInterval = 60 * 1000; // Check every 60 seconds
-
-  setInterval(() => {
-    const agents = discoverAgents();
-    const now = new Date();
-
-    for (const agent of agents) {
-      if (!agent.routines) continue;
-      for (const routine of agent.routines) {
-        const key = `${agent.id}:${routine.name}`;
-        const nextRun = getNextRun(routine.schedule, routineState[key]?.lastRun);
-        if (nextRun && now >= nextRun) {
-          console.log(`[Scheduler] Running routine: ${routine.name} (${agent.name})`);
-          executeRoutine(agent, routine, key);
-        }
-      }
-    }
-  }, checkInterval).unref(); // see heartbeat unref note: listener keeps process alive in production
-}
-
-function getNextRun(schedule, lastRunISO) {
-  if (!schedule) return null;
-  const now = new Date();
-  const s = schedule.toLowerCase();
-
-  // Parse "every day at HH:MM"
-  const dailyMatch = s.match(/every day at (\d{2}):(\d{2})/);
-  if (dailyMatch) {
-    // Don't re-run if already ran today. This suppression (fed by the
-    // persisted routine state) is the ONLY thing standing between a due
-    // routine and a duplicate fire, which is why it is checked first.
-    if (lastRunISO) {
-      const lastRun = new Date(lastRunISO);
-      if (lastRun.toDateString() === now.toDateString() && lastRun.getHours() >= parseInt(dailyMatch[1])) return null;
-    }
-    const target = new Date(now);
-    target.setHours(parseInt(dailyMatch[1]), parseInt(dailyMatch[2]), 0, 0);
-    // A target already past today stays TODAY: the scheduler's `now >= nextRun`
-    // check fires it on the next tick (same-day catch-up). The previous code
-    // rolled it to tomorrow, which meant the fire condition was only
-    // satisfiable in the single millisecond HH:MM:00.000 - routines whose
-    // tick did not land exactly on that instant never fired at all.
-    return target;
-  }
-
-  // Parse "every [weekday] at HH:MM"
-  const weeklyMatch = s.match(/every (\w+) at (\d{2}):(\d{2})/);
-  if (weeklyMatch) {
-    const days = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
-    const targetDay = days[weeklyMatch[1]];
-    if (targetDay === undefined) return null;
-    // Suppression first, same reasoning as the daily branch.
-    if (lastRunISO) {
-      const lastRun = new Date(lastRunISO);
-      const daysSinceLastRun = (now - lastRun) / (1000 * 60 * 60 * 24);
-      if (daysSinceLastRun < 1 && lastRun.getDay() === targetDay) return null;
-    }
-    const target = new Date(now);
-    target.setHours(parseInt(weeklyMatch[2]), parseInt(weeklyMatch[3]), 0, 0);
-    const daysUntil = (targetDay - now.getDay() + 7) % 7;
-    target.setDate(target.getDate() + daysUntil);
-    // On the target weekday a past-due target stays TODAY so the scheduler
-    // fires it (same-day catch-up); the suppression above prevents re-fires.
-    // See the daily branch for why the old roll-forward meant never firing.
-    return target;
-  }
-
-  return null;
-}
-
-function executeRoutine(agent, routine, key) {
-  const startTime = Date.now();
-  // Persisted immediately: if the server dies mid-run, the restarted process
-  // still knows the run started and will not fire it again in the same window.
-  recordRoutineRun(key, { lastRun: new Date().toISOString(), status: 'running', duration: null });
-
-  // Notify connected clients
-  broadcastRoutineUpdate();
-
-  const recordOutcome = (ok) => {
-    const duration = Math.round((Date.now() - startTime) / 1000);
-    recordRoutineRun(key, {
-      lastRun: new Date().toISOString(),
-      status: ok ? 'completed' : 'failed',
-      duration
-    });
-    console.log(`[Scheduler] Routine "${routine.name}" ${ok ? 'completed' : 'failed'} (${duration}s)`);
-    recordEvent('routine_run', { agent: agent.id, runtime: agent.runtime || 'claude', d: { routine: routine.name, status: ok ? 'completed' : 'failed', duration } });
-    broadcastRoutineUpdate();
-  };
-
-  if (agent.runtime === 'codex') {
-    // Codex agents run their routines on the shared Codex app-server: one
-    // fresh thread per run, the routine prompt travelling with the agent's
-    // instructions (Codex has no --agent equivalent). Routines run
-    // unattended with nobody to approve escalations, so approvalPolicy is
-    // an EXPLICIT 'never' (the client refuses to default to it):
-    // sandbox-blocked actions fail instead of hanging on an approval,
-    // matching the retired exec mode. The agent's plan choice is honoured
-    // even for unattended work.
-    const routinePrompt = [readAgentInstructions(agent), buildSystemPrompt(agent), routine.prompt].filter(Boolean).join('\n\n');
-    (async () => {
-      const server = await getCodexAppServer();
-      await waitForCodexReady(server);
-      const { threadId } = await server.startThread({
-        cwd: WORKSPACE,
-        model: agent.model || undefined,
-        sandbox: 'workspace-write',
-        approvalPolicy: 'never',
-      });
-      const sub = server.startTurn(threadId, routinePrompt);
-      const status = await new Promise((resolve) => {
-        sub.on('event', (ev) => { if (ev.type === 'done') resolve(ev.status); });
-      });
-      return status === 'completed';
-    })().then(recordOutcome, (err) => {
-      console.error(`[Scheduler] Codex routine "${routine.name}" failed to run: ${err.message}`);
-      recordOutcome(false);
-    });
-    return;
-  }
-
-  // Routines run unattended (no user to approve), so bypass permissions.
-  const args = [...getBareArgs(), ...modelArgs(agent), '--print', '--output-format', 'stream-json', '--verbose', '--dangerously-skip-permissions'];
-  if (agent.id !== 'default') args.push('--agent', agent.id);
-  args.push(routine.prompt);
-
-  const proc = spawnClaude(args, {
-    cwd: WORKSPACE,
-    env: getSpawnEnv(null),
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
-
-  proc.on('close', (code) => recordOutcome(code === 0));
-}
-
-function broadcastRoutineUpdate() {
-  const agents = discoverAgents();
-  const msg = JSON.stringify({ type: 'agents', agents });
-  wss.clients.forEach(client => {
-    if (client.readyState === 1) client.send(msg);
-  });
-}
+// The scheduler (startScheduler, getNextRun, executeRoutine, the routine
+// broadcast) lives in lib/scheduler.js.
 
 // Workspace analysis (Seven Signals, SKILL_CLUSTERS) lives in
 // lib/workspace/analysis.js.

--- a/server.js
+++ b/server.js
@@ -498,8 +498,8 @@ const {
   startScheduler, getNextRun, executeRoutine,
 } = schedulerLib;
 // Hand lib/agents its root-owned dependencies (see the module headers).
-// routineState goes over BY IDENTITY: the scheduler mutates it in place.
-agentsDiscovery.setRoutineState(routineState);
+// (routineState needs no wiring: discovery requires lib/scheduler.js
+// directly and reads the module-owned state at use time.)
 agentsPrompt.wirePromptDeps({ discoverSkills, detectCodexCached });
 workspaceAnalysis.wireAnalysisDeps({ parseSkillFile });
 workspaceScaffold.wireScaffoldDeps({ invalidateAgentCache, rebaselineAgentsWatcher });

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -48,10 +48,12 @@ const AREA_DEFS = [
   ['server.js', '  - wireProcessHandlers (stream-json + interception)', /^function wireProcessHandlers\(/, /^function handleScopeReturn/],
   ['server.js', '  - handleScopeReturn', /^function handleScopeReturn/, /^function handleDelegation/],
   ['server.js', '  - handleDelegation', /^function handleDelegation/, /^wss\.on\('connection'/],
-  // Slice 3 retarget: the scheduler's old end anchor (analyzeWorkspace)
-  // moved to lib/workspace/; the area now runs to the HTTP server, with
-  // only pointer comments in between.
-  ['server.js', 'Scheduler (getNextRun + startScheduler + executeRoutine)', /^function startScheduler\(/, /^const server = http\.createServer/],
+  // Slice 6 migration: the scheduler moved to lib/scheduler.js and keeps
+  // its floor under the same label. The area now genuinely contains the
+  // routine-state persistence (loadRoutineState/saveRoutineState/
+  // recordRoutineRun), which in the root sat outside every area span and
+  // was only floored via the file overall.
+  ['lib/scheduler.js', 'Scheduler (getNextRun + startScheduler + executeRoutine)', /^const unwired/, /^module\.exports/],
   // Slice 2 migrations: discovery + frontmatter parsing and the system
   // prompt / roster builders moved to lib/agents/ and keep their floors
   // under the same labels. The prompt area now genuinely contains the
@@ -62,7 +64,10 @@ const AREA_DEFS = [
   ['lib/agents/discovery.js', 'Agent discovery + frontmatter parsing', /^let _agentCache/, /^module\.exports/],
   ['server.js', 'Skill discovery', /^function discoverSkills\(/, /^function getFileTree\(/],
   ['lib/agents/prompt.js', 'System prompt + roster builders', /^const unwired/, /^module\.exports/],
-  ['server.js', 'Codex probe + root caches + open-file watch (remainder)', /^let _codexDetectCache/, /^\/\/ ===== SCHEDULER =====/],
+  // Slice 6 retarget: the area's old end anchor (the SCHEDULER banner)
+  // moved to lib/scheduler.js; the area now runs to the HTTP server, with
+  // only pointer comments in between.
+  ['server.js', 'Codex probe + root caches + open-file watch (remainder)', /^let _codexDetectCache/, /^const server = http\.createServer/],
   // Slice 3 migrations: analysis and scaffolding moved to lib/workspace/
   // and keep their floors under the same labels. Boundary grants get their
   // own NEW area: in the root they sat outside every area span and were
@@ -99,7 +104,7 @@ const OVERALL_FILES = [
   'lib/config.js', 'lib/store/persistence.js', 'lib/store/transcripts.js',
   'lib/agents/discovery.js', 'lib/agents/prompt.js',
   'lib/workspace/boundary.js', 'lib/workspace/analysis.js', 'lib/workspace/scaffold.js',
-  'lib/signals.js', 'lib/runtime/codex-glue.js',
+  'lib/signals.js', 'lib/runtime/codex-glue.js', 'lib/scheduler.js',
 ];
 
 // ---------------------------------------------------------------------------

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -40,6 +40,7 @@
     "WebSocket message handlers": 96.3,
     "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 98.1,
     "Runtime status + server permission bridge (root remainder)": 100,
-    "Codex glue (app-server lifecycle, turns, delegate wiring)": 96
+    "Codex glue (app-server lifecycle, turns, delegate wiring)": 96,
+    "OVERALL lib/scheduler.js": 100.0
   }
 }

--- a/test/unit/agents-lib.test.js
+++ b/test/unit/agents-lib.test.js
@@ -6,11 +6,12 @@
 //    existing characterization suite keeps exercising the moved code.
 // 2. LIVE WORKSPACE: discovery reads getWorkspace() at use time, never a
 //    value captured at require time.
-// 3. NAMED INJECTION: root-owned state the modules need arrives through named
-//    wiring functions, by identity: routineState (root-owned until the
-//    scheduler slice) into discovery; discoverSkills and detectCodexCached
+// 3. NAMED INJECTION / SHARED STATE: discoverSkills and detectCodexCached
 //    (both stay in the root: skill discovery has its own area, and the codex
-//    probe cache is shared with the settings runtime probe) into prompt.
+//    probe cache is shared with the settings runtime probe) arrive in prompt
+//    through named wiring; routineState is owned by lib/scheduler.js and
+//    discovery reads that one live object directly (no wiring), so root
+//    mutations via the _internal re-export are visible by identity.
 const { test, describe, after } = require('node:test');
 const assert = require('node:assert');
 
@@ -55,7 +56,7 @@ describe('lib/agents module seams', () => {
     assert.ok(!names.includes('alpha'), 'workspace A agent gone after switch');
   });
 
-  test('routineState is injected by identity: root mutations are visible to discovery', () => {
+  test('routineState is shared by identity: root mutations are visible to discovery', () => {
     useWorkspace({
       agents: {
         cos: agentFile({

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -1,0 +1,116 @@
+'use strict';
+// Seam tests for lib/scheduler.js. The scheduler's behaviour (the grammar,
+// the tick, routine execution on both runtimes) is pinned by the existing
+// characterization suite driving the wired module through the root's
+// _internal re-exports; these tests pin the SEAMS themselves: unwired root
+// deps refuse loudly, the wiring is restorable, routineState is mutated in
+// place (never reassigned) so every holder of the object sees the same
+// state, and persistence resolves the workspace at USE time so a switch
+// redirects the very next read and write.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
+
+// A private copy per test: wiring one test's fakes must never leak into
+// another test (or into the shared instance other requires would see).
+function freshScheduler() {
+  const cached = require.cache[SCHEDULER_KEY];
+  delete require.cache[SCHEDULER_KEY];
+  const mod = require(SCHEDULER_KEY);
+  delete require.cache[SCHEDULER_KEY];
+  if (cached) require.cache[SCHEDULER_KEY] = cached;
+  return mod;
+}
+
+function withTempWorkspace(fn) {
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-lib-'));
+  try {
+    config.setWorkspace(ws);
+    return fn(ws, config);
+  } finally {
+    config.setWorkspace(original);
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+}
+
+test('unwired root deps throw the named wiring error at first use', () => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    // executeRoutine records the run (persistence works: the workspace is
+    // real), then broadcasts, which is the first wired-dep touch. The named
+    // throw is the proof the module got exactly that far on its own.
+    assert.throws(
+      () => sched.executeRoutine({ id: 'runner', name: 'Runner' }, { name: 'r', prompt: 'p' }, 'runner:r'),
+      /lib\/scheduler: getWssClients not wired \(call wireSchedulerDeps at boot\)/,
+    );
+  });
+});
+
+test('wireSchedulerDeps returns the previous set, restorable by identity', () => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    const prev = sched.wireSchedulerDeps({ getWssClients: () => [] });
+    assert.strictEqual(typeof prev.getWssClients, 'function');
+    sched.wireSchedulerDeps(prev);
+    assert.throws(
+      () => sched.executeRoutine({ id: 'runner', name: 'Runner' }, { name: 'r', prompt: 'p' }, 'runner:r'),
+      /getWssClients not wired/,
+    );
+  });
+});
+
+test('routine state follows the workspace at USE time, and routineState mutates in place', () => {
+  const sched = freshScheduler();
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const stateRef = sched.routineState; // held BEFORE any call: identity must survive
+  const wsA = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-ws-a-'));
+  const wsB = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-ws-b-'));
+  try {
+    config.setWorkspace(wsA);
+    sched.recordRoutineRun('cos:briefing', { lastRun: '2026-08-12T09:00:00Z', status: 'completed', duration: 3 });
+    assert.ok(fs.existsSync(path.join(wsA, '.rundock', 'routine-state.json')),
+      'the record landed in workspace A with no re-wiring');
+
+    config.setWorkspace(wsB);
+    sched.recordRoutineRun('cos:evening', { lastRun: '2026-08-12T18:00:00Z', status: 'completed', duration: 2 });
+    assert.ok(fs.existsSync(path.join(wsB, '.rundock', 'routine-state.json')),
+      'the very next record followed the switch to workspace B');
+
+    // Back on A: loadRoutineState clears IN PLACE and restores A's view.
+    // The evening run (recorded while B was active) is not in A's file.
+    config.setWorkspace(wsA);
+    sched.loadRoutineState();
+    assert.strictEqual(sched.routineState, stateRef, 'routineState is never reassigned');
+    assert.ok(stateRef['cos:briefing'], "workspace A's run restored through the held reference");
+    assert.strictEqual(stateRef['cos:evening'], undefined, "workspace B's run is not in A's state");
+  } finally {
+    config.setWorkspace(original);
+    fs.rmSync(wsA, { recursive: true, force: true });
+    fs.rmSync(wsB, { recursive: true, force: true });
+  }
+});
+
+test('a run left "running" by a dead server loads back as "interrupted", still suppressing a re-fire', () => {
+  const sched = freshScheduler();
+  withTempWorkspace((ws) => {
+    const dir = path.join(ws, '.rundock');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'routine-state.json'), JSON.stringify({
+      'cos:briefing': { lastRun: '2026-08-12T09:00:00Z', status: 'running', duration: null },
+      'bad:entry': { status: 'completed' }, // no lastRun string: dropped
+    }));
+    sched.loadRoutineState();
+    assert.strictEqual(sched.routineState['cos:briefing'].status, 'interrupted',
+      'a running entry from a dead process surfaces honestly');
+    assert.strictEqual(sched.routineState['cos:briefing'].lastRun, '2026-08-12T09:00:00Z',
+      'lastRun survives so the window suppression still holds');
+    assert.strictEqual(sched.routineState['bad:entry'], undefined, 'entries without a lastRun string are dropped');
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the routine scheduler from `server.js` to `lib/scheduler.js` (239 lines): the 60-second tick (`startScheduler`), the schedule grammar (`getNextRun`), routine execution on both runtimes (`executeRoutine` + the routine broadcast), and the persisted routine state (`routineState` + `loadRoutineState`/`saveRoutineState`/`recordRoutineRun`). `server.js` drops to 5,404 lines.

Four commits, each green: verbatim move, wiring retirement, seam tests, instrument migration.

## Design

- **`routineState` is module-owned and exported BY IDENTITY.** The scheduler mutates it in place and never reassigns, so the root's test re-exports and `lib/agents/discovery.js` observe the same live object. The existing scheduler characterization suite runs against the moved code with zero retargets.
- **Workspace read at USE time.** Persistence goes through `rundockDir()` and routine cwd through `getWorkspace()`, so a workspace switch immediately redirects where state lands and where routines run (pinned across two workspaces in the seam tests).
- **Named DI with throwing unwired defaults** for what stays root-owned: the Claude spawn plumbing (`spawnClaude`/`getBareArgs`/`modelArgs`/`getSpawnEnv`, until its own extraction) and the WebSocket client set as an accessor (`wss` is created later at boot). Direct lib requires, no wiring: `rundockDir`, `recordEvent`, `buildSystemPrompt`, the codex app-server surface, `discoverAgents`.
- **The `setRoutineState` wiring is retired.** Discovery now requires the scheduler directly, at USE time inside `discoverAgents`: the scheduler top-requires the codex glue, which top-requires discovery, so a top-level require would close that cycle and hand one of the three a partially-built module. The rationale is documented at both the module header and the require site.

## Seams pinned (new `test/unit/scheduler-lib.test.js`)

- Unwired root deps throw the named wiring error at first use.
- `wireSchedulerDeps` returns the previous set, restorable by identity.
- Routine state follows the workspace at use time; `routineState` mutates in place, never reassigned (proven through one held reference across a workspace round trip).
- A run left `running` by a dead server loads back as `interrupted` with `lastRun` intact, so the re-fire suppression still holds.

## Instrument migration

- The scheduler area keeps its label and its 100 floor, and now genuinely contains the routine-state persistence, which in the root sat outside every area span (floored only via the file overall).
- The `Codex probe + root caches + open-file watch (remainder)` end anchor retargets to the HTTP server (its old end, the scheduler banner, moved with the code).
- `OVERALL lib/scheduler.js` enters at 100.0 (238/238), verified under CPU load.

## Floor honesty note

`server.js` overall measures 96.5 against its 96.6 floor: zero coverage lost (188 uncovered lines before and after; the dip is pure denominator arithmetic from extracting fully covered lines, absorbed by the tolerance as designed). `handleDelegation` measured 95.4 this run, above its 94.3 floor; the raise is declined again as schedule-sensitive credit. 39 floors hold quiet and loaded.

## Numbers

- `server.js`: 5,573 → 5,404 lines; `lib/scheduler.js`: 239 lines
- Suite: 1,462 (was 1,458); e2e: 103/103
- Floors: 39, all holding quiet and under CPU load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
