### PR TITLE
Adopt tokens for every value that cannot change a pixel

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,7 +13,17 @@ module.exports = defineConfig({
   // because they need the same fixtures and server, but they assert nothing on
   // their own: they capture state for a human to compare across two builds.
   // See test/e2e/style-snapshot.tool.js.
-  testIgnore: '**/*.tool.js',
+  //
+  // What excludes them from CI is the NAME, not a rule: Playwright's default
+  // testMatch collects only *.spec.js and *.test.js, so a *.tool.js file is
+  // never picked up. This shipped in 0.11.7 with a testIgnore entry that read
+  // as the mechanism and was in fact dead: removing it changes nothing, and
+  // relying on it would have been a rule nobody could see was inert.
+  //
+  // RUN_TOOLS=1 points testMatch AT the tools, so a hand run collects the
+  // instruments and nothing else. Without it they cannot be run at all, which
+  // is what the first attempt shipped.
+  testMatch: process.env.RUN_TOOLS ? '**/*.tool.js' : undefined,
   workers: 1,
   fullyParallel: false,
   // 60s is a ceiling, not a wait: green tests are unaffected (typical spec

--- a/public/styles/base.css
+++ b/public/styles/base.css
@@ -5,7 +5,7 @@
    here applies across views; anything belonging to one view lives under
    views/ instead. */
 
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; transition: background-color var(--duration-slow) ease, border-color var(--duration-slow) ease, color var(--duration-slow) ease; }
 html, body { height: 100%; font-family: 'Inter', system-ui, -apple-system, sans-serif; background: var(--base); color: var(--text-1); -webkit-font-smoothing: antialiased; }
 button { border: none; background: none; cursor: pointer; font-family: inherit; color: inherit; }
 input { border: none; background: none; font-family: inherit; color: inherit; outline: none; }
@@ -23,14 +23,14 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
 
 /* Main panel */
 .main { flex: 1; display: flex; flex-direction: column; background: var(--elevated); overflow: hidden; position: relative; }
-.main-view-transition { animation: viewFadeIn 0.15s ease; }
+.main-view-transition { animation: viewFadeIn var(--duration-base) ease; }
 @keyframes viewFadeIn { from { opacity: 0; } to { opacity: 1; } }
 
 
 
 ::-webkit-scrollbar { width: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: transparent; border-radius: 3px; transition: background 0.2s ease; }
+::-webkit-scrollbar-thumb { background: transparent; border-radius: 3px; transition: background var(--duration-slow) ease; }
 *:hover > ::-webkit-scrollbar-thumb, *:hover::-webkit-scrollbar-thumb { background: var(--border); }
 .messages::-webkit-scrollbar-thumb { background: transparent; }
 .messages:hover::-webkit-scrollbar-thumb { background: var(--border); }
@@ -38,7 +38,7 @@ input { border: none; background: none; font-family: inherit; color: inherit; ou
 
 
 /* Empty state CTA */
-.empty-cta { padding: 10px 24px; background: var(--accent); color: white; font-size: var(--body); font-weight: 600; border-radius: 8px; transition: background 0.15s ease; cursor: pointer; }
+.empty-cta { padding: 10px 24px; background: var(--accent); color: white; font-size: var(--body); font-weight: 600; border-radius: var(--radius-lg); transition: background var(--duration-base) ease; cursor: pointer; }
 .empty-cta:hover { background: var(--accent-hover); }
 
 /* View panels */

--- a/public/styles/components/connection-bar.css
+++ b/public/styles/components/connection-bar.css
@@ -3,5 +3,5 @@
 /* Connection bar */
 .connection-bar { padding: 6px 24px; font-size: var(--caption); font-weight: 500; text-align: center; }
 .connection-bar.connected { background: rgba(107,198,126,0.1); color: var(--success); }
-.connection-bar.disconnected { background: rgba(232,90,90,0.1); color: #E85A5A; }
+.connection-bar.disconnected { background: rgba(232,90,90,0.1); color: var(--danger); }
 .connection-bar.connecting { background: rgba(122,162,232,0.1); color: var(--working); }

--- a/public/styles/components/find-bar.css
+++ b/public/styles/components/find-bar.css
@@ -4,14 +4,14 @@
    panel area so it floats over whichever view is active. Match highlights
    below apply to both <mark class="find-match"> (conversation, legacy file
    preview) and .find-match decoration spans inside the markdown editor. */
-.find-bar { position: absolute; top: 12px; right: 16px; z-index: 100; display: flex; align-items: center; gap: 6px; padding: 6px 8px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.25); }
+.find-bar { position: absolute; top: 12px; right: 16px; z-index: 100; display: flex; align-items: center; gap: 6px; padding: 6px 8px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: 0 4px 16px rgba(0,0,0,0.25); }
 .find-bar.hidden { display: none; }
 .find-bar input { background: transparent; border: none; outline: none; color: var(--text-1); font-size: var(--body); min-width: 180px; padding: 4px 6px; font-family: inherit; }
 .find-bar input::placeholder { color: var(--text-3); }
 .find-count { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; min-width: 56px; text-align: right; padding: 0 4px; }
-.find-count.no-results { color: #E85A5A; }
+.find-count.no-results { color: var(--danger); }
 .find-count:empty { display: none; }
-.find-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; background: transparent; color: var(--text-2); border: none; border-radius: 4px; cursor: pointer; transition: background 0.15s ease, color 0.15s ease; }
+.find-btn { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; padding: 0; background: transparent; color: var(--text-2); border: none; border-radius: var(--radius-sm); cursor: pointer; transition: background var(--duration-base) ease, color var(--duration-base) ease; }
 .find-btn:hover { background: var(--accent-glow); color: var(--accent); }
 .find-btn:disabled { opacity: 0.35; cursor: default; pointer-events: none; }
 .find-btn svg { display: block; }

--- a/public/styles/components/floating-toolbar.css
+++ b/public/styles/components/floating-toolbar.css
@@ -1,8 +1,8 @@
 /* The selection toolbar in the editor, its dropdowns and its link popover. */
 
-.floating-toolbar { position: absolute; display: none; gap: 2px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 6px; box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 4px 12px rgba(0,0,0,0.16); z-index: 50; left: 0; top: 0; }
+.floating-toolbar { position: absolute; display: none; gap: 2px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-md); box-shadow: 0 1px 2px rgba(0,0,0,0.10), 0 4px 12px rgba(0,0,0,0.16); z-index: 50; left: 0; top: 0; }
 .floating-toolbar.visible { display: inline-flex; }
-.floating-toolbar .tb-btn { display: inline-flex; align-items: center; justify-content: center; min-width: 28px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-2); border: none; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
+.floating-toolbar .tb-btn { display: inline-flex; align-items: center; justify-content: center; min-width: 28px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-2); border: none; border-radius: var(--radius-sm); cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
 .floating-toolbar .tb-btn[data-style="b"] { font-weight: 700; }
 .floating-toolbar .tb-btn[data-style="i"] { font-style: italic; }
 .floating-toolbar .tb-btn:hover { background: var(--accent-glow); color: var(--accent); }
@@ -12,17 +12,17 @@
    list types. The menu is position:absolute so it never changes the toolbar's
    measured box (which the positioning math depends on). */
 .floating-toolbar .tb-sep { width: 1px; align-self: stretch; margin: 4px 4px; background: var(--border); }
-.floating-toolbar .tb-dd { display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-1); border: none; border-radius: 4px; cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
+.floating-toolbar .tb-dd { display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 8px; background: transparent; color: var(--text-1); border: none; border-radius: var(--radius-sm); cursor: pointer; font-size: 13px; font-weight: 600; font-family: inherit; }
 .floating-toolbar .tb-dd:hover, .floating-toolbar .tb-dd[aria-expanded="true"] { background: var(--accent-glow); color: var(--accent); }
 .floating-toolbar .tb-dd svg { display: block; opacity: 0.75; }
-.floating-toolbar .tb-menu { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; width: 216px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.10), 0 8px 20px rgba(0,0,0,0.16); z-index: 51; }
+.floating-toolbar .tb-menu { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; width: 216px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: 0 2px 6px rgba(0,0,0,0.10), 0 8px 20px rgba(0,0,0,0.16); z-index: 51; }
 .floating-toolbar .tb-menu.open { display: block; }
 /* Flip upward near the foot of the viewport so the menu never spills past the
    bottom (or extends the editor's scroll region). */
 .floating-toolbar .tb-menu.up { top: auto; bottom: 100%; margin-top: 0; margin-bottom: 6px; box-shadow: 0 -2px 6px rgba(0,0,0,0.10), 0 -8px 20px rgba(0,0,0,0.16); }
-.floating-toolbar .tb-menu-item { display: flex; align-items: center; gap: 11px; width: 100%; height: 32px; padding: 0 10px; background: transparent; border: none; border-radius: 6px; color: var(--text-1); font-size: 13.5px; font-family: inherit; text-align: left; cursor: pointer; }
+.floating-toolbar .tb-menu-item { display: flex; align-items: center; gap: 11px; width: 100%; height: 32px; padding: 0 10px; background: transparent; border: none; border-radius: var(--radius-md); color: var(--text-1); font-size: 13.5px; font-family: inherit; text-align: left; cursor: pointer; }
 .floating-toolbar .tb-menu-item:hover { background: var(--accent-glow); }
-.floating-toolbar .tb-menu-ic { width: 22px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; color: var(--text-2); font-size: 11px; font-weight: 700; font-family: 'SF Mono', ui-monospace, monospace; }
+.floating-toolbar .tb-menu-ic { width: 22px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center; color: var(--text-2); font-size: var(--label); font-weight: 700; font-family: 'SF Mono', ui-monospace, monospace; }
 .floating-toolbar .tb-menu-ic svg { display: block; }
 .floating-toolbar .tb-menu-label { flex: 1; }
 .floating-toolbar .tb-menu-check { display: none; color: var(--accent); }
@@ -30,7 +30,7 @@
 .floating-toolbar .tb-menu-sep { height: 1px; background: var(--border); margin: 4px 6px; }
 /* In-UI link popover: an input row anchored under the toolbar (replaces the
    OS-native prompt). Absolutely positioned so it sits below the flex row. */
-.floating-toolbar .tb-linkpop { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; align-items: center; gap: 4px; width: 288px; max-width: 80vw; padding: 5px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.10), 0 8px 20px rgba(0,0,0,0.16); z-index: 51; }
+.floating-toolbar .tb-linkpop { position: absolute; top: 100%; left: 0; margin-top: 6px; display: none; align-items: center; gap: 4px; width: 288px; max-width: 80vw; padding: 5px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: 0 2px 6px rgba(0,0,0,0.10), 0 8px 20px rgba(0,0,0,0.16); z-index: 51; }
 /* Light theme: pure-black shadows read harsher on a light background, so use a
    lighter ambient. Toolbar and its dropped panels form one elevation cluster. */
 body.light .floating-toolbar { box-shadow: 0 1px 2px rgba(0,0,0,0.05), 0 4px 12px rgba(0,0,0,0.10); }

--- a/public/styles/components/message-content.css
+++ b/public/styles/components/message-content.css
@@ -7,15 +7,15 @@
 
 /* Thinking */
 .thinking-bubble { min-height: 24px; display: flex; align-items: center; gap: 12px; }
-.thinking-pulse { width: 24px; height: 24px; border-radius: 50%; animation: agentPulse 1.8s ease-in-out infinite; flex-shrink: 0; }
+.thinking-pulse { width: 24px; height: 24px; border-radius: var(--radius-circle); animation: agentPulse 1.8s ease-in-out infinite; flex-shrink: 0; }
 .thinking-label { font-size: var(--caption); color: var(--text-2); }
-.thinking-status { font-size: var(--caption); color: var(--text-2); transition: opacity 0.2s ease; }
+.thinking-status { font-size: var(--caption); color: var(--text-2); transition: opacity var(--duration-slow) ease; }
 @keyframes agentPulse { 0%,100% { opacity: 0.3; transform: scale(0.9); } 50% { opacity: 0.8; transform: scale(1.05); } }
 
 /* Markdown rendering (chat bubbles, file preview, profile) */
 .msg-bubble h1,.msg-bubble h2,.msg-bubble h3,.msg-bubble h4 { margin: 14px 0 4px; line-height: 1.3; }
 .msg-bubble *:first-child { margin-top: 0; }
