### PR TITLE
Clear the last two blockers on the app.js decomposition acceptance line

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -452,10 +452,7 @@ function handle(d) {
       break;
     }
     case 'permission_timeout': {
-      const card = document.getElementById('perm-' + d.requestId);
-      if (card) {
-        card.innerHTML = `<div class="permission-resolved denied"><span>✕ Timed out</span></div>`;
-      }
+      resolvePermissionCard(d.requestId, false, '✕ Timed out', false);
       pendingPermissions.delete(d.requestId);
       // Expired: a copy queued for a background conversation must never be
       // rendered (and answered) after the server has auto-denied it.

--- a/public/app.js
+++ b/public/app.js
@@ -678,19 +678,6 @@ function executeEffects(convoId, effects) {
     else console.warn('[Effects] Unknown effect type:', ef.type);
   }
 }
-// Flush a deferred "resumed" badge into the message stream.
-// Build a delegation divider element. Used by live agent_switch, in-memory replay, and history replay.
-function buildDelegationDivider(agentData, isReturn, opts = {}) {
-  const divider = document.createElement('div');
-  divider.className = 'msg-delegation' + (opts.historyClass ? ' history-msg' : '');
-  if (opts.noAnimation) divider.style.animation = 'none';
-  const label = isReturn ? 'resumed' : 'joined';
-  const colour = agentData?.colour || 'var(--accent)';
-  const icon = agentData?.icon || '?';
-  const name = agentData?.displayName || 'Agent';
-  divider.innerHTML = `<div class="delegation-line"></div><div class="delegation-badge" style="color:${colour}"><span class="avatar xs" style="background:${colour}">${icon}</span>${name} ${label}</div><div class="delegation-line"></div>`;
-  return divider;
-}
 
 function isStaleProcess(d, convoId) {
   // The activeProcessId acceptance rule lives in the reducer module; this

--- a/public/chat-markup.js
+++ b/public/chat-markup.js
@@ -1,5 +1,7 @@
 'use strict';
-// The single source of chat message markup. Pure string builders: no DOM, no
+// The single source of chat thread markup: agent and user messages, the
+// thinking indicator, delegation dividers and resolved permission cards.
+// Pure string builders: no DOM, no
 // globals, no clock. Callers create the element, set innerHTML from one of
 // these, and own every side effect.
 //
@@ -21,6 +23,8 @@
 //                     its innerHTML on every frame of a response
 //   #thinking-status  ensure-tool-status and update-tool-status write the
 //                     current tool name into it by id
+//   .permission-*     the resolved card reads .permission-summary out of the
+//                     card it is replacing, so the two shapes are a pair
 // Renaming any of them means changing those readers in the same commit.
 //
 // Load-order and naming note. Unlike the modules under public/views/, this one
@@ -29,10 +33,11 @@
 // resolve moved functions as bare window properties. Nothing resolves these
 // names that way: every call site is ordinary module code written against
 // this API, so one namespaced global is enough and the client's global surface
-// does not grow by six more names.
+// does not grow by eight more names.
 //
 // Behaviour contract pinned by test/unit/chat-markup.test.js, whose expected
-// strings were produced by evaluating the original seven literals.
+// strings were produced by evaluating the original literals at every call site
+// this module replaced.
 (/** @param {any} root @param {() => object} factory */ function (root, factory) {
   if (typeof module === 'object' && module.exports) module.exports = factory();
   else root.RundockChatMarkup = factory();
@@ -95,6 +100,27 @@
     return `<div class="msg-bubble">${escapedHtml}</div>`;
   }
 
+  // The rule between two agents in a thread: a hairline either side of a badge
+  // naming who took over. `joined` on a handoff, `resumed` when an orchestrator
+  // takes the thread back.
+  /** @param {AgentLike} agent @param {boolean} [isReturn] */
+  function delegationDividerHtml(agent, isReturn) {
+    const colour = agent?.colour || 'var(--accent)';
+    return `<div class="delegation-line"></div><div class="delegation-badge" style="color:${colour}"><span class="avatar xs" style="background:${colour}">${agent?.icon || '?'}</span>${agent?.displayName || 'Agent'} ${isReturn ? 'resumed' : 'joined'}</div><div class="delegation-line"></div>`;
+  }
+
+  // What a permission card becomes once it has been answered, whether the user
+  // answered it or the server timed it out. The class comes from the decision
+  // rather than the label, because the label varies ('✓', '✓ Always', '✕',
+  // '✕ Timed out') while the styling only cares whether it was allowed.
+  //
+  // `text` arrives already escaped and the separating space is emitted only
+  // when there is text, so the timeout card renders exactly as it always did.
+  /** @param {boolean} allowed @param {string} label @param {string} [text] */
+  function permissionResolvedHtml(allowed, label, text) {
+    return `<div class="permission-resolved ${allowed ? 'allowed' : 'denied'}"><span>${label}</span>${text ? ' ' + text : ''}</div>`;
+  }
+
   return {
     msgTimeHtml,
     agentSenderHtml,
@@ -102,5 +128,7 @@
     agentStreamingMessageHtml,
     thinkingIndicatorHtml,
     userBubbleHtml,
+    delegationDividerHtml,
+    permissionResolvedHtml,
   };
 }));

