### PR TITLE
Give the design tokens their own served stylesheet, and build the net that verifies it

### DIFF
--- a/lib/http-router.js
+++ b/lib/http-router.js
@@ -246,11 +246,12 @@ function handleHttpRequest(req, res) {
       res.writeHead(404);
       res.end('Not found');
     }
-  } else if (/^\/(editor|vendor|viewers|views)\/[\w./-]+\.(m?js|css)$/.test(req.url)) {
+  } else if (/^\/(editor|styles|vendor|viewers|views)\/[\w./-]+\.(m?js|css)$/.test(req.url)) {
     // Static JS/MJS/CSS files for the Tiptap editor module, its vendor bundle,
-    // vendored assets (e.g. highlight.js), the file-type registry, and the
-    // extracted view modules under /views/. Path is constrained to
-    // /editor/..., /vendor/..., /viewers/... and /views/... under public/,
+    // vendored assets (e.g. highlight.js), the file-type registry, the
+    // extracted view modules under /views/, and the stylesheets under
+    // /styles/. Path is constrained to /editor/..., /styles/..., /vendor/...,
+    // /viewers/... and /views/... under public/,
     // with only .js/.mjs/.css extensions and only
     // word chars + dot/slash/hyphen in the path. The realpath check below blocks
     // any directory traversal that somehow gets past the regex.

--- a/public/index.html
+++ b/public/index.html
@@ -27,56 +27,14 @@
 <script src="/chat-markup.js"></script>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<!-- Tokens first: everything below resolves var(--x) against this file. -->
+<link rel="stylesheet" href="/styles/tokens.css">
 <style>
-:root {
-  --base: #1A1A1A; --surface: #212121; --elevated: #272727;
-  /* The window chrome (top bar + rail) sits BEHIND the content, so it is
-     recessed rather than level with it. Deliberately its own token, not a
-     shift of --surface: that is used in eleven places including every hover
-     state and the composer, and moving it to gain one edge would move all of
-     them. --base to --surface was a 6-point luma step, too soft to delineate
-     the rail once its border was removed; chrome to --surface is 14. */
-  --chrome: #131313;
-  --card: #333333; --border: #3D3D3D;
-  --text-1: #F0EDE8; --text-2: #9A9590;
-  --accent: #E87A5A; --accent-hover: #F09070; --accent-glow: rgba(232,122,90,0.12);
-  --success: #6BC67E; --attention: #E8A84C; --working: #7AA2E8; --idle: #7A756E;
-  --heading: 22px; --title: 18px; --body: 14px; --caption: 12px; --label: 11px;
-  --org-name: 20px; --org-role: 15px;
-}
-
-body.light {
-  --base: #F5F2ED; --surface: #FAF8F5; --elevated: #FFFFFF;
-  /* Same direction in light: the chrome recedes. Light theme has no headroom
-     to lighten the panel (--surface is already near-white), so darkening the
-     chrome is the only lever, and it happens to be the same one. */
-  --chrome: #E8E4DC;
-  --card: #F0EDE8; --border: #E5E0D8;
-  --text-1: #1A1A1A; --text-2: #7A756E;
-  --accent-glow: rgba(232,122,90,0.08);
-}
-
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
 html, body { height: 100%; font-family: 'Inter', system-ui, -apple-system, sans-serif; background: var(--base); color: var(--text-1); -webkit-font-smoothing: antialiased; }
 button { border: none; background: none; cursor: pointer; font-family: inherit; color: inherit; }
 input { border: none; background: none; font-family: inherit; color: inherit; outline: none; }
 .hidden { display: none !important; }
-
-/* The window chrome reserves an inset on each side and the platform supplies
-   the values: macOS traffic lights sit left, Windows caption buttons sit
-   right. Both are 0 in a browser and on Linux, which is the same path.
-   There is deliberately NO per-platform CSS anywhere; chrome-insets.js is the
-   only platform-aware code. See Window-Chrome-Topbar-Spec. */
-/* The bar is as tall as the rail is wide, so the chrome's corner is a true
-   square rather than an arbitrary rectangle, and the rail's icons sit on the
-   same rhythm as the bar above them. */
-/* --tb-cluster is the width of our own controls in the right gutter (a 30px
-   Help button plus 8px padding). The gutter each side is then the LARGER of
-   the two sides' total occupancy, which is what keeps the middle column
-   centred on the WINDOW rather than on the leftover space. */
-:root { --chrome-inset-left: 0px; --chrome-inset-right: 0px; --nav-rail-width: 60px; --topbar-height: 50px; --content-radius: 12px;
-        --tb-cluster: 38px;
-        --chrome-gutter: max(var(--chrome-inset-left), calc(var(--chrome-inset-right) + var(--tb-cluster))); }
 
 /* .app is a COLUMN: the top bar spans the full width and the three original
    panes sit in the body row beneath it. min-height: 0 on the body row is

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -1,0 +1,61 @@
+/* Design tokens. The first stylesheet in the cascade, and the only file the
+   rest of the styling is allowed to take its colours, type sizes and layout
+   metrics from.
+
+   Load order is the contract: this file, then base, then components, then
+   views. Everything downstream resolves var(--x) against what is declared
+   here, so if this file arrives late or not at all, the app paints unstyled.
+   test/e2e/theme.spec.js asserts these tokens resolve at DOMContentLoaded for
+   exactly that reason.
+
+   THE LIGHT THEME OVERRIDES ON body, NOT ON :root. That is deliberate (the
+   theme is a class the app toggles on body) and it has one consequence worth
+   knowing before you debug something odd: anything that styles <html> itself
+   resolves against the :root block below and therefore always gets the dark
+   value, whatever theme is showing. Today the only such rule is the canvas
+   background, which the app's own full-height chrome covers, so it is
+   invisible. Do not style <html> expecting it to follow the theme. */
+
+:root {
+  --base: #1A1A1A; --surface: #212121; --elevated: #272727;
+  /* The window chrome (top bar + rail) sits BEHIND the content, so it is
+     recessed rather than level with it. Deliberately its own token, not a
+     shift of --surface: that is used in eleven places including every hover
+     state and the composer, and moving it to gain one edge would move all of
+     them. --base to --surface was a 6-point luma step, too soft to delineate
+     the rail once its border was removed; chrome to --surface is 14. */
+  --chrome: #131313;
+  --card: #333333; --border: #3D3D3D;
+  --text-1: #F0EDE8; --text-2: #9A9590;
+  --accent: #E87A5A; --accent-hover: #F09070; --accent-glow: rgba(232,122,90,0.12);
+  --success: #6BC67E; --attention: #E8A84C; --working: #7AA2E8; --idle: #7A756E;
+  --heading: 22px; --title: 18px; --body: 14px; --caption: 12px; --label: 11px;
+  --org-name: 20px; --org-role: 15px;
+}
+
+body.light {
+  --base: #F5F2ED; --surface: #FAF8F5; --elevated: #FFFFFF;
+  /* Same direction in light: the chrome recedes. Light theme has no headroom
+     to lighten the panel (--surface is already near-white), so darkening the
+     chrome is the only lever, and it happens to be the same one. */
+  --chrome: #E8E4DC;
+  --card: #F0EDE8; --border: #E5E0D8;
+  --text-1: #1A1A1A; --text-2: #7A756E;
+  --accent-glow: rgba(232,122,90,0.08);
+}
+
+/* The window chrome reserves an inset on each side and the platform supplies
+   the values: macOS traffic lights sit left, Windows caption buttons sit
+   right. Both are 0 in a browser and on Linux, which is the same path.
+   There is deliberately NO per-platform CSS anywhere; chrome-insets.js is the
+   only platform-aware code. See Window-Chrome-Topbar-Spec. */
+/* The bar is as tall as the rail is wide, so the chrome's corner is a true
+   square rather than an arbitrary rectangle, and the rail's icons sit on the
+   same rhythm as the bar above them. */
+/* --tb-cluster is the width of our own controls in the right gutter (a 30px
+   Help button plus 8px padding). The gutter each side is then the LARGER of
+   the two sides' total occupancy, which is what keeps the middle column
+   centred on the WINDOW rather than on the leftover space. */
+:root { --chrome-inset-left: 0px; --chrome-inset-right: 0px; --nav-rail-width: 60px; --topbar-height: 50px; --content-radius: 12px;
+        --tb-cluster: 38px;
+        --chrome-gutter: max(var(--chrome-inset-left), calc(var(--chrome-inset-right) + var(--tb-cluster))); }

--- a/test/e2e/theme.spec.js
+++ b/test/e2e/theme.spec.js
@@ -1,0 +1,245 @@
+'use strict';
+// Theme and token cascade, end to end.
+//
+// This suite is the safety net for splitting the 1,125-line <style> block in
+// index.html into linked stylesheets. Until it landed there was NO rendered
+// theme coverage anywhere: the only theme test in the repo was
+// test/unit/theme-choice.test.js, which tests the pure decision function and
+// never renders a pixel. A broken cascade would therefore have reached a user
+// before it reached a test.
+//
+// It asserts resolved values on a real page rather than class names, because
+// a class name flipping proves nothing about whether the light-theme block
+// still wins over :root once the two live in different files.
+//
+const base = require('@playwright/test');
+const { appendRawCoverage, writeLcov, isClientEntry } = require('./coverage.js');
+
+const test = base.test.extend({
+  page: async ({ page }, use) => {
+    await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    await use(page);
+    const entries = await page.coverage.stopJSCoverage();
+    appendRawCoverage(entries.filter(e => isClientEntry(e.url)));
+  },
+});
+const { expect } = base;
+
+test.afterAll(async () => {
+  await writeLcov();
+});
+
+// Every token the light theme overrides. If the split breaks the cascade,
+// these stop changing between themes, which is the failure this suite exists
+// to catch.
+const THEMED = [
+  '--base', '--surface', '--elevated', '--chrome', '--card',
+  '--border', '--text-1', '--text-2', '--accent-glow',
+];
+
+// Tokens deliberately shared by both themes. The accent is the brand and does
+// not shift; the type scale and layout metrics are not colours at all. If one
+// of these starts changing, a light-theme block has grown a declaration it
+// should not have.
+const INVARIANT = [
+  '--accent', '--accent-hover', '--success', '--attention', '--working', '--idle',
+  '--heading', '--title', '--body', '--caption', '--label',
+  '--nav-rail-width', '--topbar-height', '--content-radius',
+];
+
+const NAV_SECTIONS = ['conversations', 'team', 'files', 'skills', 'settings'];
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+async function boot(page) {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+}
+
+// Read a batch of custom properties as the browser resolves them on <body>.
+//
+// Read them off <body>, never off documentElement. The light theme overrides
+// tokens through `body.light { ... }`, so :root always reports the dark values
+// however the app is themed. Custom properties inherit, so <body> sees both the
+// :root declarations and the light overrides, which is what the app's own rules
+// resolve against. Probing :root here silently passed the invariance test and
+// failed the consumption test, which is how this was found.
+function readTokens(page, names) {
+  return page.evaluate((list) => {
+    const cs = getComputedStyle(document.body);
+    const out = {};
+    for (const n of list) out[n] = cs.getPropertyValue(n).trim();
+    return out;
+  }, names);
+}
+
+// Switch theme and wait for it to finish arriving.
+//
+// The settle step is not optional. The universal selector carries
+// `transition: background-color 0.2s ease, border-color .., color ..`, so for
+// 200ms after a theme change getComputedStyle returns the INTERPOLATED colour
+// rather than the target: a dark theme reports a light background and looks
+// exactly like a broken cascade. This cost an hour to diagnose the first time.
+//
+// It polls rather than sleeping, so it settles as fast as the transition does
+// and stays correct if that duration is ever tokenised to another value.
+async function setTheme(page, light) {
+  await page.evaluate((wantLight) => {
+    if (document.body.classList.contains('light') !== wantLight) toggleTheme();
+  }, light);
+  await expect.poll(
+    () => page.evaluate(() => document.body.classList.contains('light')),
+  ).toBe(light);
+  await expect.poll(
+    () => page.evaluate(() => {
+      const cs = getComputedStyle(document.body);
+      return cs.backgroundColor === tokenAsRgb(cs, '--base');
+      function tokenAsRgb(style, name) {
+        const m = /^#([0-9a-f]{6})$/i.exec(style.getPropertyValue(name).trim());
+        if (!m) return null;
+        const n = parseInt(m[1], 16);
+        return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+      }
+    }),
+    { message: `theme transition must settle (light=${light})` },
+  ).toBe(true);
+}
+
+// Relative luminance, good enough to order two greys. Accepts the hex forms
+// the token file actually uses.
+function luma(hex) {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return 0.2126 * ((n >> 16) & 255) + 0.7152 * ((n >> 8) & 255) + 0.0722 * (n & 255);
+}
+
+// ── the cascade ──────────────────────────────────────────────────────────────
+
+test('every light-theme token override actually takes effect', async ({ page }) => {
+  await boot(page);
+
+  await setTheme(page, false);
+  const dark = await readTokens(page, THEMED);
+  await setTheme(page, true);
+  const light = await readTokens(page, THEMED);
+
+  for (const name of THEMED) {
+    expect(dark[name], `${name} must resolve in dark`).not.toBe('');
+    expect(light[name], `${name} must resolve in light`).not.toBe('');
+    expect(
+      light[name],
+      `${name} is the same in both themes, so the light override is not winning`,
+    ).not.toBe(dark[name]);
+  }
+});
+
+test('tokens shared by both themes do not drift apart', async ({ page }) => {
+  await boot(page);
+
+  await setTheme(page, false);
+  const dark = await readTokens(page, INVARIANT);
+  await setTheme(page, true);
+  const light = await readTokens(page, INVARIANT);
+
+  for (const name of INVARIANT) {
+    expect(dark[name], `${name} must resolve`).not.toBe('');
+    expect(light[name], `${name} must not change with the theme`).toBe(dark[name]);
+  }
+});
+
+test('the tokens are consumed, not merely declared', async ({ page }) => {
+  await boot(page);
+
+  // A token can resolve correctly while nothing uses it. Reading it back off a
+  // painted element proves the declaration reaches the pixels. setTheme has
+  // already waited out the colour transition, so these reads are the settled
+  // values.
+  for (const light of [false, true]) {
+    await setTheme(page, light);
+    const settled = await page.evaluate(() => {
+      const cs = getComputedStyle(document.body);
+      const hex = (v) => {
+        const m = /^#([0-9a-f]{6})$/i.exec(cs.getPropertyValue(v).trim());
+        if (!m) return null;
+        const n = parseInt(m[1], 16);
+        return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+      };
+      return { bg: cs.backgroundColor, wantBg: hex('--base'), fg: cs.color, wantFg: hex('--text-1') };
+    });
+    expect(settled.bg, `body background must be --base (light=${light})`).toBe(settled.wantBg);
+    expect(settled.fg, `body colour must be --text-1 (light=${light})`).toBe(settled.wantFg);
+  }
+});
+
+test('the chrome stays recessed behind the content in both themes', async ({ page }) => {
+  await boot(page);
+
+  // Documented intent in the token file: the top bar and rail sit BEHIND the
+  // content, so the chrome is always further from the content than the panel
+  // surface is. In dark that means darker; in light the same direction is
+  // achieved by darkening, because the surface has no headroom to lighten.
+  for (const light of [false, true]) {
+    await setTheme(page, light);
+    const t = await readTokens(page, ['--chrome', '--surface']);
+    const chrome = luma(t['--chrome']);
+    const surface = luma(t['--surface']);
+    expect(chrome, `--chrome must be a plain hex (light=${light})`).not.toBeNull();
+    expect(surface, `--surface must be a plain hex (light=${light})`).not.toBeNull();
+    expect(chrome, `chrome must sit behind surface (light=${light})`).toBeLessThan(surface);
+  }
+});
+
+// ── load order ───────────────────────────────────────────────────────────────
+
+test('tokens resolve before first paint, with no flash of unstyled content', async ({ page }) => {
+  // Recorded at DOMContentLoaded rather than after load, so a stylesheet that
+  // 404s, or arrives late enough to repaint, fails here instead of being
+  // noticed by a user as a flicker. This is the specific regression the split
+  // into linked stylesheets risks.
+  await page.addInitScript(() => {
+    window.addEventListener('DOMContentLoaded', () => {
+      const cs = getComputedStyle(document.body);
+      window.__themeAtDcl = {
+        base: cs.getPropertyValue('--base').trim(),
+        text: cs.getPropertyValue('--text-1').trim(),
+        rail: cs.getPropertyValue('--nav-rail-width').trim(),
+      };
+    });
+  });
+  await boot(page);
+
+  const atDcl = await page.evaluate(() => window.__themeAtDcl);
+  expect(atDcl, 'the DOMContentLoaded probe must have run').toBeTruthy();
+  expect(atDcl.base, '--base must resolve before first paint').not.toBe('');
+  expect(atDcl.text, '--text-1 must resolve before first paint').not.toBe('');
+  expect(atDcl.rail, '--nav-rail-width must resolve before first paint').not.toBe('');
+});
+
+// ── every view, both themes ──────────────────────────────────────────────────
+
+test('no view leaves a token unresolved in either theme', async ({ page }) => {
+  await boot(page);
+
+  // The standing acceptance criterion is a per-view eyeball in both themes.
+  // This is the mechanical half: it cannot judge whether a colour looks right,
+  // but it does catch a view whose stylesheet failed to load, which is exactly
+  // what an eyeball on a busy day misses.
+  for (const light of [false, true]) {
+    await setTheme(page, light);
+    for (const nav of NAV_SECTIONS) {
+      await page.evaluate((n) => switchNav(n), nav);
+      await expect(page.locator(`.nav-item.active[data-nav="${nav}"]`)).toBeVisible();
+
+      const unresolved = await page.evaluate((names) => {
+        const cs = getComputedStyle(document.body);
+        return names.filter(n => cs.getPropertyValue(n).trim() === '');
+      }, THEMED.concat(INVARIANT));
+
+      expect(
+        unresolved,
+        `${nav} view, light=${light}: these tokens stopped resolving`,
+      ).toEqual([]);
+    }
+  }
+});

--- a/test/integration/http-api.test.js
+++ b/test/integration/http-api.test.js
@@ -65,6 +65,35 @@ describe('static + JSON endpoints', () => {
     }
   });
 
