### PR TITLE
Pin the delegate-close arms deterministically so the engine floors stop riding the CI schedule

### DIFF
--- a/test/integration/delegation-chain-edges.test.js
+++ b/test/integration/delegation-chain-edges.test.js
@@ -99,6 +99,137 @@ test('RETURN from a sub-delegate auto-continues the living orchestrator with the
   h.reapConvo(convoId);
 });
 
+// ---------------------------------------------------------------------------
+// Deterministic pins for the delegate-close arms that flipped with the CI
+// schedule (the two identical main-run floor trips at 95.4/93.2). Each arm
+// below was covered only when unrelated tests won a timing race; these
+// constructions drive them by design. The circuit breaker is armed by
+// pre-setting the per-conversation resume count through the identity-exported
+// map, so ONE close crosses the threshold: no multi-hop timing chain.
+// ---------------------------------------------------------------------------
+
+test('skip-level RETURN with the resume budget spent trips the breaker: auto-pause, no auto-continue', async () => {
+  const convoId = h.freshConvoId('skipbrk');
+  await startOrchestrator(convoId, 'skipbrk-setup');
+  h.writeScenario([
+    { match: { agent: 'content-lead', promptIncludes: 'skipbrk task' },
+      turn: [{ agentTool: { subagent_type: 'content-analyst', prompt: 'skipbrk sub brief' } }] },
+    { match: { agent: 'content-analyst', promptIncludes: 'skipbrk sub brief' },
+      turn: [{ text: 'Outside my scope. <!-- RUNDOCK:RETURN -->' }] },
+  ]);
+
+  // Two resumes already spent: the skip-level restore's increment is the third.
+  h.internal.agentAutoResumeCount.set(convoId, h.internal.MAX_CONSECUTIVE_AGENT_RESUMES - 1);
+
+  const since = client.messages.length;
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'content-lead', context: 'skipbrk task' });
+
+  const { index: subResultIdx } = await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-analyst', { since, label: 'sub-delegate result' });
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { since: subResultIdx, label: 'skip-level switch back' });
+  const { msg: paused, index: pausedIdx } = await client.waitFor(
+    m => m.type === 'assistant' && m._conversationId === convoId && /Auto-paused: \d+ consecutive agent handoffs/.test(m.message?.content || ''),
+    { since: subResultIdx, label: 'auto-pause card' });
+  assert.match(paused.message.content, /Agents involved: content-analyst/, 'the skip-level breaker wording names the chain');
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId, { since: subResultIdx, label: 'done after pause' });
+
+  const started = client.messages.slice(pausedIdx).find(
+    m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m.autoContinue);
+  assert.ok(!started, 'a tripped breaker never auto-continues');
+  const entry = h.internal.chatProcesses.get(convoId);
+  assert.strictEqual(entry.idle, true, 'the orchestrator is parked idle for the user');
+  assert.strictEqual(h.internal.agentAutoResumeCount.get(convoId), 0, 'the breaker resets the budget');
+  h.reapConvo(convoId);
+});
+
+test('end_delegation after a delegate follow-up auto-continues the parked parent with the pending request', async () => {
+  const convoId = h.freshConvoId('wsret');
+  await startOrchestrator(convoId, 'wsret-setup');
+  h.writeScenario([
+    { match: { agent: 'content-lead', promptIncludes: 'wsret task' }, turn: [{ text: 'Delegate here, staying in the conversation.' }] },
+    { match: { agent: 'content-lead', promptIncludes: 'wsret-followup' }, turn: [{ text: 'Follow-up handled by the delegate.' }] },
+    { match: { agent: 'chief-of-staff', promptIncludes: 'The specialist just returned because the user asked' },
+      turn: [{ text: 'Routing wsret onward.' }] },
+  ]);
+
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'content-lead', context: 'wsret task' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead', { label: 'delegate first result' });
+
+  // A user follow-up to the LIVE delegate sets receivedFollowUp on its entry
+  // (the arm's gate) and becomes the pending request the parent must route.
+  const since1 = client.messages.length;
+  client.send({ type: 'chat', conversationId: convoId, agent: 'content-lead', content: 'wsret-followup please' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead' && /Follow-up handled/.test(m.result || ''), { since: since1, label: 'follow-up result' });
+  assert.strictEqual(h.internal.chatProcesses.get(convoId).receivedFollowUp, true, 'the follow-up armed the auto-continue gate');
+
+  const since2 = client.messages.length;
+  client.send({ type: 'end_delegation', conversationId: convoId });
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { since: since2, label: 'restore switch' });
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m._agent === 'chief-of-staff' && m.autoContinue, { since: since2, label: 'auto-continue on the parked parent' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'chief-of-staff' && /Routing wsret onward/.test(m.result || ''), { since: since2, label: 'routing answer' });
+  h.reapConvo(convoId);
+});
+
+test('end_delegation after a follow-up with the resume budget spent trips the OTHER breaker wording', async () => {
+  const convoId = h.freshConvoId('wsbrk');
+  await startOrchestrator(convoId, 'wsbrk-setup');
+  h.writeScenario([
+    { match: { agent: 'content-lead', promptIncludes: 'wsbrk task' }, turn: [{ text: 'Delegate here.' }] },
+    { match: { agent: 'content-lead', promptIncludes: 'wsbrk-followup' }, turn: [{ text: 'Follow-up done.' }] },
+  ]);
+
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'content-lead', context: 'wsbrk task' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead', { label: 'delegate first result' });
+  const since1 = client.messages.length;
+  client.send({ type: 'chat', conversationId: convoId, agent: 'content-lead', content: 'wsbrk-followup please' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead' && /Follow-up done/.test(m.result || ''), { since: since1, label: 'follow-up result' });
+
+  // The chat follow-up RESET the budget, so spend it now, after the reset.
+  h.internal.agentAutoResumeCount.set(convoId, h.internal.MAX_CONSECUTIVE_AGENT_RESUMES - 1);
+
+  const since2 = client.messages.length;
+  client.send({ type: 'end_delegation', conversationId: convoId });
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { since: since2, label: 'restore switch' });
+  const { msg: paused, index: pausedIdx } = await client.waitFor(
+    m => m.type === 'assistant' && m._conversationId === convoId && /Auto-paused: \d+ consecutive agent handoffs/.test(m.message?.content || ''),
+    { since: since2, label: 'auto-pause card' });
+  assert.match(paused.message.content, /Last specialist: content-lead/, 'the delegate-return breaker wording names the specialist');
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId, { since: since2, label: 'done after pause' });
+  const started = client.messages.slice(pausedIdx).find(
+    m => m.type === 'system' && m.subtype === 'process_started' && m._conversationId === convoId && m.autoContinue);
+  assert.ok(!started, 'a tripped breaker never auto-continues');
+  h.reapConvo(convoId);
+});
+
+test('a delegate closing after its original is gone cleans up and unblocks, restoring nothing', async () => {
+  const convoId = h.freshConvoId('wsgone');
+  await startOrchestrator(convoId, 'wsgone-setup');
+  h.writeScenario([
+    { match: { agent: 'content-lead', promptIncludes: 'wsgone task' }, turn: [{ text: 'Delegate here.' }] },
+  ]);
+  client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'content-lead', context: 'wsgone task' });
+  await client.waitFor(m => m.type === 'result' && m._conversationId === convoId && m._agent === 'content-lead', { label: 'delegate result' });
+
+  // The parked original dies out from under the delegation (identity access
+  // through the live map: this is the exact state a crashed parent leaves).
+  // Kill the real process too: once the entry leaves the map at close time,
+  // reapConvo can no longer reach it, and a leaked stub child would hold the
+  // test process's event loop open past the suite.
+  const delegateEntry = h.internal.chatProcesses.get(convoId);
+  assert.ok(delegateEntry.delegation && delegateEntry.delegation.originalEntry, 'delegation carries the parked original');
+  const goneOriginal = delegateEntry.delegation.originalEntry;
+  try { goneOriginal.process.kill('SIGKILL'); } catch (e) {}
+  goneOriginal.exited = true;
+
+  const since = client.messages.length;
+  client.send({ type: 'end_delegation', conversationId: convoId });
+  await client.waitFor(m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId && m._agent === 'content-lead', { since, label: 'done after orphan close' });
+  const switched = client.messages.slice(since).find(
+    m => m.type === 'system' && m.subtype === 'agent_switch' && m._conversationId === convoId);
+  assert.ok(!switched, 'nothing to restore: no agent_switch is announced');
+  assert.ok(!h.internal.chatProcesses.has(convoId), 'the conversation entry is removed');
+  h.reapConvo(convoId);
+});
+
 test('agent CRUD while a delegation is live flags the delegate AND the parked parent', async () => {
   const convoId = h.freshConvoId('crudflag');
   await startOrchestrator(convoId, 'crudflag-setup');


### PR DESCRIPTION
## Summary

Main's push run tripped the same two coverage floors at the same numbers three times in one day (Delegation / orchestration engine 95.4 vs 96; handleDelegation 93.2 vs 94.3), while the identical tree passed locally even under 10-way CPU load. Re-runs pass or fail by runner schedule: a coin-flip gate.

## Line-level evidence (via the lcov artifact added in #108)

Diffing the failing run against a passing run isolates 21 flipped lines, all delegate-close arms whose coverage existed only when unrelated tests won a timing race:

- both circuit-breaker blocks (skip-level restore and delegate-return restore)
- the end_delegation auto-continue arm, whose guard (`receivedFollowUp` plus a writable parent stdin) silently skips on slow runners
- the delegate-close branch for an already-gone original process

## The fix: deterministic constructions, not raised timeouts

Four new tests in delegation-chain-edges.test.js (the #103 file, built for exactly this failure class):

- The breakers are armed by pre-setting the per-conversation resume budget through the identity-exported map, so a single close crosses the threshold. Each site's distinct auto-pause wording is pinned, no-auto-continue-after-trip is asserted, and the budget reset is checked.
- The auto-continue arm is driven end to end: a follow-up to the live delegate arms the gate (asserted before the close), then end_delegation, then the parked parent's autoContinue signal and routing answer are awaited.
- The original-gone branch: the parked parent dies out from under the delegation (identity access through the live map), the delegate closes, and cleanup/done with no agent_switch is asserted. The test kills the abandoned stub process itself: once the entry leaves the map, reapConvo cannot reach it, and a leaked child holds the suite's event loop open.

## Numbers

- Engine 98.2, handleDelegation 98.3: identical quiet and under CPU load (deterministic, as designed)
- Remaining uncovered pair: the auto-continue's stdin-write defensive catch, enumerated
- 49 floors hold quiet and loaded; floors file untouched (the bar stays; the measurement is now deterministic). Raises declined: the engine moves to lib/ in the next extraction, which migrates its keys anyway.
- Suite 1493 green; test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)