--- a/public/views/chat.js
+++ b/public/views/chat.js
@@ -701,19 +701,26 @@ function respondPermission(requestId, allow, always, allowFolder) {
   }
 
   // Replace the card with a resolved indicator
-  const card = document.getElementById('perm-' + requestId);
-  if (card) {
-    const summary = card.querySelector('.permission-summary')?.textContent || '';
-    const detail = card.querySelector('.permission-detail')?.textContent || '';
-    const label = allow ? (always ? '✓ Always' : '✓') : '✕';
-    card.innerHTML = `<div class="permission-resolved ${allow ? 'allowed' : 'denied'}">
-      <span>${label}</span> ${esc(summary)}
-    </div>`;
-  }
+  resolvePermissionCard(requestId, allow, allow ? (always ? '✓ Always' : '✓') : '✕', true);
 
   // Resume thinking indicator
   const t = document.getElementById('thinking-indicator');
   if (t) t.style.display = '';
+}
+
+// Replace an answered permission card with its resolved indicator. Shared with
+// the WS permission_timeout branch in app.js, which answers the same card when
+// the server auto-denies it: that branch used to write its own markup, which
+// had drifted to a different shape from this one.
+//
+// keepSummary decides whether the card's own summary text is carried into the
+// resolved state. The user-answered path keeps it so the thread still reads as
+// a record of what was approved; the timeout path never showed it.
+function resolvePermissionCard(requestId, allowed, label, keepSummary) {
+  const card = document.getElementById('perm-' + requestId);
+  if (!card) return;
+  const summary = keepSummary ? (card.querySelector('.permission-summary')?.textContent || '') : '';
+  card.innerHTML = RundockChatMarkup.permissionResolvedHtml(allowed, label, summary ? esc(summary) : '');
 }
 
 function formatToolName(name) {
@@ -783,6 +790,7 @@ return {
   addToolMsg, createHistoryDivider, renderSessionHistory, classifyRisk,
   describeToolRequest, toolAllowKey, handlePermissionRequest,
   renderPermissionCard, renderPendingPermissionCards, respondPermission,
+  resolvePermissionCard,
   formatToolName, formatToolShort, buildActivitySummary, scrollBottom,
 };
 }));

--- a/public/views/chat.js
+++ b/public/views/chat.js
@@ -21,8 +21,13 @@
 // the DOMContentLoaded scroll listener writes it. Helpers reached the same
 // way: esc, formatMd, formatTimeAgo, stripRundockMarkers, getConvoState,
 // persistConversation, renderConvoList, updateUnreadBadge, updateWorkingBadge,
