### PR TITLE
Extract the skills view: first view module, /views/ serving infrastructure

### DIFF
--- a/lib/http-router.js
+++ b/lib/http-router.js
@@ -246,10 +246,11 @@ function handleHttpRequest(req, res) {
       res.writeHead(404);
       res.end('Not found');
     }
-  } else if (/^\/(editor|vendor|viewers)\/[\w./-]+\.(m?js|css)$/.test(req.url)) {
+  } else if (/^\/(editor|vendor|viewers|views)\/[\w./-]+\.(m?js|css)$/.test(req.url)) {
     // Static JS/MJS/CSS files for the Tiptap editor module, its vendor bundle,
-    // vendored assets (e.g. highlight.js), and the file-type registry. Path is
-    // constrained to /editor/..., /vendor/... and /viewers/... under public/,
+    // vendored assets (e.g. highlight.js), the file-type registry, and the
+    // extracted view modules under /views/. Path is constrained to
+    // /editor/..., /vendor/..., /viewers/... and /views/... under public/,
     // with only .js/.mjs/.css extensions and only
     // word chars + dot/slash/hyphen in the path. The realpath check below blocks
     // any directory traversal that somehow gets past the regex.

--- a/public/app.js
+++ b/public/app.js
@@ -4064,111 +4064,13 @@ function formatMd(text) { return renderMarkdown(text); }
 function formatMdFull(text) { return renderMarkdown(text, { callouts: true }); }
 
 // ===== 13. SKILLS =====
+// View functions live in views/skills.js (RundockSkillsView, republished on
+// window for the generated onclick handlers and cross-view callers).
+// currentSkillId stays here: routing reads it (switchNav) and the workspace
+// lifecycle resets it (onWorkspaceReady), so it is shared state, not
+// view-local.
 
 let currentSkillId = null;
-
-function renderSkills() {
-  // Progressive disclosure: hide skills nav tab when 0 skills
-  const skillsNav = document.querySelector('.nav-item[data-nav="skills"]');
-  if (skillsNav) {
-    if (skills.length === 0) { skillsNav.style.display = 'none'; return; }
-    else { skillsNav.style.display = ''; }
-  }
-
-  renderSkillsSidebar(skills);
-
-  // Only refresh the detail panel if the user is already on the skills view.
-  // Without this guard, background saves (SAVE_SKILL markers) would yank
-  // the user out of the conversation and into the skills detail page.
-  if (currentView === 'skills') {
-    if (currentSkillId && skills.find(s => s.id === currentSkillId)) {
-      selectSkill(currentSkillId);
-    } else if (skills.length) {
-      selectSkill(skills[0].id);
-    }
-  }
-}
-
-function renderSkillsSidebar(list) {
-  const sidebar = document.getElementById('skills-sidebar-list');
-  sidebar.innerHTML = list.map(s => `
-    <div class="skill-sidebar-item${s.id === currentSkillId ? ' active' : ''}" data-skill="${s.id}" onclick="selectSkill('${s.id}')">
-      <span class="skill-sidebar-name">${esc(s.name)}</span>
-    </div>
-  `).join('');
-}
-
-function selectSkill(id) {
-  const s = skills.find(x => x.id === id);
-  if (!s) return;
-
-  currentSkillId = id;
-  showView('skills');
-
-  // Sidebar highlight
-  document.querySelectorAll('.skill-sidebar-item').forEach(el => el.classList.remove('active'));
-  document.querySelector(`.skill-sidebar-item[data-skill="${id}"]`)?.classList.add('active');
-
-  // Build detail HTML using profile-* classes (matches agent profile pattern)
-  const boltSvg = '<svg viewBox="0 0 24 24" width="26" height="26" fill="currentColor" stroke="none"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>';
-
-  let h = `
-    <div class="profile-header">
-      <div class="profile-avatar skill-avatar">${boltSvg}</div>
-      <div>
-        <div class="profile-name">${esc(s.name)}</div>
-        <div style="font-size:var(--body);color:var(--text-2)">Skill</div>
-      </div>
-    </div>`;
-
-  if (s.description) {
-    h += `<p class="profile-desc" style="margin-bottom:24px">${esc(s.description)}</p>`;
-  }
-
-  // Used by card
-  if (s.assignedAgents.length) {
-    h += `<div class="profile-card"><div class="profile-card-section">
-      <div class="profile-section-label">Used by</div>
-      <div style="display:flex;flex-wrap:wrap;gap:8px;padding-top:4px">`;
-    for (const a of s.assignedAgents) {
-      h += `<div class="agent-chip" title="View ${esc(a.name)}'s profile" onclick="switchNav('team');showProfile('${esc(a.id)}')">
-        <div class="avatar sm" style="background:${a.colour}">${a.icon}</div>
-        <div>
-          <div class="agent-chip-name">${esc(a.name)}</div>
-          <div class="agent-chip-role">${esc(a.role || '')}</div>
-        </div>
-      </div>`;
-    }
-    h += `</div></div></div>`;
-  } else {
-    const guide = getGuide();
-    h += `<div class="profile-card"><div class="profile-card-section">
-      <div class="profile-section-label">Used by</div>
-      <div class="profile-card-text" style="padding-top:4px">Available to all agents</div>
-      <div style="margin-top:8px;font-size:var(--caption);color:var(--text-2);line-height:1.5">
-        Want to assign this to a specific agent?
-        ${guide ? `<span style="font-size:var(--caption);font-weight:500;color:var(--accent);cursor:pointer" onclick="startConversation('${guide.id}')" title="Open a conversation with Doc">Talk to Doc</span>.` : ''}
-      </div>
-    </div></div>`;
-  }
-
-  // Collapsible instructions card
-  if (s.instructions) {
-    const instructionsId = `skill-instructions-${s.id}`;
-    h += `<div class="profile-card" style="cursor:pointer" onclick="document.getElementById('${instructionsId}').classList.toggle('hidden')">
-      <div class="profile-card-section">
-        <div class="profile-section-label">Instructions &#9662;</div>
-        <div id="${instructionsId}" class="hidden">
-          <div style="font-size:var(--caption);line-height:1.6;white-space:pre-wrap;color:var(--text-2);padding-top:8px">${esc(s.instructions)}</div>
-        </div>
-      </div>
-    </div>`;
-  }
-
-  const detail = document.getElementById('skill-detail-content');
-  detail.innerHTML = h;
-  detail.scrollTop = 0;
-}
 
 // ===== 14. SETTINGS =====
 

--- a/public/index.html
+++ b/public/index.html
@@ -1383,6 +1383,7 @@ mark.find-match.current,
 
 <!-- Kanban parser/serializer (UMD): sets window.Kanban for the board view. -->
 <script src="/kanban.js"></script>
+<script src="/views/skills.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/public/views/skills.js
+++ b/public/views/skills.js
@@ -1,0 +1,129 @@
+'use strict';
+// Skills view: sidebar list + detail panel. Extracted verbatim from app.js
+// (section 13) as the first Foundations view module. Same UMD pattern as
+// markers.js (node-requireable, window-attached); additionally republishes
+// each view function on the root object, because classic-script function
+// declarations were window properties and the callers rely on that: the
+// generated onclick handlers (selectSkill), the WS dispatch (renderSkills),
+// routing, the palette, and agent profiles (selectSkill).
+//
+// Shared state stays in app.js and is reached through the global lexical
+// environment at call time: skills, currentView, currentSkillId (read by
+// routing in switchNav, reset by onWorkspaceReady, so it is shared state,
+// not view-local), plus the helpers esc, showView and getGuide. Load order
+// (views before app.js) is safe because nothing here touches shared state
+// until the app boots. Function bodies are byte-identical to the app.js
+// originals at column 0.
+(/** @param {any} root @param {() => object} factory */ function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else {
+    root.RundockSkillsView = factory();
+    Object.assign(root, root.RundockSkillsView);
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+function renderSkills() {
+  // Progressive disclosure: hide skills nav tab when 0 skills
+  const skillsNav = document.querySelector('.nav-item[data-nav="skills"]');
+  if (skillsNav) {
+    if (skills.length === 0) { skillsNav.style.display = 'none'; return; }
+    else { skillsNav.style.display = ''; }
+  }
+
+  renderSkillsSidebar(skills);
+
+  // Only refresh the detail panel if the user is already on the skills view.
+  // Without this guard, background saves (SAVE_SKILL markers) would yank
+  // the user out of the conversation and into the skills detail page.
+  if (currentView === 'skills') {
+    if (currentSkillId && skills.find(s => s.id === currentSkillId)) {
+      selectSkill(currentSkillId);
+    } else if (skills.length) {
+      selectSkill(skills[0].id);
+    }
+  }
+}
+
+function renderSkillsSidebar(list) {
+  const sidebar = document.getElementById('skills-sidebar-list');
+  sidebar.innerHTML = list.map(s => `
+    <div class="skill-sidebar-item${s.id === currentSkillId ? ' active' : ''}" data-skill="${s.id}" onclick="selectSkill('${s.id}')">
+      <span class="skill-sidebar-name">${esc(s.name)}</span>
+    </div>
+  `).join('');
+}
+
+function selectSkill(id) {
+  const s = skills.find(x => x.id === id);
+  if (!s) return;
+
+  currentSkillId = id;
+  showView('skills');
+
+  // Sidebar highlight
+  document.querySelectorAll('.skill-sidebar-item').forEach(el => el.classList.remove('active'));
+  document.querySelector(`.skill-sidebar-item[data-skill="${id}"]`)?.classList.add('active');
+
+  // Build detail HTML using profile-* classes (matches agent profile pattern)
+  const boltSvg = '<svg viewBox="0 0 24 24" width="26" height="26" fill="currentColor" stroke="none"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>';
+
+  let h = `
+    <div class="profile-header">
+      <div class="profile-avatar skill-avatar">${boltSvg}</div>
+      <div>
+        <div class="profile-name">${esc(s.name)}</div>
+        <div style="font-size:var(--body);color:var(--text-2)">Skill</div>
+      </div>
+    </div>`;
+
+  if (s.description) {
+    h += `<p class="profile-desc" style="margin-bottom:24px">${esc(s.description)}</p>`;
+  }
+
+  // Used by card
+  if (s.assignedAgents.length) {
+    h += `<div class="profile-card"><div class="profile-card-section">
+      <div class="profile-section-label">Used by</div>
+      <div style="display:flex;flex-wrap:wrap;gap:8px;padding-top:4px">`;
+    for (const a of s.assignedAgents) {
+      h += `<div class="agent-chip" title="View ${esc(a.name)}'s profile" onclick="switchNav('team');showProfile('${esc(a.id)}')">
+        <div class="avatar sm" style="background:${a.colour}">${a.icon}</div>
+        <div>
+          <div class="agent-chip-name">${esc(a.name)}</div>
+          <div class="agent-chip-role">${esc(a.role || '')}</div>
+        </div>
+      </div>`;
+    }
+    h += `</div></div></div>`;
+  } else {
+    const guide = getGuide();
+    h += `<div class="profile-card"><div class="profile-card-section">
+      <div class="profile-section-label">Used by</div>
+      <div class="profile-card-text" style="padding-top:4px">Available to all agents</div>
+      <div style="margin-top:8px;font-size:var(--caption);color:var(--text-2);line-height:1.5">
+        Want to assign this to a specific agent?
+        ${guide ? `<span style="font-size:var(--caption);font-weight:500;color:var(--accent);cursor:pointer" onclick="startConversation('${guide.id}')" title="Open a conversation with Doc">Talk to Doc</span>.` : ''}
+      </div>
+    </div></div>`;
+  }
+
+  // Collapsible instructions card
+  if (s.instructions) {
+    const instructionsId = `skill-instructions-${s.id}`;
+    h += `<div class="profile-card" style="cursor:pointer" onclick="document.getElementById('${instructionsId}').classList.toggle('hidden')">
+      <div class="profile-card-section">
+        <div class="profile-section-label">Instructions &#9662;</div>
+        <div id="${instructionsId}" class="hidden">
+          <div style="font-size:var(--caption);line-height:1.6;white-space:pre-wrap;color:var(--text-2);padding-top:8px">${esc(s.instructions)}</div>
+        </div>
+      </div>
+    </div>`;
+  }
+
+  const detail = document.getElementById('skill-detail-content');
+  detail.innerHTML = h;
+  detail.scrollTop = 0;
+}
+
+return { renderSkills, renderSkillsSidebar, selectSkill };
+}));

