### PR TITLE
Document the browser client, and correct the architecture map it contradicted

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,8 @@ The browser is the visual interface. It renders the org chart, the conversation 
 
 The client opens a single WebSocket to the server on load and uses HTTP for static assets and a small number of synchronous endpoints (workspace picker, permission decisions, agent listing). All ongoing conversation traffic flows over the WebSocket.
 
+How `public/` is put together, and why it has no build step, is its own page: [CLIENT-ARCHITECTURE.md](docs/CLIENT-ARCHITECTURE.md). Read it before changing anything in `public/`.
+
 ### The Node.js server
 
 `server.js` is the single server entry point. It does seven things, in roughly this order of importance.
@@ -116,13 +118,19 @@ A handful of source files, three production dependencies, no bundler.
 
 | File | Approximate size | What it owns |
 |---|---|---|
-| `server.js` | ~5,100 lines | HTTP and WebSocket server. Agent and skill discovery. Frontmatter parsing. Subprocess spawn and stdin/stdout bridging. Delegation interception. Conversation persistence. Routine scheduler. Permission mediation. Universal search wiring (engine lifecycle, reconcile triggers, the `search_universal` and `search_conversations` handlers, grep fallback). |
-| `search.js` | ~750 lines | The universal search engine: SQLite FTS5 index over workspace files and conversation transcripts, query sanitisation, fuzzy title scoring. Pure module: no WebSocket, no globals, fully unit-testable. See Universal search, below. |
-| `codex.js` | ~200 lines | Codex runtime support: binary/auth/Windows-sandbox detection, thread-id hygiene, error classification, rollout-file resolution. Pure module, fully unit-testable. |
-| `codex-appserver.js` | ~640 lines | The Codex app-server protocol client and supervisor: one long-lived `codex app-server` process serves every Codex conversation (JSON-RPC over stdio), with streamed turns, first-class approval requests, interrupt, crash restart, and pinned policy invariants. Pure module, fully unit-testable against the protocol stub. |
-| `public/app.js` | ~4,400 lines | Single-page client. WebSocket client. Conversation rendering. Streaming token display. Org chart. Sidebar. File browser. Settings drawer. Permission card UI. Search palette (Cmd+K). |
-| `public/editor/` | ~2,600 lines | The rich markdown editor (Tiptap-based): tables with byte-exact source preservation, CriticMarkup review annotations, the review panel, and the round-trip pipeline. |
-| `public/index.html` | ~900 lines | Layout, CSS, and markup. Nav rail, sidebar, main panel, search palette. No external stylesheet. |
+| `server.js` | ~2,970 lines | HTTP and WebSocket server, composition root, and the wiring that binds the modules below. Subprocess supervision, skill discovery, universal search wiring, permission mediation. |
+| `lib/` | ~6,200 lines | Most of what `server.js` used to hold, extracted into focused modules: `agents/` (discovery, frontmatter parsing, system prompts), `delegation/` (the orchestrator handoff engine, markers, state, handback), `runtime/` (Claude and Codex spawn plumbing), `protocol/handlers/` (one module per WebSocket message family), `workspace/` (boundary, analysis, scaffolding), `store/` (persistence, transcripts), plus `lib/scheduler.js`, `lib/http-router.js`, `lib/config.js`, `lib/signals.js`. |
+| `search.js` | ~1,070 lines | The universal search engine: SQLite FTS5 index over workspace files and conversation transcripts, query sanitisation, fuzzy title scoring. Pure module: no WebSocket, no globals, fully unit-testable. See Universal search, below. |
+| `codex.js` | ~250 lines | Codex runtime support: binary/auth/Windows-sandbox detection, thread-id hygiene, error classification, rollout-file resolution. Pure module, fully unit-testable. |
+| `codex-appserver.js` | ~760 lines | The Codex app-server protocol client and supervisor: one long-lived `codex app-server` process serves every Codex conversation (JSON-RPC over stdio), with streamed turns, first-class approval requests, interrupt, crash restart, and pinned policy invariants. Pure module, fully unit-testable against the protocol stub. |
+| `public/app.js` | ~1,745 lines | The client's composition root: boot, WebSocket client, view routing, shared state, and five enumerated rendering retentions. Not the whole client any more. |
+| `public/views/` | ~4,365 lines | Nine view modules (files, chat, conversations, find, palette, team, settings, skills, profile). Each is node-requireable and republishes its surface onto the global object. |
+| `public/` standalone modules | ~2,170 lines | Fourteen pure, unit-tested modules shared across views: markers, permissions, conversation-state, palette-model, chat-markup, unread-state, and others. |
+| `public/viewers/` | ~1,790 lines | The file-type viewer registry and the artifact review loop. |
+| `public/editor/` | ~5,740 lines | The rich markdown editor (Tiptap-based): tables with byte-exact source preservation, CriticMarkup review annotations, the review panel, and the round-trip pipeline. |
+| `public/index.html` | ~1,400 lines | Layout, CSS, and markup. Nav rail, sidebar, main panel, search palette. No external stylesheet. |
+
+How `public/` is organised, and the rules that keep it that way, is documented in [docs/CLIENT-ARCHITECTURE.md](docs/CLIENT-ARCHITECTURE.md).
 
 **Production dependencies:** `ws` for WebSocket, `marked` for markdown rendering in conversation messages, `electron-updater` for the packaged app. Nothing else.
 