-.msg-bubble h1 { font-size: 17px; } .msg-bubble h2 { font-size: 15px; } .msg-bubble h3 { font-size: var(--body); font-weight: 600; } .msg-bubble h4 { font-size: var(--body); font-weight: 600; }
+.msg-bubble h1 { font-size: 17px; } .msg-bubble h2 { font-size: var(--org-role); } .msg-bubble h3 { font-size: var(--body); font-weight: 600; } .msg-bubble h4 { font-size: var(--body); font-weight: 600; }
 .msg-bubble p { margin: 0 0 8px; } .msg-bubble p:last-child { margin-bottom: 0; }
 /* 32px, not 20px: the list marker is drawn inside this padding, so a marker
    wider than it is drawn outside the bubble. Measured at 14px Inter, decimal
@@ -34,14 +34,14 @@
 .msg-bubble li > ul,.msg-bubble li > ol { margin: 2px 0 2px; }
 .msg-bubble > :last-child { margin-bottom: 0; }
 .msg-bubble p + ul,.msg-bubble p + ol { margin-top: -4px; }
-.msg-bubble code { background: var(--elevated); padding: 2px 6px; border-radius: 4px; font-size: 13px; font-family: 'SF Mono','Fira Code','Consolas',monospace; }
-.msg-bubble pre { background: var(--elevated); padding: 12px 16px; border-radius: 8px; overflow-x: auto; margin: 8px 0; }
+.msg-bubble code { background: var(--elevated); padding: 2px 6px; border-radius: var(--radius-sm); font-size: 13px; font-family: 'SF Mono','Fira Code','Consolas',monospace; }
+.msg-bubble pre { background: var(--elevated); padding: 12px 16px; border-radius: var(--radius-lg); overflow-x: auto; margin: 8px 0; }
 .msg-bubble pre code:not(.hljs) { background: none; padding: 0; display: block; line-height: 1.5; }
 /* Code block with header (language label + copy button) and syntax highlighting */
-.code-block-wrapper { margin: 8px 0; border-radius: 8px; overflow: hidden; border: 1px solid var(--border); }
+.code-block-wrapper { margin: 8px 0; border-radius: var(--radius-lg); overflow: hidden; border: 1px solid var(--border); }
 .code-block-header { display: flex; justify-content: space-between; align-items: center; background: var(--card); padding: 4px 12px 4px 16px; min-height: 32px; }
-.code-lang { font-size: 12px; color: var(--text-2); font-family: 'SF Mono','Fira Code','Consolas',monospace; }
-.copy-code-btn { background: none; border: none; color: var(--text-2); cursor: pointer; padding: 4px; border-radius: 4px; display: flex; align-items: center; justify-content: center; line-height: 0; transition: color 0.15s; }
+.code-lang { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono','Fira Code','Consolas',monospace; }
+.copy-code-btn { background: none; border: none; color: var(--text-2); cursor: pointer; padding: 4px; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; line-height: 0; transition: color var(--duration-base); }
 .copy-code-btn:hover { color: var(--text-1); }
 .copy-code-btn.copied { color: var(--success); }
 .code-block-wrapper pre { margin: 0; padding: 0; background: transparent; border-radius: 0; overflow: visible; }
@@ -59,9 +59,9 @@
 .msg-bubble th { background: var(--card); font-weight: 600; }
 .msg-bubble hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
 .msg-bubble a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; }
-.msg-bubble img { max-width: 100%; border-radius: 8px; margin: 8px 0; }
+.msg-bubble img { max-width: 100%; border-radius: var(--radius-lg); margin: 8px 0; }
 .msg-bubble mark { background: rgba(232,122,90,0.2); color: var(--text-1); padding: 1px 4px; border-radius: 3px; }
 .msg-bubble .wikilink { color: var(--accent); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
-.msg-bubble .md-tag { background: var(--card); color: var(--accent); padding: 2px 8px; border-radius: 4px; font-size: var(--caption); font-weight: 500; }
+.msg-bubble .md-tag { background: var(--card); color: var(--accent); padding: 2px 8px; border-radius: var(--radius-sm); font-size: var(--caption); font-weight: 500; }
 .msg-bubble input[type="checkbox"] { margin-right: 8px; accent-color: var(--accent); }
 

--- a/public/styles/components/nav-rail.css
+++ b/public/styles/components/nav-rail.css
@@ -11,10 +11,10 @@
    would quietly make it 13. */
 .nav-main { display: flex; flex-direction: column; gap: 4px; flex: 1; align-items: center; }
 .nav-bottom { display: flex; flex-direction: column; gap: 4px; align-items: center; }
-.nav-item { position: relative; width: 42px; height: 42px; display: flex; align-items: center; justify-content: center; border-radius: 12px; color: var(--text-2); transition: all 0.2s ease; }
+.nav-item { position: relative; width: 42px; height: 42px; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-xl); color: var(--text-2); transition: all var(--duration-slow) ease; }
 .nav-item:hover { color: var(--text-1); background: var(--surface); }
 .nav-item.active { color: var(--accent); background: var(--accent-glow); }
-.nav-item[data-tooltip]::after { content: attr(data-tooltip); position: absolute; left: calc(100% + 6px); top: 50%; transform: translateY(-50%) translateX(-4px); opacity: 0; pointer-events: none; white-space: nowrap; font-size: 12px; font-weight: 500; letter-spacing: 0.01em; color: var(--text-1); background: var(--elevated); padding: 4px 10px; border-radius: 6px; backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); z-index: 100; transition: opacity 150ms ease, transform 150ms ease; transition-delay: 0ms; }
+.nav-item[data-tooltip]::after { content: attr(data-tooltip); position: absolute; left: calc(100% + 6px); top: 50%; transform: translateY(-50%) translateX(-4px); opacity: 0; pointer-events: none; white-space: nowrap; font-size: var(--caption); font-weight: 500; letter-spacing: 0.01em; color: var(--text-1); background: var(--elevated); padding: 4px 10px; border-radius: var(--radius-md); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); z-index: 100; transition: opacity var(--duration-base) ease, transform var(--duration-base) ease; transition-delay: 0ms; }
 .nav-item[data-tooltip]:hover::after { opacity: 1; transform: translateY(-50%) translateX(0); transition-delay: 400ms; }
 .nav-item svg { width: 21px; height: 21px; }
 .nav-item .icon-filled { display: none; }

--- a/public/styles/components/palette.css
+++ b/public/styles/components/palette.css
@@ -35,7 +35,7 @@
 /* Same width expression as the field, via the same gutter variable, so the
    two are the same object in two states and the panel cannot overlap the
    window controls any more than the field could. */
-.palette { width: min(680px, calc(100vw - 2 * var(--chrome-gutter) - 32px)); max-height: min(72vh, 640px); display: flex; flex-direction: column; background: var(--elevated); border: 1px solid var(--border); box-shadow: 0 18px 50px rgba(0,0,0,0.4), 0 2px 8px rgba(0,0,0,0.2); overflow: hidden; animation: palette-in 160ms cubic-bezier(0.16, 1, 0.3, 1); transform-origin: top center; border-radius: 12px; }
+.palette { width: min(680px, calc(100vw - 2 * var(--chrome-gutter) - 32px)); max-height: min(72vh, 640px); display: flex; flex-direction: column; background: var(--elevated); border: 1px solid var(--border); box-shadow: 0 18px 50px rgba(0,0,0,0.4), 0 2px 8px rgba(0,0,0,0.2); overflow: hidden; animation: palette-in 160ms cubic-bezier(0.16, 1, 0.3, 1); transform-origin: top center; border-radius: var(--radius-xl); }
 /* Grows downward out of the field rather than sliding in from above. */
 @keyframes palette-in { from { opacity: 0.4; transform: scaleY(0.88); } to { opacity: 1; transform: none; } }
 @media (prefers-reduced-motion: reduce) { .palette { animation: none; } }
@@ -54,14 +54,14 @@
    results as well as looking like a mistake. */
 .palette-scope-row { display: flex; align-items: center; gap: 6px; height: 37px; flex-shrink: 0; padding: 0 12px; border-bottom: 1px solid var(--border); overflow-x: auto; scrollbar-width: none; -ms-overflow-style: none; }
 .palette-scope-row::-webkit-scrollbar { display: none; }
-.palette-scope { font-size: var(--caption); font-weight: 500; color: var(--text-2); padding: 4px 10px; border-radius: 999px; border: 1px solid transparent; cursor: pointer; white-space: nowrap; transition: color 0.15s ease, background 0.15s ease; }
+.palette-scope { font-size: var(--caption); font-weight: 500; color: var(--text-2); padding: 4px 10px; border-radius: 999px; border: 1px solid transparent; cursor: pointer; white-space: nowrap; transition: color var(--duration-base) ease, background var(--duration-base) ease; }
 .palette-scope:hover { color: var(--text-1); background: var(--card); }
 .palette-scope:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .palette-scope.active { color: var(--accent); background: var(--accent-glow); border-color: transparent; }
 .palette-results { flex: 1; overflow-y: auto; padding: 6px 6px 10px; scroll-padding: 40px; }
 .palette-group-label { font-size: var(--label); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); padding: 12px 12px 5px; display: flex; align-items: center; gap: 6px; }
 .palette-group-count { font-weight: 500; letter-spacing: 0; text-transform: none; opacity: 0.75; }
-.palette-item { display: flex; align-items: center; gap: 10px; padding: 8px 10px; border-radius: 8px; cursor: pointer; }
+.palette-item { display: flex; align-items: center; gap: 10px; padding: 8px 10px; border-radius: var(--radius-lg); cursor: pointer; }
 /* Hover and selected are two different FILLS, not one fill plus a hairline:
    neutral card for the pointer, the same accent-glow the sidebar's active
    row uses for the keyboard selection. .selected is declared after :hover

--- a/public/styles/components/sidebar.css
+++ b/public/styles/components/sidebar.css
@@ -16,26 +16,26 @@
 .sidebar-resize-handle.dragging { border-right-color: var(--accent); }
 .sidebar > div { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
 .sidebar-header { padding: 24px 16px 8px; position: relative; }
-.files-add-btn { position: absolute; top: 18px; right: 10px; display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 6px; color: var(--text-2); }
+.files-add-btn { position: absolute; top: 18px; right: 10px; display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-md); color: var(--text-2); }
 .files-add-btn:hover { color: var(--text-1); background: var(--elevated); }
-.files-menu { position: fixed; z-index: 200; min-width: 180px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.25); display: flex; flex-direction: column; }
-.files-menu-item { display: flex; align-items: center; gap: 9px; text-align: left; padding: 7px 10px; border-radius: 6px; color: var(--text-1); font-size: var(--body); }
+.files-menu { position: fixed; z-index: 200; min-width: 180px; padding: 4px; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: 0 4px 16px rgba(0,0,0,0.25); display: flex; flex-direction: column; }
+.files-menu-item { display: flex; align-items: center; gap: 9px; text-align: left; padding: 7px 10px; border-radius: var(--radius-md); color: var(--text-1); font-size: var(--body); }
 .files-menu-item svg { flex: 0 0 auto; color: var(--text-2); }
 .files-menu-item:hover { background: var(--elevated); }
 .files-menu-item:hover svg { color: var(--text-1); }
-.files-menu-item.danger:hover { color: var(--danger, #E85A5A); }
+.files-menu-item.danger:hover { color: var(--danger, var(--danger)); }
 .files-menu-divider { height: 1px; background: var(--border); margin: 4px 6px; }
 .files-menu-field { padding: 2px; }
-.files-menu-field input { width: 100%; background: var(--elevated); border: 1px solid var(--accent); border-radius: 6px; color: var(--text-1); font-size: var(--body); padding: 6px 8px; outline: none; }
+.files-menu-field input { width: 100%; background: var(--elevated); border: 1px solid var(--accent); border-radius: var(--radius-md); color: var(--text-1); font-size: var(--body); padding: 6px 8px; outline: none; }
 .sidebar-label { font-size: var(--label); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); }
 
 /* Compact agent status list */
 .agent-status-list { flex: 1; overflow-y: auto; padding: 8px; }
-.agent-status-item { display: flex; align-items: center; gap: 8px; padding: 10px 8px; border-radius: 8px; cursor: pointer; transition: background 0.15s ease; }
+.agent-status-item { display: flex; align-items: center; gap: 8px; padding: 10px 8px; border-radius: var(--radius-lg); cursor: pointer; transition: background var(--duration-base) ease; }
 .agent-status-item:hover { background: var(--elevated); }
 .agent-status-item.active { background: var(--elevated); }
