### PR TITLE
CI: retry the full npm ci installs that run network postinstalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,19 @@ jobs:
           cache: npm
 
       - name: Install dependencies (incl. dev, for Playwright)
-        run: npm ci
+        # The full install runs network postinstalls (electron, ffmpeg-static)
+        # that npm's own fetch retries do not cover; registry socket hang-ups
+        # have killed this step three times. Retry the whole install with a
+        # clean node_modules between attempts.
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then exit 0; fi
+            echo "npm ci failed (attempt $attempt); cleaning and retrying in 20s"
+            rm -rf node_modules
+            sleep 20
+          done
+          echo "npm ci failed on all 3 attempts"
+          exit 1
 
       - name: Install Chromium
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,19 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
       - name: Install dependencies (incl. dev, for Playwright)
-        run: npm ci
+        # The full install runs network postinstalls (electron, ffmpeg-static)
+        # that npm's own fetch retries do not cover; registry socket hang-ups
+        # have killed this step three times. Retry the whole install with a
+        # clean node_modules between attempts.
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then exit 0; fi
+            echo "npm ci failed (attempt $attempt); cleaning and retrying in 20s"
+            rm -rf node_modules
+            sleep 20
+          done
+          echo "npm ci failed on all 3 attempts"
+          exit 1
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
       - name: Run E2E suite
@@ -88,7 +100,19 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        run: npm ci
+        # The full install runs network postinstalls (electron, ffmpeg-static)
+        # that npm's own fetch retries do not cover; registry socket hang-ups
+        # have killed this step three times. Retry the whole install with a
+        # clean node_modules between attempts.
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then exit 0; fi
+            echo "npm ci failed (attempt $attempt); cleaning and retrying in 20s"
+            rm -rf node_modules
+            sleep 20
+          done
+          echo "npm ci failed on all 3 attempts"
+          exit 1
 
       - name: Decode App Store Connect API key
         env:
@@ -145,7 +169,19 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install dependencies
-        run: npm ci
+        # The full install runs network postinstalls (electron, ffmpeg-static)
+        # that npm's own fetch retries do not cover; registry socket hang-ups
+        # have killed this step three times. Retry the whole install with a
+        # clean node_modules between attempts.
+        run: |
+          for attempt in 1 2 3; do
+            if npm ci; then exit 0; fi
+            echo "npm ci failed (attempt $attempt); cleaning and retrying in 20s"
+            rm -rf node_modules
+            sleep 20
+          done
+          echo "npm ci failed on all 3 attempts"
+          exit 1
 
       - name: Extract release name and notes from the changelog
         shell: bash


### PR DESCRIPTION
The full dev install has died on registry `socket hang up` three times (twice noted in the #109 closure, once killing the E2E job on the latest main push run before any test ran). npm's fetch retries don't cover postinstall binary downloads (electron, ffmpeg-static), so this wraps the whole install: three attempts, clean `node_modules` between them, 20s backoff.

Scope: the four full `npm ci` steps (E2E in ci.yml and release.yml, both release build installs). The lean `--omit=dev` installs and the pinned `--ignore-scripts` jsdom step are unchanged.

Verification: yaml validated; the PR's own CI run exercises the changed E2E install step on the happy path (the retry arms only on failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)