### PR TITLE
Lint for style drift, with an allowlist that has to be read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
   # Fast, dependency-free guard: no internal run codenames, review-round or
   # priority labels, or private workspace paths leak into the public source.
   hygiene:
-    name: Hygiene (no internal references)
+    name: Hygiene (internal references, style drift)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         uses: actions/checkout@v5
       - name: Check for internal references
         run: node scripts/check-internal-refs.js
+      # Neither needs dependencies: both read the repo's own files.
+      - name: Check for style drift
+        run: node test/tools/style-drift.js
 
   test:
     name: Test (Node ${{ matrix.node }})

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "node scripts/release.js",
     "test:e2e": "playwright test",
     "check:refs": "node scripts/check-internal-refs.js",
+    "lint:styles": "node test/tools/style-drift.js",
     "typecheck": "tsc -p tsconfig.server.json && tsc -p tsconfig.client.json",
     "screenshots": "node scripts/screenshots/run.mjs",
     "smoke": "node scripts/smoke/run.mjs",

--- a/scripts/release-gate.js
+++ b/scripts/release-gate.js
@@ -90,6 +90,10 @@ function defaultExec(cmd, args = []) {
 function buildSteps(live) {
   const steps = [
     { name: 'hygiene', cmd: ['npm', ['run', 'check:refs']] },
+    // Cheap and file-only, so it sits beside hygiene rather than in the
+    // expensive half: a release that reintroduces a hardcoded colour fails
+    // before anything is built.
+    { name: 'style drift', cmd: ['npm', ['run', 'lint:styles']] },
     // Fails fast if the installed runtime has moved past the committed
     // stream capture, or the stub has drifted from it: no candidate gets
     // validated against a stale model of the stream.

--- a/test/tools/style-drift-allowlist.json
+++ b/test/tools/style-drift-allowlist.json
@@ -1,0 +1,221 @@
+{
+  "public/editor/styles.js": {
+    "why": "The editor's runtime-injected stylesheet, and the largest single pocket of drift: 77 literals, of which #E87A5A appears 26 times and IS --accent. The file already uses var(--...) 78 times, so it can read tokens; these are simply the places that did not. Alpha tints of colours that already have tokens (accent 232,122,90; success 107,198,126; working 122,162,232; attention 232,168,76). Each is the token re-typed as raw channels, so editing the token no longer moves them. Waiting on a decision about how a tint of a token is written: colour-mix() or relative colour syntax both work in Electron, and both change the computed value, so it is a visual change rather than a substitution. It also carries #E06C6C, one of five near-identical reds in the codebase (#E85A5A, now --danger; #e85d5d; #d9534f; #E06C6C; #e55). Waiting on the polish pass choosing one and deleting the rest. Plus radius values a step off the scale (--radius-sm 4, md 6, lg 8, xl 12). waiting on the polish pass, which moves them onto it; each move is a visible change. And animation durations, not transition durations. these are timed to what the animation says (a slow pulse, a spinner, a flash) rather than to the interaction scale, so they are deliberate and permanent rather than debt.",
+    "allow": {
+      "#E87A5A": 26,
+      "#E06C6C": 5,
+      "#fff": 1,
+      "#1A1A1A": 1,
+      "rgba(232,122,90,0.12)": 1,
+      "rgba(107,198,126,0.16)": 2,
+      "rgba(107,198,126,0.6)": 1,
+      "rgba(224,108,108,0.14)": 2,
+      "rgba(232,176,90,0.22)": 1,
+      "rgba(232,122,90,0.15)": 5,
+      "rgba(224,108,108,0.10)": 1,
+      "rgba(107,198,126,0.14)": 2,
+      "rgba(232,122,90,0.25)": 1,
+      "rgba(232,122,90,0.35)": 1,
+      "rgba(232,122,90,0.2)": 1,
+      "rgba(128,128,128,0.12)": 1,
+      "rgba(232,122,90,0.3)": 1,
+      "rgba(232,122,90,0.4)": 1,
+      "rgba(0,0,0,0.35)": 1,
+      "3px": 4,
+      "100px": 3,
+      "2px": 2,
+      "8px": 4,
+      "6px": 1,
+      "4px": 1,
+      "1.2s": 3,
+      "160ms": 2,
+      "0.25s": 1,
+      "0.15s": 1
+    }
+  },
+  "public/styles/base.css": {
+    "why": "A single 3px radius on a scrollbar thumb. Radius values a step off the scale (--radius-sm 4, md 6, lg 8, xl 12). Waiting on the polish pass, which moves them onto it; each move is a visible change.",
+    "allow": {
+      "3px": 1
+    }
+  },
+  "public/styles/components/connection-bar.css": {
+    "why": "Alpha tints of colours that already have tokens (accent 232,122,90; success 107,198,126; working 122,162,232; attention 232,168,76). Each is the token re-typed as raw channels, so editing the token no longer moves them. Waiting on a decision about how a tint of a token is written: colour-mix() or relative colour syntax both work in Electron, and both change the computed value, so it is a visual change rather than a substitution.",
+    "allow": {
+      "rgba(107,198,126,0.1)": 1,
+      "rgba(232,90,90,0.1)": 1,
+      "rgba(122,162,232,0.1)": 1
+    }
+  },
+  "public/styles/components/find-bar.css": {
+    "why": "A hardcoded copy of the dark theme's --base. This one is a BUG rather than debt: it does not follow the theme, so it is wrong in light mode. Tokenising it is a visible fix and belongs in the polish pass. Also a shadow black and an attention tint. Alpha tints of colours that already have tokens (accent 232,122,90; success 107,198,126; working 122,162,232; attention 232,168,76). Each is the token re-typed as raw channels, so editing the token no longer moves them. Waiting on a decision about how a tint of a token is written: colour-mix() or relative colour syntax both work in Electron, and both change the computed value, so it is a visual change rather than a substitution.",
+    "allow": {
+      "#1a1a1a": 1,
+      "rgba(0,0,0,0.25)": 1,
+      "rgba(232,168,76,0.4)": 1,
+      "2px": 1
+    }
+  },
+  "public/styles/components/floating-toolbar.css": {
+    "why": "Shadow blacks. There is no elevation scale, so every surface picked its own alpha and nine different ones are now in use across the app. Waiting on a shadow scale in tokens.css. This file alone uses five different blacks across its light and dark shadow pairs, which is the clearest argument for the scale. Plus one absolute white and two 5px radii. Absolute white or black, chosen for contrast against a coloured fill rather than as a theme colour. Deliberate: a token here would make it follow the theme, which is the opposite of what it is for.",
+    "allow": {
+      "#fff": 1,
+      "rgba(0,0,0,0.10)": 8,
+      "rgba(0,0,0,0.16)": 5,
+      "rgba(0,0,0,0.05)": 1,
+      "rgba(0,0,0,0.06)": 2,
+      "5px": 2
+    }
+  },
+  "public/styles/components/message-content.css": {
+    "why": "An accent tint, a 3px radius, and a 1.8s agent pulse. Animation durations, not transition durations. These are timed to what the animation says (a slow pulse, a spinner, a flash) rather than to the interaction scale, so they are deliberate and permanent rather than debt.",
+    "allow": {
+      "rgba(232,122,90,0.2)": 1,
+      "3px": 1,
+      "1.8s": 1
+    }
+  },
+  "public/styles/components/palette.css": {
+    "why": "Shadow blacks. There is no elevation scale, so every surface picked its own alpha and nine different ones are now in use across the app. Waiting on a shadow scale in tokens.css. Plus 999px and 7px radii and three animation durations. Animation durations, not transition durations. These are timed to what the animation says (a slow pulse, a spinner, a flash) rather than to the interaction scale, so they are deliberate and permanent rather than debt.",
+    "allow": {
+      "rgba(0,0,0,0.18)": 1,
+      "rgba(0,0,0,0.4)": 1,
+      "rgba(0,0,0,0.2)": 1,
+      "999px": 1,
+      "7px": 1,
+      "2px": 1,
+      "160ms": 1,
+      "0.8s": 1,
+      "1.6s": 1
+    }
+  },
+  "public/styles/components/sidebar.css": {
+    "why": "Shadow blacks. There is no elevation scale, so every surface picked its own alpha and nine different ones are now in use across the app. Waiting on a shadow scale in tokens.css. Plus #e55, one of five near-identical reds in the codebase (#E85A5A, now --danger; #e85d5d; #d9534f; #E06C6C; #e55). Waiting on the polish pass choosing one and deleting the rest. Plus two absolute whites, accent and success tints, a 999px pill, a 10px radius, and two 2s status animations.",
+    "allow": {
+      "#e55": 1,
+      "#fff": 2,
+      "rgba(0,0,0,0.08)": 1,
+      "rgba(0,0,0,0.25)": 1,
+      "rgba(0,0,0,0.12)": 1,
+      "rgba(0,0,0,0.06)": 1,
+      "rgba(232,122,90,0.18)": 1,
+      "rgba(0,0,0,0.15)": 2,
+      "rgba(232,122,90,0.3)": 2,
+      "rgba(107,198,126,0.1)": 1,
+      "999px": 1,
+      "10px": 1,
+      "0.25s": 1,
+      "2s": 2
+    }
+  },
+  "public/styles/components/topbar.css": {
+    "why": "A single 7px radius on the search field. Radius values a step off the scale (--radius-sm 4, md 6, lg 8, xl 12). Waiting on the polish pass, which moves them onto it; each move is a visible change.",
+    "allow": {
+      "7px": 1
+    }
+  },
+  "public/styles/components/update-strip.css": {
+    "why": "A 900ms progress animation. Animation durations, not transition durations. These are timed to what the animation says (a slow pulse, a spinner, a flash) rather than to the interaction scale, so they are deliberate and permanent rather than debt.",
+    "allow": {
+      "900ms": 1
+    }
+  },
+  "public/styles/views/chat.css": {
+    "why": "Permission and status cards, which is where the red problem is most visible: #e85d5d twice plus three rgba(232,93,93,...) tints of the same colour, none of them --danger. One of five near-identical reds in the codebase (#E85A5A, now --danger; #e85d5d; #d9534f; #E06C6C; #e55). Waiting on the polish pass choosing one and deleting the rest. Also a hardcoded copy of the dark theme's --base. this one is a bug rather than debt: it does not follow the theme, so it is wrong in light mode. tokenising it is a visible fix and belongs in the polish pass. Alpha tints of colours that already have tokens (accent 232,122,90; success 107,198,126; working 122,162,232; attention 232,168,76). Each is the token re-typed as raw channels, so editing the token no longer moves them. Waiting on a decision about how a tint of a token is written: colour-mix() or relative colour syntax both work in Electron, and both change the computed value, so it is a visual change rather than a substitution.",
+    "allow": {
+      "#1a1a1a": 1,
+      "#e85d5d": 2,
+      "rgba(107,198,126,0.12)": 3,
+      "rgba(107,198,126,0.22)": 1,
+      "rgba(0,0,0,0.06)": 1,
+      "rgba(232,122,90,0.15)": 1,
+      "rgba(232,168,76,0.08)": 1,
+      "rgba(122,162,232,0.07)": 1,
+      "rgba(122,162,232,0.35)": 1,
+      "rgba(232,122,90,0.12)": 1,
+      "rgba(107,198,126,0.06)": 1,
+      "rgba(232,122,90,0.3)": 1,
+      "rgba(232,122,90,0.4)": 1,
+      "rgba(232,93,93,0.15)": 1,
+      "rgba(232,93,93,0.25)": 1,
+      "rgba(232,93,93,0.12)": 1,
+      "16px": 1,
+      "20px": 2,
+      "10px": 1,
+      "0.25s": 1
+    }
+  },
+  "public/styles/views/editor.css": {
+    "why": "Callout accents, one hue per callout type (note, tip, warning, danger, quote, example), which is a palette of its own that no token set covers. Alpha tints of colours that already have tokens (accent 232,122,90; success 107,198,126; working 122,162,232; attention 232,168,76). Each is the token re-typed as raw channels, so editing the token no longer moves them. Waiting on a decision about how a tint of a token is written: colour-mix() or relative colour syntax both work in Electron, and both change the computed value, so it is a visual change rather than a substitution. It also carries #d9534f and #A07AE8, a purple with no token at all, four 100px pills and three absolute whites.",
+    "allow": {
+      "#A07AE8": 3,
+      "#fff": 3,
+      "#d9534f": 2,
+      "rgba(232,168,76,0.32)": 1,
+      "rgba(232,122,90,0.55)": 1,
+      "rgba(122,162,232,0.08)": 5,
+      "rgba(232,168,76,0.08)": 3,
+      "rgba(107,198,126,0.08)": 3,
+      "rgba(232,90,90,0.08)": 2,
+      "rgba(160,122,232,0.08)": 2,
+      "rgba(232,122,90,0.04)": 1,
+      "rgba(232,122,90,0.10)": 1,
+      "rgba(232,168,76,0.10)": 1,
+      "rgba(232,168,76,0.35)": 1,
+      "rgba(107,198,126,0.15)": 1,
+      "rgba(122,117,110,0.15)": 1,
+      "rgba(122,162,232,0.20)": 3,
+      "rgba(107,198,126,0.20)": 1,
+      "rgba(232,168,76,0.20)": 1,
+      "rgba(232,90,90,0.20)": 1,
+      "rgba(160,122,232,0.20)": 1,
+      "2px": 2,
+      "100px": 4,
+      "3px": 1,
+      "0.3s": 1
+    }
+  },
+  "public/styles/views/org-chart.css": {
+    "why": "Shadow blacks. There is no elevation scale, so every surface picked its own alpha and nine different ones are now in use across the app. Waiting on a shadow scale in tokens.css. Plus 10px and 14px radii and a 2s working pulse.",
+    "allow": {
+      "rgba(0,0,0,0.15)": 1,
+      "rgba(0,0,0,0.12)": 1,
+      "rgba(0,0,0,0.08)": 1,
+      "rgba(0,0,0,0.2)": 1,
+      "10px": 1,
+      "14px": 1,
+      "2s": 1
+    }
+  },
+  "public/styles/views/profile.css": {
+    "why": "An accent tint and a shadow black. Shadow blacks. There is no elevation scale, so every surface picked its own alpha and nine different ones are now in use across the app. Waiting on a shadow scale in tokens.css.",
+    "allow": {
+      "rgba(232,122,90,0.2)": 1,
+      "rgba(0,0,0,0.08)": 1
+    }
+  },
+  "public/styles/views/settings.css": {
+    "why": "Two shadow blacks and 10px and 7px radii. Shadow blacks. There is no elevation scale, so every surface picked its own alpha and nine different ones are now in use across the app. Waiting on a shadow scale in tokens.css.",
+    "allow": {
+      "rgba(0,0,0,0.08)": 1,
+      "rgba(0,0,0,0.18)": 1,
+      "10px": 1,
+      "7px": 1
+    }
+  },
+  "public/styles/views/skills.css": {
+    "why": "14px and 10px radii on the skill rows. Radius values a step off the scale (--radius-sm 4, md 6, lg 8, xl 12). Waiting on the polish pass, which moves them onto it; each move is a visible change.",
+    "allow": {
+      "14px": 1,
+      "10px": 1
+    }
+  },
+  "public/views/find.js": {
+    "why": "Search-match highlight colours, set from JavaScript because they are applied to ranges the CSS cannot select. Tints of attention and accent, plus absolute black for text on the highlight. Absolute white or black, chosen for contrast against a coloured fill rather than as a theme colour. Deliberate: a token here would make it follow the theme, which is the opposite of what it is for. Waiting on the JS-set style cleanup, which is tracked separately.",
+    "allow": {
+      "#000": 1,
+      "rgba(232,168,76,0.30)": 1,
+      "rgba(232,122,90,0.55)": 1
+    }
+  }
+}

--- a/test/tools/style-drift.js
+++ b/test/tools/style-drift.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+'use strict';
+// Style drift lint.
+//
+// A design token only works if it is the ONLY place its value is written. The
+// moment a colour, a radius or a duration is typed as a literal somewhere else,
+// changing the token stops changing the app, and the drift is invisible until
+// someone notices two things that should match no longer do. Rundock had four
+// near-identical reds by the time this was written, for exactly that reason.
+//
+// This flags a literal wherever one is written outside tokens.css, and refuses
+// to pass unless that literal is listed in style-drift-allowlist.json with a
+// reason and a count. It is a RATCHET: the counts are maxima, so drift can be
+// paid down but not accumulated.
+//
+//   node test/tools/style-drift.js            check, exit non-zero on drift
+//   node test/tools/style-drift.js --report   print what is there, exit 0
+//   node test/tools/style-drift.js --write    regenerate the counts (keeps reasons)
+//
+// Adding an entry to the allowlist is deliberately a code review, not a
+// formality: the reason field is the only part a person has to write, and it is
+// the only part worth reading.
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const ALLOWLIST = path.join(__dirname, 'style-drift-allowlist.json');
+
+// Where styling can be written. tokens.css is the source of truth and is
+// exempt by definition; vendor/ is third-party and not ours to tidy.
+function surfaces() {
+  const out = [];
+  const walk = (dir) => {
+    for (const e of fs.readdirSync(path.join(ROOT, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${e.name}`;
+      if (e.isDirectory()) walk(rel);
+      else if (e.name.endsWith('.css') && e.name !== 'tokens.css') out.push(rel);
+    }
+  };
+  walk('public/styles');
+  out.push('public/index.html', 'public/app.js', 'public/editor/styles.js');
+  for (const f of fs.readdirSync(path.join(ROOT, 'public/views'))) {
+    if (f.endsWith('.js')) out.push(`public/views/${f}`);
+  }
+  return out.sort();
+}
+
+// ── detectors ────────────────────────────────────────────────────────────────
+
+// A hex colour, but NOT an HTML numeric character reference. `&#8593;` is an
+// up arrow and its digits are all valid hex, so length cannot tell them apart:
+// the `&` is the only signal. index.html and three view modules are full of
+// them, and a scan without this rule reports arrow glyphs as colour drift.
+const HEX = /(^|[^&\w])(#[0-9a-fA-F]{3,8})\b/g;
+const FUNC = /\b(rgba?|hsla?)\(\s*[\d.]/g;
+const RADIUS = /border-radius:\s*([^;}\n]+)/g;
+const TIMED = /\b(?:transition|animation)(?:-duration)?:\s*([^;}\n]+)/g;
+const TIME = /\b\d*\.?\d+m?s\b/g;
+
+function findings(rel) {
+  const src = fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+  const lines = src.split('\n');
+  const found = [];
+  const at = (idx) => src.slice(0, idx).split('\n').length;
+
+  for (const m of src.matchAll(HEX)) {
+    found.push({ kind: 'colour', literal: m[2], line: at(m.index) });
+  }
+  for (const m of src.matchAll(FUNC)) {
+    // Re-read the whole call so the recorded literal is the value, not a prefix.
+    const tail = src.slice(m.index);
+    const close = tail.indexOf(')');
+    if (close === -1) continue;
+    found.push({ kind: 'colour', literal: tail.slice(0, close + 1).replace(/\s+/g, ''), line: at(m.index) });
+  }
+  for (const m of src.matchAll(RADIUS)) {
+    for (const v of m[1].match(/\b\d+px\b/g) || []) {
+      found.push({ kind: 'radius', literal: v, line: at(m.index) });
+    }
+  }
+  for (const m of src.matchAll(TIMED)) {
+    for (const v of m[1].match(TIME) || []) {
+      found.push({ kind: 'duration', literal: v, line: at(m.index) });
+    }
+  }
+  return found.map(f => ({ ...f, file: rel, text: (lines[f.line - 1] || '').trim().slice(0, 100) }));
+}
+
+function scan() {
+  const byFile = {};
+  for (const rel of surfaces()) {
+    const f = findings(rel);
+    if (f.length) byFile[rel] = f;
+  }
+  return byFile;
+}
+
+// ── modes ────────────────────────────────────────────────────────────────────
+
+function counts(byFile) {
+  const out = {};
+  for (const [file, items] of Object.entries(byFile)) {
+    out[file] = {};
+    for (const i of items) out[file][i.literal] = (out[file][i.literal] || 0) + 1;
+  }
+  return out;
+}
+
+function main() {
+  const mode = process.argv[2] || '--check';
+  const byFile = scan();
+  const total = Object.values(byFile).reduce((a, l) => a + l.length, 0);
+
+  if (mode === '--report') {
+    for (const [file, items] of Object.entries(byFile)) {
+      console.log(`\n${file}  (${items.length})`);
+      for (const i of items) console.log(`  ${i.line}: ${i.kind} ${i.literal}`);
+    }
+    console.log(`\nstyle-drift: ${total} literals across ${Object.keys(byFile).length} files`);
+    return 0;
+  }
+
+  const allow = JSON.parse(fs.readFileSync(ALLOWLIST, 'utf-8'));
+
+  if (mode === '--write') {
+    const next = counts(byFile);
+    for (const [file, lits] of Object.entries(next)) {
+      const why = allow[file] && allow[file].why;
+      next[file] = { why: why || 'TODO: say why these are not tokens yet, and what they wait on.', allow: lits };
+    }
+    fs.writeFileSync(ALLOWLIST, JSON.stringify(next, null, 2) + '\n');
+    console.log(`style-drift: wrote ${Object.keys(next).length} file entries`);
+    return 0;
+  }
+
+  const errors = [];
+  for (const [file, items] of Object.entries(counts(byFile))) {
+    const entry = allow[file];
+    if (!entry) {
+      errors.push(`${file}: not in the allowlist, and writes ${Object.values(items).reduce((a, b) => a + b, 0)} literals`);
+      continue;
+    }
+    for (const [lit, n] of Object.entries(items)) {
+      const cap = entry.allow[lit];
+      if (cap === undefined) {
+        const where = byFile[file].filter(f => f.literal === lit).map(f => f.line).join(', ');
+        errors.push(`${file}:${where}: ${lit} is not in the allowlist. Use a token from public/styles/tokens.css, or add it with a reason.`);
+      } else if (n > cap) {
+        errors.push(`${file}: ${lit} appears ${n} times, allowed ${cap}. The allowlist is a ratchet: counts come down, never up.`);
+      }
+    }
+  }
+  // A stale allowlist is drift of its own: an entry describing a literal that
+  // no longer exists reads as an unpaid debt and hides that it was paid.
+  for (const [file, entry] of Object.entries(allow)) {
+    const actual = counts(byFile)[file] || {};
+    for (const [lit, cap] of Object.entries(entry.allow)) {
+      if (actual[lit] === undefined) {
+        errors.push(`${file}: allowlist still lists ${lit} (${cap}), which is no longer written. Remove it.`);
+      } else if (actual[lit] < cap) {
+        errors.push(`${file}: allowlist allows ${cap} of ${lit} but only ${actual[lit]} remain. Lower it to ${actual[lit]}.`);
+      }
+    }
+  }
+
+  if (errors.length) {
+    console.error('style-drift: FAIL\n');
+    for (const e of errors) console.error('  ' + e);
+    console.error(`\n  ${errors.length} problem(s). Tokens live in public/styles/tokens.css.`);
+    console.error('  Paying drift down is a visual change: check it with test/e2e/style-snapshot.tool.js.');
+    return 1;
+  }
+  console.log(`style-drift: clean (${total} allowlisted literals across ${Object.keys(byFile).length} files)`);
+  return 0;
+}
+
+if (require.main === module) process.exit(main());
+module.exports = { scan, counts, findings, surfaces };

--- a/test/unit/style-drift.test.js
+++ b/test/unit/style-drift.test.js
@@ -1,0 +1,108 @@
+'use strict';
+// The drift lint's own logic.
+//
+// A lint that over-reports is worse than none: people learn to add allowlist
+// entries without reading them, and the allowlist stops meaning anything. The
+// cases below are the ones where this lint nearly did exactly that.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { findings, surfaces } = require('../tools/style-drift.js');
+
+const ROOT = path.join(__dirname, '..', '..');
+const ALLOW = JSON.parse(fs.readFileSync(path.join(ROOT, 'test/tools/style-drift-allowlist.json'), 'utf-8'));
+
+// findings() reads relative to the repo root, so a fixture has to live in it.
+function withFixture(contents, fn) {
+  const rel = `public/styles/__drift-fixture.css`;
+  const abs = path.join(ROOT, rel);
+  fs.writeFileSync(abs, contents);
+  try { return fn(rel); } finally { fs.unlinkSync(abs); }
+}
+
+describe('style drift detection', () => {
+  test('an HTML numeric character reference is not a colour', () => {
+    // &#8593; is an up arrow. Its digits are all valid hex and it is four of
+    // them, so nothing about the shape distinguishes it from #8593: only the
+    // ampersand does. index.html and three view modules are full of these, and
+    // the first version of this lint reported every arrow glyph in the app as
+    // colour drift.
+    const found = withFixture('.a::after { content: "&#8593;&#8595;&#9166;"; }', findings);
+    assert.deepStrictEqual(found.filter(f => f.kind === 'colour'), []);
+  });
+
+  test('a real hex colour is still caught beside an entity', () => {
+    const found = withFixture('.a { color: #BADA55; } .b::after { content: "&#8593;"; }', findings);
+    assert.deepStrictEqual(found.filter(f => f.kind === 'colour').map(f => f.literal), ['#BADA55']);
+  });
+
+  test('a colour function is recorded as its whole value, not a prefix', () => {
+    const found = withFixture('.a { background: rgba(1, 2, 3, 0.4); }', findings);
+    const c = found.filter(f => f.kind === 'colour');
+    assert.deepStrictEqual(c.map(f => f.literal), ['rgba(1,2,3,0.4)']);
+  });
+
+  test('a token reference is not drift', () => {
+    const found = withFixture(
+      '.a { color: var(--accent); border-radius: var(--radius-lg); transition: color var(--duration-base) ease; }',
+      findings,
+    );
+    assert.deepStrictEqual(found, []);
+  });
+
+  test('durations only count inside a transition or animation', () => {
+    // A duration is only a duration in context. `grid-auto-columns: 2s` is not
+    // a thing, but neither is every bare number a timing value, and flagging
+    // them everywhere would bury the real ones.
+    const found = withFixture(
+      '.a { transition: opacity 0.3s ease; } .b { animation: spin 2s linear; } .c { content: "5s"; }',
+      findings,
+    );
+    assert.deepStrictEqual(found.filter(f => f.kind === 'duration').map(f => f.literal).sort(), ['0.3s', '2s']);
+  });
+
+  test('a multi-value border-radius reports every literal in it', () => {
+    const found = withFixture('.a { border-radius: 8px 8px 0 0; }', findings);
+    assert.deepStrictEqual(found.filter(f => f.kind === 'radius').map(f => f.literal), ['8px', '8px']);
+  });
+
+  test('tokens.css and vendor are never scanned', () => {
+    const list = surfaces();
+    assert.ok(!list.some(f => f.endsWith('tokens.css')), 'tokens.css defines the literals; it cannot be drift');
+    assert.ok(!list.some(f => f.includes('/vendor/')), 'vendored third-party code is not ours to tidy');
+    assert.ok(list.includes('public/editor/styles.js'), 'the editor injects CSS from JS and must be scanned');
+    assert.ok(list.includes('public/index.html'), 'index.html must be scanned even though its styling moved out');
+  });
+});
+
+describe('the drift allowlist is a document, not a dump', () => {
+  test('every file entry gives a reason of substance', () => {
+    for (const [file, entry] of Object.entries(ALLOW)) {
+      assert.ok(entry.why, `${file} has no reason`);
+      assert.ok(
+        entry.why.length > 80,
+        `${file}'s reason is too short to be one: an allowlist whose reasons are "legacy" teaches people to skip reading it`,
+      );
+      assert.ok(!/^TODO/.test(entry.why), `${file} still has the generated placeholder reason`);
+    }
+  });
+
+  test('every allowed literal has a positive count', () => {
+    for (const [file, entry] of Object.entries(ALLOW)) {
+      assert.ok(Object.keys(entry.allow).length > 0, `${file} allows nothing and should be removed`);
+      for (const [lit, n] of Object.entries(entry.allow)) {
+        assert.ok(Number.isInteger(n) && n > 0, `${file}: ${lit} has a non-count of ${n}`);
+      }
+    }
+  });
+
+  test('each allowlisted file still exists and is still scanned', () => {
+    const list = new Set(surfaces());
+    for (const file of Object.keys(ALLOW)) {
+      assert.ok(list.has(file), `${file} is allowlisted but no longer scanned; remove its entry`);
+    }
+  });
+});


### PR DESCRIPTION
A design token only works if it is the **only** place its value is written. The
moment a colour is typed as raw channels somewhere else, editing the token stops
moving the app, and nothing says so until two things that should match no longer
do.

By the time this landed there were **five near-identical reds** in the codebase:
`#E85A5A` (now `--danger`), `#e85d5d`, `#d9534f`, `#E06C6C` and `#e55`. Three of
them also appear again in `rgba()` form. That is the failure this exists to stop.

## What it does

Flags colour, radius and duration literals anywhere styling is written: every
stylesheet except `tokens.css`, plus `index.html`, `app.js`, the view modules,
and the editor's runtime-injected stylesheet. Reports file, line and literal, and
fails unless that literal is allowlisted with a count.

**224 literals across 17 files** today.

| Surface | Literals |
| --- | --- |
| `public/editor/styles.js` | 77 |
| `views/editor.css` | 46 |
| `views/chat.css` | 24 |
| `components/floating-toolbar.css` | 19 |
| `components/sidebar.css` | 18 |
| eleven others | 40 |

The single largest pocket is the editor's injected stylesheet, where `#E87A5A`
appears **26 times** and is simply `--accent`. That file already uses `var(--…)`
78 times, so it can read tokens; those 26 are places that did not.

## The allowlist ratchets both ways

Exceeding a count fails. **So does paying drift down without lowering the
count**, so the file cannot come to describe a debt that was already settled and
quietly overstate the work remaining.

## The reasons are the point

Each of the 17 entries says what its literals are and what they wait on. A test
rejects any reason under eighty characters, or left as the generated
placeholder, because an allowlist whose reasons read "legacy" teaches people to
add entries without reading them.

Writing them surfaced four distinct categories, which is more useful than the
raw count:

1. **Alpha tints of colours that already have tokens.** The token re-typed as
   raw channels. Waiting on a decision about how a tint of a token is written:
   `color-mix()` and relative colour syntax both work in Electron and both change
   the computed value, so it is a visual change, not a substitution.
2. **Shadow blacks.** There is no elevation scale, so every surface picked its
   own alpha and nine are now in use. The floating toolbar alone uses five.
3. **Radii a step off the scale**, waiting on the polish pass.
4. **Animation durations**, timed to what the animation says rather than to the
   interaction scale. These are **deliberate and permanent**, not debt, and the
   allowlist says so rather than leaving them looking like arrears.

## One detector needed care

`&#8593;` is an up arrow. Its digits are all valid hex and there are four of
them, so nothing about its shape distinguishes it from `#8593`: **only the
ampersand does.** `index.html` and three view modules are full of these, and the
first version of this lint reported every arrow glyph in the app as colour drift.

A lint that over-reports is worse than none, because people learn to add
allowlist entries without reading them and the allowlist stops meaning anything.
That case is now a named test, along with five other detector cases.

## Wiring

The CI hygiene job and the release gate, both of which run it without installing
anything, so a release that reintroduces a hardcoded colour fails before
anything is built.

## Test results

Suite **1,584** from a measured baseline of **1,574**, the delta being ten
assertions on the detector and the allowlist's shape. E2E **110 of 110**. All
**50 coverage floors** hold. Typecheck, reference check and the new lint clean.

Proved red four ways: a new literal appears, an allowed literal appears more
often than allowed, drift is paid down without lowering the count, and a file is
missing from the allowlist entirely.

No user-visible change.
