### PR TITLE
Extract spawn plumbing to lib/runtime/claude.js

### DIFF
--- a/lib/runtime/claude.js
+++ b/lib/runtime/claude.js
@@ -1,0 +1,295 @@
+'use strict';
+// Spawn plumbing for the Claude runtime: per-spawn args and env (modelArgs,
+// getBareArgs, getSpawnEnv), the child-pid registry (pid file + recycling
+// guard), Claude binary resolution, process-tree kill, and spawnClaude
+// itself. Extracted verbatim from server.js.
+//
+// The child-pid registry lives HERE, with spawnClaude, because spawnClaude
+// is its writer (register on spawn, unregister on close). The root's cleanup
+// machinery (killAllChildren, cleanOrphanedProcesses, the workspace-move
+// clear) reads and prunes the same file by calling in: root -> lib.
+//
+// The workspace root is read at USE time via lib/config.js getWorkspace(),
+// so a workspace switch redirects args, env, and the pid file location on
+// the very next call. Only the listening port is wired in from the
+// composition root: it exists only after server.listen() runs.
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+const { getWorkspace, DEFAULT_MODEL } = require('../config.js');
+const { rundockDir, readState } = require('../store/persistence.js');
+const codexRuntime = require('../../codex.js');
+
+// Root-owned dependencies, named and wired at boot. Unwired deps throw so a
+// missed wiring fails loudly at first use, never silently.
+const unwired = (name) => () => { throw new Error(`lib/runtime/claude: ${name} not wired (call wireClaudeRuntimeDeps at boot)`); };
+const deps = {
+  getActualPort: unwired('getActualPort'),
+};
+function wireClaudeRuntimeDeps(next) {
+  const prev = { ...deps };
+  Object.assign(deps, next);
+  return prev;
+}
+
+// Default model for any agent that does not declare one in its frontmatter, and
+// for the synthesised orchestrator and Doc. Sonnet is the balanced choice and is
+// available on every paid plan; complex agents opt up to a stronger model via `model: opus`
+// in their frontmatter, quick agents opt down to `model: haiku`. Always passing
+// an explicit --model (see modelArgs + spawnClaude) keeps model selection
+// predictable instead of inheriting whatever Claude Code resolves from the user's
+// environment (e.g. a Pro subscription resolving the invalid model name "pro").
+// The value itself lives in lib/config.js so lib/agents/discovery.js resolves
+// the same default without reaching back into the root.
+function modelArgs(agent) {
+  return ['--model', (agent && agent.model) || DEFAULT_MODEL];
+}
+
+// Returns startup args that configure workspace context without using --bare.
+// Previously used --bare for faster startup, but --bare skips keychain/OAuth reads
+// which causes "Not logged in" errors for users who authenticate via `claude login`.
+// We now pass context flags explicitly without --bare so auth works normally.
+function getBareArgs() {
+  if (!getWorkspace()) return [];
+  const args = [];
+  // Ensure CLAUDE.md discovery for the workspace
+  args.push('--add-dir', getWorkspace());
+  // Load hooks (permission system) from settings.local.json
+  const settingsPath = path.join(getWorkspace(), '.claude', 'settings.local.json');
+  if (fs.existsSync(settingsPath)) {
+    args.push('--settings', settingsPath);
+  }
+  // Load MCP server access from .mcp.json
+  const mcpPath = path.join(getWorkspace(), '.mcp.json');
+  if (fs.existsSync(mcpPath)) {
+    args.push('--mcp-config', mcpPath);
+  }
+  return args;
+}
+
+// Returns spawn env with workspace mode flag for the permission hook.
+function getSpawnEnv(convoId) {
+  const env = { ...process.env, TERM: 'dumb', RUNDOCK: '1', RUNDOCK_PORT: String(deps.getActualPort()), RUNDOCK_WORKSPACE: getWorkspace() || '' };
+  if (convoId) env.RUNDOCK_CONVO_ID = convoId;
+  // Never let spawned agent processes inherit the test runner's coverage
+  // collection: a child killed mid-turn (e.g. a superseded Codex exec)
+  // leaves truncated coverage JSON that corrupts the runner's merge and
+  // intermittently fails npm run test:coverage.
+  delete env.NODE_V8_COVERAGE;
+  // In the packaged app there is no system `node`, so the PreToolUse permission
+  // hook is run with Rundock's bundled runtime (process.execPath) behaving as
+  // Node via ELECTRON_RUN_AS_NODE. The hook is a child of the spawned claude
+  // process and inherits this env. Without it, on a machine with no Node the
+  // hook can't run at all and the permission system silently does nothing.
+  if (process.env.RUNDOCK_ELECTRON) env.ELECTRON_RUN_AS_NODE = '1';
+  try {
+    const state = readState();
+    if (state.workspaceMode === 'code') env.RUNDOCK_CODE_MODE = '1';
+  } catch (e) { /* default knowledge mode */ }
+  return env;
+}
+
+// PID file: track all spawned Claude Code process PIDs so orphans can be cleaned up
+// on restart if the parent crashes without running exit handlers.
+function pidFilePath() {
+  if (!getWorkspace()) return null;
+  return path.join(rundockDir(), 'child-pids.json');
+}
+
+function loadPidFile() {
+  const p = pidFilePath();
+  if (!p) return [];
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch (e) { return []; }
+}
+
+function savePidFile(pids) {
+  const p = pidFilePath();
+  if (!p) return;
+  try {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(pids));
+  } catch (e) {}
+}
+
+// Pid records carry the command they were spawned as, so a pid the OS has
+// since recycled onto an unrelated process is not signalled. The file used to
+// hold bare integers with no way to tell the difference; those are still read
+// for one upgrade, and simply lack the recycling guard.
+function pidOf(rec) { return typeof rec === 'number' ? rec : (rec && rec.pid); }
+
+// Read a process's command line.
+//
+// Deliberately `args=` and not `comm=`. On Linux `comm` is the THREAD name from
+// /proc, not the executable: Node 24 renames its main thread to "MainThread",
+// so every record would have been judged foreign and discarded, defeating the
+// tracking this guard exists to protect. Node 22 on the same machine reports
+// "node". The command line is stable across both, and across macOS, where
+// `comm` gives a full path instead.
+function processCommand(pid) {
+  if (process.platform === 'win32') return null; // no cheap equivalent; skip the check
+  try {
+    const { execFileSync } = require('child_process');
+    return execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
+      encoding: 'utf-8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch (e) { return null; } // not running, or ps unavailable
+}
+
+/** Running AND still the process we spawned, rather than a recycled pid. */
+function pidRecordAlive(rec) {
+  const pid = pidOf(rec);
+  if (!pid) return false;
+  try { process.kill(pid, 0); } catch (e) { return false; }
+  const expected = typeof rec === 'object' && rec ? rec.cmd : null;
+  if (!expected) return true; // legacy record, or a platform without the check
+  const actual = processCommand(pid);
+  if (actual == null) return true; // cannot tell; assume ours rather than leak it
+  return commandsMatch(actual, expected);
+}
+
+// Does this command line still look like the thing we spawned?
+//
+// Deliberately loose: the guard only has to tell "the process we started" from
+// "something unrelated that inherited this id". Command-line formatting varies
+// by platform and by runtime version, and a strict comparison has already
+// broken once that way. Being too permissive means a redundant signal to a
+// process that is probably ours; being too strict means untracked processes
+// leaking forever, which is the failure this whole area exists to prevent.
+function commandsMatch(actual, expected) {
+  const e = path.basename(String(expected || '').trim());
+  const a = String(actual || '').trim();
+  if (!e || !a) return true;
+  return a.includes(e);
+}
+
+function registerChildPid(pid, cmd) {
+  const records = loadPidFile();
+  if (records.some(r => pidOf(r) === pid)) return;
+  records.push({ pid, at: Date.now(), cmd: cmd ? path.basename(cmd) : null });
+  savePidFile(records);
+}
+
+function unregisterChildPid(pid) {
+  savePidFile(loadPidFile().filter(r => pidOf(r) !== pid));
+}
+
+// Resolve the Claude binary path lazily and cache it. Independent of
+// Electron's findClaude so Path B users (running `node server.js` directly
+// without Electron) get correct .cmd resolution on Windows too. On lookup
+// failure, returns the literal 'claude' so spawn's 'error' event surfaces the
+// real ENOENT rather than masking it. The absolute path lets Node execute
+// .cmd files on Windows without `shell: true`, which would expose args
+// (containing user and system prompts) to command-injection risk.
+let _resolvedClaudeBin = null;
+function resolveClaudeBin() {
+  if (_resolvedClaudeBin) return _resolvedClaudeBin;
+  const isWindows = process.platform === 'win32';
+  try {
+    const { execSync } = require('child_process');
+    const lookupCmd = isWindows ? 'where.exe claude' : 'which claude';
+    // PROBE_STDIO closes stdin: on Windows a version/which probe against an
+    // open piped stdin can hang for its full timeout (verified live for
+    // codex, Findings 4/5); the claude probes take the same precaution.
+    const output = execSync(lookupCmd, { timeout: 5000, encoding: 'utf-8', stdio: codexRuntime.PROBE_STDIO }).trim();
+    if (!output) return (_resolvedClaudeBin = 'claude');
+    if (isWindows) {
+      const candidates = output.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      const exe = candidates.find(c => c.toLowerCase().endsWith('.exe'));
+      const cmd = candidates.find(c => c.toLowerCase().endsWith('.cmd'));
+      _resolvedClaudeBin = exe || cmd || candidates[0] || 'claude';
+    } else {
+      _resolvedClaudeBin = output;
+    }
+    return _resolvedClaudeBin;
+  } catch {
+    return (_resolvedClaudeBin = 'claude');
+  }
+}
+
+// Spawn a Claude Code process with PID tracking for crash cleanup.
+// Drop-in replacement for spawn('claude', ...) that registers/unregisters PIDs.
+// Signal a spawned process AND everything it started.
+//
+// An agent CLI spawns its own children: an MCP server per configured entry,
+// plus tool subprocesses. Those are grandchildren we hold no handle on and
+// never record, so signalling one pid leaves them running and reparented,
+// holding memory until the machine restarts.
+//
+// On POSIX the children are spawned detached, which puts each in its own
+// process group whose id equals the leader's pid, so a negative pid signals
+// the whole group. Windows has no process groups; taskkill /T walks the tree
+// instead. Windows also has no real signal semantics (Node maps kill() onto
+// TerminateProcess), so the graceful and forceful paths are the same there.
+function killProcessTree(target, signal = 'SIGTERM') {
+  const pid = typeof target === 'number' ? target : (target && target.pid);
+  if (!pid) return;
+  // Floor: kill at least the process itself, so no path here can end up doing
+  // less than the single-pid kill this replaced.
+  const killJustThis = () => {
+    try {
+      if (typeof target === 'number') process.kill(pid, signal);
+      else target.kill(signal);
+    } catch (e) { /* already dead */ }
+  };
+
+  if (process.platform === 'win32') {
+    // Windows has no process groups; taskkill walks the tree instead. It is
+    // spawned rather than awaited, so a missing binary arrives as an error
+    // EVENT and never reaches a try/catch: without the listener below a
+    // failure would kill nothing at all, which is worse than what this
+    // replaced. Order matters, since killing the parent first would orphan
+    // the children out of taskkill's reach.
+    let killer = null;
+    try {
+      killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
+      killer.on('error', killJustThis);
+    } catch (e) {
+      killJustThis();
+    }
+    return;
+  }
+
+  // Negative pid = the whole process group. Fails with ESRCH if the group is
+  // already gone, or EPERM if the child was never detached; fall back to the
+  // single process so this is never worse than the old behaviour.
+  try { process.kill(-pid, signal); return; } catch (e) {}
+  killJustThis();
+}
+
+function spawnClaude(args, options, onError) {
+  // Safety net: never spawn Claude Code without an explicit --model. Call sites
+  // pass the agent's model (see modelArgs); this guards any path that doesn't,
+  // so the model can never silently fall back to the user's environment.
+  if (!args.includes('--model')) args = ['--model', DEFAULT_MODEL, ...args];
+  // detached puts the child at the head of its own process group so its whole
+  // subtree can be signalled together. Safe for terminal users: the server
+  // installs its own SIGINT and SIGTERM handlers and kills children explicitly,
+  // so Ctrl-C never depended on the terminal reaching them by group.
+  const proc = spawn(resolveClaudeBin(), args, { ...options, detached: process.platform !== 'win32' });
+  if (proc.pid) {
+    registerChildPid(proc.pid, resolveClaudeBin());
+    proc.on('close', () => unregisterChildPid(proc.pid));
+  }
+  // Always attach a baseline 'error' listener so an unhandled error event
+  // cannot propagate out of the WebSocket message handler and tear down the
+  // connection. Caller-provided onError does the user-facing surfacing; this
+  // wrapper guarantees the listener exists and that the callback runs inside
+  // try/catch.
+  proc.on('error', (err) => {
+    try {
+      console.error(`[spawnClaude] spawn error code=${err.code || ''} msg=${err.message}`);
+      if (typeof onError === 'function') onError(err);
+    } catch (e) {
+      console.error('[spawnClaude] onError handler threw:', e);
+    }
+  });
+  return proc;
+}
+
+module.exports = {
+  wireClaudeRuntimeDeps,
+  modelArgs, getBareArgs, getSpawnEnv,
+  pidFilePath, loadPidFile, savePidFile, pidOf, processCommand, pidRecordAlive,
+  registerChildPid, unregisterChildPid,
+  resolveClaudeBin, killProcessTree, spawnClaude,
+};

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -13,10 +13,11 @@
 // for routine cwd), so a workspace switch immediately redirects where
 // state persists and where routines run.
 //
-// Root-owned capabilities arrive through wireSchedulerDeps: the Claude
-// spawn plumbing (spawnClaude/getBareArgs/modelArgs/getSpawnEnv) until its
-// own extraction, and the WebSocket client set as an accessor (the wss is
-// created later at boot). Unwired deps throw at first use.
+// The spawn plumbing (spawnClaude/getBareArgs/modelArgs/getSpawnEnv) is a
+// direct lib require since its own extraction. The one root-owned
+// capability left arrives through wireSchedulerDeps: the WebSocket client
+// set as an accessor (the wss is created later at boot). Unwired deps
+// throw at first use.
 const fs = require('fs');
 const path = require('path');
 const { getWorkspace } = require('./config.js');
@@ -25,15 +26,12 @@ const { recordEvent } = require('./signals.js');
 const { buildSystemPrompt } = require('./agents/prompt.js');
 const { getCodexAppServer, waitForCodexReady, readAgentInstructions } = require('./runtime/codex-glue.js');
 const { discoverAgents } = require('./agents/discovery.js');
+const { spawnClaude, getBareArgs, modelArgs, getSpawnEnv } = require('./runtime/claude.js');
 
 const unwired = (name) => () => {
   throw new Error(`lib/scheduler: ${name} not wired (call wireSchedulerDeps at boot)`);
 };
 const deps = {
-  spawnClaude: unwired('spawnClaude'),
-  getBareArgs: unwired('getBareArgs'),
-  modelArgs: unwired('modelArgs'),
-  getSpawnEnv: unwired('getSpawnEnv'),
   getWssClients: unwired('getWssClients'),  // () => wss.clients (created at boot)
 };
 function wireSchedulerDeps(next) {
@@ -210,13 +208,13 @@ function executeRoutine(agent, routine, key) {
   }
 
   // Routines run unattended (no user to approve), so bypass permissions.
-  const args = [...deps.getBareArgs(), ...deps.modelArgs(agent), '--print', '--output-format', 'stream-json', '--verbose', '--dangerously-skip-permissions'];
+  const args = [...getBareArgs(), ...modelArgs(agent), '--print', '--output-format', 'stream-json', '--verbose', '--dangerously-skip-permissions'];
   if (agent.id !== 'default') args.push('--agent', agent.id);
   args.push(routine.prompt);
 
-  const proc = deps.spawnClaude(args, {
+  const proc = spawnClaude(args, {
     cwd: getWorkspace(),
-    env: deps.getSpawnEnv(null),
+    env: getSpawnEnv(null),
     stdio: ['ignore', 'pipe', 'pipe']
   });
 

--- a/server.js
+++ b/server.js
@@ -100,19 +100,10 @@ const DISALLOWED_TOOLS = DISALLOWED_TOOLS_KNOWLEDGE;
 const ALLOWED_TOOLS_INTERACTIVE_BASE = 'Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,ToolSearch,Agent,Skill';
 const ALLOWED_TOOLS_LEGACY_BASE = 'Bash,WebFetch,WebSearch';
 
-// Default model for any agent that does not declare one in its frontmatter, and
-// for the synthesised orchestrator and Doc. Sonnet is the balanced choice and is
-// available on every paid plan; complex agents opt up to a stronger model via `model: opus`
-// in their frontmatter, quick agents opt down to `model: haiku`. Always passing
-// an explicit --model (see modelArgs + spawnClaude) keeps model selection
-// predictable instead of inheriting whatever Claude Code resolves from the user's
-// environment (e.g. a Pro subscription resolving the invalid model name "pro").
-// The value itself lives in lib/config.js so lib/agents/discovery.js resolves
-// the same default without reaching back into the root.
+// DEFAULT_MODEL lives in lib/config.js (shared with lib/agents and
+// lib/runtime/claude.js, where modelArgs and spawnClaude apply it); the
+// root re-reads it only for the _internal export.
 const { DEFAULT_MODEL } = config;
-function modelArgs(agent) {
-  return ['--model', (agent && agent.model) || DEFAULT_MODEL];
-}
 
 // readMcpServerNames lives in lib/workspace/analysis.js (used only by the
 // workspace analysis).
@@ -143,50 +134,8 @@ function getPermissionMode() {
   return 'acceptEdits';
 }
 
-// Returns startup args that configure workspace context without using --bare.
-// Previously used --bare for faster startup, but --bare skips keychain/OAuth reads
-// which causes "Not logged in" errors for users who authenticate via `claude login`.
-// We now pass context flags explicitly without --bare so auth works normally.
-function getBareArgs() {
-  if (!WORKSPACE) return [];
-  const args = [];
-  // Ensure CLAUDE.md discovery for the workspace
-  args.push('--add-dir', WORKSPACE);
-  // Load hooks (permission system) from settings.local.json
-  const settingsPath = path.join(WORKSPACE, '.claude', 'settings.local.json');
-  if (fs.existsSync(settingsPath)) {
-    args.push('--settings', settingsPath);
-  }
-  // Load MCP server access from .mcp.json
-  const mcpPath = path.join(WORKSPACE, '.mcp.json');
-  if (fs.existsSync(mcpPath)) {
-    args.push('--mcp-config', mcpPath);
-  }
-  return args;
-}
-
-// Returns spawn env with workspace mode flag for the permission hook.
-function getSpawnEnv(convoId) {
-  const env = { ...process.env, TERM: 'dumb', RUNDOCK: '1', RUNDOCK_PORT: String(ACTUAL_PORT), RUNDOCK_WORKSPACE: WORKSPACE || '' };
-  if (convoId) env.RUNDOCK_CONVO_ID = convoId;
-  // Never let spawned agent processes inherit the test runner's coverage
-  // collection: a child killed mid-turn (e.g. a superseded Codex exec)
-  // leaves truncated coverage JSON that corrupts the runner's merge and
-  // intermittently fails npm run test:coverage.
-  delete env.NODE_V8_COVERAGE;
-  // In the packaged app there is no system `node`, so the PreToolUse permission
-  // hook is run with Rundock's bundled runtime (process.execPath) behaving as
-  // Node via ELECTRON_RUN_AS_NODE. The hook is a child of the spawned claude
-  // process and inherits this env. Without it, on a machine with no Node the
-  // hook can't run at all and the permission system silently does nothing.
-  if (process.env.RUNDOCK_ELECTRON) env.ELECTRON_RUN_AS_NODE = '1';
-  try {
-    const state = readState();
-    if (state.workspaceMode === 'code') env.RUNDOCK_CODE_MODE = '1';
-  } catch (e) { /* default knowledge mode */ }
-  return env;
-}
-
+// getBareArgs and getSpawnEnv live in lib/runtime/claude.js (spawn
+// plumbing); the workspace root and listening port are read at use time.
 // Pending permission requests from PreToolUse hooks (keyed by requestId).
 // Each entry holds the HTTP response object so we can resolve it when the user decides.
 const pendingPermissionRequests = new Map();
@@ -503,6 +452,18 @@ const {
 agentsPrompt.wirePromptDeps({ discoverSkills, detectCodexCached });
 workspaceAnalysis.wireAnalysisDeps({ parseSkillFile });
 workspaceScaffold.wireScaffoldDeps({ invalidateAgentCache, rebaselineAgentsWatcher });
+// ===== SPAWN PLUMBING (lib/runtime/claude.js) =====
+// modelArgs/getBareArgs/getSpawnEnv, the child-pid registry, resolveClaudeBin,
+// killProcessTree, and spawnClaude. Only the listening port is wired in:
+// everything else the module needs is lib-owned or read at use time.
+const claudeRuntime = require('./lib/runtime/claude.js');
+const {
+  modelArgs, getBareArgs, getSpawnEnv,
+  resolveClaudeBin, killProcessTree, spawnClaude,
+  registerChildPid, unregisterChildPid,
+  loadPidFile, savePidFile, pidOf, pidRecordAlive, processCommand,
+} = claudeRuntime;
+claudeRuntime.wireClaudeRuntimeDeps({ getActualPort: () => ACTUAL_PORT });
 const codexGlue = require('./lib/runtime/codex-glue.js');
 const {
   shutdownCodexAppServer,
@@ -3894,89 +3855,9 @@ function getFileTreeCached() {
 
 // ===== PROCESS CLEANUP (S4) =====
 
-// PID file: track all spawned Claude Code process PIDs so orphans can be cleaned up
-// on restart if the parent crashes without running exit handlers.
-function pidFilePath() {
-  if (!WORKSPACE) return null;
-  return path.join(rundockDir(), 'child-pids.json');
-}
-
-function loadPidFile() {
-  const p = pidFilePath();
-  if (!p) return [];
-  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch (e) { return []; }
-}
-
-function savePidFile(pids) {
-  const p = pidFilePath();
-  if (!p) return;
-  try {
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.writeFileSync(p, JSON.stringify(pids));
-  } catch (e) {}
-}
-
-// Pid records carry the command they were spawned as, so a pid the OS has
-// since recycled onto an unrelated process is not signalled. The file used to
-// hold bare integers with no way to tell the difference; those are still read
-// for one upgrade, and simply lack the recycling guard.
-function pidOf(rec) { return typeof rec === 'number' ? rec : (rec && rec.pid); }
-
-// Read a process's command line.
-//
-// Deliberately `args=` and not `comm=`. On Linux `comm` is the THREAD name from
-// /proc, not the executable: Node 24 renames its main thread to "MainThread",
-// so every record would have been judged foreign and discarded, defeating the
-// tracking this guard exists to protect. Node 22 on the same machine reports
-// "node". The command line is stable across both, and across macOS, where
-// `comm` gives a full path instead.
-function processCommand(pid) {
-  if (process.platform === 'win32') return null; // no cheap equivalent; skip the check
-  try {
-    const { execFileSync } = require('child_process');
-    return execFileSync('ps', ['-p', String(pid), '-o', 'args='], {
-      encoding: 'utf-8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch (e) { return null; } // not running, or ps unavailable
-}
-
-/** Running AND still the process we spawned, rather than a recycled pid. */
-function pidRecordAlive(rec) {
-  const pid = pidOf(rec);
-  if (!pid) return false;
-  try { process.kill(pid, 0); } catch (e) { return false; }
-  const expected = typeof rec === 'object' && rec ? rec.cmd : null;
-  if (!expected) return true; // legacy record, or a platform without the check
-  const actual = processCommand(pid);
-  if (actual == null) return true; // cannot tell; assume ours rather than leak it
-  return commandsMatch(actual, expected);
-}
-
-// Does this command line still look like the thing we spawned?
-//
-// Deliberately loose: the guard only has to tell "the process we started" from
-// "something unrelated that inherited this id". Command-line formatting varies
-// by platform and by runtime version, and a strict comparison has already
-// broken once that way. Being too permissive means a redundant signal to a
-// process that is probably ours; being too strict means untracked processes
-// leaking forever, which is the failure this whole area exists to prevent.
-function commandsMatch(actual, expected) {
-  const e = path.basename(String(expected || '').trim());
-  const a = String(actual || '').trim();
-  if (!e || !a) return true;
-  return a.includes(e);
-}
-
-function registerChildPid(pid, cmd) {
-  const records = loadPidFile();
-  if (records.some(r => pidOf(r) === pid)) return;
-  records.push({ pid, at: Date.now(), cmd: cmd ? path.basename(cmd) : null });
-  savePidFile(records);
-}
-
-function unregisterChildPid(pid) {
-  savePidFile(loadPidFile().filter(r => pidOf(r) !== pid));
-}
+// The child-pid registry (pid file, recycling guard, register/unregister)
+// lives in lib/runtime/claude.js with spawnClaude, its writer. The cleanup
+// machinery below reads and prunes the same file through the lib module.
 
 // Stop whatever executes a conversation entry. Claude entries own a child
 // process and get the signal; Codex entries are process-less (their turns
@@ -4116,118 +3997,8 @@ function handleChatSpawnError(err, convoId) {
   }
 }
 
-// Resolve the Claude binary path lazily and cache it. Independent of
-// Electron's findClaude so Path B users (running `node server.js` directly
-// without Electron) get correct .cmd resolution on Windows too. On lookup
-// failure, returns the literal 'claude' so spawn's 'error' event surfaces the
-// real ENOENT rather than masking it. The absolute path lets Node execute
-// .cmd files on Windows without `shell: true`, which would expose args
-// (containing user and system prompts) to command-injection risk.
-let _resolvedClaudeBin = null;
-function resolveClaudeBin() {
-  if (_resolvedClaudeBin) return _resolvedClaudeBin;
-  const isWindows = process.platform === 'win32';
-  try {
-    const { execSync } = require('child_process');
-    const lookupCmd = isWindows ? 'where.exe claude' : 'which claude';
-    // PROBE_STDIO closes stdin: on Windows a version/which probe against an
-    // open piped stdin can hang for its full timeout (verified live for
-    // codex, Findings 4/5); the claude probes take the same precaution.
-    const output = execSync(lookupCmd, { timeout: 5000, encoding: 'utf-8', stdio: codexRuntime.PROBE_STDIO }).trim();
-    if (!output) return (_resolvedClaudeBin = 'claude');
-    if (isWindows) {
-      const candidates = output.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
-      const exe = candidates.find(c => c.toLowerCase().endsWith('.exe'));
-      const cmd = candidates.find(c => c.toLowerCase().endsWith('.cmd'));
-      _resolvedClaudeBin = exe || cmd || candidates[0] || 'claude';
-    } else {
-      _resolvedClaudeBin = output;
-    }
-    return _resolvedClaudeBin;
-  } catch {
-    return (_resolvedClaudeBin = 'claude');
-  }
-}
-
-// Spawn a Claude Code process with PID tracking for crash cleanup.
-// Drop-in replacement for spawn('claude', ...) that registers/unregisters PIDs.
-// Signal a spawned process AND everything it started.
-//
-// An agent CLI spawns its own children: an MCP server per configured entry,
-// plus tool subprocesses. Those are grandchildren we hold no handle on and
-// never record, so signalling one pid leaves them running and reparented,
-// holding memory until the machine restarts.
-//
-// On POSIX the children are spawned detached, which puts each in its own
-// process group whose id equals the leader's pid, so a negative pid signals
-// the whole group. Windows has no process groups; taskkill /T walks the tree
-// instead. Windows also has no real signal semantics (Node maps kill() onto
-// TerminateProcess), so the graceful and forceful paths are the same there.
-function killProcessTree(target, signal = 'SIGTERM') {
-  const pid = typeof target === 'number' ? target : (target && target.pid);
-  if (!pid) return;
-  // Floor: kill at least the process itself, so no path here can end up doing
-  // less than the single-pid kill this replaced.
-  const killJustThis = () => {
-    try {
-      if (typeof target === 'number') process.kill(pid, signal);
-      else target.kill(signal);
-    } catch (e) { /* already dead */ }
-  };
-
-  if (process.platform === 'win32') {
-    // Windows has no process groups; taskkill walks the tree instead. It is
-    // spawned rather than awaited, so a missing binary arrives as an error
-    // EVENT and never reaches a try/catch: without the listener below a
-    // failure would kill nothing at all, which is worse than what this
-    // replaced. Order matters, since killing the parent first would orphan
-    // the children out of taskkill's reach.
-    let killer = null;
-    try {
-      killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
-      killer.on('error', killJustThis);
-    } catch (e) {
-      killJustThis();
-    }
-    return;
-  }
-
-  // Negative pid = the whole process group. Fails with ESRCH if the group is
-  // already gone, or EPERM if the child was never detached; fall back to the
-  // single process so this is never worse than the old behaviour.
-  try { process.kill(-pid, signal); return; } catch (e) {}
-  killJustThis();
-}
-
-function spawnClaude(args, options, onError) {
-  // Safety net: never spawn Claude Code without an explicit --model. Call sites
-  // pass the agent's model (see modelArgs); this guards any path that doesn't,
-  // so the model can never silently fall back to the user's environment.
-  if (!args.includes('--model')) args = ['--model', DEFAULT_MODEL, ...args];
-  // detached puts the child at the head of its own process group so its whole
-  // subtree can be signalled together. Safe for terminal users: the server
-  // installs its own SIGINT and SIGTERM handlers and kills children explicitly,
-  // so Ctrl-C never depended on the terminal reaching them by group.
-  const proc = spawn(resolveClaudeBin(), args, { ...options, detached: process.platform !== 'win32' });
-  if (proc.pid) {
-    registerChildPid(proc.pid, resolveClaudeBin());
-    proc.on('close', () => unregisterChildPid(proc.pid));
-  }
-  // Always attach a baseline 'error' listener so an unhandled error event
-  // cannot propagate out of the WebSocket message handler and tear down the
-  // connection. Caller-provided onError does the user-facing surfacing; this
-  // wrapper guarantees the listener exists and that the callback runs inside
-  // try/catch.
-  proc.on('error', (err) => {
-    try {
-      console.error(`[spawnClaude] spawn error code=${err.code || ''} msg=${err.message}`);
-      if (typeof onError === 'function') onError(err);
-    } catch (e) {
-      console.error('[spawnClaude] onError handler threw:', e);
-    }
-  });
-  return proc;
-}
+// resolveClaudeBin, killProcessTree, and spawnClaude live in
+// lib/runtime/claude.js (spawn plumbing).
 
 // ===== RUNTIME STATUS =====
 // The Codex runtime glue (shared app-server lifecycle, turns, delegate

--- a/server.js
+++ b/server.js
@@ -482,9 +482,8 @@ codexGlue.wireCodexGlueDeps({
 });
 
 schedulerLib.wireSchedulerDeps({
-  // Root spawn plumbing until its own extraction slice; the client set is
-  // read through an accessor because wss is created later at boot.
-  spawnClaude, getBareArgs, modelArgs, getSpawnEnv,
+  // The client set is read through an accessor: wss is created later at
+  // boot. The spawn plumbing is a direct lib require inside the scheduler.
   getWssClients: () => wss.clients,
 });
 const httpRouter = require('./lib/http-router.js');

--- a/test/integration/process-tree-kill.test.js
+++ b/test/integration/process-tree-kill.test.js
@@ -83,3 +83,48 @@ describe('agent subprocess trees', () => {
       + `The modelled MCP process (pid ${kidPid}) outlived the server's own cleanup.`);
   });
 });
+
+describe('orphan cleanup on launch', () => {
+  // cleanOrphanedProcesses is what boot runs against a previous session's
+  // pid file. Three record fates: a dead pid is forgotten (continue), a live
+  // pid is signalled, and a signalled pid still alive on the immediate
+  // re-check stays tracked so a later launch can try again.
+  test('signals live records, keeps SIGTERM survivors, forgets the dead', async () => {
+    const { spawn } = require('child_process');
+    const fs = require('fs');
+    const path = require('path');
+    const pidFile = path.join(h.workspaceDir, '.rundock', 'child-pids.json');
+    const priorContent = fs.existsSync(pidFile) ? fs.readFileSync(pidFile, 'utf-8') : null;
+
+    // A record whose process has exited (and been reaped): skipped, forgotten.
+    const dead = spawn(process.execPath, ['-e', '']);
+    await new Promise(res => dead.on('exit', res));
+    // A record whose process ignores SIGTERM: signalled, observed still
+    // alive, kept for the next launch. The child prints once its handler is
+    // installed; signalling before that would hit the default action and
+    // kill it (a boot race, not the behaviour under test).
+    const ignorer = spawn(process.execPath,
+      ['-e', 'process.on("SIGTERM", () => {}); console.log("armed"); setInterval(() => {}, 1000);'],
+      { stdio: ['ignore', 'pipe', 'ignore'] });
+    try {
+      await new Promise((res) => ignorer.stdout.once('data', res));
+      fs.mkdirSync(path.dirname(pidFile), { recursive: true });
+      fs.writeFileSync(pidFile, JSON.stringify([
+        { pid: dead.pid, at: Date.now(), cmd: 'node' },
+        { pid: ignorer.pid, at: Date.now(), cmd: 'node' },
+      ]));
+
+      h.internal.cleanOrphanedProcesses();
+
+      assert.ok(h.pidAlive(ignorer.pid),
+        'the SIGTERM-ignoring orphan survives one signal (cleanup must not assume delivery worked)');
+      const remaining = JSON.parse(fs.readFileSync(pidFile, 'utf-8'));
+      assert.deepStrictEqual(remaining.map(r => r.pid), [ignorer.pid],
+        'the survivor stays tracked for the next launch; the dead record is forgotten');
+    } finally {
+      try { ignorer.kill('SIGKILL'); } catch (e) {}
+      if (priorContent == null) { try { fs.rmSync(pidFile, { force: true }); } catch (e) {} }
+      else fs.writeFileSync(pidFile, priorContent);
+    }
+  });
+});

--- a/test/integration/spawn-plumbing.test.js
+++ b/test/integration/spawn-plumbing.test.js
@@ -1,7 +1,8 @@
 'use strict';
 // Characterisation: spawn plumbing (resolveClaudeBin, spawnClaude,
-// killProcessTree), pinned as it behaves today, before it moves out of
-// server.js.
+// killProcessTree). Written before the move to lib/runtime/claude.js; the
+// pins drive the moved code through server.js's identity re-exports, so
+// they held across the move unchanged.
 //
 // resolveClaudeBin memoises its first answer for the life of the process, and
 // the harness boot gate already forces that first call (asserting the stub

--- a/test/tools/coverage-areas.js
+++ b/test/tools/coverage-areas.js
@@ -97,9 +97,11 @@ const AREA_DEFS = [
   // remainder area covers what deliberately stayed: getRuntimeStatus with
   // its probe caches (settings machinery that sat mid-span) and
   // requestServerPermission (the generic bridge, injected into the glue).
-  // The spawn-plumbing end anchor retargets to the remainder banner (its
-  // old end, the CODEX RUNTIME banner, moved with the glue).
-  ['server.js', 'Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', /^function resolveClaudeBin\(/, /^\/\/ ===== RUNTIME STATUS =====/],
+  // The spawn plumbing (args/env trio, child-pid registry, resolveClaudeBin,
+  // killProcessTree, spawnClaude) moved to lib/runtime/claude.js; the area
+  // follows it, whole-file, and now also sees the trio and the registry,
+  // which in the root sat outside every area span (file-overall only).
+  ['lib/runtime/claude.js', 'Spawn plumbing (spawnClaude, resolveClaudeBin, errors)', /^const unwired/, /^module\.exports/],
   ['server.js', 'Runtime status + server permission bridge (root remainder)', /^\/\/ ===== RUNTIME STATUS =====/, /^\/\/ Graceful shutdown/],
   ['lib/runtime/codex-glue.js', 'Codex glue (app-server lifecycle, turns, delegate wiring)', /^let _resolvedCodexBin/, /^module\.exports/],
 ];
@@ -108,6 +110,7 @@ const AREA_DEFS = [
 const OVERALL_FILES = [
   'server.js', 'codex.js', 'codex-appserver.js', 'search.js',
   'lib/delegation/markers.js', 'lib/delegation/handback.js', 'lib/delegation/state.js',
+  'lib/runtime/claude.js',
   'lib/config.js', 'lib/store/persistence.js', 'lib/store/transcripts.js',
   'lib/agents/discovery.js', 'lib/agents/prompt.js',
   'lib/workspace/boundary.js', 'lib/workspace/analysis.js', 'lib/workspace/scaffold.js',

--- a/test/tools/coverage-floors.json
+++ b/test/tools/coverage-floors.json
@@ -43,6 +43,7 @@
     "Codex glue (app-server lifecycle, turns, delegate wiring)": 96,
     "OVERALL lib/scheduler.js": 100.0,
     "OVERALL lib/http-router.js": 98.5,
-    "HTTP server + WS bootstrap (root remainder)": 97.9
+    "HTTP server + WS bootstrap (root remainder)": 97.9,
+    "OVERALL lib/runtime/claude.js": 99.3
   }
 }

--- a/test/unit/claude-runtime-lib.test.js
+++ b/test/unit/claude-runtime-lib.test.js
@@ -1,0 +1,105 @@
+'use strict';
+// Seam tests for lib/runtime/claude.js. The plumbing's behaviour is pinned by
+// the characterisation suite (spawn-plumbing.test.js, text-helpers.test.js,
+// workspace-modes.test.js, pid-file.test.js) driving the moved code through
+// server.js's identity re-exports; these tests pin the SEAMS themselves:
+// the unwired port accessor refuses loudly, the wiring is restorable, and
+// args/env/pid-file paths resolve the workspace at USE time so a switch
+// redirects the very next call.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const LIB_KEY = require.resolve('../../lib/runtime/claude.js');
+
+// A private copy per test: wiring one test's fakes must never leak into
+// another test (or into the shared instance other requires would see).
+function freshClaudeRuntime() {
+  const cached = require.cache[LIB_KEY];
+  delete require.cache[LIB_KEY];
+  const mod = require(LIB_KEY);
+  delete require.cache[LIB_KEY];
+  if (cached) require.cache[LIB_KEY] = cached;
+  return mod;
+}
+
+function withTwoWorkspaces(fn) {
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const wsA = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-rt-a-'));
+  const wsB = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-rt-b-'));
+  try {
+    fn(config, wsA, wsB);
+  } finally {
+    config.setWorkspace(original);
+    fs.rmSync(wsA, { recursive: true, force: true });
+    fs.rmSync(wsB, { recursive: true, force: true });
+  }
+}
+
+test('unwired getActualPort throws the named wiring error at first use', () => {
+  const rt = freshClaudeRuntime();
+  assert.throws(
+    () => rt.getSpawnEnv('convo-1'),
+    /lib\/runtime\/claude: getActualPort not wired \(call wireClaudeRuntimeDeps at boot\)/,
+  );
+});
+
+test('wireClaudeRuntimeDeps returns the previous set, restorable by identity', () => {
+  const rt = freshClaudeRuntime();
+  const prev = rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  assert.strictEqual(rt.getSpawnEnv(null).RUNDOCK_PORT, '4444');
+  rt.wireClaudeRuntimeDeps(prev);
+  assert.throws(() => rt.getSpawnEnv(null), /getActualPort not wired/);
+});
+
+test('getBareArgs resolves the workspace at USE time: a switch redirects the next call', () => {
+  const rt = freshClaudeRuntime();
+  withTwoWorkspaces((config, wsA, wsB) => {
+    config.setWorkspace(wsA);
+    assert.deepStrictEqual(rt.getBareArgs(), ['--add-dir', wsA]);
+    // Workspace B carries a settings file; the switch must pick BOTH the new
+    // root and the new file up with no re-wiring.
+    fs.mkdirSync(path.join(wsB, '.claude'), { recursive: true });
+    const settings = path.join(wsB, '.claude', 'settings.local.json');
+    fs.writeFileSync(settings, '{}');
+    config.setWorkspace(wsB);
+    assert.deepStrictEqual(rt.getBareArgs(), ['--add-dir', wsB, '--settings', settings],
+      'the args followed the switch with no re-wiring');
+  });
+});
+
+test('the pid file follows the workspace: register lands in the CURRENT .rundock', () => {
+  const rt = freshClaudeRuntime();
+  withTwoWorkspaces((config, wsA, wsB) => {
+    config.setWorkspace(wsA);
+    rt.registerChildPid(999901, 'claude');
+    config.setWorkspace(wsB);
+    rt.registerChildPid(999902, 'claude');
+    const readPids = (ws) => JSON.parse(
+      fs.readFileSync(path.join(ws, '.rundock', 'child-pids.json'), 'utf-8')).map(r => r.pid);
+    assert.deepStrictEqual(readPids(wsA), [999901], 'workspace A holds only its own pid');
+    assert.deepStrictEqual(readPids(wsB), [999902], 'workspace B holds only its own pid');
+    // Unregister also resolves at use time: it prunes the CURRENT file only.
+    rt.unregisterChildPid(999902);
+    assert.deepStrictEqual(readPids(wsB), [], 'pruned from the current workspace');
+    assert.deepStrictEqual(readPids(wsA), [999901], 'the other workspace file is untouched');
+  });
+});
+
+test('getSpawnEnv carries the use-time workspace and the wired port together', () => {
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 5151 });
+  withTwoWorkspaces((config, wsA, wsB) => {
+    config.setWorkspace(wsA);
+    const envA = rt.getSpawnEnv('convo-7');
+    assert.strictEqual(envA.RUNDOCK_WORKSPACE, wsA);
+    assert.strictEqual(envA.RUNDOCK_PORT, '5151');
+    assert.strictEqual(envA.RUNDOCK_CONVO_ID, 'convo-7');
+    config.setWorkspace(wsB);
+    assert.strictEqual(rt.getSpawnEnv(null).RUNDOCK_WORKSPACE, wsB,
+      'the env followed the switch with no re-wiring');
+  });
+});

--- a/test/unit/regression.test.js
+++ b/test/unit/regression.test.js
@@ -125,6 +125,25 @@ describe('P0 regressions: data-loss and stuck-pipeline', () => {
     assert.strictEqual(realParent.delegation, null);
     srv.chatProcesses.delete(convoId);
   });
+
+  test('spawn-error surfacing: EACCES and unknown codes carry their own copy', () => {
+    // The ENOENT wording is pinned above and in the delegate-restore test;
+    // these are the two remaining branches of the code-specific copy.
+    captureOn();
+    srv.handleChatSpawnError({ code: 'EACCES', message: 'permission denied' }, 'wording-eacces');
+    const eacces = captured.find(m => m.subtype === 'info');
+    assert.ok(eacces && /permission denied\. Check your install\./.test(eacces.content),
+      'EACCES gets the permission wording, not the generic one');
+    assert.ok(captured.some(m => m.subtype === 'done'),
+      'done always fires so the client clears its thinking state');
+
+    captureOn();
+    srv.handleChatSpawnError({ code: 'EMFILE', message: 'too many open files' }, 'wording-generic');
+    const generic = captured.find(m => m.subtype === 'info');
+    assert.ok(generic && generic.content.includes("Couldn't start Claude Code: too many open files"),
+      'unknown codes surface the raw message with the version-check hint');
+    assert.ok(generic.content.includes('claude --version'), 'the hint names the check to run');
+  });
 });
 
 describe('P1 regressions', () => {

--- a/test/unit/runtime-adapter.test.js
+++ b/test/unit/runtime-adapter.test.js
@@ -14,6 +14,7 @@ const path = require('node:path');
 const ROOT = path.join(__dirname, '..', '..');
 const serverSrc = fs.readFileSync(path.join(ROOT, 'server.js'), 'utf-8');
 const glueSrc = fs.readFileSync(path.join(ROOT, 'lib', 'runtime', 'codex-glue.js'), 'utf-8');
+const claudeSrc = fs.readFileSync(path.join(ROOT, 'lib', 'runtime', 'claude.js'), 'utf-8');
 const docSrc = fs.readFileSync(path.join(ROOT, 'docs', 'RUNTIME-ADAPTER.md'), 'utf-8');
 
 describe('runtime adapter contract: the documented seams exist', () => {
@@ -36,7 +37,7 @@ describe('runtime adapter contract: the documented seams exist', () => {
   });
 
   test('the server routes both runtimes through the documented spawn seams', () => {
-    assert.match(serverSrc, /function spawnClaude/, 'Claude spawn seam');
+    assert.match(claudeSrc, /function spawnClaude/, 'Claude spawn seam (lib/runtime/claude.js)');
     assert.match(glueSrc, /function getCodexAppServer/, 'Codex shared-server seam (lib/runtime/codex-glue.js)');
     assert.match(glueSrc, /function startCodexTurn/, 'Codex turn seam (lib/runtime/codex-glue.js)');
     assert.match(serverSrc, /runtime\s*===\s*'codex'|runtime:\s*'codex'/, 'runtime routing by frontmatter field');


### PR DESCRIPTION
## Summary

Extracts the spawn plumbing from `server.js` to `lib/runtime/claude.js` (295 lines): the per-spawn args and env builders (`modelArgs`, `getBareArgs`, `getSpawnEnv`), the child-pid registry (pid file, recycling guard, register/unregister), `resolveClaudeBin`, `killProcessTree`, and `spawnClaude`. `server.js` drops to 4,958 lines.

Five commits, each suite-green: verbatim move, seam tests, scheduler wiring shrink, floor restoration, instrument migration.

## Design

- **The child-pid registry moves WITH spawnClaude**, its writer (register on spawn, unregister on close). The root's cleanup machinery (`killAllChildren`, `cleanOrphanedProcesses`, the workspace-move clear) reads and prunes the same file by calling in, root to lib. The Codex glue wiring passes the lib functions under the same names, unchanged in shape.
- **Workspace read at USE time.** Six converted sites (args, env, pid-file path) go through `getWorkspace()`, so a switch redirects the very next spawn's args, env, and pid tracking (pinned in the seam tests across a two-workspace switch).
- **Wire list is ONE entry**: `getActualPort` (the port exists only after `server.listen()`). Everything else is lib-owned (config, store persistence) or the repo-root codex.js probe constant.
- **Scheduler wiring shrinks to one dep.** The four wired spawn-plumbing deps existed only because the plumbing was root-owned; the scheduler now requires it directly, lib to lib, with no cycle. `wireSchedulerDeps` keeps exactly the WebSocket client-set accessor.
- **The kill-window machine stays in the root** (transitions, scheduleKill, failsafe, pendingKill); `killProcessTree` the function moved, per the decomposition's function-by-function exclusion list.

## One pin retarget

`runtime-adapter.test.js`'s "Claude spawn seam" now reads `lib/runtime/claude.js`. The legacy-spawn declaration-order scan needed NO retarget: it anchors on the legacy chat branch call-site text, which is WebSocket-handler territory and unmoved. Every other suite drives the moved code through `server.js`'s identity re-exports unchanged.

## Seams pinned (new `test/unit/claude-runtime-lib.test.js`)

- The unwired port accessor throws the named wiring error at first use.
- `wireClaudeRuntimeDeps` returns the previous set, restorable by identity.
- Args, env, and the pid file all resolve the workspace at use time: a two-workspace switch redirects each with no re-wiring, and the pid file lands in (and prunes from) the CURRENT workspace's `.rundock` only.

## Floor restoration (honest, not lowered)

The move's denominator arithmetic tripped the server.js overall floor (96.2 measured vs 96.6, absolute coverage unchanged). Restored by pinning previously uncovered root lines:

- `cleanOrphanedProcesses` end to end: dead records forgotten, live records signalled, SIGTERM-ignoring survivors kept tracked for the next launch.
- `handleChatSpawnError`'s EACCES and unknown-code wording branches.

`OVERALL server.js` now measures 96.8 quiet and under CPU load, above the floor itself.

## Instrument migration

- The spawn-plumbing area follows the code whole-file, keeping label and 98.1 floor (measures 99.2; it now genuinely contains the args/env trio and the registry, previously outside every area span).
- `OVERALL lib/runtime/claude.js` enters at 99.3, load-verified. The two uncovered lines are the Windows taskkill synchronous-throw fallback (the error-event path is pinned).
- Raises for `OVERALL server.js` (96.8) and the area (99.2) declined deliberately: headroom absorbs the remaining slices' arithmetic instead of inviting timing-luck credit. 42 floors, all holding quiet and loaded.

## Numbers

- `server.js`: 5,187 → 4,958 lines; `lib/runtime/claude.js`: 295 lines
- Suite: 1,473 (was 1,466); e2e: 103/103
- Floors: 42, all holding quiet and under CPU load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
