### PR TITLE
Fix set_workspace answering nothing and half-switching on a broken .rundock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
+- **Opening a broken workspace now tells you what is wrong:** choosing a folder whose `.rundock` entry is a file (not the directory Rundock expects) used to leave the app hanging on a spinner with no reply, half-switched away from your previous workspace. Rundock now refuses up front with a message naming the problem file, and any other failure during a workspace switch rolls back to the workspace you were in and reports the error.
 - **"Add to team" now works for minimal agents:** an agent file with only a name and description gained its team position OUTSIDE the file's settings block, where Rundock never saw it, so the join silently did nothing. The position now lands in the right place and the agent appears on the team immediately.
 - **Adding an agent to your team shows their place immediately:** the roster sent back after "Add to team" was built from a snapshot taken just before the join, so the new member could appear still off-team until a later refresh. The response now reflects the join at once.
 - **Opening a workspace no longer risks a spurious agent restart moments later:** when Rundock updates its own built-in agent or skill files during workspace open, that write was briefly mistaken for an external edit, which could restart a busy agent mid-conversation about two seconds in. The server's own writes are now recognised as its own.

--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -53,68 +53,96 @@ function handleListWorkspaces(ctx, ws, msg) {
 
 function handleSetWorkspace(ctx, ws, msg) {
   const dir = msg.path;
-  if (dir && fs.existsSync(dir) && fs.statSync(dir).isDirectory()) {
-    // Kill all running processes when switching workspace
-    const startup = ctx.signals.phaseTimer();
-    ctx.runtime.killAllChildren();
-    ctx.workspace.setWorkspaceRoot(dir);
-    ctx.agents.armAgentsDirWatcher();
-    // Before anything reads state that may have come from another path.
-    ctx.workspace.healWorkspaceIfMoved(dir);
-    // A workspace switch (including re-selecting the same one) is the
-    // retry trigger for a failed search-engine open, and must not
-    // serve the previous workspace's cached file/skill lists.
-    ctx.store.clearSearchFailure();
-    ctx.agents.invalidateAgentCache();
-    loadRoutineState();
-    ctx.workspace.saveRecentWorkspace(dir);
-    // Clean up orphaned processes from previous sessions in this workspace
-    ctx.runtime.cleanOrphanedProcesses();
-    startup.mark('prepare');
-
-    // Detect empty workspace before scaffolding (scaffoldWorkspace adds Doc/skills)
-    let agentList = [];
-    try { agentList = discoverAgents(); } catch (e) { console.warn('  Agent discovery failed:', e.message); }
-    startup.mark('agents');
-    const isEmpty = isEmptyWorkspace(dir, agentList);
-
-    // Empty workspace: scaffold default folders and CLAUDE.md
-    let scaffoldError = null;
-    if (isEmpty) {
-      const result = scaffoldDefaults(dir);
-      if (!result.success) scaffoldError = result.error;
-      ctx.agents.invalidateAgentCache();
-    }
-
-    try { scaffoldWorkspace(dir); } catch (e) { console.warn('Scaffold warning:', e.message); }
-    startup.mark('scaffold');
-    console.log(`  Workspace changed to: ${getWorkspace()} (empty=${isEmpty})`);
-
-    // Re-discover agents after scaffolding
-    try { agentList = discoverAgents(); } catch (e) { console.warn('  Agent discovery failed:', e.message); }
-
-    // Auto-detect and store workspace mode
-    const state = readState();
-    if (!state.workspaceMode) {
-      state.workspaceMode = detectWorkspaceMode(dir);
-      writeState(state);
-      console.log(`  Workspace mode auto-detected: ${state.workspaceMode}`);
-    }
-
-    let analysis = null;
-    try { analysis = analyzeWorkspace(dir, agentList); } catch (e) { console.warn('  Workspace analysis failed:', e.message); }
-    startup.mark('analyze');
-    ws.send(JSON.stringify({ type: 'workspace_set', path: getWorkspace(), analysis, isEmpty, workspaceMode: state.workspaceMode, setupComplete: !!state.setupComplete, scaffoldError }));
-    ws.send(JSON.stringify({ type: 'agents', agents: agentList }));
-    try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.getFileTreeCached() })); } catch (e) { console.warn('  File tree failed:', e.message); }
-    startup.mark('tree');
-    ctx.signals.reportStartup(`workspace open: ${startup.summary()}`);
-    // Warm the search index off the open path (reconcile-on-open);
-    // ensureSearchEngine also self-heals lazily on first search.
-    setImmediate(() => { try { ctx.store.ensureSearchEngine(); } catch (e) { console.warn('[Search] warm-up failed:', e.message); } });
-  } else {
+  if (!(dir && fs.existsSync(dir) && fs.statSync(dir).isDirectory())) {
     ws.send(JSON.stringify({ type: 'workspace_error', message: 'Directory not found' }));
+    return;
   }
+  // Pre-flight: a .rundock that is not a directory breaks every prepare
+  // step below. Refuse BEFORE touching any state, naming the culprit.
+  const rundockEntry = path.join(dir, '.rundock');
+  if (fs.existsSync(rundockEntry) && !fs.statSync(rundockEntry).isDirectory()) {
+    ws.send(JSON.stringify({ type: 'workspace_error',
+      message: `Could not open workspace: ${rundockEntry} is a file, but Rundock needs .rundock to be a directory. Remove or rename it and try again.` }));
+    return;
+  }
+  // Belt and braces for any OTHER throw in the open path: the switch used
+  // to die into the message-loop catch AFTER the root had changed, leaving
+  // the server half-switched and the client with no reply at all. Roll the
+  // root back and answer; never silence.
+  const previousRoot = getWorkspace();
+  try {
+    openWorkspace(ctx, ws, dir);
+  } catch (e) {
+    try {
+      ctx.workspace.setWorkspaceRoot(previousRoot);
+      ctx.agents.invalidateAgentCache();
+      ctx.store.clearSearchFailure();
+    } catch (rollbackErr) { console.warn('  Workspace rollback failed:', rollbackErr.message); }
+    ws.send(JSON.stringify({ type: 'workspace_error', message: 'Could not open workspace: ' + e.message }));
+  }
+}
+
+// The successful open path, extracted so handleSetWorkspace can guard and
+// roll it back as one unit.
+function openWorkspace(ctx, ws, dir) {
+  // Kill all running processes when switching workspace
+  const startup = ctx.signals.phaseTimer();
+  ctx.runtime.killAllChildren();
+  ctx.workspace.setWorkspaceRoot(dir);
+  ctx.agents.armAgentsDirWatcher();
+  // Before anything reads state that may have come from another path.
+  ctx.workspace.healWorkspaceIfMoved(dir);
+  // A workspace switch (including re-selecting the same one) is the
+  // retry trigger for a failed search-engine open, and must not
+  // serve the previous workspace's cached file/skill lists.
+  ctx.store.clearSearchFailure();
+  ctx.agents.invalidateAgentCache();
+  loadRoutineState();
+  ctx.workspace.saveRecentWorkspace(dir);
+  // Clean up orphaned processes from previous sessions in this workspace
+  ctx.runtime.cleanOrphanedProcesses();
+  startup.mark('prepare');
+
+  // Detect empty workspace before scaffolding (scaffoldWorkspace adds Doc/skills)
+  let agentList = [];
+  try { agentList = discoverAgents(); } catch (e) { console.warn('  Agent discovery failed:', e.message); }
+  startup.mark('agents');
+  const isEmpty = isEmptyWorkspace(dir, agentList);
+
+  // Empty workspace: scaffold default folders and CLAUDE.md
+  let scaffoldError = null;
+  if (isEmpty) {
+    const result = scaffoldDefaults(dir);
+    if (!result.success) scaffoldError = result.error;
+    ctx.agents.invalidateAgentCache();
+  }
+
+  try { scaffoldWorkspace(dir); } catch (e) { console.warn('Scaffold warning:', e.message); }
+  startup.mark('scaffold');
+  console.log(`  Workspace changed to: ${getWorkspace()} (empty=${isEmpty})`);
+
+  // Re-discover agents after scaffolding
+  try { agentList = discoverAgents(); } catch (e) { console.warn('  Agent discovery failed:', e.message); }
+
+  // Auto-detect and store workspace mode
+  const state = readState();
+  if (!state.workspaceMode) {
+    state.workspaceMode = detectWorkspaceMode(dir);
+    writeState(state);
+    console.log(`  Workspace mode auto-detected: ${state.workspaceMode}`);
+  }
+
+  let analysis = null;
+  try { analysis = analyzeWorkspace(dir, agentList); } catch (e) { console.warn('  Workspace analysis failed:', e.message); }
+  startup.mark('analyze');
+  ws.send(JSON.stringify({ type: 'workspace_set', path: getWorkspace(), analysis, isEmpty, workspaceMode: state.workspaceMode, setupComplete: !!state.setupComplete, scaffoldError }));
+  ws.send(JSON.stringify({ type: 'agents', agents: agentList }));
+  try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.getFileTreeCached() })); } catch (e) { console.warn('  File tree failed:', e.message); }
+  startup.mark('tree');
+  ctx.signals.reportStartup(`workspace open: ${startup.summary()}`);
+  // Warm the search index off the open path (reconcile-on-open);
+  // ensureSearchEngine also self-heals lazily on first search.
+  setImmediate(() => { try { ctx.store.ensureSearchEngine(); } catch (e) { console.warn('[Search] warm-up failed:', e.message); } });
 }
 
 function handlePickFolder(ctx, ws, msg) {

--- a/test/integration/legacy-mode.test.js
+++ b/test/integration/legacy-mode.test.js
@@ -99,24 +99,16 @@ test('legacy close flush: a non-JSON fragment degrades to a raw message, never a
   await client.waitFor(m => m.type === 'system' && m.subtype === 'done' && m._conversationId === convoId, { since, label: 'done after raw flush' });
 });
 