@@ -130,13 +138,13 @@ A handful of source files, three production dependencies, no bundler.
 
 **Where things are:**
 
-- Agent discovery: `discoverAgents` in `server.js`. Reads `.claude/agents/*.md`, parses frontmatter, classifies each agent as `onTeam` (has `order`), `available` (has `type` but no order), or `raw` (neither, a bare Claude Code agent).
-- Frontmatter parsing: `parseAgentFrontmatter`, `parseCapabilities`, `parseRoutines`, `parsePrompts`, `parseSkills` in `server.js`. Hand-rolled YAML subset, intentionally lenient.
+- Agent discovery: `discoverAgents` in `lib/agents/discovery.js`. Reads `.claude/agents/*.md`, parses frontmatter, classifies each agent as `onTeam` (has `order`), `available` (has `type` but no order), or `raw` (neither, a bare Claude Code agent).
+- Frontmatter parsing: `parseAgentFrontmatter`, `parseCapabilities`, `parseRoutines`, `parsePrompts`, `parseSkills` in `lib/agents/discovery.js`. Hand-rolled YAML subset, intentionally lenient.
 - Skill discovery: `discoverSkills` in `server.js`. Scans both `.claude/skills/` and `System/Playbooks/`. Matches skills to agents via the explicit `skills:` array first, then falls back to body-text scanning for the slug.
-- Subprocess spawn: `spawn` calls in `server.js` configured with `getBareArgs()` for workspace context flags and `getSpawnEnv()` for environment variables (workspace mode, conversation ID).
-- Delegation interception: search `server.js` for `agent_switch` and `delegateProcess`. The interception happens inside the stream-json line handler.
-- Markdown editor in the client: search `public/app.js` for the Tiptap initialisation. Used for inline editing of agent files, skill files, and other markdown.
-- Search engine: `search.js` (the whole file; its header comment records the design decisions). Server wiring: `ensureSearchEngine`, `reconcileSearchBeforeQuery`, `runUniversalSearch` in `server.js`. Client palette: search `public/app.js` for `openPalette`.
+- Subprocess spawn: `lib/runtime/claude.js`, which owns `getBareArgs()` for workspace context flags and `getSpawnEnv()` for environment variables (workspace mode, conversation ID). Codex spawns go through `lib/runtime/codex-glue.js`.
+- Delegation interception: `lib/delegation/engine.js`. The interception happens inside the stream-json line handler; `lib/delegation/markers.js` holds the marker grammar and `lib/delegation/state.js` the scope-return bookkeeping.
+- Markdown editor in the client: `public/views/files.js`, which owns the Tiptap lifecycle. Used for inline editing of agent files, skill files, and other markdown.
+- Search engine: `search.js` (the whole file; its header comment records the design decisions). Server wiring: `ensureSearchEngine`, `reconcileSearchBeforeQuery`, `runUniversalSearch` in `server.js`. Client palette: `public/views/palette.js`.
 
 ## Delegation interception, briefly
 