-.avatar { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 14px; color: white; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.06); }
-.avatar.sm { width: 24px; height: 24px; font-size: 12px; }
+.avatar { width: 32px; height: 32px; border-radius: var(--radius-circle); display: flex; align-items: center; justify-content: center; font-size: var(--body); color: white; flex-shrink: 0; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.06); }
+.avatar.sm { width: 24px; height: 24px; font-size: var(--caption); }
 .avatar.xs { width: 18px; height: 18px; font-size: 9px; }
 .agent-status-name { flex: 1; font-size: 13px; font-weight: 500; color: var(--text-1); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .agent-status-state { font-size: var(--caption); font-weight: 500; color: var(--idle); flex-shrink: 0; }
@@ -47,15 +47,15 @@
 
 /* Conversation list */
 .convo-list { flex: 1; overflow-y: auto; padding: 8px; }
-.convo-item { display: flex; flex-direction: column; gap: 3px; padding: 12px 8px 12px 5px; border-radius: 8px; cursor: pointer; transition: background 0.15s ease; position: relative; }
+.convo-item { display: flex; flex-direction: column; gap: 3px; padding: 12px 8px 12px 5px; border-radius: var(--radius-lg); cursor: pointer; transition: background var(--duration-base) ease; position: relative; }
 .convo-item:hover { background: var(--elevated); }
 .convo-item.active { background: var(--accent-glow); }
 .convo-item.active:hover { background: rgba(232,122,90,0.18); }
-.convo-delete { position: absolute; top: 8px; right: 6px; width: 24px; height: 24px; border: none; background: transparent; color: var(--text-3); cursor: pointer; border-radius: 4px; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.15s ease, color 0.15s ease; font-size: 14px; padding: 0; z-index: 1; }
+.convo-delete { position: absolute; top: 8px; right: 6px; width: 24px; height: 24px; border: none; background: transparent; color: var(--text-3); cursor: pointer; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity var(--duration-base) ease, color var(--duration-base) ease; font-size: var(--body); padding: 0; z-index: 1; }
 .convo-item:hover .convo-delete { opacity: 1; }
 .convo-item:hover > .convo-title { padding-right: 24px; }
 .convo-delete:hover { color: var(--danger, #e55); background: var(--surface); }
-.convo-pin { position: absolute; top: 8px; right: 6px; width: 24px; height: 24px; border: none; background: transparent; color: var(--text-3); cursor: pointer; border-radius: 4px; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.15s ease, color 0.15s ease; padding: 0; z-index: 1; }
+.convo-pin { position: absolute; top: 8px; right: 6px; width: 24px; height: 24px; border: none; background: transparent; color: var(--text-3); cursor: pointer; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity var(--duration-base) ease, color var(--duration-base) ease; padding: 0; z-index: 1; }
 .convo-item:hover .convo-pin { opacity: 1; }
 .convo-item:hover .convo-pin-indicator { opacity: 0; }
 .convo-item:hover .convo-title-row { padding-right: 24px; }
@@ -68,7 +68,7 @@
 /* Sidebar filter pills (conversations sidebar only). No divider: the bordered
    pills anchor the top of the list on their own (WhatsApp-style). */
 .sidebar-pills { padding: 8px 8px 10px; display: flex; gap: 6px; flex-shrink: 0; }
-.pill { font-size: var(--caption); font-weight: 500; padding: 4px 13px; border-radius: 999px; cursor: pointer; border: 1px solid var(--border); background: transparent; color: var(--text-2); transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease; line-height: 1.5; font-family: inherit; }
+.pill { font-size: var(--caption); font-weight: 500; padding: 4px 13px; border-radius: 999px; cursor: pointer; border: 1px solid var(--border); background: transparent; color: var(--text-2); transition: background var(--duration-fast) ease, border-color var(--duration-fast) ease, color var(--duration-fast) ease; line-height: 1.5; font-family: inherit; }
 .pill:hover { border-color: var(--text-2); color: var(--text-1); }
 .pill:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .pill.active { background: var(--accent); border-color: var(--accent); color: #fff; }
@@ -84,18 +84,18 @@
    grammar from the design system: opaque --elevated surface, 1px --border,
    shadow-3, 10px radius, tooltip-style backdrop blur. Closes on click or Esc. */
 .convo-menu { position: fixed; z-index: 1000; min-width: 180px; max-width: 260px; background: var(--elevated); border: 1px solid var(--border); border-radius: 10px; padding: 4px; box-shadow: 0 2px 8px rgba(0,0,0,0.15); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); }
-.convo-menu-item { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; padding: 7px 10px; border: none; background: transparent; color: var(--text-1); font-size: var(--caption); font-weight: 500; font-family: inherit; border-radius: 6px; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.convo-menu-item { display: flex; align-items: center; gap: 6px; width: 100%; text-align: left; padding: 7px 10px; border: none; background: transparent; color: var(--text-1); font-size: var(--caption); font-weight: 500; font-family: inherit; border-radius: var(--radius-md); cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .convo-menu-item:hover { background: var(--card); }
 .convo-menu-check { width: 14px; flex-shrink: 0; color: var(--accent); }
 /* Small-input composer pattern (matches .review-input in the editor's review
    panel): the container is the field, border goes accent on focus-within, and
    the circular submit button lives INSIDE the field: faded while empty,
    accent-filled once there is text. */
-.convo-menu-input { display: flex; align-items: center; gap: 4px; margin: 4px; padding: 2px 2px 2px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); }
+.convo-menu-input { display: flex; align-items: center; gap: 4px; margin: 4px; padding: 2px 2px 2px 10px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface); }
 .convo-menu-input:focus-within { border-color: var(--accent); }
 .convo-menu-input input { flex: 1; min-width: 0; border: none; background: transparent; padding: 4px 0; color: var(--text-1); font-size: var(--caption); font-family: inherit; outline: none; }
 .convo-menu-input input::placeholder { color: var(--text-2); }
-.convo-menu-send { width: 24px; height: 24px; border: none; border-radius: 50%; background: transparent; color: var(--text-2); display: flex; align-items: center; justify-content: center; flex-shrink: 0; cursor: pointer; padding: 0; transition: all 0.25s ease; }
+.convo-menu-send { width: 24px; height: 24px; border: none; border-radius: var(--radius-circle); background: transparent; color: var(--text-2); display: flex; align-items: center; justify-content: center; flex-shrink: 0; cursor: pointer; padding: 0; transition: all 0.25s ease; }
 .convo-menu-send svg { width: 13px; height: 13px; }
 .convo-menu-send:disabled { opacity: 0.3; cursor: default; }
 .convo-menu-send.active { background: var(--accent); color: #fff; box-shadow: 0 2px 8px rgba(232, 122, 90, 0.3); }
@@ -104,7 +104,7 @@
 /* Archive sidebar action (replaces delete on persisted, not-yet-archived items).
    Mirrors .convo-delete shape; hover uses a neutral bright text colour rather
    than danger red because archiving is non-destructive. */
-.convo-archive { position: absolute; top: 8px; right: 6px; width: 24px; height: 24px; border: none; background: transparent; color: var(--text-3); cursor: pointer; border-radius: 4px; display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity 0.15s ease, color 0.15s ease; padding: 0; z-index: 1; }
+.convo-archive { position: absolute; top: 8px; right: 6px; width: 24px; height: 24px; border: none; background: transparent; color: var(--text-3); cursor: pointer; border-radius: var(--radius-sm); display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity var(--duration-base) ease, color var(--duration-base) ease; padding: 0; z-index: 1; }
 .convo-item:hover .convo-archive { opacity: 1; }
 .convo-archive:hover { color: var(--text-1); background: var(--surface); }
 
@@ -124,7 +124,7 @@
   color: var(--text-1);
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   white-space: nowrap;
   pointer-events: none;
   z-index: 100;
@@ -133,7 +133,7 @@
 
 /* WhatsApp-style recency label, right-aligned in the meta row. */
 .convo-time { margin-left: auto; font-size: var(--label); color: var(--text-2); opacity: 0.7; }
-.sidebar-label-unread { display: inline-block; width: 6px; height: 6px; background: var(--accent); border-radius: 50%; margin-left: 6px; vertical-align: middle; }
+.sidebar-label-unread { display: inline-block; width: 6px; height: 6px; background: var(--accent); border-radius: var(--radius-circle); margin-left: 6px; vertical-align: middle; }
 .convo-pin-indicator { width: 12px; height: 12px; color: var(--accent); flex-shrink: 0; opacity: 0.7; margin-left: 4px; }
 .convo-title-row { display: flex; align-items: center; gap: 0; min-width: 0; }
 .convo-title-row .convo-title { flex: 1; min-width: 0; }
@@ -144,14 +144,14 @@
    pulses, unread holds still. A halo ring on the working dot was tried for
    an extra single-frame distinction and reviewed as too much; motion is the
    accepted separator. */
-.convo-unread { width: 8px; height: 8px; min-width: 8px; background: var(--success); border-radius: 50%; }
-.convo-working { width: 8px; height: 8px; min-width: 8px; background: var(--success); border-radius: 50%; margin-left: auto; animation: orgPulse 2s ease-in-out infinite; }
-.nav-badge { position: absolute; top: 6px; right: 6px; width: 7px; height: 7px; background: var(--attention); border-radius: 50%; pointer-events: none; }
-.nav-badge-working { position: absolute; top: 6px; right: 6px; width: 7px; height: 7px; background: var(--success); border-radius: 50%; pointer-events: none; animation: orgPulse 2s ease-in-out infinite; }
+.convo-unread { width: 8px; height: 8px; min-width: 8px; background: var(--success); border-radius: var(--radius-circle); }
+.convo-working { width: 8px; height: 8px; min-width: 8px; background: var(--success); border-radius: var(--radius-circle); margin-left: auto; animation: orgPulse 2s ease-in-out infinite; }
+.nav-badge { position: absolute; top: 6px; right: 6px; width: 7px; height: 7px; background: var(--attention); border-radius: var(--radius-circle); pointer-events: none; }
+.nav-badge-working { position: absolute; top: 6px; right: 6px; width: 7px; height: 7px; background: var(--success); border-radius: var(--radius-circle); pointer-events: none; animation: orgPulse 2s ease-in-out infinite; }
 
 /* File tree */
 .file-tree { flex: 1; overflow-y: auto; padding: 8px; min-height: 0; }
-.folder-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; cursor: pointer; font-size: var(--body); font-weight: 600; color: var(--text-1); user-select: none; }
+.folder-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: var(--radius-lg); cursor: pointer; font-size: var(--body); font-weight: 600; color: var(--text-1); user-select: none; }
 .folder-item:hover { background: var(--elevated); }
 .folder-icon { font-size: 10px; color: var(--text-2); width: 12px; text-align: center; }
 .file-children { padding-left: 20px; position: relative; }
@@ -161,19 +161,19 @@
    indentation stays easy to follow. */
 .file-children::before { content: ''; position: absolute; left: 15px; top: 0; bottom: 0; width: 1px; background: var(--border); }
 .file-children.collapsed { display: none; }
-.file-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: 8px; cursor: pointer; font-size: var(--body); color: var(--text-1); }
+.file-item { display: flex; align-items: center; gap: 8px; padding: 8px; border-radius: var(--radius-lg); cursor: pointer; font-size: var(--body); color: var(--text-1); }
 .file-item:hover { background: var(--elevated); }
 .file-item.active { background: var(--elevated); }
 .file-item-icon { width: 14px; height: 14px; color: var(--text-2); }
 
 /* Add button */
 .convo-footer { height: 76px; border-top: 1px solid var(--border); background: var(--surface); flex-shrink: 0; display: flex; align-items: center; padding: 0 8px; }
-.add-btn { display: flex; align-items: center; justify-content: flex-start; gap: 8px; padding: 10px 8px; margin: 0; width: 100%; border-radius: 8px; font-size: var(--body); font-weight: 500; color: var(--text-2); border: 1px solid transparent; transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease; }
+.add-btn { display: flex; align-items: center; justify-content: flex-start; gap: 8px; padding: 10px 8px; margin: 0; width: 100%; border-radius: var(--radius-lg); font-size: var(--body); font-weight: 500; color: var(--text-2); border: 1px solid transparent; transition: background var(--duration-base) ease, border-color var(--duration-base) ease, color var(--duration-base) ease; }
 .add-btn:hover { color: var(--accent); background: var(--accent-glow); border-color: rgba(232,122,90,0.3); }
 
 
 /* Routine sidebar items */
-.routine-item { display: flex; align-items: center; gap: 8px; padding: 8px; font-size: var(--caption); border-radius: 8px; transition: background 0.15s ease; cursor: default; }
+.routine-item { display: flex; align-items: center; gap: 8px; padding: 8px; font-size: var(--caption); border-radius: var(--radius-lg); transition: background var(--duration-base) ease; cursor: default; }
 .routine-item:hover { background: var(--elevated); }
 .routine-name { flex: 1; color: var(--text-1); font-weight: 500; font-size: var(--body); }
 .avatar.xxs { width: 20px; height: 20px; font-size: 9px; }
@@ -184,7 +184,7 @@
 .sidebar-empty-text { font-size: var(--caption); color: var(--text-2); line-height: 1.6; margin-bottom: 12px; }
 
 /* Agent action buttons (available agents) */
-.agent-action-btn { font-size: var(--caption); font-weight: 500; flex-shrink: 0; padding: 4px 8px; border-radius: 6px; }
+.agent-action-btn { font-size: var(--caption); font-weight: 500; flex-shrink: 0; padding: 4px 8px; border-radius: var(--radius-md); }
 .agent-action-btn.onboard { color: var(--accent); background: var(--accent-glow); }
 .agent-action-btn.add { color: var(--success); background: rgba(107,198,126,0.1); }
 .agent-status-desc { font-size: var(--caption); color: var(--text-2); display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/public/styles/components/topbar.css
+++ b/public/styles/components/topbar.css
@@ -55,10 +55,10 @@
      screen. Measured, not guessed; remeasure if the bar height changes. */
   margin-top: 2px;
   width: min(680px, calc(100% - 32px));
-  background: var(--surface); border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
   color: var(--text-2); font-size: var(--caption); font-family: inherit;
   cursor: pointer; user-select: none;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  transition: background var(--duration-base) ease, border-color var(--duration-base) ease, color var(--duration-base) ease;
 }
 body.light .tb-search { background: var(--card); }
 .tb-search:hover { border-color: var(--text-2); color: var(--text-1); }
@@ -75,10 +75,10 @@ body.palette-open .tb-search { visibility: hidden; }
 .tb-btn[data-tooltip]::after {
   content: attr(data-tooltip); position: absolute; top: calc(100% + 6px); right: 0;
   opacity: 0; pointer-events: none; white-space: nowrap;
-  font-size: 12px; font-weight: 500; color: var(--text-1);
+  font-size: var(--caption); font-weight: 500; color: var(--text-1);
   background: var(--elevated); border: 1px solid var(--border);
-  padding: 4px 9px; border-radius: 6px; z-index: 120;
-  transition: opacity 150ms ease; transition-delay: 0ms;
+  padding: 4px 9px; border-radius: var(--radius-md); z-index: 120;
+  transition: opacity var(--duration-base) ease; transition-delay: 0ms;
 }
 .tb-btn[data-tooltip]:hover::after { opacity: 1; transition-delay: 400ms; }
 

--- a/public/styles/components/update-strip.css
+++ b/public/styles/components/update-strip.css
@@ -23,16 +23,16 @@
 .u-collapsed-row { display: flex; align-items: center; gap: 7px; height: 22px; width: 100%; }
 .u-collapsed-pct { font-size: 10.5px; color: var(--text-2); font-variant-numeric: tabular-nums; }
 .u-row { display: flex; align-items: flex-start; gap: 9px; }
-.u-dot { width: 7px; height: 7px; min-width: 7px; border-radius: 50%; background: var(--success); flex-shrink: 0; margin-top: 4px; }
+.u-dot { width: 7px; height: 7px; min-width: 7px; border-radius: var(--radius-circle); background: var(--success); flex-shrink: 0; margin-top: 4px; }
 .u-collapsed-row .u-dot { margin-top: 0; }
 .u-text { flex: 1; min-width: 0; font-size: 11.5px; color: var(--text-2); line-height: 1.55; overflow-wrap: anywhere; text-align: left; }
 .u-text.ready { color: var(--text-1); }
 .u-text b { color: var(--text-1); font-weight: 600; }
-.u-pct { flex-shrink: 0; font-size: 11px; color: var(--text-1); font-variant-numeric: tabular-nums; font-weight: 500; margin-top: 1px; }
+.u-pct { flex-shrink: 0; font-size: var(--label); color: var(--text-1); font-variant-numeric: tabular-nums; font-weight: 500; margin-top: 1px; }
 .u-actions { display: flex; align-items: center; gap: 10px; margin-top: 8px; padding-left: 16px; }
 .u-restart-btn { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; font-weight: 600; color: var(--accent); padding: 0; }
 .u-restart-btn svg { width: 12px; height: 12px; }
-.u-collapse-link { font-size: 11px; color: var(--text-2); opacity: 0.8; padding: 0; }
+.u-collapse-link { font-size: var(--label); color: var(--text-2); opacity: 0.8; padding: 0; }
 .u-ring { flex-shrink: 0; }
 .u-ring svg { display: block; }
 .u-ring.indet { animation: uSpin 900ms linear infinite; transform-origin: 50% 50%; }

--- a/public/styles/tokens.css
+++ b/public/styles/tokens.css
@@ -29,8 +29,29 @@
   --text-1: #F0EDE8; --text-2: #9A9590;
   --accent: #E87A5A; --accent-hover: #F09070; --accent-glow: rgba(232,122,90,0.12);
   --success: #6BC67E; --attention: #E8A84C; --working: #7AA2E8; --idle: #7A756E;
+  /* The status set had no red, so every destructive and error surface reached
+     for a hex of its own and they drifted: three near-identical reds were in
+     the stylesheets when this token was added. This is the one. */
+  --danger: #E85A5A;
   --heading: 22px; --title: 18px; --body: 14px; --caption: 12px; --label: 11px;
   --org-name: 20px; --org-role: 15px;
+
+  /* Corner radius. These five absorbed 101 of the 130 radius declarations in
+     the stylesheets. The 29 left over are 10px, 2px, 100px, 7px, 3px, 999px,
+     5px, 20px, 14px and 16px: two spellings of a pill, and a set of one-offs
+     that landed a step away from a scale nobody had written down. They are
+     deliberate visual changes rather than substitutions, so they are not
+     touched here. Pick by the size of the thing: sm for chips and inputs, md
+     for menu rows, lg for cards and buttons, xl for the large panels inside
+     the window chrome. */
+  --radius-sm: 4px; --radius-md: 6px; --radius-lg: 8px; --radius-xl: 12px;
+  --radius-circle: 50%;
+
+  /* Motion. base is the default for anything that changes on hover or focus;
+     fast is for something already in view that must not feel laggy; slow is
+     for a surface arriving or leaving. Longer than slow is an animation with
+     its own reason, and it states that reason where it is written. */
+  --duration-fast: 0.12s; --duration-base: 0.15s; --duration-slow: 0.2s;
 }
 
 body.light {

--- a/public/styles/views/chat.css
+++ b/public/styles/views/chat.css
@@ -6,12 +6,12 @@
 
 /* Chat */
 .chat-header { padding: 16px 24px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
-.chat-back { display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 8px; color: var(--text-2); transition: all 0.15s ease; flex-shrink: 0; cursor: pointer; }
+.chat-back { display: flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: var(--radius-lg); color: var(--text-2); transition: all var(--duration-base) ease; flex-shrink: 0; cursor: pointer; }
 .chat-back:hover { color: var(--text-1); background: var(--card); }
-.chat-title-input { font-size: var(--body); font-weight: 600; width: 100%; background: transparent; border: 1px solid transparent; border-radius: 4px; padding: 2px 6px; margin: -2px -6px; transition: all 0.15s ease; color: var(--text-1); }
+.chat-title-input { font-size: var(--body); font-weight: 600; width: 100%; background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm); padding: 2px 6px; margin: -2px -6px; transition: all var(--duration-base) ease; color: var(--text-1); }
 .chat-title-input:hover { border-color: var(--border); }
 .chat-title-input:focus { border-color: var(--accent); background: var(--card); }
-.chat-convo-status { font-size: var(--caption); font-weight: 600; padding: 3px 10px; border-radius: 6px; cursor: pointer; transition: all 0.15s ease; flex-shrink: 0; }
+.chat-convo-status { font-size: var(--caption); font-weight: 600; padding: 3px 10px; border-radius: var(--radius-md); cursor: pointer; transition: all var(--duration-base) ease; flex-shrink: 0; }
 .chat-convo-status.active-convo { background: rgba(107,198,126,0.12); color: var(--success); }
 .chat-convo-status.active-convo:hover { background: rgba(107,198,126,0.22); }
 .chat-convo-status.archived-convo { background: var(--card); color: var(--text-2); }
@@ -22,7 +22,7 @@
 .chat-status { font-size: var(--caption); color: var(--idle); font-weight: 500; display: none; }
 .chat-status.working { color: var(--success); display: inline; margin-left: 6px; }
 .messages { flex: 1; overflow-y: auto; padding: 24px; display: flex; flex-direction: column; gap: 16px; }
-.msg { max-width: 85%; animation: fadeIn 0.2s ease; }
+.msg { max-width: 85%; animation: fadeIn var(--duration-slow) ease; }
 .msg-user { align-self: flex-end; }
 .msg-agent { align-self: flex-start; }
 .msg-sender { font-size: var(--caption); font-weight: 600; margin-bottom: 6px; display: flex; align-items: center; gap: 6px; }
@@ -33,36 +33,36 @@
 .history-msg { opacity: 0.6; }
 .history-msg:hover { opacity: 0.85; }
 .msg-system { align-self: center; font-size: var(--caption); color: var(--text-2); padding: 4px 12px; background: var(--card); border-radius: 20px; }
-.auth-error-card { align-self: stretch; max-width: 560px; margin: 8px auto; padding: 14px 16px; background: rgba(232,168,76,0.08); border: 1px solid var(--attention); border-radius: 10px; animation: fadeIn 0.2s ease; }
+.auth-error-card { align-self: stretch; max-width: 560px; margin: 8px auto; padding: 14px 16px; background: rgba(232,168,76,0.08); border: 1px solid var(--attention); border-radius: 10px; animation: fadeIn var(--duration-slow) ease; }
 .auth-error-title { font-weight: 600; font-size: var(--body); color: var(--attention); margin-bottom: 6px; }
 .auth-error-body { font-size: var(--body); line-height: 1.6; color: var(--text-1); }
 .auth-error-steps { margin: 8px 0 4px; padding-left: 20px; font-size: var(--body); line-height: 1.7; color: var(--text-1); }
-.auth-error-steps code { background: var(--elevated); padding: 1px 6px; border-radius: 4px; font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: 13px; }
-.auth-error-copy { margin-left: 6px; background: none; border: 1px solid var(--border); color: var(--text-2); cursor: pointer; padding: 1px 8px; border-radius: 4px; font-size: 11px; }
+.auth-error-steps code { background: var(--elevated); padding: 1px 6px; border-radius: var(--radius-sm); font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: 13px; }
+.auth-error-copy { margin-left: 6px; background: none; border: 1px solid var(--border); color: var(--text-2); cursor: pointer; padding: 1px 8px; border-radius: var(--radius-sm); font-size: var(--label); }
 .auth-error-copy:hover { color: var(--text-1); border-color: var(--text-2); }
 .auth-error-foot { margin-top: 8px; font-size: var(--caption); color: var(--text-2); }
 .auth-error-foot a { color: var(--working); }
 /* Codex runtime surfaces */
-.codex-error-detail { margin-top: 8px; font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: 11px; color: var(--text-2); word-break: break-word; }
-.codex-firstrun-card { align-self: center; max-width: 480px; margin: 8px auto; padding: 14px 16px; background: rgba(122,162,232,0.07); border: 1px solid rgba(122,162,232,0.35); border-radius: 12px; font-size: var(--caption); line-height: 1.6; color: var(--text-1); animation: fadeIn 0.2s ease; }
+.codex-error-detail { margin-top: 8px; font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: var(--label); color: var(--text-2); word-break: break-word; }
+.codex-firstrun-card { align-self: center; max-width: 480px; margin: 8px auto; padding: 14px 16px; background: rgba(122,162,232,0.07); border: 1px solid rgba(122,162,232,0.35); border-radius: var(--radius-xl); font-size: var(--caption); line-height: 1.6; color: var(--text-1); animation: fadeIn var(--duration-slow) ease; }
 .codex-firstrun-title { font-weight: 600; font-size: var(--caption); color: var(--working); margin-bottom: 4px; }
-.codex-firstrun-dismiss { margin-top: 8px; padding: 4px 12px; font-size: var(--label); font-weight: 600; border-radius: 6px; background: transparent; color: var(--text-2); border: 1px solid var(--border); cursor: pointer; }
+.codex-firstrun-dismiss { margin-top: 8px; padding: 4px 12px; font-size: var(--label); font-weight: 600; border-radius: var(--radius-md); background: transparent; color: var(--text-2); border: 1px solid var(--border); cursor: pointer; }
 .codex-firstrun-dismiss:hover { color: var(--text-1); border-color: var(--text-2); }
 .runtime-chip { display: inline-flex; align-items: center; gap: 6px; font-size: var(--caption); color: var(--text-2); }
-.runtime-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
-.runtime-default { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-2); border: 1px solid var(--border); padding: 1px 6px; border-radius: 4px; margin-right: 4px; }
+.runtime-dot { width: 8px; height: 8px; border-radius: var(--radius-circle); display: inline-block; flex-shrink: 0; }
+.runtime-default { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-2); border: 1px solid var(--border); padding: 1px 6px; border-radius: var(--radius-sm); margin-right: 4px; }
 .runtime-guidance { padding: 0 16px 14px; font-size: var(--caption); color: var(--text-2); line-height: 1.6; }