+  test('every local stylesheet link in index.html resolves to a live route', async () => {
+    // The <script> sibling above exists because a script tag without a route
+    // shipped once and a defensive fallback hid it. A stylesheet has no
+    // fallback and fails more quietly still: the page renders, unstyled or
+    // half-styled, and nothing throws. The styling is moving out of
+    // index.html into linked files, so this class becomes reachable for the
+    // first time and is closed here before the first file moves.
+    const html = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'index.html'), 'utf-8');
+    const hrefs = [...html.matchAll(/<link[^>]+href="(\/[^"]+\.css)"/g)].map(m => m[1]);
+    assert.ok(hrefs.length >= 1, `sanity: found ${hrefs.length} local stylesheets`);
+    assert.ok(hrefs.includes('/styles/tokens.css'), 'sanity: the token sheet is linked');
+    for (const href of hrefs) {
+      const res = await get(href);
+      assert.strictEqual(res.status, 200, `${href} must serve (link tag without a route)`);
+      assert.match(res.headers.get('content-type') || '', /text\/css/, `${href} content type`);
+    }
+  });
+
+  test('the /styles/ route serves css and refuses to leave public/', async () => {
+    assert.strictEqual((await get('/styles/tokens.css')).status, 200);
+    assert.strictEqual((await get('/styles/no-such-sheet.css')).status, 404);
+    // Traversal, both spelled out and encoded. The route pattern forbids the
+    // first and the realpath prefix check stops anything that gets past it.
+    assert.strictEqual((await get('/styles/../../server.js')).status, 404);
+    assert.strictEqual((await get('/styles/..%2F..%2Fserver.js')).status, 404);
+    // Only .css and .js may be served from it; nothing else is addressable.
+    assert.strictEqual((await get('/styles/tokens.txt')).status, 404);
+  });
+
   test('top-level module route rejects unknown files and non-module paths', async () => {
     assert.strictEqual((await get('/no-such-module.js')).status, 404);
     // Traversal cannot be expressed in the route pattern (no slashes or

--- a/test/unit/packaging.test.js
+++ b/test/unit/packaging.test.js
@@ -88,4 +88,19 @@ describe('electron-builder files whitelist', () => {
       assert.ok(fs.existsSync(path.join(root, f)), `${f} referenced by index.html does not exist`);
     }
   });
+
+  test('client stylesheets referenced by index.html are packaged', () => {
+    // Same gate as the scripts above, for <link> tags. A stylesheet missing
+    // from the packaged app does not throw on boot the way a missing module
+    // does: the app opens looking wrong, which is a worse failure to diagnose
+    // and one no smoke test would name.
+    const html = fs.readFileSync(path.join(root, 'public', 'index.html'), 'utf-8');
+    const hrefs = [...html.matchAll(/<link[^>]+href="\/([\w./-]+\.css)"/g)]
+      .map(m => `public/${m[1]}`);
+    assert.ok(hrefs.includes('public/styles/tokens.css'), 'sanity: the token sheet is linked');
+    for (const f of hrefs) {
+      assert.ok(covered(f), `index.html links /${f.replace('public/', '')} but build.files does not package it`);
+      assert.ok(fs.existsSync(path.join(root, f)), `${f} linked by index.html does not exist`);
+    }
+  });
 });