@@ -170,7 +178,7 @@ The engine is exercised by `test/unit/search-*.test.js` (including a 10k-message
 The licence invites you to fork Rundock and audit it. If you take that up, the claims on the trust page reduce to a small set of named places; this is the ten-minute guided path.
 
 - **"Every risky action asks the human first."** The permission decision path spans three layers, and all three are inspectable: the PreToolUse hook script (`scripts/`: what Claude Code consults before any tool runs), the server bridge (`server.js`: `/api/permission-request` for hook-originated requests, `requestServerPermission` for server-originated ones, both with a hard timeout that fails closed), and the client decision module **`public/permissions.js`**: the risk classification, the low-risk read-only auto-approve policy, and the rule that high-risk requests never offer a standing "Always allow" all live there, unit-tested and findable by name.
-- **"Codex agents are sandboxed, and where the sandbox cannot protect you, you approve each action."** The sandbox request and the never-bypassed flags are pinned in `test/integration/spawn-argv-freeze.test.js` (no full-access sandbox, approvals reviewer is always the user, no experimental API surface). Approval requests arrive over the app-server protocol and route through the same permission cards: `handleCodexApproval` in `server.js`, decisions mapped in one place. Platform status detection (installed / signed in / Windows sandbox) is presence-only evidence: `detectCodex` and `hasWindowsSandboxConfig` in `codex.js` never read credential files, only check they exist.
+- **"Codex agents are sandboxed, and where the sandbox cannot protect you, you approve each action."** The sandbox request and the never-bypassed flags are pinned in `test/integration/spawn-argv-freeze.test.js` (no full-access sandbox, approvals reviewer is always the user, no experimental API surface). Approval requests arrive over the app-server protocol and route through the same permission cards: `handleCodexApproval` in `lib/runtime/codex-glue.js`, decisions mapped in one place. Platform status detection (installed / signed in / Windows sandbox) is presence-only evidence: `detectCodex` and `hasWindowsSandboxConfig` in `codex.js` never read credential files, only check they exist.
 - **"Rundock itself makes no outbound network calls."** The dependency footprint is three production packages (`package.json`); the runtimes (Claude Code, Codex CLI) are separate tools you installed and authenticated yourself, spawned as subprocesses: `spawnClaude` and `getCodexAppServer` in `server.js` are the only spawn sites.
 - **"Agents cannot impersonate teammates."** The off-roster delegation block lives in the delegation interception path (`server.js`, search for the blocked-handoff notice); the orchestrator-runtime enforcement is in agent discovery.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ To pull updates later, run `npm run update` in the install directory.
 ## Tech docs
 
 - [ARCHITECTURE.md](ARCHITECTURE.md): the process model, workspace directory, and codebase structure.
+- [CLIENT-ARCHITECTURE.md](docs/CLIENT-ARCHITECTURE.md): how `public/` works. No build step, classic scripts, why modules publish onto the global object, and which settings are load-bearing.
 - [AGENTS.md](docs/AGENTS.md): the agent file format reference. Frontmatter fields, the markdown body, workspace modes, and a complete example.
 - [SKILLS.md](docs/SKILLS.md): the skill file format, discovery, and the assignment model.
 - [ROUTINES.md](docs/ROUTINES.md): the schedule format, scheduler behaviour, and where output goes.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -232,6 +232,6 @@ A few specific things that go wrong silently, in roughly the order of frequency.
 
 ## Pointers
 
-- [ARCHITECTURE.md](ARCHITECTURE.md): the process model, workspace directory, and codebase structure.
-- [CONTRIBUTING.md](CONTRIBUTING.md): dev environment setup and code conventions.
+- [ARCHITECTURE.md](../ARCHITECTURE.md): the process model, workspace directory, and codebase structure.
+- [CONTRIBUTING.md](../CONTRIBUTING.md): dev environment setup and code conventions.
 - The agent files in `.claude/agents/`: the canonical reference for what works in practice.

--- a/docs/CLIENT-ARCHITECTURE.md
+++ b/docs/CLIENT-ARCHITECTURE.md
@@ -1,0 +1,210 @@
+# The browser client
+
+Written for your first day. It explains how `public/` is put together, why it is
+put together that way, and which parts look like mistakes but are not.
+
+The short version: there is no build step, the client is a set of classic
+scripts, and modules publish their functions onto the global object on purpose.
+If that sounds like something to modernise, read the next two sections before
+you do, because the inline handlers in `index.html` depend on it.
+
+## Why there is no build step
+
+`npm start` runs `node server.js`. Change a file in `public/`, reload the
+browser. That is the whole loop. No bundler, no transpiler, no minifier, no
+watch process, no source maps to go stale.
+
+Three production dependencies (`ws`, `marked`, `electron-updater`) and none of
+them touch the client build, because there is not one.
+
+This is a deliberate constraint, not an accident of age. Rundock is a local-first
+desktop app that people run from source; a build step means a second thing to
+install, a second thing to break on someone else's machine, and a gap between
+what you read and what runs. The cost is that the client cannot use ES modules,
+`import`, JSX or TypeScript syntax. Everything below follows from paying that
+cost.
+
+## How a module is found and loaded
+
+Every client script is a classic `<script src>` tag in `public/index.html`, in
+this order:
+
+1. vendored third-party bundles (`marked`, `highlight.js`)
+2. standalone pure modules (`markers.js`, `permissions.js`, `conversation-state.js`, `chat-markup.js`, and others)
+3. the nine view modules under `public/views/`
+4. `public/app.js`, last
+
+Serving is two route patterns in `lib/http-router.js`: `/^\/[\w-]+\.m?js$/` for
+top-level files under `public/`, and `/^\/(editor|vendor|viewers|views)\/...$/`
+for the subdirectories. Both resolve against a realpath prefix check so traversal
+cannot be expressed.
+
+A script tag without a route is a silent 404 that a defensive fallback can mask,
+which shipped once (`code-language.js`, 0.10.0). `test/integration/http-api.test.js`
+now asserts every local script tag in `index.html` resolves to a live route, so
+that class cannot ship again. Add a script tag, add a serve test.
+
+Every module uses the same UMD wrapper:
+
+```js
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.RundockThing = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+  /* ... */
+  return { /* public surface */ };
+}));
+```
+
+That `typeof self` is the UMD idiom, not a load-order guard. There are 24 of
+them, one per module, and they all mean the same thing: run under Node when
+required, attach to the window when loaded in a browser.
+
+**The factory must be side-effect-free.** It may declare functions and allocate
+inert values; it may not touch the DOM, read a global from another module, or
+register a listener. If it does, `require()` throws under `node --test` and the
+module loses its unit tests. This is checkable: every module under `public/views/`
+requires cleanly in Node with `document` undefined.
+
+## Republication, and when a name must not be republished
+
+The view modules do something the standalone modules do not. After building the
+namespace object they copy every name onto the root:
+
+```js
+root.RundockFilesView = factory();
+Object.assign(root, root.RundockFilesView);
+```
+
+This exists for one reason: **things outside JavaScript resolve these names as
+bare window properties.** Specifically:
+
+- 28 inline `onclick=` attributes in `index.html` (plus one `onchange` and one
+  `onmousedown`), which call `sendMessage()`, `cancelProcessing()` and friends
+- `onclick` strings generated into HTML at render time
+- e2e specs reaching client functions through `page.evaluate`, for example
+  `page.evaluate(() => openSkillFile('CLAUDE.md'))` in `test/e2e/viewers.spec.js`
+
+None of those can see a namespaced export. Remove the republication and they
+break at runtime, not at load, and not in a way any type checker will tell you
+about.
+
+**The rule.** A module republishes when something outside module code resolves
+its names bare. A module does not republish when every caller is ordinary
+JavaScript that can say `RundockThing.method()`. `public/chat-markup.js` is the
+worked example of the second case: three modules call it, none of them through an
+inline handler, so it publishes one namespaced global instead of eight bare ones.
+
+The republished surface is currently 165 names across nine modules. It is
+enumerated in `test/unit/client-namespace.test.js`, which fails if two modules
+claim the same name, if a view claims a name `app.js` already declares at top
+level, if the surface drifts from its manifest, or if a republished name is never
+called by its bare name anywhere. Adding a public function is therefore a
+deliberate edit to that manifest.
+
+## What stays in `app.js`, and why
+
+`app.js` is 1,745 lines, down from 5,647. It owns boot, the WebSocket client,
+routing, and shared-state wiring. It also keeps five things that render, each a
+recorded decision rather than leftover mess:
+
+| What | Why it stays |
+|---|---|
+| Markdown rendering | Shared infrastructure with nine chat call sites against one files call site, and its top-level `marked` configuration cannot live in a side-effect-free factory |
+| Workspace picker | Delegated document listeners plus `onWorkspaceReady` lifecycle wiring |
+| Update strip | A top-level `window.electronAPI.onUpdate` registration |
+| `EFFECT_EXECUTORS` | The effect half of the reducer in `conversation-state.js`, cross-view by construction: the same object renders chat bubbles, repaints the sidebar, clears agent status dots, moves unread badges and persists conversations |
+| Application shell | Nav badges, sidebar resize handle, theme toggle icon: chrome present in every view, so it belongs in none of them |
+
+`test/unit/app-retentions.test.js` enforces this. It classifies every DOM-writing
+site in `app.js` by enclosing function and fails if one falls outside that list,
+and it also fails if an entry stops rendering, because a retention list naming
+functions that no longer render is how the previous version of this documentation
+went stale.
+
+Classify by enclosing function, never by the section banner above a line. Those
+banners went stale as sections moved out, and reading them produced two confident
+and wrong claims that the decomposition was finished.
+
+## How modules share state
+
+There is no import graph. Top-level `let` and `const` in a classic script live in
+the shared global lexical environment, so a function in `views/find.js` can read
+`currentView` or `activeConversation` declared in `app.js` simply by naming them.
+The read happens at call time, so the value is always current.
+
+This is why `app.js` loads last and why the retained identifiers above stay where
+they are: they have readers in more than one module.
+
+**Note `let` and `const` are not window properties.** `window.currentView` is
+undefined even though `currentView` resolves. Do not reach for `window.` when
+debugging these; use the bare name in the console.
+
+### The `typeof` guards, honestly
+
+You will find three reads written defensively:
+
+```js
+if (typeof editorMode !== 'undefined' && editorMode === 'preview') { /* ... */ }
+```
+
+There are exactly three (`editorMode` twice and `paletteOpen` once, all in
+`views/find.js`). **They are not a load-order rule, and they are inconsistent.**
+Four lines above the first one, in the same function, `currentView`,
+`activeConversation`, `activeTiptapEditor` and `currentFilePath` are read bare.
+All of them are `app.js` top-level declarations in exactly the same situation.
+
+The actual invariant is simpler: `app.js` is the last script, module factories
+are side-effect-free, and every one of these code paths is reached from a user
+event or from `app.js` itself, so the declarations are always initialised before
+anything can read them. The guards buy nothing that being last does not already
+buy.
+
+They are documented here rather than deleted because a documentation change is
+the wrong place to alter behaviour. Either remove them or apply the pattern
+consistently, in a change of its own.
+
+## Why the test settings are the way they are
+
+These look like things to tune. They are load-bearing, and each one is the
+scar of a specific failure.
+
+**Coverage floors never ratchet down.** `test/tools/coverage-floors.json` holds
+50 floors and the check exits non-zero below them. A floor rises when coverage
+rises and never falls, because the alternative is a number that quietly tracks
+whatever the code currently does, which measures nothing. If a change genuinely
+makes a floor unreachable, that is a conversation, not an edit.
+
+**E2E runs one worker, no parallelism, and no retries.** The specs share one
+stateful server and a seeded workspace, and several assert cross-view navigation
+on that shared instance, so parallelism would make them lie. No retries is the
+deliberate part: a retry converts a real timing regression into a green run with
+a footnote nobody reads. The 60 second timeout is a ceiling for a stuck test, not
+a wait, and green tests never approach it.
+
+If you meet a flaky e2e run, the useful move is to run the single spec file on
+its own. Order-dependent pollution inside one file reproduces that way and looks
+identical to flakiness in a full run.
+
+**Move slices are verified byte-identical.** When code moves file, the moved
+bodies are checked character for character against the original read back out of
+git, and any exception is enumerated in the pull request. A refactor that changes
+behaviour while claiming to be a move is the expensive kind of bug, and "it still
+passes the tests" does not distinguish the two.
+
+**Guards are written red first.** A test that has never failed has not been shown
+to test anything. Every guard in this client was proved to fail for the right
+reason before it was kept, and where a guard asserts an absence it carries a
+companion assertion that the thing it guards still exists, so it cannot pass
+vacuously the day someone renames it.
+
+## Where to look
+
+| You want | Go to |
+|---|---|
+| The process model, server, workspace layout | [ARCHITECTURE.md](../ARCHITECTURE.md) |
+| Dev setup, conventions, changelog rules | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| A view's behaviour | the header comment at the top of its module in `public/views/` |
+| What a module may and may not export | `test/unit/client-namespace.test.js` |
+| What `app.js` may still render | `test/unit/app-retentions.test.js` |
+| Chat thread markup | `public/chat-markup.js`, which is the only file allowed to write it |

--- a/docs/ROUTINES.md
+++ b/docs/ROUTINES.md
@@ -275,5 +275,5 @@ A few specific things that go wrong silently.
 ## Pointers
 
 - [AGENTS.md](AGENTS.md): the agent frontmatter reference, including a brief on the `routines:` array that points back here.
-- [ARCHITECTURE.md](ARCHITECTURE.md): where the scheduler sits in the server's process model and what `.rundock/` does and does not persist.
+- [ARCHITECTURE.md](../ARCHITECTURE.md): where the scheduler sits in the server's process model and what `.rundock/` does and does not persist.
 - The agent files in `.claude/agents/`: the canonical reference for what works in practice.

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -164,5 +164,5 @@ A handful of specific things that go wrong silently with skill files.
 ## Pointers
 
 - [AGENTS.md](AGENTS.md): the agent frontmatter reference, the `skills:` array format, and how agents are matched to skills.
-- [ARCHITECTURE.md](ARCHITECTURE.md): where skill discovery sits in the server's startup and how the two source locations interact.
+- [ARCHITECTURE.md](../ARCHITECTURE.md): where skill discovery sits in the server's startup and how the two source locations interact.
 - The skill files in `.claude/skills/`: the canonical reference for what works in practice.

--- a/test/unit/doc-links.test.js
+++ b/test/unit/doc-links.test.js
@@ -1,0 +1,53 @@
+'use strict';
+// Every relative markdown link in the repo's documentation resolves.
+//
+// Four links in docs/ pointed at ARCHITECTURE.md and CONTRIBUTING.md as if
+// they sat in the same directory; both are at the repo root, so all four
+// 404'd on GitHub. They had been broken long enough that nobody noticed,
+// which is the argument for checking it here rather than by eye.
+//
+// This is the cheapest half of keeping docs honest. It catches a link that
+// stops resolving; it cannot catch prose that stops being true. The pattern
+// worth copying for the second half is docs/RUNTIME-ADAPTER.md, whose claims
+// are pinned by test/unit/runtime-adapter.test.js reading its needles, and
+// which is the one documentation file in this repo that has not drifted.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const SKIP = new Set(['node_modules', '.git', 'test-results', 'dist', 'coverage']);
+
+function markdownFiles(dir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) markdownFiles(p, out);
+    else if (entry.name.endsWith('.md')) out.push(p);
+  }
+  return out;
+}
+
+test('every relative markdown link in the docs resolves to a file', () => {
+  const files = markdownFiles(ROOT).filter(f => !f.includes(`${path.sep}test${path.sep}fixtures${path.sep}`));
+  assert.ok(files.length >= 5, `sanity: found ${files.length} markdown files`);
+
+  const broken = [];
+  for (const file of files) {
+    const lines = fs.readFileSync(file, 'utf-8').split('\n');
+    lines.forEach((line, i) => {
+      // [text](target.md) and [text](dir/target.md#anchor). Absolute URLs and
+      // pure anchors are somebody else's problem.
+      for (const m of line.matchAll(/\[[^\]]*\]\(([^)#\s]+\.md)(?:#[^)]*)?\)/g)) {
+        const target = m[1];
+        if (/^[a-z]+:\/\//i.test(target)) continue;
+        const resolved = path.resolve(path.dirname(file), target);
+        if (!fs.existsSync(resolved)) {
+          broken.push(`${path.relative(ROOT, file)}:${i + 1} -> ${target}`);
+        }
+      }
+    });
+  }
+  assert.deepStrictEqual(broken, [], 'broken relative links in documentation');
+});


### PR DESCRIPTION
`public/` has no build step, uses classic scripts, and has modules that publish
their functions onto the global object on purpose. All three look like things to
modernise and none of them are: 28 inline `onclick` attributes in `index.html`,
generated `onclick` strings, and e2e specs reaching client functions through
`page.evaluate` all resolve those names as bare window properties.

Nothing in the repo said so. The rationale lived in nine module headers, each
explaining only its own slice, and in a spec outside the repo that a new
engineer never sees.

## What the page covers

Why there is no build step. How a module is found and loaded. **When a name must
be republished and when it must not**, with `chat-markup.js` as the worked
counter-example. The five things `app.js` still renders and why. How modules
share state through the global lexical environment, including that `let` and
`const` are not window properties. And why the test settings are the way they
are: floors that never ratchet down, e2e at one worker with no retries,
byte-identical move verification, guards written red first.

## Two corrections to what the task assumed

**There are not 28 `typeof` load-order guards.** There are 29 occurrences of
`typeof x !== 'undefined'`, of which 24 are the UMD wrapper's `typeof self` and
two more are `module`/`window` boilerplate. Only three are genuine cross-module
guards. The number 28 appears to have been borrowed from the inline `onclick`
count, which is a separate fact and is correct.

**Those three guards are inconsistent, not load-bearing.** Four lines above the
first one, in the same function, `currentView`, `activeConversation`,
`activeTiptapEditor` and `currentFilePath` are read bare. All are `app.js`
top-level declarations in identical circumstances. The page says so plainly and
leaves the code alone, because a documentation change is the wrong place to
alter behaviour. Carded separately.

## ARCHITECTURE.md described a codebase that no longer exists

It is the first thing the README sends a newcomer to, and it was wrong by
factors rather than by drift.

| File | Claimed | Actual |
| --- | --- | --- |
| `server.js` | ~5,100 | 2,970 |
| `public/app.js` | ~4,400 | 1,745 |
| `public/editor/` | ~2,600 | 5,740 |
| `public/index.html` | ~900 | 1,398 |
| `lib/` | absent from the table | ~6,200 |
| `public/views/` | absent from the table | ~4,365 |

The pointers mattered more than the numbers, because they send you to the wrong
file with confidence: agent discovery and frontmatter parsing to `server.js`
rather than `lib/agents/discovery.js`, spawn plumbing to `server.js` rather than
`lib/runtime/claude.js`, delegation to a grep of `server.js` rather than
`lib/delegation/engine.js`, the Tiptap editor and the search palette to `app.js`
when both moved to view modules, and `handleCodexApproval` to `server.js` when
it lives in `lib/runtime/codex-glue.js`.

## Four broken links, and a test so they stay fixed

`docs/ROUTINES.md`, `docs/SKILLS.md` and `docs/AGENTS.md` linked to
`ARCHITECTURE.md` and `CONTRIBUTING.md` as if they sat in the same directory.
Both are at the repo root, so all four 404'd on GitHub and had done long enough
that nobody noticed.

The new test walks every markdown file outside fixtures and asserts each
relative link resolves. Red-first: a dangling link fails it naming the file, the
line and the target.

This is the cheap half of keeping docs honest. It catches a link that stops
resolving; it cannot catch prose that stops being true. The pattern for the
other half is already here: `docs/RUNTIME-ADAPTER.md` has its claims pinned by a
test that reads its needles, and it is the one documentation file in this repo
that has not drifted.

## Out of scope, and carded

A full audit of `docs/AGENTS.md`, `docs/SKILLS.md` and `docs/ROUTINES.md` against
the code found material errors in all three, including claims that are the exact
inverse of current behaviour. Those are four cards rather than this pull request,
because they are user-facing corrections that also need the docs site changing,
and mixing them here would make a documentation diff that nothing tests
impossible to review.

## Test results

Suite **1,563** from a measured baseline of **1,562**, the delta being the link
test. Typecheck and reference check clean. No behaviour change: the only
non-markdown file added is a test.
