### PR TITLE
Reframe the client architecture page for contributors, not new hires

### DIFF
--- a/docs/CLIENT-ARCHITECTURE.md
+++ b/docs/CLIENT-ARCHITECTURE.md
@@ -1,7 +1,8 @@
 # The browser client
 
-Written for your first day. It explains how `public/` is put together, why it is
-put together that way, and which parts look like mistakes but are not.
+Read this before changing anything in `public/`. It explains how the client is
+put together, why it is put together that way, and which parts look like
+mistakes but are not.
 
 The short version: there is no build step, the client is a set of classic
 scripts, and modules publish their functions onto the global object on purpose.


### PR DESCRIPTION
`Written for your first day` reads as onboarding an employee. This is a public repository: the people who need this page are contributors and anyone reading the source, not new starters.

The replacement states the trigger instead of the audience, which is also more useful: the page matters at the moment someone is about to change something in `public/`, whoever they are.

Wording only, no content change.