-.runtime-guidance code { font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: 11px; background: var(--elevated); padding: 2px 6px; border-radius: 4px; color: var(--text-1); }
+.runtime-guidance code { font-family: 'SF Mono','Fira Code','Consolas',monospace; font-size: var(--label); background: var(--elevated); padding: 2px 6px; border-radius: var(--radius-sm); color: var(--text-1); }
 /* Tool activity: state sits in an outlined icon ring at the start of the
    chip rather than a coloured edge, so the radius is uniform and the done
    state genuinely recolours (the old border-only version left the glyph
    blue forever). */
-.msg-tool { align-self: flex-start; max-width: 85%; padding: 7px 12px 7px 8px; background: var(--card); border-radius: 8px; font-size: var(--caption); color: var(--text-2); display: flex; align-items: center; gap: 8px; animation: fadeIn 0.2s ease; }
-.msg-tool-icon { width: 16px; height: 16px; border-radius: 50%; border: 1.5px solid var(--working); color: var(--working); display: flex; align-items: center; justify-content: center; font-size: 8.5px; flex-shrink: 0; background: transparent; }
+.msg-tool { align-self: flex-start; max-width: 85%; padding: 7px 12px 7px 8px; background: var(--card); border-radius: var(--radius-lg); font-size: var(--caption); color: var(--text-2); display: flex; align-items: center; gap: 8px; animation: fadeIn var(--duration-slow) ease; }
+.msg-tool-icon { width: 16px; height: 16px; border-radius: var(--radius-circle); border: 1.5px solid var(--working); color: var(--working); display: flex; align-items: center; justify-content: center; font-size: 8.5px; flex-shrink: 0; background: transparent; }
 .msg-tool.done .msg-tool-icon { border-color: var(--success); color: var(--success); }
 /* Activity summary */
 .activity-summary { margin-top: 8px; font-size: var(--caption); color: var(--text-2); }
