### PR TITLE
Extract the HTTP request router to lib/http-router.js

### DIFF
--- a/lib/http-router.js
+++ b/lib/http-router.js
@@ -1,0 +1,272 @@
+'use strict';
+// The HTTP request router: the page and static-asset routes, the JSON API
+// (/api/agents, /api/files, file reads), the binary file transport for the
+// viewer registry, the review-sidecar write endpoint, and the permission
+// hook bridge (/api/permission-request long-poll that becomes a browser
+// permission card).
+//
+// The workspace root is read at USE time via lib/config.js: a workspace
+// switch immediately redirects every later file read. Root-owned
+// capabilities arrive through wireHttpRouterDeps BY IDENTITY: live-state
+// accessors (chatProcesses, pendingPermissionRequests) return the root's
+// own maps, never copies. Unwired deps throw at first use.
+//
+// ROOT_DIR hops from lib/ to the repo (or app.asar) root: public/ and
+// node_modules/ live there, exactly as when this code read __dirname in
+// server.js.
+const fs = require('fs');
+const path = require('path');
+const { getWorkspace } = require('./config.js');
+const { discoverAgents } = require('./agents/discovery.js');
+const { boundaryGrantCovers } = require('./workspace/boundary.js');
+const { recordEvent } = require('./signals.js');
+const { resolvePermissionConvoId } = require('../permission-routing.js');
+
+const ROOT_DIR = path.join(__dirname, '..');
+
+const unwired = (name) => () => {
+  throw new Error(`lib/http-router: ${name} not wired (call wireHttpRouterDeps at boot)`);
+};
+const deps = {
+  chatProcesses: unwired('chatProcesses'),                         // () => Map (BY IDENTITY)
+  pendingPermissionRequests: unwired('pendingPermissionRequests'), // () => Map (BY IDENTITY)
+  isInsideWorkspace: unwired('isInsideWorkspace'),
+  getFileTreeCached: unwired('getFileTreeCached'),
+  safeSend: unwired('safeSend'),
+  getPermissionTimeoutMs: unwired('getPermissionTimeoutMs'),
+};
+function wireHttpRouterDeps(next) {
+  const prev = { ...deps };
+  Object.assign(deps, next);
+  return prev;
+}
+
+const BINARY_FILE_TYPES = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.pdf': 'application/pdf',
+};
+
+function handleHttpRequest(req, res) {
+  if (req.url === '/' || req.url === '/index.html' || req.url.startsWith('/?') || req.url.startsWith('/index.html?')) {
+    res.writeHead(200, { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache, no-store, must-revalidate' });
+    res.end(fs.readFileSync(path.join(ROOT_DIR, 'public', 'index.html')));
+  } else if (req.url === '/favicon.svg') {
+    res.writeHead(200, { 'Content-Type': 'image/svg+xml' });
+    res.end(fs.readFileSync(path.join(ROOT_DIR, 'public', 'favicon.svg')));
+  } else if (req.url === '/marked.min.js') {
+    res.writeHead(200, { 'Content-Type': 'application/javascript' });
+    res.end(fs.readFileSync(path.join(ROOT_DIR, 'node_modules', 'marked', 'lib', 'marked.umd.js')));
+  } else if (req.url === '/app.js') {
+    res.writeHead(200, { 'Content-Type': 'application/javascript', 'Cache-Control': 'no-cache, no-store, must-revalidate' });
+    res.end(fs.readFileSync(path.join(ROOT_DIR, 'public', 'app.js')));
+  } else if (req.url === '/api/agents') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(discoverAgents()));
+  } else if (req.url === '/api/files') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(deps.getFileTreeCached()));
+  } else if (req.url.startsWith('/workspace-file?path=')) {
+    // Binary transport for the file-type registry's image and PDF viewers.
+    // Allowlist-only; bytes are served raw (the WS read_file path utf-8
+    // normalises and would corrupt them). Boundary guard mirrors /api/file.
+    // decodeURIComponent throws a URIError on malformed escapes (e.g. a lone
+    // '%'); guard it so one bad request cannot take the process down.
+    let filePath;
+    try { filePath = decodeURIComponent(req.url.split('path=')[1]); }
+    catch { res.writeHead(400); res.end('Bad request'); return; }
+    const fullPath = path.resolve(getWorkspace(), filePath);
+    const mime = BINARY_FILE_TYPES[path.extname(fullPath).toLowerCase()];
+    if (mime && deps.isInsideWorkspace(fullPath) && fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+      res.writeHead(200, {
+        'Content-Type': mime,
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Disposition': 'inline',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+      });
+      res.end(fs.readFileSync(fullPath));
+    } else {
+      res.writeHead(404);
+      res.end('File not found');
+    }
+  // Review-sidecar writes: the WS save_file path expects existing parent
+  // directories; sidecars live under .rundock/reviews/ which is created on
+  // first use. Constrained to exactly that directory, flat filenames only.
+  } else if (req.method === 'POST' && req.url === '/api/review-sidecar') {
+    let body = '';
+    let tooBig = false;
+    // Cap the accumulated body: an unbounded string is a memory/disk DoS
+    // primitive. Review sidecars are small; 4 MB is generous headroom.
+    const SIDECAR_MAX_BYTES = 4 * 1024 * 1024;
+    req.on('data', chunk => {
+      if (tooBig) return;
+      body += chunk;
+      if (body.length > SIDECAR_MAX_BYTES) {
+        tooBig = true;
+        body = ''; // release; stop accumulating (remaining chunks are ignored)
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Sidecar too large' }));
+      }
+    });
+    req.on('end', () => {
+      if (tooBig) return;
+      try {
+        const data = JSON.parse(body);
+        const relPath = String(data.path || '');
+        if (!/^\.rundock\/reviews\/[\w.-]+\.json$/.test(relPath) || typeof data.content !== 'string') {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid sidecar request' }));
+          return;
+        }
+        const fullPath = path.resolve(getWorkspace(), relPath);
+        if (!deps.isInsideWorkspace(fullPath)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Invalid path' }));
+          return;
+        }
+        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+        fs.writeFileSync(fullPath, data.content, 'utf-8');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ saved: true }));
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid request' }));
+      }
+    });
+
+  } else if (req.url.startsWith('/api/file?path=')) {
+    // Guard decodeURIComponent: a malformed escape (lone '%') throws a
+    // URIError that would otherwise crash the process (no top-level handler).
+    let filePath;
+    try { filePath = decodeURIComponent(req.url.split('path=')[1]); }
+    catch { res.writeHead(400); res.end('Bad request'); return; }
+    const fullPath = path.resolve(getWorkspace(), filePath);
+    if (deps.isInsideWorkspace(fullPath) && fs.existsSync(fullPath)) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(fs.readFileSync(fullPath, 'utf-8'));
+    } else {
+      res.writeHead(404);
+      res.end('File not found');
+    }
+
+  // Permission hook endpoint: receives tool requests from the PreToolUse hook script,
+  // forwards them to the browser as permission cards, and holds the connection open
+  // until the user clicks Allow or Deny (or the 120s timeout fires).
+  } else if (req.method === 'POST' && req.url === '/api/permission-request') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        const requestId = 'perm-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+        // Attribute the request to its conversation. Prefer the hook-supplied
+        // id; if empty, resolve from the session's running process so an id-less
+        // request is never misattributed to whatever conversation is on screen
+        // (L10). Log the genuinely-unattributable case so it is observable.
+        const convoId = resolvePermissionConvoId(data.conversation_id, data.session_id, deps.chatProcesses());
+        if (!convoId) {
+          console.warn(`[Permission] Unattributed request (conversation_id empty, session=${data.session_id || 'none'} unmatched): ${data.tool_name} requestId=${requestId}`);
+        }
+
+        // Workspace boundary: a standing folder grant answers without a card,
+        // which also keeps granted folders working when no browser is open.
+        if (data.boundary && data.resolved_path && boundaryGrantCovers(data.resolved_path)) {
+          console.log(`[Permission] Standing folder grant covers ${data.resolved_path}: allowed without a card`);
+          recordEvent('permission', { conv: convoId || undefined, d: { tool: data.tool_name, decision: 'allow' } });
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ allow: true, reason: 'standing-folder-grant' }));
+          return;
+        }
+
+        // Store the pending HTTP response (resolved when user decides)
+        deps.pendingPermissionRequests().set(requestId, {
+          res,
+          conversationId: convoId,
+          toolName: data.tool_name,
+          toolInput: data.tool_input,
+          boundary: !!data.boundary,
+          resolvedPath: data.resolved_path || null,
+          grantDir: data.grant_dir || null,
+          timer: setTimeout(() => {
+            const pending = deps.pendingPermissionRequests().get(requestId);
+            if (pending) {
+              deps.pendingPermissionRequests().delete(requestId);
+              console.log(`[Permission] Auto-denied (timeout): ${data.tool_name} convo=${convoId} requestId=${requestId}`);
+              recordEvent('permission', { conv: convoId, d: { tool: data.tool_name, decision: 'timeout' } });
+              // Send denied indicator to browser
+              deps.safeSend(JSON.stringify({
+                type: 'permission_timeout',
+                requestId,
+                _conversationId: convoId
+              }));
+              res.writeHead(200, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ allow: false, reason: 'timeout' }));
+            }
+          }, deps.getPermissionTimeoutMs())
+        });
+
+        // Forward to browser as a control_request (existing permission card UI handles this)
+        deps.safeSend(JSON.stringify({
+          type: 'control_request',
+          request_id: requestId,
+          request: {
+            subtype: 'can_use_tool',
+            tool_name: data.tool_name,
+            input: data.tool_input || {},
+            ...(data.boundary ? { boundary: true, resolved_path: data.resolved_path, grant_dir: data.grant_dir } : {})
+          },
+          _conversationId: convoId
+        }));
+
+        console.log(`[Permission] Hook request: ${data.tool_name} convo=${convoId} requestId=${requestId}`);
+      } catch (e) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid request' }));
+      }
+    });
+
+  } else if (/^\/[\w-]+\.m?js$/.test(req.url)) {
+    // Top-level client modules under public/ (code-language.js, markers.js,
+    // and future extracted modules). The pattern allows no slashes and no
+    // dots outside the extension, so traversal cannot be expressed; the
+    // realpath prefix check guards anything that somehow gets past it.
+    // Regression note: code-language.js shipped in 0.10.0 with a script tag
+    // but no route, so browsers 404ed it and a defensive fallback in app.js
+    // silently masked the loss. The index-html-to-route test pins every
+    // script tag to a live route now.
+    const publicRoot = path.resolve(ROOT_DIR, 'public');
+    const filePath = path.resolve(publicRoot, req.url.slice(1));
+    if (filePath.startsWith(publicRoot + path.sep) && fs.existsSync(filePath)) {
+      res.writeHead(200, { 'Content-Type': 'application/javascript', 'Cache-Control': 'no-cache, no-store, must-revalidate' });
+      res.end(fs.readFileSync(filePath));
+    } else {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  } else if (/^\/(editor|vendor|viewers)\/[\w./-]+\.(m?js|css)$/.test(req.url)) {
+    // Static JS/MJS/CSS files for the Tiptap editor module, its vendor bundle,
+    // vendored assets (e.g. highlight.js), and the file-type registry. Path is
+    // constrained to /editor/..., /vendor/... and /viewers/... under public/,
+    // with only .js/.mjs/.css extensions and only
+    // word chars + dot/slash/hyphen in the path. The realpath check below blocks
+    // any directory traversal that somehow gets past the regex.
+    const publicRoot = path.resolve(ROOT_DIR, 'public');
+    const filePath = path.resolve(publicRoot, req.url.slice(1));
+    if (filePath.startsWith(publicRoot + path.sep) && fs.existsSync(filePath)) {
+      const contentType = filePath.endsWith('.css') ? 'text/css' : 'application/javascript';
+      res.writeHead(200, { 'Content-Type': contentType, 'Cache-Control': 'no-cache, no-store, must-revalidate' });
+      res.end(fs.readFileSync(filePath));
+    } else {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+}
+
+module.exports = { wireHttpRouterDeps, handleHttpRequest };

--- a/server.js
+++ b/server.js
@@ -526,6 +526,14 @@ schedulerLib.wireSchedulerDeps({
   spawnClaude, getBareArgs, modelArgs, getSpawnEnv,
   getWssClients: () => wss.clients,
 });
+const httpRouter = require('./lib/http-router.js');
+httpRouter.wireHttpRouterDeps({
+  // Live state BY IDENTITY: the accessors return the root's own maps.
+  chatProcesses: () => chatProcesses,
+  pendingPermissionRequests: () => pendingPermissionRequests,
+  isInsideWorkspace, safeSend, getFileTreeCached,
+  getPermissionTimeoutMs: () => PERMISSION_TIMEOUT_MS,
+});
 
 // ===== AGENT HELPERS =====
 
@@ -782,224 +790,7 @@ function watchOpenFile(ws, relPath, fullPath) {
 
 // ===== HTTP SERVER =====
 
-const server = http.createServer((req, res) => {
-  if (req.url === '/' || req.url === '/index.html' || req.url.startsWith('/?') || req.url.startsWith('/index.html?')) {
-    res.writeHead(200, { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache, no-store, must-revalidate' });
-    res.end(fs.readFileSync(path.join(__dirname, 'public', 'index.html')));
-  } else if (req.url === '/favicon.svg') {
-    res.writeHead(200, { 'Content-Type': 'image/svg+xml' });
-    res.end(fs.readFileSync(path.join(__dirname, 'public', 'favicon.svg')));
-  } else if (req.url === '/marked.min.js') {
-    res.writeHead(200, { 'Content-Type': 'application/javascript' });
-    res.end(fs.readFileSync(path.join(__dirname, 'node_modules', 'marked', 'lib', 'marked.umd.js')));
-  } else if (req.url === '/app.js') {
-    res.writeHead(200, { 'Content-Type': 'application/javascript', 'Cache-Control': 'no-cache, no-store, must-revalidate' });
-    res.end(fs.readFileSync(path.join(__dirname, 'public', 'app.js')));
-  } else if (req.url === '/api/agents') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(discoverAgents()));
-  } else if (req.url === '/api/files') {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(getFileTreeCached()));
-  } else if (req.url.startsWith('/workspace-file?path=')) {
-    // Binary transport for the file-type registry's image and PDF viewers.
-    // Allowlist-only; bytes are served raw (the WS read_file path utf-8
-    // normalises and would corrupt them). Boundary guard mirrors /api/file.
-    // decodeURIComponent throws a URIError on malformed escapes (e.g. a lone
-    // '%'); guard it so one bad request cannot take the process down.
-    let filePath;
-    try { filePath = decodeURIComponent(req.url.split('path=')[1]); }
-    catch { res.writeHead(400); res.end('Bad request'); return; }
-    const fullPath = path.resolve(WORKSPACE, filePath);
-    const mime = BINARY_FILE_TYPES[path.extname(fullPath).toLowerCase()];
-    if (mime && isInsideWorkspace(fullPath) && fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
-      res.writeHead(200, {
-        'Content-Type': mime,
-        'X-Content-Type-Options': 'nosniff',
-        'Content-Disposition': 'inline',
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-      });
-      res.end(fs.readFileSync(fullPath));
-    } else {
-      res.writeHead(404);
-      res.end('File not found');
-    }
-  // Review-sidecar writes: the WS save_file path expects existing parent
-  // directories; sidecars live under .rundock/reviews/ which is created on
-  // first use. Constrained to exactly that directory, flat filenames only.
-  } else if (req.method === 'POST' && req.url === '/api/review-sidecar') {
-    let body = '';
-    let tooBig = false;
-    // Cap the accumulated body: an unbounded string is a memory/disk DoS
-    // primitive. Review sidecars are small; 4 MB is generous headroom.
-    const SIDECAR_MAX_BYTES = 4 * 1024 * 1024;
-    req.on('data', chunk => {
-      if (tooBig) return;
-      body += chunk;
-      if (body.length > SIDECAR_MAX_BYTES) {
-        tooBig = true;
-        body = ''; // release; stop accumulating (remaining chunks are ignored)
-        res.writeHead(413, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Sidecar too large' }));
-      }
-    });
-    req.on('end', () => {
-      if (tooBig) return;
-      try {
-        const data = JSON.parse(body);
-        const relPath = String(data.path || '');
-        if (!/^\.rundock\/reviews\/[\w.-]+\.json$/.test(relPath) || typeof data.content !== 'string') {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid sidecar request' }));
-          return;
-        }
-        const fullPath = path.resolve(WORKSPACE, relPath);
-        if (!isInsideWorkspace(fullPath)) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'Invalid path' }));
-          return;
-        }
-        fs.mkdirSync(path.dirname(fullPath), { recursive: true });
-        fs.writeFileSync(fullPath, data.content, 'utf-8');
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ saved: true }));
-      } catch (e) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Invalid request' }));
-      }
-    });
-
-  } else if (req.url.startsWith('/api/file?path=')) {
-    // Guard decodeURIComponent: a malformed escape (lone '%') throws a
-    // URIError that would otherwise crash the process (no top-level handler).
-    let filePath;
-    try { filePath = decodeURIComponent(req.url.split('path=')[1]); }
-    catch { res.writeHead(400); res.end('Bad request'); return; }
-    const fullPath = path.resolve(WORKSPACE, filePath);
-    if (isInsideWorkspace(fullPath) && fs.existsSync(fullPath)) {
-      res.writeHead(200, { 'Content-Type': 'text/plain' });
-      res.end(fs.readFileSync(fullPath, 'utf-8'));
-    } else {
-      res.writeHead(404);
-      res.end('File not found');
-    }
-
-  // Permission hook endpoint: receives tool requests from the PreToolUse hook script,
-  // forwards them to the browser as permission cards, and holds the connection open
-  // until the user clicks Allow or Deny (or the 120s timeout fires).
-  } else if (req.method === 'POST' && req.url === '/api/permission-request') {
-    let body = '';
-    req.on('data', chunk => { body += chunk; });
-    req.on('end', () => {
-      try {
-        const data = JSON.parse(body);
-        const requestId = 'perm-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
-        // Attribute the request to its conversation. Prefer the hook-supplied
-        // id; if empty, resolve from the session's running process so an id-less
-        // request is never misattributed to whatever conversation is on screen
-        // (L10). Log the genuinely-unattributable case so it is observable.
-        const convoId = resolvePermissionConvoId(data.conversation_id, data.session_id, chatProcesses);
-        if (!convoId) {
-          console.warn(`[Permission] Unattributed request (conversation_id empty, session=${data.session_id || 'none'} unmatched): ${data.tool_name} requestId=${requestId}`);
-        }
-
-        // Workspace boundary: a standing folder grant answers without a card,
-        // which also keeps granted folders working when no browser is open.
-        if (data.boundary && data.resolved_path && boundaryGrantCovers(data.resolved_path)) {
-          console.log(`[Permission] Standing folder grant covers ${data.resolved_path}: allowed without a card`);
-          recordEvent('permission', { conv: convoId || undefined, d: { tool: data.tool_name, decision: 'allow' } });
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ allow: true, reason: 'standing-folder-grant' }));
-          return;
-        }
-
-        // Store the pending HTTP response (resolved when user decides)
-        pendingPermissionRequests.set(requestId, {
-          res,
-          conversationId: convoId,
-          toolName: data.tool_name,
-          toolInput: data.tool_input,
-          boundary: !!data.boundary,
-          resolvedPath: data.resolved_path || null,
-          grantDir: data.grant_dir || null,
-          timer: setTimeout(() => {
-            const pending = pendingPermissionRequests.get(requestId);
-            if (pending) {
-              pendingPermissionRequests.delete(requestId);
-              console.log(`[Permission] Auto-denied (timeout): ${data.tool_name} convo=${convoId} requestId=${requestId}`);
-              recordEvent('permission', { conv: convoId, d: { tool: data.tool_name, decision: 'timeout' } });
-              // Send denied indicator to browser
-              safeSend(JSON.stringify({
-                type: 'permission_timeout',
-                requestId,
-                _conversationId: convoId
-              }));
-              res.writeHead(200, { 'Content-Type': 'application/json' });
-              res.end(JSON.stringify({ allow: false, reason: 'timeout' }));
-            }
-          }, PERMISSION_TIMEOUT_MS)
-        });
-
-        // Forward to browser as a control_request (existing permission card UI handles this)
-        safeSend(JSON.stringify({
-          type: 'control_request',
-          request_id: requestId,
-          request: {
-            subtype: 'can_use_tool',
-            tool_name: data.tool_name,
-            input: data.tool_input || {},
-            ...(data.boundary ? { boundary: true, resolved_path: data.resolved_path, grant_dir: data.grant_dir } : {})
-          },
-          _conversationId: convoId
-        }));
-
-        console.log(`[Permission] Hook request: ${data.tool_name} convo=${convoId} requestId=${requestId}`);
-      } catch (e) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Invalid request' }));
-      }
-    });
-
-  } else if (/^\/[\w-]+\.m?js$/.test(req.url)) {
-    // Top-level client modules under public/ (code-language.js, markers.js,
-    // and future extracted modules). The pattern allows no slashes and no
-    // dots outside the extension, so traversal cannot be expressed; the
-    // realpath prefix check guards anything that somehow gets past it.
-    // Regression note: code-language.js shipped in 0.10.0 with a script tag
-    // but no route, so browsers 404ed it and a defensive fallback in app.js
-    // silently masked the loss. The index-html-to-route test pins every
-    // script tag to a live route now.
-    const publicRoot = path.resolve(__dirname, 'public');
-    const filePath = path.resolve(publicRoot, req.url.slice(1));
-    if (filePath.startsWith(publicRoot + path.sep) && fs.existsSync(filePath)) {
-      res.writeHead(200, { 'Content-Type': 'application/javascript', 'Cache-Control': 'no-cache, no-store, must-revalidate' });
-      res.end(fs.readFileSync(filePath));
-    } else {
-      res.writeHead(404);
-      res.end('Not found');
-    }
-  } else if (/^\/(editor|vendor|viewers)\/[\w./-]+\.(m?js|css)$/.test(req.url)) {
-    // Static JS/MJS/CSS files for the Tiptap editor module, its vendor bundle,
-    // vendored assets (e.g. highlight.js), and the file-type registry. Path is
-    // constrained to /editor/..., /vendor/... and /viewers/... under public/,
-    // with only .js/.mjs/.css extensions and only
-    // word chars + dot/slash/hyphen in the path. The realpath check below blocks
-    // any directory traversal that somehow gets past the regex.
-    const publicRoot = path.resolve(__dirname, 'public');
-    const filePath = path.resolve(publicRoot, req.url.slice(1));
-    if (filePath.startsWith(publicRoot + path.sep) && fs.existsSync(filePath)) {
-      const contentType = filePath.endsWith('.css') ? 'text/css' : 'application/javascript';
-      res.writeHead(200, { 'Content-Type': contentType, 'Cache-Control': 'no-cache, no-store, must-revalidate' });
-      res.end(fs.readFileSync(filePath));
-    } else {
-      res.writeHead(404);
-      res.end('Not found');
-    }
-  } else {
-    res.writeHead(404);
-    res.end('Not found');
-  }
-});
+const server = http.createServer(httpRouter.handleHttpRequest);
 
 // ===== WEBSOCKET SERVER =====
 