-test('a handler throwing inside the message loop is contained: the connection keeps serving', async () => {
-  // set_workspace into a directory whose .rundock is a FILE throws in the
-  // handler (the carded silent-no-reply gap). This test pins CONTAINMENT
-  // only: the loop's catch swallows the throw and the connection stays
-  // usable. It deliberately does NOT pin the missing error reply, so the
-  // carded fix (answer with a workspace_error) lands without touching this.
-  const fs = require('node:fs');
-  const os = require('node:os');
-  const path = require('node:path');
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-broken-ws-'));
-  fs.writeFileSync(path.join(dir, '.rundock'), 'a file, not a directory');
-  try {
-    const since = client.messages.length;
-    client.send({ type: 'set_workspace', path: dir });
-    client.send({ type: 'get_workspaces' });
-    const { msg } = await client.waitFor(m => m.type === 'workspaces', { since, label: 'loop alive after handler throw' });
-    assert.ok(msg, 'the message loop survived the throwing handler');
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+test('a throw inside the message loop is contained: the connection keeps serving', async () => {
+  // The loop's catch is the last line of defence for ANY throw between
+  // parse and dispatch. Drive it with a frame that is not JSON at all: the
+  // parse throws before any handler runs, which keeps this pin independent
+  // of every handler's own error handling (the original construction used
+  // the broken-.rundock set_workspace throw, which the handler now answers
+  // properly instead of throwing).
+  const since = client.messages.length;
+  client.ws.send('this is not json {');
+  client.send({ type: 'get_workspaces' });
+  const { msg } = await client.waitFor(m => m.type === 'workspaces', { since, label: 'loop alive after parse throw' });
+  assert.ok(msg, 'the message loop survived the malformed frame');
 });

--- a/test/integration/ws-handler-edges.test.js
+++ b/test/integration/ws-handler-edges.test.js
@@ -61,12 +61,30 @@ describe('workspace lifecycle edges', () => {
     }
   });
 
+  test('set_workspace into a workspace whose .rundock is a FILE answers an error and stays put', async () => {
+    // Discovered during the handler characterisation: the prepare steps
+    // threw into the message-loop catch AFTER the root had already switched,
+    // so the client got NO reply and the server was left half-switched.
+    const before = h.internal.getWorkspace();
+    const dir = makeTempDir('rundock-test-brokenrd-');
+    fs.writeFileSync(path.join(dir, 'notes.md'), '# not empty\n');
+    fs.writeFileSync(path.join(dir, '.rundock'), 'a file, not a directory');
+    try {
+      const res = await request({ type: 'set_workspace', path: dir },
+        m => m.type === 'workspace_error', 'workspace_error broken .rundock');
+      assert.match(res.message, /\.rundock/, 'the error names the broken .rundock');
+      assert.strictEqual(h.internal.getWorkspace(), before,
+        'the previous workspace remains active: no half-switch');
+    } finally {
+      h.internal.setWorkspace(h.workspaceDir);
+    }
+  });
+
   test('set_workspace_mode surfaces a persistence failure as a workspace_error', async () => {
     // .rundock as a FILE makes writeState throw (the slice-3 trick). The
-    // switch itself happens through the internal seam: the WS open path
-    // cannot enter a workspace whose .rundock is a file (its prepare steps
-    // throw into the message-loop catch and answer nothing; recorded as a
-    // discovered edge, not driven here).
+    // switch happens through the internal seam because the WS open path now
+    // REFUSES a workspace whose .rundock is a file (see the broken-.rundock
+    // test above).
     const dir = makeTempDir('rundock-test-badmode-');
     fs.writeFileSync(path.join(dir, 'notes.md'), '# not empty\n');
     try {

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -111,6 +111,58 @@ describe('handler seams (stub ctx, capture ws)', () => {
     }
   });
 
+  test('set_workspace rolls the root back and answers when the open path throws', () => {
+    const table = buildDispatch();
+    const original = config.getWorkspace();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-handlers-'));
+    const rolledBack = [];
+    const invalidated = [];
+    const ctx = {
+      signals: { phaseTimer: () => { throw new Error('prepare exploded'); } },
+      runtime: { killAllChildren: () => {} },
+      workspace: { setWorkspaceRoot: (d) => { rolledBack.push(d); config.setWorkspace(d); } },
+      agents: { invalidateAgentCache: () => invalidated.push('agents') },
+      store: { clearSearchFailure: () => invalidated.push('search') },
+    };
+    try {
+      const ws = captureWs();
+      table.set_workspace(ctx, ws, { type: 'set_workspace', path: dir });
+      assert.strictEqual(ws.sent.length, 1, 'exactly one reply, never silence');
+      assert.strictEqual(ws.sent[0].type, 'workspace_error');
+      assert.match(ws.sent[0].message, /^Could not open workspace: prepare exploded$/);
+      assert.deepStrictEqual(rolledBack, [original], 'the previous root was restored');
+      assert.deepStrictEqual(invalidated, ['agents', 'search'], 'caches cleared after rollback');
+      assert.strictEqual(config.getWorkspace(), original, 'no half-switch persists');
+    } finally {
+      config.setWorkspace(original);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('set_workspace still answers when even the rollback throws', () => {
+    const table = buildDispatch();
+    const original = config.getWorkspace();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-handlers-'));
+    const ctx = {
+      signals: { phaseTimer: () => { throw new Error('prepare exploded'); } },
+      runtime: { killAllChildren: () => {} },
+      workspace: { setWorkspaceRoot: () => { throw new Error('rollback exploded too'); } },
+      agents: { invalidateAgentCache: () => {} },
+      store: { clearSearchFailure: () => {} },
+    };
+    try {
+      const ws = captureWs();
+      table.set_workspace(ctx, ws, { type: 'set_workspace', path: dir });
+      assert.strictEqual(ws.sent.length, 1, 'the reply survives a failed rollback');
+      assert.strictEqual(ws.sent[0].type, 'workspace_error');
+      assert.match(ws.sent[0].message, /^Could not open workspace: prepare exploded$/,
+        'the ORIGINAL failure is reported, not the rollback failure');
+    } finally {
+      config.setWorkspace(original);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('create_path routes its guard through ctx.workspace', () => {
     const table = buildDispatch();
     const original = config.getWorkspace();


### PR DESCRIPTION
Opening a workspace whose `.rundock` entry is a FILE threw in the prepare steps AFTER the root had already switched: the message-loop catch swallowed it, the client hung with NO reply, and the server was left half-switched. Found by the handler characterisation (#108), carded then, fixed red-first now.

- **Red-first:** the new integration test reproduces the silence (it timed out against the old code) and now asserts a `workspace_error` naming the broken `.rundock` with the previous workspace still active.
- **Fix, two layers:** a pre-flight refusal before any state changes, plus a rollback guard around the extracted `openWorkspace` path for any OTHER throw (root restored, caches cleared, original error answered; a failed rollback still answers).
- **Instrument integrity:** both guard layers are seam-tested through a stub ctx, keeping `workspace.js` at its 100 floor; the message-loop containment pin re-anchors on a malformed frame (parse throw), so it no longer depends on this handler throwing. 50 floors hold.
- Changelog Fixed entry included. Suite: 1,519 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)