### PR TITLE
Fix add_to_team writing the order outside the frontmatter for minimal agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **"Add to team" now works for minimal agents:** an agent file with only a name and description gained its team position OUTSIDE the file's settings block, where Rundock never saw it, so the join silently did nothing. The position now lands in the right place and the agent appears on the team immediately.
 - **Adding an agent to your team shows their place immediately:** the roster sent back after "Add to team" was built from a snapshot taken just before the join, so the new member could appear still off-team until a later refresh. The response now reflects the join at once.
 - **Opening a workspace no longer risks a spurious agent restart moments later:** when Rundock updates its own built-in agent or skill files during workspace open, that write was briefly mistaken for an external edit, which could restart a busy agent mid-conversation about two seconds in. The server's own writes are now recognised as its own.
 - **Setup completes when your team exists, however it was created:** the workspace used to leave "setup pending" only when agents were created through the standard onboarding flow. A team created any other way (an agent writing the files directly, or you dropping agent files into place) now completes setup too, within a couple of seconds of the files appearing.

--- a/lib/protocol/handlers/team.js
+++ b/lib/protocol/handlers/team.js
@@ -42,10 +42,17 @@ function handleAddToTeam(ctx, ws, msg) {
     if (content.match(/^order:\s/m)) {
       content = content.replace(/^order:\s.*/m, `order: ${nextOrder}`);
     } else {
-      // Add order after the type field, or after description
+      // Add order after the type field, else after the description LINE,
+      // else after the opening fence (save_agent's proven insert). The old
+      // fallback (`description:[\s\S]*?\n\w`) jumped the closing fence on a
+      // name+description-only agent and wrote the order into the BODY, where
+      // discovery never saw it, so the join silently did nothing.
       content = content.replace(/^(type:\s.*)/m, `$1\norder: ${nextOrder}`);
       if (!content.match(/^order:/m)) {
-        content = content.replace(/^(description:[\s\S]*?)(\n\w)/m, `$1\norder: ${nextOrder}$2`);
+        content = content.replace(/^(description:\s.*)/m, `$1\norder: ${nextOrder}`);
+      }
+      if (!content.match(/^order:/m)) {
+        content = content.replace(/^(---[ \t]*\r?\n)/, `$1order: ${nextOrder}\n`);
       }
     }
     fs.writeFileSync(filePath, content, 'utf-8');

--- a/test/integration/ws-handler-edges.test.js
+++ b/test/integration/ws-handler-edges.test.js
@@ -117,11 +117,26 @@ describe('team CRUD edges', () => {
     assert.strictEqual((file.match(/^order:\s/gm) || []).length, 1, 'exactly one order line');
   });
 
-  // NOTE (discovered during this characterisation): add_to_team on an agent
-  // whose frontmatter has a description but no type line writes the order
-  // OUTSIDE the frontmatter (the fallback regex jumps the closing fence into
-  // the body), so the join silently does nothing. Deliberately NOT pinned
-  // here: pinning would freeze a bug. The red-first fix ships separately.
+  test('add_to_team on a name+description-only agent lands the order INSIDE the frontmatter', async () => {
+    // Discovered during the handler characterisation: the old fallback regex
+    // jumped the closing fence and wrote `order:` into the BODY, so discovery
+    // never saw it and the join silently did nothing.
+    const body = 'You are a minimal bench agent.\n\nNo type line above, on purpose.\n';
+    fs.writeFileSync(path.join(h.workspaceDir, '.claude', 'agents', 'edge-minimal.md'),
+      `---\nname: Edge Minimal\ndescription: Minimal bench agent.\n---\n${body}`);
+    h.internal.invalidateAgentCache();
+    const updated = (await request({ type: 'add_to_team', agentId: 'edge-minimal' },
+      m => m.type === 'agents', 'agents after minimal join')).agents;
+    const joined = updated.find(a => a.id === 'edge-minimal');
+    assert.ok(joined, 'the agent is discovered');
+    assert.ok(Number.isInteger(joined.order) && joined.order > 0,
+      'the roster broadcast shows the agent ON the team (order assigned)');
+    const file = fs.readFileSync(path.join(h.workspaceDir, '.claude', 'agents', 'edge-minimal.md'), 'utf-8');
+    const fm = file.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    assert.ok(fm, 'frontmatter still well-formed');
+    assert.match(fm[1], /^order: \d+$/m, 'order landed INSIDE the frontmatter');
+    assert.strictEqual(fm[2], body, 'the body is untouched');
+  });
 
   test('save_agent with type but no order gains an order after the type line', async () => {
     const res = await request({


### PR DESCRIPTION
An agent file with only a name and description hit the add_to_team fallback insert, whose regex (`description:[\s\S]*?\n\w`) jumped the closing frontmatter fence and wrote `order:` into the BODY. Discovery never saw it, so "Add to team" silently did nothing. Found by the handler characterisation (#108), carded then, fixed red-first now.

- **Red-first:** the new test reproduces the silent no-op over a live WebSocket (order assigned in the roster broadcast, `order:` inside the frontmatter, body byte-identical) and failed against the old code.
- **Fix:** the fallback mirrors save_agent's proven insert: after the description LINE, else after the opening fence.
- Changelog Fixed entry included (user-visible).
- Suite: 1,516 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)