-// buildDelegationDivider, tryMessageAnchor, and the classic-script globals
-// RundockPermissions and RundockConversationState.
+// tryMessageAnchor, and the classic-script globals RundockPermissions,
+// RundockConversationState and RundockChatMarkup.
+//
+// buildDelegationDivider moved the other way, from app.js into this module,
+// once the markup came out of it: it renders a thread element, and both of its
+// other callers (the agent_switch effect executor in app.js, in-memory replay
+// in the conversations view) reach it through the root republication.
 //
 // alwaysAllowedTools is the one piece of view-local state: the session-level
 // "always allow" grant set has no reader outside the permission cards, and a
@@ -284,6 +289,18 @@ function addAgentMsg(text,agentId,anim=true,timestamp=null) {
 }
 function addUserMsg(text,anim=true) { const m=document.getElementById('messages'),d=document.createElement('div'); d.className='msg msg-user'; if(!anim)d.style.animation='none'; d.innerHTML=RundockChatMarkup.userBubbleHtml(esc(text)); m.appendChild(d); scrollBottom(true); }
 function addSystemMsg(text) { const m=document.getElementById('messages'),d=document.createElement('div'); d.className='msg-system'; d.textContent=text; m.appendChild(d); scrollBottom(); }
+
+// Build a delegation divider element. Used by live agent_switch (the effect
+// executor in app.js), in-memory replay in the conversations view, and history
+// replay below. It lived in app.js until the markup came out of it; it is
+// chat thread rendering, so it belongs with the rest of the thread.
+function buildDelegationDivider(agentData, isReturn, opts = {}) {
+  const divider = document.createElement('div');
+  divider.className = 'msg-delegation' + (opts.historyClass ? ' history-msg' : '');
+  if (opts.noAnimation) divider.style.animation = 'none';
+  divider.innerHTML = RundockChatMarkup.delegationDividerHtml(agentData, isReturn);
+  return divider;
+}
 
 // Recovery card shown when the Claude Code sign-in expires (401). Replaces the
 // raw error blob with a clear explanation and the steps to reconnect.
