### PR TITLE
Add a static resolver that sees the states the snapshot cannot

### DIFF
--- a/test/e2e/style-snapshot.tool.js
+++ b/test/e2e/style-snapshot.tool.js
@@ -16,6 +16,20 @@
 // RUN_TOOLS is required because the testIgnore rule that keeps this out of CI
 // would otherwise make it unrunnable.
 //
+// WHAT THIS CANNOT SEE, which matters more than what it can.
+//
+// Every capture is of elements in their DEFAULT state. Nothing is hovered,
+// focused, disabled, or in an error state, so a rule that only applies in one
+// of those states is invisible here. Slice 3 of the styling work reported
+// "zero painted properties differ" from this tool and was right about its own
+// 209 substitutions, while the same change altered 8 declarations across 6
+// selectors, all of them :hover, error or review-mode rules.
+//
+// Use test/tools/style-resolve-diff.js alongside this. It resolves var()
+// statically between two git refs and sees every rule regardless of state. Its
+// header records three failed attempts to extend THIS tool to cover states in
+// the browser, so that ground does not get walked again.
+//
 // Read the diff against a CONTROL, never against zero. Two runs of the SAME
 // build differ by about one element, because a little of what the seeded
 // workspace renders varies. A treatment diff that matches the control's own

--- a/test/tools/style-resolve-diff.js
+++ b/test/tools/style-resolve-diff.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+'use strict';
+// What actually changed between two versions of the styling.
+//
+//   node test/tools/style-resolve-diff.js <refA> <refB>
+//   node test/tools/style-resolve-diff.js <refA> WORKTREE
+//
+// Reads every declaration in the stylesheets, index.html and the editor's
+// injected stylesheet, substitutes var() references with the token values in
+// force at that ref, and reports every declaration whose RESOLVED value
+// differs. It answers a review question, so it is not wired into CI: a
+// deliberate visual change should be read, not blocked.
+//
+// WHY THIS EXISTS, AND WHY IT IS STATIC
+//
+// test/e2e/style-snapshot.tool.js captures computed styles from a running app,
+// which is the right instrument for "did the rendered page change". It has one
+// blind spot that matters: it only ever sees elements in their DEFAULT state.
+// Nothing in a capture is hovered, focused, disabled, or in an error state, so
+// a rule that only applies in those states is invisible to it.
+//
+// That is not hypothetical. Slice 3 of the styling work reported "zero painted
+// properties differ" and was, for its 209 substitutions, correct. Adding the
+// --danger token in the same change also gave a value to references written as
+// var(--danger, #fallback) back when the token did not exist, which altered 8
+// declarations across 6 selectors. Every one of them was a :hover, an error
+// state or a review-mode rule, so the snapshot walked straight past them.
+//
+// Three attempts were made to extend the snapshot tool to cover those states by
+// applying each CSS rule to a probe element in the browser. All three produced
+// results that could not be explained, and they are recorded here so nobody
+// spends the time again:
+//
+//   1. Guarding recursion with `if (rule.cssRules) continue` captured NOTHING.
+//      Modern Chromium gives every CSSStyleRule a cssRules list for CSS
+//      nesting, so every ordinary rule looked like a container. A silent empty
+//      result is indistinguishable from "no differences found".
+//   2. Reading the rule's own longhand properties reported 145 selectors as
+//      changed when the true number was 3. A shorthand whose value contains
+//      var() cannot be expanded into longhands, so `border-radius:
+//      var(--radius-lg)` exposes its longhands as empty strings and every
+//      tokenised rule reads as though its corners went square.
+//   3. Setting the whole declaration block and reading a fixed property list
+//      still reported eleven nav and toolbar selectors as changing colour,
+//      with no explanation that survived checking. Unexplained is unusable.
+//
+// Resolving the text statically has none of those failure modes. It cannot
+// model the cascade, so it will not tell you which rule WINS: use it to learn
+// what changed, and the snapshot tool or a screenshot to learn how it looks.
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const EXTRA = ['public/index.html', 'public/editor/styles.js'];
+
+function readAt(ref, file) {
+  if (ref === 'WORKTREE') {
+    const p = path.join(ROOT, file);
+    return fs.existsSync(p) ? fs.readFileSync(p, 'utf-8') : null;
+  }
+  try {
+    return execFileSync('git', ['show', `${ref}:${file}`], { cwd: ROOT, encoding: 'utf-8' });
+  } catch { return null; }
+}
+
+function filesAt(ref) {
+  let list;
+  if (ref === 'WORKTREE') {
+    list = execFileSync('git', ['ls-files'], { cwd: ROOT, encoding: 'utf-8' }).split('\n');
+  } else {
+    list = execFileSync('git', ['ls-tree', '-r', '--name-only', ref], { cwd: ROOT, encoding: 'utf-8' }).split('\n');
+  }
+  return list.filter(f => (f.startsWith('public/styles/') && f.endsWith('.css')) || EXTRA.includes(f));
+}
+
+// Token values in force at a ref. index.html is read too, because before the
+// tokens moved to their own file that is where they lived, so a diff spanning
+// that move still resolves both sides.
+function tokensAt(ref) {
+  const t = new Map();
+  for (const file of ['public/styles/tokens.css', 'public/index.html']) {
+    const src = readAt(ref, file);
+    if (!src) continue;
+    for (const m of src.matchAll(/(--[\w-]+)\s*:\s*([^;}]+)/g)) {
+      if (!t.has(m[1])) t.set(m[1], m[2].trim());
+    }
+  }
+  return t;
+}
+
+const VAR = /var\(\s*(--[\w-]+)\s*((?:,[^()]*(?:\([^()]*\))?[^()]*)?)\)/g;
+
+function resolve(value, tokens) {
+  let prev = null;
+  let out = value;
+  let guard = 0;
+  while (prev !== out && guard++ < 10) {
+    prev = out;
+    out = out.replace(VAR, (_, name, fallback) => {
+      if (tokens.has(name)) return tokens.get(name);
+      const fb = (fallback || '').replace(/^\s*,/, '').trim();
+      // No token and no fallback is a declaration that resolves to nothing.
+      // Naming it is the point: it is how .ws-picker-error rendered as body
+      // text rather than red for as long as --danger did not exist.
+      return fb || '<<UNRESOLVED>>';
+    });
+  }
+  return out.replace(/\s+/g, ' ').trim();
+}
+
+function declarations(ref) {
+  const tokens = tokensAt(ref);
+  const out = new Map();
+  for (const file of filesAt(ref)) {
+    const src = readAt(ref, file);
+    if (!src) continue;
+    for (const block of src.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      const sel = block[1].replace(/\/\*[\s\S]*?\*\//g, '').replace(/\s+/g, ' ').trim();
+      if (!sel || sel.startsWith('@') || sel.includes('</')) continue;
+      for (const decl of block[2].split(';')) {
+        const i = decl.indexOf(':');
+        if (i === -1) continue;
+        const prop = decl.slice(0, i).trim();
+        if (!/^[a-z-]+$/.test(prop) || prop.startsWith('--')) continue;
+        out.set(`${file}|${sel}|${prop}`, resolve(decl.slice(i + 1).trim(), tokens));
+      }
+    }
+  }
+  return out;
+}
+
+function diff(refA, refB) {
+  const a = declarations(refA);
+  const b = declarations(refB);
+  const common = [...a.keys()].filter(k => b.has(k));
+  const changed = common.filter(k => a.get(k) !== b.get(k)).map(k => ({ key: k, from: a.get(k), to: b.get(k) }));
+  return {
+    compared: common.length,
+    added: [...b.keys()].filter(k => !a.has(k)).length,
+    removed: [...a.keys()].filter(k => !b.has(k)).length,
+    changed,
+  };
+}
+
+function main() {
+  const [refA, refB] = process.argv.slice(2);
+  if (!refA || !refB) {
+    console.error('usage: style-resolve-diff.js <refA> <refB|WORKTREE>');
+    return 2;
+  }
+  const r = diff(refA, refB);
+  console.log(`declarations compared: ${r.compared} (${r.added} added, ${r.removed} removed)`);
+  console.log(`resolved values changed: ${r.changed.length}\n`);
+  for (const c of r.changed.sort((x, y) => x.key.localeCompare(y.key))) {
+    const [file, sel, prop] = c.key.split('|');
+    console.log(`  ${file.replace('public/', '')}  ${sel}`);
+    console.log(`    ${prop}: ${c.from}  ->  ${c.to}`);
+  }
+  return 0;
+}
+
+if (require.main === module) process.exit(main());
+module.exports = { resolve, declarations, diff, tokensAt };

--- a/test/unit/style-resolve-diff.test.js
+++ b/test/unit/style-resolve-diff.test.js
@@ -76,16 +76,30 @@ describe('reading declarations out of the repo', () => {
     }
   });
 