--- a/test/e2e/coverage.js
+++ b/test/e2e/coverage.js
@@ -28,6 +28,8 @@ const CLIENT_FILES = [
   'palette-model.js', 'code-language.js', 'conversation-state.js',
   // File-view registry + review modules
   'viewers/registry.js', 'viewers/text-anchor.js', 'viewers/sidecar-controller.js', 'viewers/artifact-review.js',
+  // Extracted view modules
+  'views/skills.js',
 ];
 
 function isClientEntry(url) {

--- a/test/integration/http-api.test.js
+++ b/test/integration/http-api.test.js
@@ -161,6 +161,13 @@ describe('path traversal guards', () => {
     assert.ok(res.body.includes('classify'), 'registry module content served');
   });
 
+  test('/views/skills.js is served as javascript (the first extracted view module)', async () => {
+    const res = await get('/views/skills.js');
+    assert.strictEqual(res.status, 200);
+    assert.match(res.headers.get('content-type') || '', /javascript/);
+    assert.ok(res.body.includes('RundockSkillsView'), 'skills view module content served');
+  });
+
 
   test('WS read_file is guarded the same way as /api/file', async () => {
     const outside = path.join(h.workspaceDir, '..', `ws-secret-${Date.now()}.md`);

--- a/test/integration/http-api.test.js
+++ b/test/integration/http-api.test.js
@@ -145,12 +145,14 @@ describe('path traversal guards', () => {
     }
   });
 
-  test('/editor, /vendor and /viewers static routes reject traversal and unknown extensions', async () => {
+  test('/editor, /vendor, /viewers and /views static routes reject traversal and unknown extensions', async () => {
     assert.strictEqual((await get('/editor/../server.js')).status, 404);
     assert.strictEqual((await get('/vendor/x.png')).status, 404);
     assert.strictEqual((await get('/editor/%2e%2e/server.js')).status, 404);
     assert.strictEqual((await get('/viewers/../server.js')).status, 404);
     assert.strictEqual((await get('/viewers/x.png')).status, 404);
+    assert.strictEqual((await get('/views/../server.js')).status, 404);
+    assert.strictEqual((await get('/views/x.png')).status, 404);
   });
 
   test('/viewers/registry.js is served as javascript (the file-type registry module)', async () => {
@@ -158,6 +160,7 @@ describe('path traversal guards', () => {
     assert.strictEqual(res.status, 200);
     assert.ok(res.body.includes('classify'), 'registry module content served');
   });
+
 
   test('WS read_file is guarded the same way as /api/file', async () => {
     const outside = path.join(h.workspaceDir, '..', `ws-secret-${Date.now()}.md`);


### PR DESCRIPTION
First slice of the app.js decomposition: the skills view becomes the first extracted view module, and the serving/guard infrastructure for `public/views/` lands with it.

## What moved

`renderSkills`, `renderSkillsSidebar` and `selectSkill` (app.js section 13, ~110 lines) move byte-identical into `public/views/skills.js`, wrapped in the same UMD pattern as `markers.js` (node-requireable, window-attached). The wrapper additionally republishes each function on the root object: classic-script function declarations were window properties, and the generated onclick handlers, the WS dispatch, routing, the palette, and agent profiles all rely on that resolution.

`currentSkillId` stays in app.js. Scoping found two external touchpoints (routing reads it in `switchNav`; the workspace lifecycle resets it in `onWorkspaceReady`), so it is shared state, not view-local.

Script order: models, then views, then app.js. Load order is safe because nothing in the module touches shared state until the app boots.

app.js: 5,647 -> 5,549 lines.

## Serving and guards (one-time infrastructure)

- The static subdirectory route regex gains `views` alongside `editor|vendor|viewers`, same realpath prefix guard, same extension allowlist; traversal-rejection tests extended to the new prefix.
- `/views/skills.js` gets an explicit serve test (status, content type, module content).
- `views/skills.js` joins the e2e coverage tool's client file list: 52/129 lines measured by the existing golden paths (the palette's skill destination drives `selectSkill` end to end).
- The generic index-html-to-route and packaging guards cover the new script tag by construction; `build.files` already packages `public/**/*`.

## Verification

- Node suite: 1,520/1,520, all 50 coverage floors hold.
- E2E: 103/103, first run.
- Smoke: 20/20 stub checks.
- `node --check` on both files; the module requires cleanly under Node.

Commits: route infra, verbatim move, guards — separated per the move-commit discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