@@ -761,7 +778,7 @@ function scrollBottom(force) {
 return {
   dispatchMessage, sendMessage, startProcessing, finishProcessing,
   cancelProcessing, handleActiveProcesses, addAgentMsg, addUserMsg,
-  addSystemMsg, renderAuthErrorCard, copyAuthCmd, agentDisplayName,
+  addSystemMsg, buildDelegationDivider, renderAuthErrorCard, copyAuthCmd, agentDisplayName,
   renderCodexQuotaCard, renderCodexGuidanceCard, renderCodexErrorPill,
   addToolMsg, createHistoryDivider, renderSessionHistory, classifyRisk,
   describeToolRequest, toolAllowKey, handlePermissionRequest,

--- a/test/unit/app-retentions.test.js
+++ b/test/unit/app-retentions.test.js
@@ -1,0 +1,86 @@
+'use strict';
+// The decomposition acceptance line, as a test rather than a judgement call.
+//
+// The spec says app.js contains no view rendering outside its enumerated
+// retentions. That line was claimed complete twice and failed both times,
+// because both checks classified app.js by reading the section banner above a
+// line rather than the code around it, and the banners had gone stale as
+// sections moved out. This test classifies by ENCLOSING FUNCTION, which is
+// what caught the two real misses.
+//
+// It fails in both directions on purpose. A new DOM-writing function in app.js
+// fails it as unenumerated, which is the drift it exists to stop. Removing a
+// retention's last DOM write also fails it, because the manifest then names a
+// function that no longer renders and the list has quietly gone stale, which
+// is exactly how the banners got wrong.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Every function in app.js allowed to write DOM, and the retention that covers
+// it. Adding an entry here is amending the spec's retention list, so it should
+// be as deliberate as that: a named reason, written down at the time.
+const ALLOWED = {
+  copyCode: 'retention 1: markdown rendering',
+  showWorkspacePicker: 'retention 2: workspace picker',
+  renderUpdateStrip: 'retention 3: update strip',
+  EFFECT_EXECUTORS: 'retention 4: effect executors',
+  updateWorkingBadge: 'retention 5: application shell',
+  updateUnreadBadge: 'retention 5: application shell',
+  initSidebarResize: 'retention 5: application shell',
+  applyTheme: 'retention 5: application shell',
+  // Not a retention and not rendering: esc builds a detached node purely to
+  // escape text and never attaches it. It shows up in any createElement scan
+  // and has wasted time in two previous passes, so it is named here.
+  esc: 'not rendering: detached node used to escape text',
+};
+
+const DOM_WRITE = /\.innerHTML\s*=|createElement\(|insertAdjacentHTML|\.appendChild\(/;
+
+function domWritersByFunction(src) {
+  const lines = src.split('\n');
+  const owners = new Map();
+  for (let i = 0; i < lines.length; i++) {
+    if (!DOM_WRITE.test(lines[i])) continue;
+    // Walk back to the nearest column-0 function or const declaration. Column 0
+    // matters: it is what makes this a top-level owner rather than a callback
+    // nested inside one.
+    let owner = '(top level)';
+    for (let j = i; j >= 0; j--) {
+      const l = lines[j];
+      if (l.startsWith(' ') || l.startsWith('\t')) continue;
+      const m = /^(?:async )?function (\w+)|^const (\w+)\s*=/.exec(l);
+      if (m) { owner = m[1] || m[2]; break; }
+    }
+    if (!owners.has(owner)) owners.set(owner, []);
+    owners.get(owner).push(i + 1);
+  }
+  return owners;
+}
+
+test('every DOM-writing function in app.js is an enumerated retention', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'app.js'), 'utf-8');
+  const owners = domWritersByFunction(src);
+
+  assert.ok(owners.size >= 5, `sanity: found ${owners.size} DOM-writing functions`);
+
+  const unenumerated = [...owners.entries()]
+    .filter(([name]) => !(name in ALLOWED))
+    .map(([name, lines]) => `${name} (app.js:${lines.join(', ')})`);
+
+  assert.deepStrictEqual(
+    unenumerated, [],
+    'app.js renders outside its enumerated retentions; either move it into a view module or amend the spec with a named reason and add it here'
+  );
+});
+
+test('the retention manifest has no entries that stopped rendering', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'app.js'), 'utf-8');
+  const owners = domWritersByFunction(src);
+  const stale = Object.keys(ALLOWED).filter(name => !owners.has(name));
+  assert.deepStrictEqual(
+    stale, [],
+    'these are listed as retentions but no longer write DOM in app.js; drop them here and from the spec'
+  );
+});

