### PR TITLE
CI: stop the jsdom install step re-running unrelated package installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install test-only DOM dependency
         # The editor round-trip suite boots the real editor under jsdom.
         # Version must match package.json/package-lock.json.
-        run: npm install --no-save jsdom@29.1.1
+        run: npm install --no-save --ignore-scripts jsdom@29.1.1
 
       - name: Run tests
         run: npm test
@@ -110,7 +110,7 @@ jobs:
         run: npm ci --omit=dev
 
       - name: Install test-only DOM dependency
-        run: npm install --no-save jsdom@29.1.1
+        run: npm install --no-save --ignore-scripts jsdom@29.1.1
 
       - name: Run suite with coverage and enforce floors
         run: npm run test:coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         # The editor round-trip suite boots the real editor under jsdom, a
         # devDependency the lean install omits. Same pinned install as CI;
         # without it the gate fails on ERR_MODULE_NOT_FOUND.
-        run: npm install --no-save jsdom@29.1.1
+        run: npm install --no-save --ignore-scripts jsdom@29.1.1
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Summary

The test-only `npm install --no-save jsdom@29.1.1` step re-runs lifecycle scripts for packages npm touches while grafting jsdom into the tree. Concretely: ffmpeg-static's postinstall re-downloads its binary over the network on every CI job, and that fetch failed with ECONNRESET three times today (one PR-run job, both failed jobs on the latest main push run), each time before a single test executed.

`--ignore-scripts` limits the step to what it actually is: adding one pure-JS test dependency. Every runtime package's install scripts already ran under `npm ci`; nothing in the Node suites references ffmpeg. Applied to all three occurrences (both CI jobs and the release workflow's test phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)