@@ -3960,14 +3751,7 @@ const VIEWABLE_FILE_RE = /\.(md|txt|json|html?|svg|png|jpe?g|gif|webp|pdf)$/i;
 // The /workspace-file allowlist: binary types only. Everything else either
 // rides the WS text path or is not served at all; this endpoint must never
 // become a generic file server for the workspace.
-const BINARY_FILE_TYPES = {
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-  '.pdf': 'application/pdf',
-};
+// BINARY_FILE_TYPES (the viewer mime allowlist) lives in lib/http-router.js.
 
 // Classify a file for its tree icon: a .md whose frontmatter carries the
 // kanban-plugin key is a board, other .md are notes, and the rest by extension.

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -83,7 +83,14 @@ const AREA_DEFS = [
   ['lib/store/persistence.js', 'Conversation / state persistence', /^function rundockDir\(/, /^module\.exports/],
   ['lib/signals.js', 'Signal layer (events, retention, skill usage, docs-gap)', /^const EVENTS_RETENTION_MONTHS/, /^module\.exports/],
   ['server.js', 'Transcript composition (root remainder)', /^function appendTranscript\(/, /^function safeSend\(/],
-  ['server.js', 'HTTP request router (incl. permission bridge)', /^const server = http\.createServer/, /^\/\/ Transcript primitives \(convoTranscripts cache/],
+  // Slice 7 migration: the request router moved to lib/http-router.js and
+  // keeps its floor under the same label (the area also gains the
+  // BINARY_FILE_TYPES map, whose single user is the router's binary
+  // transport). The root remainder area covers what deliberately stayed:
+  // the HTTP server itself, the WebSocket server bootstrap, and the
+  // connection state that lived below the router.
+  ['lib/http-router.js', 'HTTP request router (incl. permission bridge)', /^const unwired/, /^module\.exports/],
+  ['server.js', 'HTTP server + WS bootstrap (root remainder)', /^const server = http\.createServer/, /^function appendTranscript\(/],
   ['server.js', 'WebSocket message handlers', /^wss\.on\('connection'/, /^function discoverSkills\(/],
   // Slice 5 migration: the Codex glue (app-server lifecycle, turns,
   // delegate wiring) moved to lib/runtime/codex-glue.js. The root
@@ -105,6 +112,7 @@ const OVERALL_FILES = [
   'lib/agents/discovery.js', 'lib/agents/prompt.js',
   'lib/workspace/boundary.js', 'lib/workspace/analysis.js', 'lib/workspace/scaffold.js',
   'lib/signals.js', 'lib/runtime/codex-glue.js', 'lib/scheduler.js',
+  'lib/http-router.js',
 ];
 
 // ---------------------------------------------------------------------------

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -41,6 +41,8 @@
     "Spawn plumbing (spawnClaude, resolveClaudeBin, errors)": 98.1,
     "Runtime status + server permission bridge (root remainder)": 100,
     "Codex glue (app-server lifecycle, turns, delegate wiring)": 96,
-    "OVERALL lib/scheduler.js": 100.0
+    "OVERALL lib/scheduler.js": 100.0,
+    "OVERALL lib/http-router.js": 98.5,
+    "HTTP server + WS bootstrap (root remainder)": 97.9
   }
 }

--- a/test/unit/http-router-lib.test.js
+++ b/test/unit/http-router-lib.test.js
@@ -1,0 +1,92 @@
+'use strict';
+// Seam tests for lib/http-router.js. The routes' behaviour is pinned by the
+// HTTP integration suite driving the wired module through a booted server;
+// these tests pin the SEAMS themselves: unwired root deps refuse loudly,
+// the wiring is restorable, ROOT_DIR reaches the real public/ assets from
+// lib/ (the packaged-app path base), and file reads resolve the workspace
+// at USE time so a switch redirects the very next request.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROUTER_KEY = require.resolve('../../lib/http-router.js');
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+// A private copy per test: wiring one test's fakes must never leak into
+// another test (or into the shared instance other requires would see).
+function freshRouter() {
+  const cached = require.cache[ROUTER_KEY];
+  delete require.cache[ROUTER_KEY];
+  const mod = require(ROUTER_KEY);
+  delete require.cache[ROUTER_KEY];
+  if (cached) require.cache[ROUTER_KEY] = cached;
+  return mod;
+}
+
+function fakeRes() {
+  const calls = { writeHead: [], end: [] };
+  return {
+    calls,
+    writeHead(code, headers) { calls.writeHead.push([code, headers]); },
+    end(payload) { calls.end.push(payload); },
+  };
+}
+
+test('unwired root deps throw the named wiring error at first use', () => {
+  const router = freshRouter();
+  assert.throws(
+    () => router.handleHttpRequest({ url: '/api/files', method: 'GET' }, fakeRes()),
+    /lib\/http-router: getFileTreeCached not wired \(call wireHttpRouterDeps at boot\)/,
+  );
+});
+
+test('wireHttpRouterDeps returns the previous set, restorable by identity', () => {
+  const router = freshRouter();
+  const prev = router.wireHttpRouterDeps({ getFileTreeCached: () => [] });
+  assert.strictEqual(typeof prev.getFileTreeCached, 'function');
+  router.wireHttpRouterDeps(prev);
+  assert.throws(
+    () => router.handleHttpRequest({ url: '/api/files', method: 'GET' }, fakeRes()),
+    /getFileTreeCached not wired/,
+  );
+});
+
+test('ROOT_DIR reaches the repo public/ assets from lib/ with no deps involved', () => {
+  const router = freshRouter();
+  const res = fakeRes();
+  router.handleHttpRequest({ url: '/favicon.svg', method: 'GET' }, res);
+  assert.strictEqual(res.calls.writeHead[0][0], 200);
+  assert.strictEqual(res.calls.writeHead[0][1]['Content-Type'], 'image/svg+xml');
+  assert.deepStrictEqual(res.calls.end[0], fs.readFileSync(path.join(REPO_ROOT, 'public', 'favicon.svg')),
+    'the bytes are the real public/favicon.svg, one hop up from lib/');
+});
+
+test('file reads resolve the workspace at USE time: a switch redirects the next request', () => {
+  const router = freshRouter();
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const wsA = fs.mkdtempSync(path.join(os.tmpdir(), 'router-ws-a-'));
+  const wsB = fs.mkdtempSync(path.join(os.tmpdir(), 'router-ws-b-'));
+  try {
+    fs.writeFileSync(path.join(wsA, 'note.md'), 'Body from workspace A.');
+    fs.writeFileSync(path.join(wsB, 'note.md'), 'Body from workspace B.');
+    router.wireHttpRouterDeps({ isInsideWorkspace: () => true });
+
+    config.setWorkspace(wsA);
+    const resA = fakeRes();
+    router.handleHttpRequest({ url: '/api/file?path=note.md', method: 'GET' }, resA);
+    assert.strictEqual(resA.calls.end[0], 'Body from workspace A.');
+
+    config.setWorkspace(wsB);
+    const resB = fakeRes();
+    router.handleHttpRequest({ url: '/api/file?path=note.md', method: 'GET' }, resB);
+    assert.strictEqual(resB.calls.end[0], 'Body from workspace B.',
+      'the read followed the switch with no re-wiring');
+  } finally {
+    config.setWorkspace(original);
+    fs.rmSync(wsA, { recursive: true, force: true });
+    fs.rmSync(wsB, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Extracts the HTTP request router from `server.js` to `lib/http-router.js` (273 lines): the page and static-asset routes, the JSON API, the binary file transport for the viewer registry, the review-sidecar write endpoint, and the permission hook bridge (`/api/permission-request` long-poll). `server.js` drops to 5,188 lines.

Three commits, each green: verbatim move, seam tests, instrument migration.

## Design

- **The root keeps the server itself.** `http.createServer(handler)`, the WebSocket server bootstrap, and the connection state that lived below the router (`chatProcesses`, the auto-resume circuit breaker, `connectedClients`, `disconnectBuffer`) stay where they were. The router exports a named handler; the root wires it in one line.
- **Workspace read at USE time.** The three workspace-relative resolves go through `getWorkspace()`, so a switch redirects the very next request (pinned in the seam tests).
- **`ROOT_DIR` hops one level up from `lib/`** to the repo (or app.asar) root for the `public/` and `node_modules/` reads — the same base the code always read via `__dirname` in the root, byte-compared in the seam tests.
- **Named DI with throwing unwired defaults** for what stays root-owned: `isInsideWorkspace` (shared with many WS handlers), `getFileTreeCached` (root cache), `safeSend`, the `chatProcesses` and `pendingPermissionRequests` maps as identity accessors, and the permission timeout as a getter. Direct lib requires, no wiring: `discoverAgents`, `boundaryGrantCovers`, `recordEvent`, `resolvePermissionConvoId`.
- **`BINARY_FILE_TYPES` moves with the router** — its single user is the binary file transport route.

## Zero test retargets

The HTTP behaviour pins drive a booted server and keep exercising the moved code through the wired module. The one source scan that names a folder-picker handler anchors on WebSocket-handler text that has not moved. Every count-asserted conversion is enumerated in the move commit.

## Seams pinned (new `test/unit/http-router-lib.test.js`)

- Unwired root deps throw the named wiring error at first use.
- `wireHttpRouterDeps` returns the previous set, restorable by identity.
- `ROOT_DIR` reaches the real `public/` assets from `lib/` (byte-compared favicon, no deps involved).
- File reads resolve the workspace at use time across a two-workspace switch.

## Instrument migration

- The router area keeps its label and its 98 floor (measuring 98.4, now also containing `BINARY_FILE_TYPES` and the wiring seam).
- A new root remainder area covers what deliberately stayed (97.9, floored at measurement).
- `OVERALL lib/http-router.js` enters at 98.5. Both new floors verified under CPU load.

## Floor honesty note

`server.js` overall measures 96.5 against its 96.6 floor: absolute coverage improved (184 uncovered lines, was 188 — the router's four uncovered guards left the file); the remaining dip is denominator arithmetic within tolerance. 41 floors hold quiet and loaded.

## Numbers

- `server.js`: 5,404 → 5,188 lines; `lib/http-router.js`: 273 lines
- Suite: 1,466 (was 1,462); e2e: 103/103
- Floors: 41, all holding quiet and under CPU load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