-.activity-summary summary { cursor: pointer; user-select: none; padding: 4px 0; list-style: none; opacity: 0.6; transition: opacity 0.15s ease; }
+.activity-summary summary { cursor: pointer; user-select: none; padding: 4px 0; list-style: none; opacity: 0.6; transition: opacity var(--duration-base) ease; }
 .activity-summary summary::-webkit-details-marker { display: none; }
 .activity-summary summary:hover { opacity: 1; }
 .activity-summary summary::before { content: '\25B8  '; }
@@ -72,8 +72,8 @@
 .activity-time { color: var(--text-2); min-width: 48px; text-align: right; font-variant-numeric: tabular-nums; opacity: 0.5; }
 .activity-tool { color: var(--text-1); font-weight: 500; opacity: 0.7; }
 /* Permission prompt cards */
-.msg-permission { align-self: flex-start; max-width: 85%; animation: fadeIn 0.2s ease; }
-.permission-card { background: var(--card); border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
+.msg-permission { align-self: flex-start; max-width: 85%; animation: fadeIn var(--duration-slow) ease; }
+.permission-card { background: var(--card); border-radius: var(--radius-xl); padding: 14px 16px; display: flex; flex-direction: column; gap: 10px; }
 .permission-card.risk-low { border: 1px solid var(--border); }
 .permission-card.risk-medium { border: 1px solid var(--border); }
 .permission-card.risk-high { border: 1px solid var(--attention); }
@@ -86,27 +86,27 @@
 .risk-medium .permission-icon { color: var(--text-1); }
 .risk-high .permission-icon { color: var(--attention); }
 .permission-context { font-size: var(--caption); color: var(--text-2); margin-top: -4px; padding-left: 24px; }
-.permission-detail { display: block; background: var(--elevated); padding: 8px 12px; border-radius: 6px; font-size: 13px; font-family: 'SF Mono','Fira Code','Consolas',monospace; color: var(--text-2); word-break: break-all; line-height: 1.4; overflow: hidden; max-height: 80px; }
+.permission-detail { display: block; background: var(--elevated); padding: 8px 12px; border-radius: var(--radius-md); font-size: 13px; font-family: 'SF Mono','Fira Code','Consolas',monospace; color: var(--text-2); word-break: break-all; line-height: 1.4; overflow: hidden; max-height: 80px; }
 .permission-detail-collapse { font-size: var(--caption); color: var(--text-3); }
 .permission-detail-collapse summary { cursor: pointer; padding: 4px 0; color: var(--text-2); opacity: 0.8; }
 .permission-detail-collapse summary:hover { opacity: 1; }
 .permission-detail-collapse .permission-detail { max-height: none; margin-top: 6px; }
 .permission-actions { display: flex; gap: 8px; align-items: center; }
-.btn-perm { padding: 6px 16px; border-radius: 8px; font-size: var(--caption); font-weight: 500; cursor: pointer; border: 1px solid var(--border); transition: all 0.15s ease; }
+.btn-perm { padding: 6px 16px; border-radius: var(--radius-lg); font-size: var(--caption); font-weight: 500; cursor: pointer; border: 1px solid var(--border); transition: all var(--duration-base) ease; }
 .btn-allow { background: var(--success); color: #1a1a1a; border-color: var(--success); }
 .btn-allow:hover { filter: brightness(1.1); }
 .btn-always { background: transparent; color: var(--success); border-color: var(--success); }
 .btn-always:hover { background: rgba(107,198,126,0.12); }
 .btn-deny { background: transparent; color: var(--text-2); }
 .btn-deny:hover { background: var(--elevated); color: var(--text-1); }
-.permission-resolved { font-size: var(--caption); padding: 6px 12px; border-radius: 8px; display: flex; align-items: flex-start; gap: 6px; flex-wrap: wrap; }
+.permission-resolved { font-size: var(--caption); padding: 6px 12px; border-radius: var(--radius-lg); display: flex; align-items: flex-start; gap: 6px; flex-wrap: wrap; }
 .permission-resolved-detail { color: var(--text-3); }
 .permission-resolved .permission-detail-collapse { width: 100%; margin-top: 2px; }
 .permission-resolved.allowed { background: rgba(107,198,126,0.12); color: var(--success); }
 .permission-resolved.denied { background: rgba(232,122,90,0.12); color: var(--accent); }
 .permission-resolved.auto-allowed { background: rgba(107,198,126,0.06); color: var(--text-2); font-style: italic; }
 .chat-input { padding: 16px 24px; border-top: 1px solid var(--border); display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
-.chat-input textarea { flex: 1; padding: 12px 16px; background: var(--card); border-radius: 8px; font-size: var(--body); border: 1px solid transparent; transition: all 0.2s ease; resize: none; overflow-y: auto; min-height: 44px; max-height: 200px; line-height: 1.5; font-family: inherit; color: var(--text-1); outline: none; }
+.chat-input textarea { flex: 1; padding: 12px 16px; background: var(--card); border-radius: var(--radius-lg); font-size: var(--body); border: 1px solid transparent; transition: all var(--duration-slow) ease; resize: none; overflow-y: auto; min-height: 44px; max-height: 200px; line-height: 1.5; font-family: inherit; color: var(--text-1); outline: none; }
 .chat-input textarea::-webkit-scrollbar { display: none; }
 /* Text inputs take the accent on their BORDER, not a 2px offset outline.
    This is not a softer exception invented for the composer: it is the rule
@@ -126,21 +126,21 @@
 .chat-input textarea:focus { box-shadow: 0 0 0 1px var(--text-2); }
 .chat-input textarea::placeholder { color: var(--text-2); }
 .chat-input textarea:disabled { opacity: 0.5; }
-.send-btn { width: 42px; height: 42px; background: var(--card); color: var(--text-2); border-radius: 50%; display: flex; align-items: center; justify-content: center; transition: all 0.25s ease; flex-shrink: 0; }
+.send-btn { width: 42px; height: 42px; background: var(--card); color: var(--text-2); border-radius: var(--radius-circle); display: flex; align-items: center; justify-content: center; transition: all 0.25s ease; flex-shrink: 0; }
 .send-btn.active { background: var(--accent); color: white; box-shadow: 0 2px 8px rgba(232,122,90,0.3); }
 .send-btn.active:hover { background: var(--accent-hover); transform: translateY(-1px); box-shadow: 0 4px 12px rgba(232,122,90,0.4); }
 .send-btn:disabled { opacity: 0.3; cursor: not-allowed; }
 .send-btn.cancel { background: rgba(232,93,93,0.15); color: #e85d5d; cursor: pointer; opacity: 1; }
 .send-btn.cancel:hover { background: rgba(232,93,93,0.25); }
-.cancelled-badge { display: inline-block; font-size: 11px; color: #e85d5d; background: rgba(232,93,93,0.12); padding: 2px 8px; border-radius: 4px; margin-top: 8px; }
+.cancelled-badge { display: inline-block; font-size: var(--label); color: #e85d5d; background: rgba(232,93,93,0.12); padding: 2px 8px; border-radius: var(--radius-sm); margin-top: 8px; }
 .send-btn svg { width: 18px; height: 18px; }
 
 /* Chat prompts */
 .chat-prompts { display: flex; flex-direction: column; align-items: center; justify-content: center; flex: 1; padding: 48px 24px; gap: 16px; }
-.chat-prompts-avatar { width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 24px; }
+.chat-prompts-avatar { width: 56px; height: 56px; border-radius: var(--radius-circle); display: flex; align-items: center; justify-content: center; font-size: 24px; }
 .chat-prompts-title { font-size: var(--heading); font-weight: 700; color: var(--text-1); }
 .chat-prompts-list { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; max-width: 480px; margin-top: 8px; }
-.prompt-pill { background: var(--card); border: 1px solid var(--border); border-radius: 20px; padding: 8px 16px; font-size: var(--body); color: var(--text-1); cursor: pointer; transition: all 0.15s ease; }
+.prompt-pill { background: var(--card); border: 1px solid var(--border); border-radius: 20px; padding: 8px 16px; font-size: var(--body); color: var(--text-1); cursor: pointer; transition: all var(--duration-base) ease; }
 .prompt-pill:hover { border-color: var(--accent); background: var(--accent-glow); }
 /* Welcome bubble with inline prompt pills */
 .chat-prompts-inline { flex: none; padding: 0 0 0 44px; justify-content: flex-start; align-items: flex-start; }

--- a/public/styles/views/conversations.css
+++ b/public/styles/views/conversations.css
@@ -1,7 +1,7 @@
 /* The conversations view's agent cards. */
 
 /* Conversation agent cards */
-.convo-agent-card { display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 12px 16px; border-radius: 12px; cursor: pointer; transition: background 0.15s ease; min-width: 72px; }
+.convo-agent-card { display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 12px 16px; border-radius: var(--radius-xl); cursor: pointer; transition: background var(--duration-base) ease; min-width: 72px; }
 .convo-agent-card:hover { background: var(--card); }
 .convo-agent-card-name { font-size: var(--caption); color: var(--text-1); font-weight: 500; }
 .convo-agent-card-role { font-size: var(--label); color: var(--text-2); }

--- a/public/styles/views/editor.css
+++ b/public/styles/views/editor.css
@@ -5,7 +5,7 @@
 .editor-header { padding: 16px 24px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 12px; }
 .editor-filename { font-size: var(--body); font-weight: 600; flex: 1; }
 .editor-status { font-size: var(--caption); color: var(--success); }
-.editor-toggle { padding: 4px 12px; font-size: var(--caption); font-weight: 600; border-radius: 6px; background: var(--card); color: var(--text-2); transition: all 0.15s ease; }
+.editor-toggle { padding: 4px 12px; font-size: var(--caption); font-weight: 600; border-radius: var(--radius-md); background: var(--card); color: var(--text-2); transition: all var(--duration-base) ease; }
 .editor-toggle:hover { color: var(--text-1); }
 .editor-toggle.active { background: var(--accent-glow); color: var(--accent); }
 .editor-content { flex: 1; padding: 24px 32px; overflow-y: auto; font-size: var(--body); line-height: 1.7; outline: none; }
@@ -26,15 +26,15 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .editor-content.formatted ul, .editor-content.formatted ol { margin: 0 0 12px; padding-left: 24px; }
 .editor-content.formatted li { margin-bottom: 4px; list-style: disc; line-height: 1.6; }
 .editor-content.formatted strong { font-weight: 600; }
-.editor-content.formatted code { background: var(--card); padding: 2px 6px; border-radius: 4px; font-size: 13px; font-family: 'SF Mono', 'Fira Code', monospace; }
-.editor-content.formatted pre { background: var(--card); padding: 16px; border-radius: 8px; overflow-x: auto; margin: 12px 0; }
+.editor-content.formatted code { background: var(--card); padding: 2px 6px; border-radius: var(--radius-sm); font-size: 13px; font-family: 'SF Mono', 'Fira Code', monospace; }
+.editor-content.formatted pre { background: var(--card); padding: 16px; border-radius: var(--radius-lg); overflow-x: auto; margin: 12px 0; }
 .editor-content.formatted pre code { background: none; padding: 0; }
 .editor-content.formatted hr { border: none; border-top: 1px solid var(--border); margin: 24px 0; }
 .editor-content.formatted table { border-collapse: collapse; margin: 12px 0; width: 100%; }
 .editor-content.formatted th, .editor-content.formatted td { padding: 8px 12px; border: 1px solid var(--border); text-align: left; font-size: var(--body); }
 .editor-content.formatted th { background: var(--card); font-weight: 600; }
 .editor-content.formatted blockquote { border-left: 3px solid var(--accent); padding-left: 16px; color: var(--text-2); margin: 12px 0; }
-.callout { border-radius: 8px; padding: 12px 16px; margin: 8px 0; border-left: 3px solid; }
+.callout { border-radius: var(--radius-lg); padding: 12px 16px; margin: 8px 0; border-left: 3px solid; }
 .callout-title { font-weight: 600; font-size: var(--body); margin-bottom: 4px; display: flex; align-items: center; gap: 6px; }
 .callout-content { font-size: var(--body); line-height: 1.6; }
 .callout-content .callout { margin: 8px 0 4px; }
@@ -46,8 +46,8 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .callout-warning .callout-title, .callout-caution .callout-title { color: var(--attention); }
 .callout-tip, .callout-important { background: rgba(107,198,126,0.08); border-color: var(--success); }
 .callout-tip .callout-title, .callout-important .callout-title { color: var(--success); }
-.callout-danger, .callout-error, .callout-bug { background: rgba(232,90,90,0.08); border-color: #E85A5A; }
-.callout-danger .callout-title, .callout-error .callout-title, .callout-bug .callout-title { color: #E85A5A; }
+.callout-danger, .callout-error, .callout-bug { background: rgba(232,90,90,0.08); border-color: var(--danger); }
+.callout-danger .callout-title, .callout-error .callout-title, .callout-bug .callout-title { color: var(--danger); }
 .callout-success, .callout-check, .callout-done { background: rgba(107,198,126,0.08); border-color: var(--success); }
 .callout-success .callout-title, .callout-check .callout-title { color: var(--success); }
 .callout-question, .callout-help, .callout-faq { background: rgba(232,168,76,0.08); border-color: var(--attention); }
@@ -59,7 +59,7 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .callout-todo { background: rgba(122,162,232,0.08); border-color: var(--working); }
 .callout-todo .callout-title { color: var(--working); }
 .editor-content.formatted a { color: var(--accent); cursor: pointer; }
-.editor-content.formatted img { max-width: 100%; border-radius: 8px; }
+.editor-content.formatted img { max-width: 100%; border-radius: var(--radius-lg); }
 
 /* Tiptap editor styles. Scoped under .tiptap-editor-pane and .tiptap-editor
    so the legacy non-markdown preview/edit pane and non-editor views stay
@@ -67,17 +67,17 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
    (.wikilink, .callout), and the floating toolbar all live here. */
 .tiptap-editor-pane { flex: 1; overflow-y: auto; padding: 24px 32px; position: relative; }
 .tiptap-editor-pane.hidden { display: none; }
-.tiptap-editor-pane .properties { display: none; background: var(--card); border: 1px solid var(--border); border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
+.tiptap-editor-pane .properties { display: none; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 16px; overflow: hidden; }
 .tiptap-editor-pane .properties.visible { display: block; }
 .tiptap-editor-pane .properties-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border); }
-.tiptap-editor-pane .properties-header .label { font-size: 11px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); }
-.tiptap-editor-pane .properties-header .meta { font-size: 12px; color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; margin-left: auto; }
+.tiptap-editor-pane .properties-header .label { font-size: var(--label); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); }
+.tiptap-editor-pane .properties-header .meta { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; margin-left: auto; }
 .tiptap-editor-pane .properties-body { padding: 4px 0 8px; }
 .tiptap-editor-pane .prop-row { display: grid; grid-template-columns: 32px 160px 1fr; align-items: center; gap: 8px; padding: 6px 12px; min-height: 32px; }
-.tiptap-editor-pane .prop-row:hover { background: rgba(232,122,90,0.04); border-radius: 6px; }
+.tiptap-editor-pane .prop-row:hover { background: rgba(232,122,90,0.04); border-radius: var(--radius-md); }
 .tiptap-editor-pane .prop-icon { width: 16px; color: var(--text-2); justify-self: center; display: flex; align-items: center; justify-content: center; }
 .tiptap-editor-pane .prop-icon svg { width: 14px; height: 14px; }
-.tiptap-editor-pane .prop-key { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 12px; color: var(--text-2); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tiptap-editor-pane .prop-key { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: var(--caption); color: var(--text-2); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tiptap-editor-pane .prop-value { font-size: var(--body); color: var(--text-1); display: flex; flex-wrap: wrap; gap: 6px; align-items: center; min-width: 0; }
 .tiptap-editor-pane .prop-value.empty { color: var(--text-2); font-style: italic; }
 /* Frontmatter wikilinks: clickable like inline wikilinks; unresolvable targets look dead, not broken. */
@@ -86,32 +86,32 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor-pane .prop-wikilink:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; border-radius: 2px; }
 .tiptap-editor-pane .prop-wikilink.dead { color: var(--text-2); cursor: default; text-decoration: underline dashed; text-underline-offset: 3px; opacity: 0.75; }
 /* Inline property editing: values invite a click; chips remove; lists add. */
-.props-editable .prop-row.editable .prop-value { cursor: text; border-radius: 4px; }
+.props-editable .prop-row.editable .prop-value { cursor: text; border-radius: var(--radius-sm); }
 .props-editable .prop-row.editable .prop-value:hover { background: var(--accent-glow, rgba(232,122,90,0.10)); }
 .props-editable .prop-row.editable .prop-value .bool { cursor: pointer; }
-.prop-edit-input { flex: 1; min-width: 120px; background: var(--card); border: 1px solid var(--accent); border-radius: 4px; color: var(--text-1); font-size: var(--body); font-family: inherit; padding: 2px 8px; outline: none; }
-.prop-chip-remove { display: none; background: none; border: none; color: var(--text-2); font-size: 12px; line-height: 1; padding: 0 0 0 4px; cursor: pointer; }
+.prop-edit-input { flex: 1; min-width: 120px; background: var(--card); border: 1px solid var(--accent); border-radius: var(--radius-sm); color: var(--text-1); font-size: var(--body); font-family: inherit; padding: 2px 8px; outline: none; }
+.prop-chip-remove { display: none; background: none; border: none; color: var(--text-2); font-size: var(--caption); line-height: 1; padding: 0 0 0 4px; cursor: pointer; }
 .props-editable .prop-chip:hover .prop-chip-remove, .props-editable .prop-link-item:hover .prop-chip-remove { display: inline; }
 .prop-chip-remove:hover { color: var(--accent); }
 /* Wikilink list items render as inline links (not pills), keeping the x. */
 .tiptap-editor-pane .prop-link-item { display: inline-flex; align-items: center; }
 /* Inline add affordance: always present but subtle, brightening on hover, so
    the way to add a tag or link is visible without hovering to discover it. */
-.prop-add { display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px dashed var(--border); border-radius: 100px; color: var(--text-2); width: 20px; height: 20px; line-height: 1; cursor: pointer; font-size: 13px; opacity: 0.55; transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease; }
+.prop-add { display: inline-flex; align-items: center; justify-content: center; background: none; border: 1px dashed var(--border); border-radius: 100px; color: var(--text-2); width: 20px; height: 20px; line-height: 1; cursor: pointer; font-size: 13px; opacity: 0.55; transition: opacity var(--duration-base) ease, color var(--duration-base) ease, border-color var(--duration-base) ease; }
 .props-editable .prop-row.editable:hover .prop-add { opacity: 1; }
 .prop-add:hover { color: var(--accent); border-color: var(--accent); opacity: 1; }
 /* External-edit conflict banner: a visible choice, never a silent overwrite. */
 #external-edit-banner { display: flex; align-items: center; gap: 10px; padding: 10px 24px; background: rgba(232,168,76,0.10); border-bottom: 1px solid rgba(232,168,76,0.35); font-size: var(--body); color: var(--text-1); }
 #external-edit-banner .banner-text { flex: 1; }
-#external-edit-banner .banner-btn { padding: 4px 14px; border-radius: 6px; border: 1px solid var(--border); background: var(--card); color: var(--text-1); font-size: 12px; font-weight: 600; cursor: pointer; }
+#external-edit-banner .banner-btn { padding: 4px 14px; border-radius: var(--radius-md); border: 1px solid var(--border); background: var(--card); color: var(--text-1); font-size: var(--caption); font-weight: 600; cursor: pointer; }
 #external-edit-banner .banner-btn:hover { border-color: var(--accent); color: var(--accent); }
 #external-edit-banner .banner-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
 #external-edit-banner .banner-btn.primary:hover { opacity: 0.9; color: #fff; }
-.tiptap-editor-pane .prop-value .bool { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px; border-radius: 100px; font-size: 12px; font-weight: 600; letter-spacing: 0.04em; }
+.tiptap-editor-pane .prop-value .bool { display: inline-flex; align-items: center; gap: 6px; padding: 2px 10px; border-radius: 100px; font-size: var(--caption); font-weight: 600; letter-spacing: 0.04em; }
 .tiptap-editor-pane .prop-value .bool.t { background: rgba(107,198,126,0.15); color: var(--success); }
 .tiptap-editor-pane .prop-value .bool.f { background: rgba(122,117,110,0.15); color: var(--idle); }
-.tiptap-editor-pane .prop-value .bool .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
-.tiptap-editor-pane .prop-chip { display: inline-flex; align-items: center; padding: 2px 10px; background: transparent; border: 1px solid var(--accent); border-radius: 100px; font-size: 12px; color: var(--accent); transition: background 0.15s ease; }
+.tiptap-editor-pane .prop-value .bool .dot { width: 6px; height: 6px; border-radius: var(--radius-circle); background: currentColor; }
+.tiptap-editor-pane .prop-chip { display: inline-flex; align-items: center; padding: 2px 10px; background: transparent; border: 1px solid var(--accent); border-radius: 100px; font-size: var(--caption); color: var(--accent); transition: background var(--duration-base) ease; }
 .tiptap-editor-pane .prop-chip:hover { background: var(--accent-glow); }
 /* A nested (map/list) property item: readable but not editable, so it reads as
    muted rather than an actionable pill. */
@@ -126,7 +126,7 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror p { margin: 0 0 12px 0; line-height: 1.7; }
 .tiptap-editor .ProseMirror h1 { font-size: 24px; font-weight: 700; line-height: 1.3; margin: 24px 0 12px; }
 .tiptap-editor .ProseMirror h1:first-child { margin-top: 0; }
-.tiptap-editor .ProseMirror h2 { font-size: 18px; font-weight: 700; line-height: 1.3; margin: 20px 0 10px; }
+.tiptap-editor .ProseMirror h2 { font-size: var(--title); font-weight: 700; line-height: 1.3; margin: 20px 0 10px; }
 .tiptap-editor .ProseMirror h3 { font-size: 16px; font-weight: 600; line-height: 1.3; margin: 16px 0 8px; }
 .tiptap-editor .ProseMirror ul, .tiptap-editor .ProseMirror ol { padding-left: 24px; margin: 0 0 12px 0; }
 .tiptap-editor .ProseMirror li { margin: 4px 0; }
@@ -145,8 +145,8 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror ul[data-type="taskList"] input[type="checkbox"] { accent-color: var(--accent); }
 .tiptap-editor .ProseMirror ul[data-type="taskList"] > li[data-checked="true"] > div { color: var(--text-2); }
 .tiptap-editor .ProseMirror blockquote { border-left: 2px solid var(--border); padding-left: 16px; margin: 0 0 12px 0; color: var(--text-2); }
-.tiptap-editor .ProseMirror code { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; background: var(--card); padding: 2px 6px; border-radius: 4px; color: var(--text-1); }
-.tiptap-editor .ProseMirror pre { background: var(--card); border-radius: 8px; padding: 12px 16px; margin: 0 0 12px 0; overflow-x: auto; position: relative; }
+.tiptap-editor .ProseMirror code { font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; background: var(--card); padding: 2px 6px; border-radius: var(--radius-sm); color: var(--text-1); }
+.tiptap-editor .ProseMirror pre { background: var(--card); border-radius: var(--radius-lg); padding: 12px 16px; margin: 0 0 12px 0; overflow-x: auto; position: relative; }
 /* Copy control on editor code blocks, injected as a widget decoration (see
    editor/plugins/code-copy.js) so it never becomes document content.
    `float: right` keeps it out of the text flow, so the first line of code is
@@ -161,9 +161,9 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror pre .editor-copy-code-btn {
   position: sticky; float: right; right: 0; top: 0; z-index: 2;
   background: var(--card); border: none; color: var(--text-2); cursor: pointer;
-  padding: 4px; border-radius: 4px; display: flex; align-items: center;
+  padding: 4px; border-radius: var(--radius-sm); display: flex; align-items: center;
   justify-content: center; line-height: 0; opacity: 0;
-  transition: color 0.15s ease, opacity 0.15s ease;
+  transition: color var(--duration-base) ease, opacity var(--duration-base) ease;
 }
 .tiptap-editor .ProseMirror pre:hover .editor-copy-code-btn { opacity: 1; }
 .tiptap-editor .ProseMirror pre .editor-copy-code-btn:hover { color: var(--text-1); }
@@ -171,17 +171,17 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror pre .editor-copy-code-btn.copied { opacity: 1; color: var(--success); }
 .tiptap-editor .ProseMirror pre code { background: transparent; padding: 0; font-size: 13px; line-height: 1.5; }
 .tiptap-editor .ProseMirror a { color: var(--accent); text-decoration: underline; cursor: pointer; }
-.tiptap-editor .ProseMirror a.wikilink { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; padding: 0 2px; border-radius: 3px; transition: background 0.15s ease, color 0.15s ease; }
+.tiptap-editor .ProseMirror a.wikilink { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; cursor: pointer; padding: 0 2px; border-radius: 3px; transition: background var(--duration-base) ease, color var(--duration-base) ease; }
 .tiptap-editor .ProseMirror a.wikilink:hover { color: var(--accent-hover); background: var(--accent-glow); }
 .tiptap-editor .ProseMirror a.wikilink.ProseMirror-selectednode { background: var(--accent-glow); outline: 1px solid var(--accent); outline-offset: 1px; }
-.tiptap-editor .ProseMirror .callout { background: rgba(122,162,232,0.08); border: 1px solid rgba(122,162,232,0.20); border-radius: 8px; padding: 12px 16px; margin: 12px 0; --callout-color: var(--working); }
+.tiptap-editor .ProseMirror .callout { background: rgba(122,162,232,0.08); border: 1px solid rgba(122,162,232,0.20); border-radius: var(--radius-lg); padding: 12px 16px; margin: 12px 0; --callout-color: var(--working); }
 .tiptap-editor .ProseMirror .callout-note, .tiptap-editor .ProseMirror .callout-info, .tiptap-editor .ProseMirror .callout-abstract { --callout-color: var(--working); background: rgba(122,162,232,0.08); border-color: rgba(122,162,232,0.20); }
 .tiptap-editor .ProseMirror .callout-tip, .tiptap-editor .ProseMirror .callout-success, .tiptap-editor .ProseMirror .callout-todo { --callout-color: var(--success); background: rgba(107,198,126,0.08); border-color: rgba(107,198,126,0.20); }
 .tiptap-editor .ProseMirror .callout-warning, .tiptap-editor .ProseMirror .callout-question, .tiptap-editor .ProseMirror .callout-example { --callout-color: var(--attention); background: rgba(232,168,76,0.08); border-color: rgba(232,168,76,0.20); }
-.tiptap-editor .ProseMirror .callout-danger, .tiptap-editor .ProseMirror .callout-failure, .tiptap-editor .ProseMirror .callout-bug { --callout-color: #E85A5A; background: rgba(232,90,90,0.08); border-color: rgba(232,90,90,0.20); }
+.tiptap-editor .ProseMirror .callout-danger, .tiptap-editor .ProseMirror .callout-failure, .tiptap-editor .ProseMirror .callout-bug { --callout-color: var(--danger); background: rgba(232,90,90,0.08); border-color: rgba(232,90,90,0.20); }
 .tiptap-editor .ProseMirror .callout-quote { --callout-color: #A07AE8; background: rgba(160,122,232,0.08); border-color: rgba(160,122,232,0.20); }
 .tiptap-editor .ProseMirror .callout-header { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
-.tiptap-editor .ProseMirror .callout-tag { display: inline-block; padding: 2px 10px; background: var(--callout-color); color: #fff; border-radius: 100px; font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
+.tiptap-editor .ProseMirror .callout-tag { display: inline-block; padding: 2px 10px; background: var(--callout-color); color: #fff; border-radius: 100px; font-size: var(--label); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
 .tiptap-editor .ProseMirror .callout-title { font-size: var(--body); font-weight: 600; color: var(--text-1); }
 .tiptap-editor .ProseMirror .callout-body { font-size: var(--body); color: var(--text-1); line-height: 1.55; }
 .tiptap-editor .ProseMirror .callout-line { min-height: 1.55em; }
@@ -189,19 +189,19 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 /* Foldable callouts (+ open, - closed): native details/summary, disclosure caret on the header. */
 .tiptap-editor .ProseMirror .callout details.callout-fold > summary { cursor: pointer; list-style: none; }
 .tiptap-editor .ProseMirror .callout details.callout-fold > summary::-webkit-details-marker { display: none; }
-.tiptap-editor .ProseMirror .callout details.callout-fold > summary.callout-header::before { content: '\25B8'; color: var(--callout-color); font-size: 15px; line-height: 1; transition: transform 0.15s ease; }
+.tiptap-editor .ProseMirror .callout details.callout-fold > summary.callout-header::before { content: '\25B8'; color: var(--callout-color); font-size: var(--org-role); line-height: 1; transition: transform var(--duration-base) ease; }
 .tiptap-editor .ProseMirror .callout details.callout-fold[open] > summary.callout-header::before { content: '\25BE'; }
 .tiptap-editor .ProseMirror .callout details.callout-fold > summary.callout-header { margin-bottom: 0; }
 .tiptap-editor .ProseMirror .callout details.callout-fold[open] > summary.callout-header { margin-bottom: 6px; }
 /* Nested callouts render as real boxes inside the parent body. */
-.tiptap-editor .ProseMirror .callout .callout-nested { border: 1px solid rgba(122,162,232,0.20); border-radius: 8px; padding: 10px 14px; margin: 8px 0; }
+.tiptap-editor .ProseMirror .callout .callout-nested { border: 1px solid rgba(122,162,232,0.20); border-radius: var(--radius-lg); padding: 10px 14px; margin: 8px 0; }
 /* In-place editing: an edit control that reveals on hover, and the raw-markdown textarea. */
 .tiptap-editor .ProseMirror .callout-editable .callout-header { position: relative; }
-.tiptap-editor .ProseMirror .callout-edit-btn { margin-left: auto; display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: 6px; color: var(--callout-color); opacity: 0; transition: opacity 0.12s ease, background 0.12s ease; cursor: pointer; }
+.tiptap-editor .ProseMirror .callout-edit-btn { margin-left: auto; display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-md); color: var(--callout-color); opacity: 0; transition: opacity var(--duration-fast) ease, background var(--duration-fast) ease; cursor: pointer; }
 .tiptap-editor .ProseMirror .callout-editable:hover .callout-edit-btn { opacity: 0.75; }
 .tiptap-editor .ProseMirror .callout-edit-btn:hover { opacity: 1; background: color-mix(in srgb, var(--callout-color) 16%, transparent); }
 .tiptap-editor .ProseMirror .callout.callout-editing { padding-top: 10px; }
-.tiptap-editor .ProseMirror .callout-edit { width: 100%; box-sizing: border-box; resize: none; background: var(--elevated); border: 1px solid var(--callout-color); border-radius: 6px; color: var(--text-1); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; line-height: 1.5; padding: 8px 10px; outline: none; }
+.tiptap-editor .ProseMirror .callout-edit { width: 100%; box-sizing: border-box; resize: none; background: var(--elevated); border: 1px solid var(--callout-color); border-radius: var(--radius-md); color: var(--text-1); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; line-height: 1.5; padding: 8px 10px; outline: none; }
 /* Rejected edit (an invalid callout head): a brief red flash instead of a
    silent revert, so the typed text is kept and the reason is visible. */
 .tiptap-editor .ProseMirror .callout-edit.callout-edit-invalid { border-color: var(--danger, #d9534f); box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger, #d9534f) 30%, transparent); animation: callout-edit-shake 0.3s ease; }

--- a/public/styles/views/org-chart.css
+++ b/public/styles/views/org-chart.css
@@ -4,16 +4,16 @@
 /* Org chart */
 .org-chart { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 32px; overflow: auto; position: relative; }
 .org-zoom { position: fixed; bottom: 24px; right: 24px; display: flex; flex-direction: column; background: var(--elevated); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; z-index: 5; box-shadow: 0 2px 8px rgba(0,0,0,0.15); }
-.org-zoom button { width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; color: var(--text-2); font-size: 18px; font-weight: 500; line-height: 1; }
+.org-zoom button { width: 36px; height: 36px; display: flex; align-items: center; justify-content: center; color: var(--text-2); font-size: var(--title); font-weight: 500; line-height: 1; }
 .org-zoom button:hover { color: var(--text-1); background: var(--surface); }
 .org-zoom .org-zoom-divider { height: 1px; background: var(--border); }
 /* org-chart-title removed: redundant label */
 .org-tree { display: flex; flex-direction: column; align-items: center; transform-origin: top center; position: relative; }
-.org-card { position: relative; background: var(--card); border-radius: 14px; padding: 24px 30px; display: flex; align-items: center; gap: 16px; cursor: pointer; transition: all 0.2s ease; border: 1px solid transparent; box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08); max-width: 320px; }
+.org-card { position: relative; background: var(--card); border-radius: 14px; padding: 24px 30px; display: flex; align-items: center; gap: 16px; cursor: pointer; transition: all var(--duration-slow) ease; border: 1px solid transparent; box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08); max-width: 320px; }
 .org-card:hover { box-shadow: 0 4px 16px rgba(0,0,0,0.2), 0 0 0 1px var(--accent); }
 .org-card-name { font-size: var(--org-name); font-weight: 700; color: var(--text-1); }
 .org-card-role { font-size: var(--org-role); color: var(--text-2); display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
-.org-status-dot { position: absolute; top: 8px; right: 8px; border-radius: 50%; background: transparent; flex-shrink: 0; }
+.org-status-dot { position: absolute; top: 8px; right: 8px; border-radius: var(--radius-circle); background: transparent; flex-shrink: 0; }
 .org-status-dot.working { background: var(--success); animation: orgPulse 2s ease-in-out infinite; }
 @keyframes orgPulse { 0%,100% { opacity: 0.3; transform: scale(0.95); } 50% { opacity: 1; transform: scale(1.1); } }
 .org-card .avatar { width: 48px; height: 48px; font-size: 21px; }
@@ -35,6 +35,6 @@
 .org-platform-label { font-size: var(--caption); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); margin-bottom: 16px; }
 .org-card-sm { padding: 12px 19px; max-width: 240px; }
 .org-card-sm:hover { transform: none; }
-.org-card-sm .avatar { width: 28px; height: 28px; font-size: 12px; }
+.org-card-sm .avatar { width: 28px; height: 28px; font-size: var(--caption); }
 .org-card-sm .org-card-name { font-size: var(--body); }
 .org-card-sm .org-card-role { font-size: var(--caption); }

--- a/public/styles/views/profile.css
+++ b/public/styles/views/profile.css
@@ -2,27 +2,27 @@
 
 /* Agent profile */
 .profile { flex: 1; overflow-y: auto; padding: 32px; }
-.profile-back { font-size: var(--body); font-weight: 500; color: var(--text-2); display: inline-flex; align-items: center; gap: 6px; margin-bottom: 24px; cursor: pointer; transition: color 0.15s ease; }
+.profile-back { font-size: var(--body); font-weight: 500; color: var(--text-2); display: inline-flex; align-items: center; gap: 6px; margin-bottom: 24px; cursor: pointer; transition: color var(--duration-base) ease; }
 .profile-back:hover { color: var(--accent); }
 .profile-header { display: flex; align-items: center; gap: 16px; margin-bottom: 24px; }
-.profile-avatar { width: 56px; height: 56px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 24px; color: white; }
+.profile-avatar { width: 56px; height: 56px; border-radius: var(--radius-circle); display: flex; align-items: center; justify-content: center; font-size: 24px; color: white; }
 .profile-name { font-size: var(--title); font-weight: 700; margin-bottom: 2px; }
 .profile-desc { font-size: var(--body); color: var(--text-2); line-height: 1.5; }
 .profile-cta { margin-bottom: 24px; }
-.profile-cta-btn { padding: 8px 20px; background: var(--accent); color: white; font-size: var(--body); font-weight: 600; border-radius: 8px; transition: all 0.2s ease; }
+.profile-cta-btn { padding: 8px 20px; background: var(--accent); color: white; font-size: var(--body); font-weight: 600; border-radius: var(--radius-lg); transition: all var(--duration-slow) ease; }
 .profile-cta-btn:hover { background: var(--accent-hover); box-shadow: 0 0 24px rgba(232,122,90,0.2); }
 .profile-section { margin-bottom: 24px; }
-.profile-card { background: var(--card); border-radius: 12px; padding: 4px 0; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+.profile-card { background: var(--card); border-radius: var(--radius-xl); padding: 4px 0; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
 .profile-card-section { padding: 12px 16px; }
 .profile-card-section + .profile-card-section { border-top: 1px solid var(--border); }
 .profile-card-text { font-size: var(--body); line-height: 1.6; color: var(--text-1); }
 .profile-card-item { font-size: var(--body); padding: 6px 0; color: var(--text-1); }
 .profile-section-label { font-size: var(--label); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); margin-bottom: 8px; }
 .profile-list { display: flex; flex-direction: column; gap: 4px; }
-.profile-list-item { padding: 10px 16px; background: var(--card); border-radius: 12px; font-size: var(--body); color: var(--text-1); }
+.profile-list-item { padding: 10px 16px; background: var(--card); border-radius: var(--radius-xl); font-size: var(--body); color: var(--text-1); }
 .profile-existing { margin-bottom: 24px; }
 .profile-existing-label { font-size: var(--caption); color: var(--text-2); margin-bottom: 8px; }
-.profile-existing-item { display: flex; align-items: center; gap: 8px; padding: 10px 12px; background: var(--card); border-radius: 8px; cursor: pointer; transition: background 0.15s ease; margin-bottom: 4px; }
+.profile-existing-item { display: flex; align-items: center; gap: 8px; padding: 10px 12px; background: var(--card); border-radius: var(--radius-lg); cursor: pointer; transition: background var(--duration-base) ease; margin-bottom: 4px; }
 .profile-existing-item:hover { background: var(--elevated); border: 1px solid var(--accent); margin: -1px; margin-bottom: 3px; }
 .profile-existing-title { font-size: var(--body); font-weight: 500; flex: 1; }
 .profile-existing-meta { font-size: var(--caption); color: var(--text-2); }

--- a/public/styles/views/settings.css
+++ b/public/styles/views/settings.css
@@ -2,23 +2,23 @@
 
 /* Settings */
 .settings-nav { padding: 0 8px; }
-.settings-nav-item { display: flex; align-items: center; gap: 10px; padding: 10px 8px; border-radius: 8px; cursor: pointer; font-size: 13px; font-weight: 500; color: var(--text-1); transition: background 0.15s ease; }
+.settings-nav-item { display: flex; align-items: center; gap: 10px; padding: 10px 8px; border-radius: var(--radius-lg); cursor: pointer; font-size: 13px; font-weight: 500; color: var(--text-1); transition: background var(--duration-base) ease; }
 .settings-nav-item:hover { background: var(--elevated); }
 .settings-nav-item.active { background: var(--elevated); }
 .settings-nav-item svg { width: 16px; height: 16px; color: var(--text-2); flex-shrink: 0; }
 .settings-content { max-width: 560px; padding: 32px; }
 .settings-section-title { font-size: var(--title); font-weight: 700; margin-bottom: 20px; }
-.settings-card { background: var(--card); border-radius: 12px; padding: 4px 0; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+.settings-card { background: var(--card); border-radius: var(--radius-xl); padding: 4px 0; margin-bottom: 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
 .settings-row { display: flex; align-items: center; justify-content: space-between; padding: 14px 16px; }
 .settings-row + .settings-row { border-top: 1px solid var(--border); }
 .settings-label { font-size: var(--body); font-weight: 500; color: var(--text-1); }
 .settings-value { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono','Fira Code','Consolas',monospace; max-width: 320px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.settings-btn { padding: 6px 14px; font-size: var(--caption); font-weight: 600; border-radius: 6px; background: var(--card); color: var(--text-1); border: 1px solid var(--border); transition: all 0.15s ease; cursor: pointer; }
+.settings-btn { padding: 6px 14px; font-size: var(--caption); font-weight: 600; border-radius: var(--radius-md); background: var(--card); color: var(--text-1); border: 1px solid var(--border); transition: all var(--duration-base) ease; cursor: pointer; }
 .settings-btn:hover { border-color: var(--accent); color: var(--accent); }
-.settings-btn-primary { padding: 6px 14px; font-size: var(--caption); font-weight: 600; border-radius: 6px; background: var(--accent); color: white; border: none; transition: all 0.15s ease; cursor: pointer; }
+.settings-btn-primary { padding: 6px 14px; font-size: var(--caption); font-weight: 600; border-radius: var(--radius-md); background: var(--accent); color: white; border: none; transition: all var(--duration-base) ease; cursor: pointer; }
 .settings-btn-primary:hover { background: var(--accent-hover); }
 .mode-toggle { display: flex; background: var(--base); border: 1px solid var(--border); border-radius: 10px; padding: 4px; gap: 0; }
-.mode-toggle-btn { flex: 1; padding: 9px 16px; font-size: var(--caption); font-weight: 600; border-radius: 7px; border: 1px solid transparent; background: transparent; color: var(--text-2); transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease; cursor: pointer; text-align: center; }
+.mode-toggle-btn { flex: 1; padding: 9px 16px; font-size: var(--caption); font-weight: 600; border-radius: 7px; border: 1px solid transparent; background: transparent; color: var(--text-2); transition: background var(--duration-base) ease, color var(--duration-base) ease, box-shadow var(--duration-base) ease; cursor: pointer; text-align: center; }
 .mode-toggle-btn:hover:not(.active) { color: var(--text-1); background: var(--elevated); }
 .mode-toggle-btn.active { background: var(--card); color: var(--text-1); border-color: var(--border); box-shadow: 0 1px 3px rgba(0,0,0,0.18); }
 .mode-description { font-size: var(--caption); color: var(--text-2); line-height: 1.5; padding: 8px 0 4px; }

--- a/public/styles/views/skills.css
+++ b/public/styles/views/skills.css
@@ -1,13 +1,13 @@
 /* The skills view and its sidebar rows. */
 
 /* Skills */
-.skill-sidebar-item { display: flex; align-items: center; gap: 8px; padding: 10px 8px; border-radius: 8px; cursor: pointer; transition: background 0.15s ease; }
+.skill-sidebar-item { display: flex; align-items: center; gap: 8px; padding: 10px 8px; border-radius: var(--radius-lg); cursor: pointer; transition: background var(--duration-base) ease; }
 .skill-sidebar-item:hover { background: var(--elevated); }
 .skill-sidebar-item.active { background: var(--elevated); }
 .skill-sidebar-name { font-size: 13px; font-weight: 500; color: var(--text-1); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; }
 .skills-sidebar-list { flex: 1; overflow-y: auto; padding: 8px; }
 .profile-avatar.skill-avatar { border-radius: 14px; background: var(--card); border: 1px solid var(--border); color: var(--text-2); }
-.agent-chip { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--elevated); border-radius: 10px; cursor: pointer; transition: all 0.15s ease; border: 1px solid transparent; }
+.agent-chip { display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px; background: var(--elevated); border-radius: 10px; cursor: pointer; transition: all var(--duration-base) ease; border: 1px solid transparent; }
 .agent-chip:hover { border-color: var(--accent); background: var(--accent-glow); }
 .agent-chip-name { font-size: var(--body); font-weight: 500; color: var(--text-1); }
 .agent-chip-role { font-size: var(--caption); color: var(--text-2); }

--- a/public/styles/views/workspace.css
+++ b/public/styles/views/workspace.css
@@ -1,7 +1,7 @@
 /* The workspace picker and its cards. */
 
 /* Workspace picker */
-.ws-card { display: flex; align-items: center; gap: 12px; padding: 12px 16px; background: var(--card); border-radius: 12px; cursor: pointer; transition: all 0.15s ease; margin-bottom: 4px; }
+.ws-card { display: flex; align-items: center; gap: 12px; padding: 12px 16px; background: var(--card); border-radius: var(--radius-xl); cursor: pointer; transition: all var(--duration-base) ease; margin-bottom: 4px; }
 .ws-card:hover { box-shadow: 0 0 0 1px var(--accent); }
 .ws-card-icon { color: var(--text-2); flex-shrink: 0; }
 .ws-card-body { flex: 1; text-align: left; min-width: 0; }
@@ -12,12 +12,12 @@
 .ws-picker-divider { border-top: 1px solid var(--border); padding-top: 16px; display: flex; flex-direction: column; align-items: center; gap: 12px; }
 .ws-picker-or { font-size: var(--caption); color: var(--text-2); }
 .ws-picker-btn-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; width: 100%; }
-.ws-picker-create-btn, .ws-picker-open-btn { padding: 10px 24px; background: var(--card); color: var(--text-1); font-size: var(--body); font-weight: 600; border-radius: 8px; border: 1px solid var(--border); transition: all 0.15s ease; cursor: pointer; }
+.ws-picker-create-btn, .ws-picker-open-btn { padding: 10px 24px; background: var(--card); color: var(--text-1); font-size: var(--body); font-weight: 600; border-radius: var(--radius-lg); border: 1px solid var(--border); transition: all var(--duration-base) ease; cursor: pointer; }
 .ws-picker-create-btn:hover, .ws-picker-open-btn:hover { border-color: var(--accent); color: var(--accent); }
-.ws-picker-input { flex: 1; padding: 10px 14px; background: var(--card); border-radius: 8px; font-size: var(--body); border: 1px solid var(--border); color: var(--text-1); transition: border-color 0.15s ease; }
+.ws-picker-input { flex: 1; padding: 10px 14px; background: var(--card); border-radius: var(--radius-lg); font-size: var(--body); border: 1px solid var(--border); color: var(--text-1); transition: border-color var(--duration-base) ease; }
 .ws-picker-input:focus { border-color: var(--accent); }
-.ws-picker-submit { padding: 10px 20px; background: var(--accent); color: white; font-size: var(--body); font-weight: 600; border-radius: 8px; transition: background 0.15s ease; flex-shrink: 0; cursor: pointer; }
+.ws-picker-submit { padding: 10px 20px; background: var(--accent); color: white; font-size: var(--body); font-weight: 600; border-radius: var(--radius-lg); transition: background var(--duration-base) ease; flex-shrink: 0; cursor: pointer; }
 .ws-picker-submit:hover { background: var(--accent-hover); }
 .ws-picker-hint { font-size: var(--caption); color: var(--text-2); margin-top: 6px; text-align: left; }
-.ws-picker-error { font-size: var(--caption); color: #E85A5A; margin-top: 4px; display: none; }
+.ws-picker-error { font-size: var(--caption); color: var(--danger); margin-top: 4px; display: none; }
 

--- a/test/e2e/style-snapshot.tool.js
+++ b/test/e2e/style-snapshot.tool.js
@@ -8,10 +8,13 @@
 // cannot prove that on their own: regrouping rules changes their order, and
 // order is what a cascade is made of.
 //
-//   SNAP_OUT=/tmp/a.json npx playwright test test/e2e/style-snapshot.tool.js
+//   RUN_TOOLS=1 SNAP_OUT=/tmp/a.json npx playwright test test/e2e/style-snapshot.tool.js
 //   ...change the stylesheets...
-//   SNAP_OUT=/tmp/b.json npx playwright test test/e2e/style-snapshot.tool.js
+//   RUN_TOOLS=1 SNAP_OUT=/tmp/b.json npx playwright test test/e2e/style-snapshot.tool.js
 //   ...then diff a.json against b.json.
+//
+// RUN_TOOLS is required because the testIgnore rule that keeps this out of CI
+// would otherwise make it unrunnable.
 //
 // Read the diff against a CONTROL, never against zero. Two runs of the SAME
 // build differ by about one element, because a little of what the seeded

--- a/test/e2e/theme.spec.js
+++ b/test/e2e/theme.spec.js
@@ -43,8 +43,11 @@ const THEMED = [
 // should not have.
 const INVARIANT = [
   '--accent', '--accent-hover', '--success', '--attention', '--working', '--idle',
+  '--danger',
   '--heading', '--title', '--body', '--caption', '--label',
   '--nav-rail-width', '--topbar-height', '--content-radius',
+  '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl', '--radius-circle',
+  '--duration-fast', '--duration-base', '--duration-slow',
 ];
 
 const NAV_SECTIONS = ['conversations', 'team', 'files', 'skills', 'settings'];


### PR DESCRIPTION
**209 literals become tokens**, under a rule that is mechanical rather than
editorial: a substitution belongs in this pull request only if the token's value
is **identical** to the literal it replaces. Anything that would move a pixel is
a deliberate visual change and waits for the polish pass.

| Category | Replaced |
| --- | --- |
| `border-radius` | 101 |
| transition and animation durations | 75 |
| `font-size` | 26 |
| the error red | 7 |

## The proof

Zero painted properties differ across **5,766 elements**, five nav sections and
both themes, against a control run that also differed by zero.

That required fixing the instrument first. Adding tokens to `:root` changes
every element's *inherited* property list without changing anything rendered, so
the naive diff reported all 5,316 elements as changed. Custom properties are now
excluded from the comparison, which is the only way it can answer the question
tokenisation actually poses. Both the control and the treatment were re-run
through the corrected differ.

## What was deliberately left alone

The point of the pixel-identity rule is that it decides these cases for me
rather than my taste deciding them.

- **29 radius values**: `10px`, `2px`, `100px`, `7px`, `3px`, `999px`, `5px`,
  `20px`, `14px`, `16px`. Two spellings of a pill, and a set of one-offs that
  each landed a step away from a scale nobody had written down.
- **Two near-identical reds**, `#e85d5d` and `#d9534f`, which are not the error
  red and cannot be substituted for it without changing what renders.
- **A hardcoded `#1a1a1a`**, which is the dark theme's `--base`. Tokenising it
  would make it start following the theme, which is almost certainly right and
  is certainly not a no-op.
- **105 remaining colour literals**, mostly alpha tints of colours that already
  have tokens. Expressing those as tints of their token is the change that makes
  a token edit actually propagate, and it is worth doing carefully rather than
  as a footnote here.

## Four token groups added

`--danger`, because the status set had `--success`, `--attention`, `--working`
and `--idle` but no red, and three near-identical reds had grown in its absence.
A **radius scale** that absorbed 101 of 130 declarations. A **duration scale**,
where `150ms` and `0.15s` turned out to be the same duration written two ways.

Each group carries the rule for choosing between its steps, not just its values,
because a scale without a selection rule just moves the guesswork.

The theme suite now asserts all nine new tokens resolve and stay theme-invariant.
Removing one fails it by name, verified.

## A correction to what the previous pull request claimed

`#131` said a `testIgnore` rule keeps `*.tool.js` out of CI. **That rule is
inert.** Playwright's default `testMatch` collects only `*.spec.js` and
`*.test.js`, so the filename was always what excluded it; deleting the rule
changes nothing.

Worse, the rule made the tool impossible to run at all, which is how this was
found. It is replaced by a `testMatch` that `RUN_TOOLS=1` points at the tools,
so a hand run collects the instruments and nothing else. "Excluded from CI" and
"impossible to run" are different things and the first attempt shipped the
second.

## Scope note

The drift lint was planned for this slice and is deliberately not here. It needs
an allowlist covering roughly 150 surviving literals, each with a justification
and a note on what it is waiting for, and that is the substance of the lint
rather than a footnote to a substitution pass. It is the next slice.

## Test results

Suite **1,569**, unchanged, because this adds no assertions to the Node suite.
E2E **109 of 109**, unchanged, which also confirms the tool is still excluded.
All **50 coverage floors** hold. Typecheck and reference check clean.

No user-visible change, measured rather than asserted.