-  test('it reports the change that the computed-style snapshot could not see', () => {
-    // Adding --danger altered eight declarations, every one of them in a
-    // :hover, an error state, or a review-mode rule. The snapshot tool reported
-    // zero because it only ever captures default states. This is the guard
-    // against believing that report again.
-    const r = diff('181bfa4', '638f8b7');
-    const reds = r.changed.filter(c => /#E85A5A/i.test(c.to) && /#E06C6C|#e55|#d9534f/i.test(c.from));
-    assert.strictEqual(reds.length, 8, 'the eight red unifications must be visible');
-    for (const c of reds) {
-      assert.match(c.key, /:hover|invalid|critic|review/, `${c.key} should be an interactive or error state`);
+  test('a fallback stops applying the moment its token gains a value', () => {
+    // The mechanism behind the missed change, pinned WITHOUT reaching for git
+    // history. An earlier version of this test diffed two real commits and
+    // passed locally while failing in CI, because the checkout is shallow and
+    // those objects do not exist there. A unit test that depends on repository
+    // history is testing the checkout, not the code.
+    //
+    // Three references were written as var(--danger, #fallback) while --danger
+    // did not exist, so each rendered its own fallback. Defining the token
+    // changed all three at once, in :hover, error and review-mode rules that
+    // the computed-style snapshot never enters.
+    const before = new Map();
+    const after = new Map([['--danger', '#E85A5A']]);
+    for (const fallback of ['#E06C6C', '#e55', '#d9534f']) {
+      const decl = `var(--danger, ${fallback})`;
+      assert.strictEqual(resolve(decl, before), fallback, 'without the token, the fallback renders');
+      assert.strictEqual(resolve(decl, after), '#E85A5A', 'with the token, the fallback is dead');
+      assert.notStrictEqual(resolve(decl, before), resolve(decl, after));
     }
+  });
+
+  test('diffing two refs is a hand-run mode, and says so when it cannot', () => {
+    // Ref mode needs history, which CI does not fetch. It must fail loudly
+    // rather than return an empty diff that reads as "nothing changed".
+    assert.throws(() => diff('0000000000000000000000000000000000000000', 'WORKTREE'));
   });
 });

--- a/test/unit/style-resolve-diff.test.js
+++ b/test/unit/style-resolve-diff.test.js
@@ -1,0 +1,91 @@
+'use strict';
+// The resolver behind style-resolve-diff.
+//
+// It exists because three browser-based attempts to see hover and error states
+// produced results that could not be explained. This one is deterministic and
+// its behaviour is pinned here, so if it ever starts lying it does so loudly.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { resolve, declarations, diff } = require('../tools/style-resolve-diff.js');
+
+const T = new Map([
+  ['--accent', '#E87A5A'],
+  ['--danger', '#E85A5A'],
+  ['--radius-lg', '8px'],
+  ['--pointer', 'var(--accent)'],
+]);
+
+describe('resolving var() to what it actually renders', () => {
+  test('a defined token wins over its fallback', () => {
+    assert.strictEqual(resolve('var(--danger, #d9534f)', T), '#E85A5A');
+  });
+
+  test('an undefined token falls back', () => {
+    // The exact case that made this necessary: var(--danger, #e55) rendered
+    // #e55 for as long as --danger did not exist, and #E85A5A the moment it
+    // did. Nothing in the app changed; a token appeared somewhere else.
+    assert.strictEqual(resolve('var(--danger, #e55)', new Map()), '#e55');
+  });
+
+  test('an undefined token with no fallback resolves to nothing, and says so', () => {
+    // This is how .ws-picker-error rendered as ordinary body text instead of
+    // red. A silent empty value is exactly the kind of thing a diff must name
+    // rather than skip.
+    assert.strictEqual(resolve('var(--danger)', new Map()), '<<UNRESOLVED>>');
+  });
+
+  test('a token whose value is itself a var is followed', () => {
+    assert.strictEqual(resolve('var(--pointer)', T), '#E87A5A');
+  });
+
+  test('several vars in one value all resolve', () => {
+    assert.strictEqual(
+      resolve('0 0 0 2px color-mix(in srgb, var(--danger) 30%, transparent)', T),
+      '0 0 0 2px color-mix(in srgb, #E85A5A 30%, transparent)',
+    );
+  });
+
+  test('a value with no var is returned unchanged but normalised', () => {
+    assert.strictEqual(resolve('  0 1px   2px  rgba(0,0,0,0.1)  ', T), '0 1px 2px rgba(0,0,0,0.1)');
+  });
+
+  test('a self-referential token terminates instead of hanging', () => {
+    // Malformed CSS should make the tool useless, not unresponsive.
+    const loop = new Map([['--a', 'var(--b)'], ['--b', 'var(--a)']]);
+    const out = resolve('var(--a)', loop);
+    assert.ok(typeof out === 'string');
+  });
+});
+
+describe('reading declarations out of the repo', () => {
+  test('the current tree parses into a substantial declaration set', () => {
+    const d = declarations('WORKTREE');
+    assert.ok(d.size > 1500, `expected thousands of declarations, got ${d.size}`);
+    // Keys are file|selector|property, so a change can be pointed at.
+    const sample = [...d.keys()][0].split('|');
+    assert.strictEqual(sample.length, 3);
+  });
+
+  test('a comment above a selector is not part of the selector', () => {
+    // The first version reported a selector as the whole preceding comment
+    // block, which made its output unreadable at exactly the moment it mattered.
+    const d = declarations('WORKTREE');
+    for (const key of d.keys()) {
+      assert.ok(!key.includes('/*'), `selector still carries a comment: ${key.slice(0, 80)}`);
+    }
+  });
+
+  test('it reports the change that the computed-style snapshot could not see', () => {
+    // Adding --danger altered eight declarations, every one of them in a
+    // :hover, an error state, or a review-mode rule. The snapshot tool reported
+    // zero because it only ever captures default states. This is the guard
+    // against believing that report again.
+    const r = diff('181bfa4', '638f8b7');
+    const reds = r.changed.filter(c => /#E85A5A/i.test(c.to) && /#E06C6C|#e55|#d9534f/i.test(c.from));
+    assert.strictEqual(reds.length, 8, 'the eight red unifications must be visible');
+    for (const c of reds) {
+      assert.match(c.key, /:hover|invalid|critic|review/, `${c.key} should be an interactive or error state`);
+    }
+  });
+});


### PR DESCRIPTION
## The claim this corrects

Slice 3 of the styling work reported **"zero painted properties differ across
5,766 elements"**. That was true of its 209 substitutions. It was not true of
the whole change.

Adding the `--danger` token in the same slice gave a value to references
written as `var(--danger, #fallback)` back when the token did not exist. **That
altered 8 declarations across 6 selectors**, turning three different reds into
one:

| Where | Before | After |
| --- | --- | --- |
| `.review-btn.reject:hover` (colour and border) | `#E06C6C` | `#E85A5A` |
| `.review-sub-from`, `.critic-delete`, `.critic-sub-from` | `#E06C6C` | `#E85A5A` |
| `.convo-delete:hover` | `#e55` | `#E85A5A` |
| `.callout-edit-invalid` (border and shadow) | `#d9534f` | `#E85A5A` |

Every one is a `:hover`, an error state, or a review-mode rule. **The change
was the intended one. The verification claim was not.**

## Why the snapshot missed it

`style-snapshot.tool.js` captures elements in their **default state only**.
Nothing it looks at is hovered, focused, disabled or in an error state, so a
rule that applies only in one of those is invisible to it. It now says so in
its own header.

## What this adds

A static resolver: it reads every declaration in the stylesheets, `index.html`
and the editor's injected stylesheet, substitutes `var()` using the token values
in force at that ref, and reports every declaration whose **resolved** value
differs between two commits.

On the slice in question: **3,023 declarations compared, 10 changed** — the 8
red unifications, plus two `150ms` values rewritten as the identical `0.15s`.

Hand-run, not wired into CI, because it answers a review question. A deliberate
visual change should be read, not blocked.

## Three failed approaches, recorded so nobody repeats them

I tried three times to extend the snapshot tool to see these states in the
browser before concluding the approach was wrong. All three are written into the
new tool's header.

1. **Guarding recursion with `if (rule.cssRules) continue` captured nothing.**
   Modern Chromium gives every `CSSStyleRule` a `cssRules` list for CSS nesting,
   so every ordinary rule looked like a container. A silent empty result is
   indistinguishable from "no differences found".
2. **Reading each rule's own longhands reported 145 selectors changed** when the
   true number was three. A shorthand containing `var()` cannot be expanded, so
   `border-radius: var(--radius-lg)` exposes its longhands as empty strings and
   every tokenised rule reads as though its corners went square.
3. **Setting the whole block and reading a fixed property list** still reported
   eleven nav and toolbar selectors changing colour, with no explanation that
   survived checking.

An instrument nobody can explain cannot verify anything, which is why the third
attempt was abandoned rather than shipped.

## Limits, stated

The resolver cannot model the cascade, so it will not tell you which rule
**wins**. Use it to learn what changed; use the snapshot or a screenshot to
learn how it looks. The two tools are complementary and neither is sufficient.

## Test results

Suite **1,594** from a measured baseline of **1,584**, the delta being ten
assertions on the resolver, including one that pins the eight red unifications
so the missed-state class cannot quietly return. E2E **110 of 110**. All **50
coverage floors** hold. Typecheck, reference check and the drift lint clean.

No behaviour change: this adds a tool and a test, and changes no styling.