--- a/test/unit/chat-markup.test.js
+++ b/test/unit/chat-markup.test.js
@@ -242,7 +242,13 @@ test('no chat message markup is written outside chat-markup.js', () => {
   // carry an id the helpers have no reason to take, and a class rename breaks
   // them loudly because the stylesheet stops applying. Production authoring is
   // what drifts silently, and that is what this guards.
-  const TOKENS = ['class="msg-sender"', 'class="msg-bubble', 'class="streaming-text"'];
+  const TOKENS = [
+    'class="msg-sender"', 'class="msg-bubble', 'class="streaming-text"',
+    // Added after the resolved permission card was found written two different
+    // ways, in app.js and views/chat.js: the same defect as the bubbles, one
+    // component over, which the original token list did not cover.
+    'class="permission-resolved', 'class="delegation-',
+  ];
   const publicDir = path.join(__dirname, '..', '..', 'public');
   const owner = path.join(publicDir, 'chat-markup.js');
 

--- a/test/unit/chat-markup.test.js
+++ b/test/unit/chat-markup.test.js
@@ -23,6 +23,8 @@ const {
   agentStreamingMessageHtml,
   thinkingIndicatorHtml,
   userBubbleHtml,
+  delegationDividerHtml,
+  permissionResolvedHtml,
 } = require('../../public/chat-markup.js');
 
 const AGENT = { colour: '#f00', icon: 'D', displayName: 'Dev' };
@@ -144,17 +146,67 @@ test('userBubbleHtml renders a bare bubble with no sender line', () => {
 
 // ── module shape ────────────────────────────────────────────────────────────
 
-test('module exports exactly its six helpers and nothing else', () => {
+test('module exports exactly its eight helpers and nothing else', () => {
   // The surface is enumerated so adding a public helper is a deliberate edit
   // to this test rather than a side effect.
   assert.deepStrictEqual(Object.keys(require('../../public/chat-markup.js')).sort(), [
     'agentMessageHtml',
     'agentSenderHtml',
     'agentStreamingMessageHtml',
+    'delegationDividerHtml',
     'msgTimeHtml',
+    'permissionResolvedHtml',
     'thinkingIndicatorHtml',
     'userBubbleHtml',
   ]);
+});
+
+// ── delegationDividerHtml ───────────────────────────────────────────────────
+
+test('delegationDividerHtml matches the markup buildDelegationDivider held', () => {
+  assert.strictEqual(
+    delegationDividerHtml(AGENT, false),
+    '<div class="delegation-line"></div><div class="delegation-badge" style="color:#f00"><span class="avatar xs" style="background:#f00">D</span>Dev joined</div><div class="delegation-line"></div>'
+  );
+});
+
+test('delegationDividerHtml says resumed on a return leg and joined otherwise', () => {
+  assert.ok(delegationDividerHtml(AGENT, true).includes('Dev resumed'));
+  assert.ok(delegationDividerHtml(AGENT, false).includes('Dev joined'));
+});
+
+test('delegationDividerHtml falls back the same way the sender line does', () => {
+  const html = delegationDividerHtml(null, false);
+  assert.ok(html.includes('color:var(--accent)'));
+  assert.ok(html.includes('>?</span>Agent joined'));
+});
+
+// ── permissionResolvedHtml ──────────────────────────────────────────────────
+
+test('permissionResolvedHtml renders the timeout card byte-identically', () => {
+  // This is the exact string the WS permission_timeout branch wrote before the
+  // builder existed. It has no trailing text, so no separator is emitted.
+  assert.strictEqual(
+    permissionResolvedHtml(false, '✕ Timed out', ''),
+    '<div class="permission-resolved denied"><span>✕ Timed out</span></div>'
+  );
+});
+
+test('permissionResolvedHtml separates label from summary when both are present', () => {
+  assert.strictEqual(
+    permissionResolvedHtml(true, '✓', 'ESC(ran a command)'),
+    '<div class="permission-resolved allowed"><span>✓</span> ESC(ran a command)</div>'
+  );
+});
+
+test('permissionResolvedHtml picks the class from the decision, not the label', () => {
+  assert.ok(permissionResolvedHtml(true, 'x', '').includes('permission-resolved allowed'));
+  assert.ok(permissionResolvedHtml(false, 'x', '').includes('permission-resolved denied'));
+});
+
+test('permissionResolvedHtml does not escape its text, which arrives escaped', () => {
+  // The click path passes esc(summary); escaping again would show entities.
+  assert.ok(permissionResolvedHtml(true, '✓', '&amp;').includes('&amp;'));
 });
 
 // ── the invariant that keeps this module the only source ────────────────────


### PR DESCRIPTION
Clears the last two items standing between `app.js` and the decomposition
acceptance line, and turns that line from something a person checks by hand
into a test.

## Why this was needed twice

The acceptance line says `app.js` contains no view rendering outside its
enumerated retentions. It has been claimed complete twice and failed both
times. Both failures had the same cause: the check classified `app.js` by
reading the **section banner** above a line rather than the code around it, and
the banners had gone stale as sections moved out from under them.

Classifying by **enclosing function** is what found the two real misses, so
that is what the new test does.

## The two blockers

**`buildDelegationDivider`** rendered a chat thread element from `app.js`. It
survived every earlier slice because it has three callers and no single view
could claim it: the `agent_switch` effect executor in `app.js`, in-memory replay
in the conversations view, and history replay in the chat view. The chat view
owns the message thread, so it now owns this. The other two reach it through the
root republication.

**The `permission_timeout` branch** wrote its own resolved-card markup, in a
different shape from the one `views/chat.js` writes when the user answers the
card themselves. Same component, two authors, already diverged: one line versus
a version carrying newlines and indentation inside the div. Both now call
`resolvePermissionCard` in the chat view, which owns permission cards and
already knows how to read a card's summary out of the DOM before replacing it.

`keepSummary` preserves the one place the two genuinely differ: the answered
card carries its summary into the resolved state so the thread still records
what was approved, the timeout card never showed one.

## The acceptance line, as a test

`test/unit/app-retentions.test.js` classifies every DOM-writing site in
`app.js` by enclosing function and asserts each one falls inside an enumerated
retention. It fails in **both** directions, proved before it was kept:

- a stray DOM writer appended to `app.js` fails it, naming the function and line
- a manifest entry that no longer writes DOM fails the companion assertion,
  because a retention list naming functions that stopped rendering is precisely
  how the section banners went wrong

`esc` is named in the manifest as explicitly **not** rendering. It builds a
detached node to escape text, shows up in any `createElement` scan, and has cost
two previous passes time.

Current state, all five retentions accounted for:

| Function | Sites | Retention |
| --- | --- | --- |
| `copyCode` | 4 | markdown rendering |
| `showWorkspacePicker` | 5 | workspace picker |
| `renderUpdateStrip` | 4 | update strip |
| `EFFECT_EXECUTORS` | 15 | effect executors |
| `updateWorkingBadge`, `updateUnreadBadge`, `initSidebarResize`, `applyTheme` | 7 | application shell |
| `esc` | 1 | not rendering |

## Guard extended

`class="permission-resolved` and `class="delegation-` join the markup guard's
token list, both red-first. The original list covered chat message markup only,
which is exactly why it did not catch the permission card being written two ways
in two files.

## Byte identity

The timeout card is byte-identical to the string it replaced. The answered card
is not, and that is the single enumerated exception: the helper emits one line
where the literal had a newline and six spaces after the opening div and a
newline and four before the closing one. HTML collapses both and no test asserts
on either.

## Two pieces of dead matter removed

A dangling comment above the divider, "Flush a deferred resumed badge into the
message stream", describing a function that is no longer there: some earlier
extraction took the code and left the comment. And a local in the answered
permission path that read `.permission-detail` into a variable nothing uses.

## Test results

Suite **1,558** from a measured baseline of **1,549**: seven helper tests and
two retention tests. All **50 coverage floors** hold, smoke **20 of 20**,
typecheck and reference check clean.

**Local e2e is not clean and I want that on the record rather than buried.**
Three consecutive local runs failed one or two different specs each time: board
lane count in `viewers.spec.js:1107`, then the link popover in
`toolbar-block-dropdown.spec.js:183` and a callout edit in
`viewers.spec.js:532`. None touches chat markup, permission cards or delegation
dividers. The first was chased to ground: it reproduces identically on `main` at
`8bd6eb0` with none of this branch's changes present, so it is pre-existing
pollution inside `viewers.spec.js` where an earlier test leaves a fourth board
lane behind. Different specs failing on each run, all timing-sensitive, is a
flake signature rather than a regression, and CI on a clean machine is the
arbiter.

No user-visible change, so no changelog entry.