--- a/test/unit/packaging.test.js
+++ b/test/unit/packaging.test.js
@@ -15,15 +15,43 @@ const root = path.join(__dirname, '..', '..');
 const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
 const files = pkg.build && pkg.build.files || [];
 
-// A whitelist entry covers a root-level file if it names it exactly or is a
-// directory glob whose prefix contains it (e.g. public/**/* covers
-// public/code-language.js).
+// Does build.files package this path?
+//
+// electron-builder applies the list IN ORDER and a later entry overrides an
+// earlier one, so a leading `!` excludes what a previous glob included. This
+// used to be a plain `.some()` over positive matches, which meant negation
+// entries were invisible to it: `public/**/*` followed by `!public/styles/**`
+// read as covered, and the guard would have stayed green while the packaged
+// app shipped with no stylesheets. build.files already carries three negations
+// today, so the hole was real rather than hypothetical. Found on 2026-08-13
+// while proving the stylesheet guard below could fail; it could not.
 function covered(relPath) {
-  return files.some(entry => {
-    if (entry === relPath) return true;
-    const dir = entry.split('/**')[0];
-    return entry.includes('**') && relPath.startsWith(dir + '/');
-  });
+  let included = false;
+  for (const entry of files) {
+    const negated = entry.startsWith('!');
+    const pattern = negated ? entry.slice(1) : entry;
+    if (matches(pattern, relPath)) included = !negated;
+  }
+  return included;
+}
+
+// The glob shapes build.files uses: an exact path, or a directory prefix
+// followed by `/**`, `/**/*`, or `/**/*.ext`.
+//
+// The extension is honoured rather than ignored. A first cut treated
+// `public/**/*.css` as covering everything under public/, so excluding the
+// stylesheets appeared to exclude the scripts too and the red proof pointed at
+// the wrong test. A matcher that over-matches makes the guard fail for reasons
+// that are not true, which is its own kind of useless.
+function matches(pattern, relPath) {
+  if (pattern === relPath) return true;
+  const at = pattern.indexOf('/**');
+  if (at === -1) return false;
+  const dir = pattern.slice(0, at);
+  if (!relPath.startsWith(dir + '/')) return false;
+  const tail = pattern.slice(at + 3);              // '', '/*', '/*.css'
+  const ext = /^\/\*(\.[\w.]+)$/.exec(tail);
+  return ext ? relPath.endsWith(ext[1]) : true;
 }
 
 function localRequires(file) {


### PR DESCRIPTION
Styling gets its home, starting with the instrument that makes the rest of it
verifiable.

## The finding that shaped this slice

**There was no rendered theme coverage anywhere in the repo.** The plan for
this phase leans on "e2e theme specs are the check" for the cascade split. That
check did not exist. Grepping every e2e spec for `body.light`,
`classList.contains('light')`, a theme toggle or theme storage returns nothing.
The only theme test is `test/unit/theme-choice.test.js`, which exercises the
pure decision function and never renders a pixel.

So the 1,125-line `<style>` block was about to be split into linked files with
nothing able to observe the result. The net is built first, and the first real
move is verified by it.

## What moved

The token declarations leave `index.html` for `public/styles/tokens.css`:
the `:root` block, the `body.light` override block, and the chrome-metrics
`:root` block, comments included.

Byte-identical, verified character for character against `f3919ba`'s
`index.html` read back out of git rather than against my own copy. 43 lines
moved. `index.html` goes 1,399 to 1,357.

Serving is one word, not a new route. `lib/http-router.js` already served
`.css` under `/editor/`, `/vendor/`, `/viewers/` and `/views/` behind a
realpath prefix check, so `/styles/` joins that alternation and inherits the
traversal guard. `build.files` already globs `public/**/*`, so the sheet
packages with no whitelist change.

## Two corrections to what the plan assumed

**`scripts/afterPack.js` needed no work.** The plan named three guards to teach
about `<link>` tags. afterPack's gate reads `require()` calls out of
`server.js` and never looks at `index.html`, so only two were real:
`test/unit/packaging.test.js` and `test/integration/http-api.test.js`.

**The cascade risk was smaller than stated.** The plan warned that the
light-theme overrides rely on in-file cascade order. There are exactly eight
`body.light` selectors: one token block, one topbar rule, and six
floating-toolbar shadows. The light theme is almost entirely token-driven,
which is why a component-wise split is safe.

## A guard that could not fail

While proving the new stylesheet packaging assertion could go red, it would
not. `covered()` was a `.some()` over positive matches, so electron-builder
negation entries were invisible to it. `build.files` already carries three
negations, so `public/**/*` followed by `!public/styles/**` read as covered:
the guard would have stayed green while the packaged app shipped with no
stylesheets.

Fixed to apply the list in order, where a later entry overrides an earlier
one. The first cut of the matcher ignored the extension suffix, so
`!public/**/*.css` appeared to exclude the scripts too and the red proof
pointed at the wrong test. A matcher that over-matches fails for reasons that
are not true, so the suffix is honoured.

## Everything here was proved red first

Six theme assertions, each mutated one at a time in `index.html`: dropping
`--card` from the light block, adding an `--accent` to it, breaking body's
colour, lightening the light chrome past its surface, renaming
`--nav-rail-width`, and deleting `--idle`. Each failure named the specific
token.

Four serving and packaging assertions: a linked sheet with no route, the route
removed from the alternation, a negation excluding `public/styles`, and a
linked sheet absent from disk. Each named the offending file.

## Two things the probes taught, now recorded in comments

**Tokens must be read off `<body>`, never `documentElement`.** The light theme
overrides through `body.light`, so `:root` reports the dark values whatever
theme is showing. Probing `:root` passed the invariance test and failed the
consumption test, which is how it surfaced.

**A theme change has to be waited out.** The universal selector carries a 0.2s
`background-color` transition, so `getComputedStyle` returns the interpolated
colour for 200ms afterwards. Read immediately, a dark theme reports a light
background and looks exactly like a broken cascade. The suite polls rather than
sleeping, so it settles as fast as the transition does.

## One consequence worth knowing, recorded not fixed

The light theme overrides on `body`, so anything styling `<html>` resolves
against the dark block whatever theme is showing. Today the only such rule is
the canvas background, which the app's own full-height chrome covers, so it is
invisible. It is documented in the token file's header rather than changed,
because a move is the wrong commit to alter behaviour in. Carded for the
polish pass.

## Test results

Suite **1,566** from a measured baseline of **1,563**, the delta being two
serving assertions and one packaging assertion. E2E **109 of 109**, up from
103, the delta being the theme suite. All **50 coverage floors** hold.
Typecheck and reference check clean.

No user-visible change: the tokens resolve to the same values in the same
order, which is what the theme suite asserts.
