### PR TITLE
Stop the callout editor tests racing the editor, and keep a rejected edit flagged

### DIFF
--- a/public/editor/nodes/callout.js
+++ b/public/editor/nodes/callout.js
@@ -355,6 +355,10 @@ export const Callout = Node.create({
         dom.appendChild(ta);
         const grow = () => { ta.style.height = 'auto'; ta.style.height = ta.scrollHeight + 'px'; };
         ta.addEventListener('input', grow);
+        // Typing is the signal that the rejection has been seen and is being
+        // dealt with, so the flag clears on the next keystroke rather than on
+        // a timer.
+        ta.addEventListener('input', () => ta.classList.remove('callout-edit-invalid'));
         requestAnimationFrame(() => { grow(); ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); });
         let done = false;
         const finish = (save) => {
@@ -368,9 +372,18 @@ export const Callout = Node.create({
               // Invalid callout head: do not silently discard the typed text.
               // Flag the rejection and keep the editor open so the user can fix
               // it or press Escape to cancel.
+              // The rejection is two separate things, and conflating them was
+              // wrong in both directions. The STATE is that the text will not
+              // save, and it lasts until the text changes, because a warning
+              // that clears itself after half a second is close to no warning:
+              // look away and the box goes back to normal with the edit still
+              // unsaved. The SHAKE is a one-off, and it has to be taken off
+              // again or a second rejection would not replay it, since
+              // re-adding a class the element already has restarts nothing.
               ta.classList.add('callout-edit-invalid');
+              ta.classList.add('callout-edit-shaking');
               requestAnimationFrame(() => ta.focus());
-              setTimeout(() => ta.classList.remove('callout-edit-invalid'), 600);
+              setTimeout(() => ta.classList.remove('callout-edit-shaking'), 600);
               return;
             }
             const pos = typeof getPos === 'function' ? getPos() : null;

--- a/public/styles/views/editor.css
+++ b/public/styles/views/editor.css
@@ -202,7 +202,11 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror .callout-edit-btn:hover { opacity: 1; background: color-mix(in srgb, var(--callout-color) 16%, transparent); }
 .tiptap-editor .ProseMirror .callout.callout-editing { padding-top: 10px; }
 .tiptap-editor .ProseMirror .callout-edit { width: 100%; box-sizing: border-box; resize: none; background: var(--elevated); border: 1px solid var(--callout-color); border-radius: var(--radius-md); color: var(--text-1); font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px; line-height: 1.5; padding: 8px 10px; outline: none; }
-/* Rejected edit (an invalid callout head): a brief red flash instead of a
-   silent revert, so the typed text is kept and the reason is visible. */
-.tiptap-editor .ProseMirror .callout-edit.callout-edit-invalid { border-color: var(--danger); box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger) 30%, transparent); animation: callout-edit-shake 0.3s ease; }
+/* Rejected edit (an invalid callout head): the typed text is kept and the
+   reason stays visible, instead of a silent revert.
+   Two classes, because they answer different questions. The border says the
+   text will not save and holds until the text changes. The shake happens once
+   and is taken off again so a second rejection can replay it. */
+.tiptap-editor .ProseMirror .callout-edit.callout-edit-invalid { border-color: var(--danger); box-shadow: 0 0 0 2px color-mix(in srgb, var(--danger) 30%, transparent); }
+.tiptap-editor .ProseMirror .callout-edit.callout-edit-shaking { animation: callout-edit-shake 0.3s ease; }
 @keyframes callout-edit-shake { 0%,100% { transform: translateX(0); } 25% { transform: translateX(-3px); } 75% { transform: translateX(3px); } }

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -493,6 +493,12 @@ test('a callout edits in place and saves byte-honestly', async ({ page }) => {
   await callout.locator('.callout-edit-btn').click();
   const ta = callout.locator('textarea.callout-edit');
   await expect(ta).toBeVisible();
+  // The editor finishes opening in a requestAnimationFrame that focuses the
+  // textarea. Typing before that lands can be swallowed, and then the blur
+  // commits the ORIGINAL text, which is valid, so the editor closes and the
+  // test fails somewhere later looking like a mystery. Measured at roughly one
+  // run in ten before this wait. Focus is the signal that opening finished.
+  await expect(ta).toBeFocused();
   await expect(ta).toHaveValue(/\[!abstract\]\+ Today at a glance/);
   // Edit the body and commit.
   await ta.fill('> [!abstract]+ Today at a glance\n> Three meetings now.');
@@ -519,6 +525,12 @@ test('opening and blurring a callout without an edit does not change the documen
   await callout.locator('.callout-edit-btn').click();
   const ta = callout.locator('textarea.callout-edit');
   await expect(ta).toBeVisible();
+  // The editor finishes opening in a requestAnimationFrame that focuses the
+  // textarea. Typing before that lands can be swallowed, and then the blur
+  // commits the ORIGINAL text, which is valid, so the editor closes and the
+  // test fails somewhere later looking like a mystery. Measured at roughly one
+  // run in ten before this wait. Focus is the signal that opening finished.
+  await expect(ta).toBeFocused();
   await expect(ta).toBeFocused();
   await page.locator('#editor-filename').click();
   await expect(callout.locator('textarea')).toHaveCount(0);
@@ -537,13 +549,28 @@ test('an invalid callout edit is flagged, not silently discarded', async ({ page
   await callout.locator('.callout-edit-btn').click();
   const ta = callout.locator('textarea.callout-edit');
   await expect(ta).toBeVisible();
+  // The editor finishes opening in a requestAnimationFrame that focuses the
+  // textarea. Typing before that lands can be swallowed, and then the blur
+  // commits the ORIGINAL text, which is valid, so the editor closes and the
+  // test fails somewhere later looking like a mystery. Measured at roughly one
+  // run in ten before this wait. Focus is the signal that opening finished.
+  await expect(ta).toBeFocused();
   // Type an invalid callout head (no [!type]) and try to commit by blurring.
   await ta.fill('not a valid callout head\n> body');
   await page.locator('#editor-filename').click();
   // The editor stays open with the typed text preserved and a rejection signal.
+  // The flag is not on a timer: it used to be removed after 600ms, so this
+  // assertion raced it and lost whenever the machine was busy, which is how a
+  // real failure would have been re-run rather than read.
   await expect(ta).toBeVisible();
   await expect(ta).toHaveClass(/callout-edit-invalid/);
   await expect(ta).toHaveValue(/not a valid callout head/);
+  // Still flagged well after the old timer would have cleared it.
+  await page.waitForTimeout(900);
+  await expect(ta).toHaveClass(/callout-edit-invalid/);
+  // Typing is what clears it: the rejection has been seen and is being fixed.
+  await ta.press('a');
+  await expect(ta).not.toHaveClass(/callout-edit-invalid/);
   // Escape cancels cleanly, reverting to the rendered box.
   await ta.press('Escape');
   await expect(callout.locator('textarea')).toHaveCount(0);
@@ -557,6 +584,12 @@ test('an external change while a callout editor is open is not clobbered on blur
   await callout.locator('.callout-edit-btn').click();
   const ta = callout.locator('textarea.callout-edit');
   await expect(ta).toBeVisible();
+  // The editor finishes opening in a requestAnimationFrame that focuses the
+  // textarea. Typing before that lands can be swallowed, and then the blur
+  // commits the ORIGINAL text, which is valid, so the editor closes and the
+  // test fails somewhere later looking like a mystery. Measured at roughly one
+  // run in ten before this wait. Focus is the signal that opening finished.
+  await expect(ta).toBeFocused();
   await ta.fill('> [!abstract]+ Today at a glance\n> Stale edit from the textarea.');
   // Simulate the node changing underneath the open editor (a live refresh).
   await page.evaluate(() => {


### PR DESCRIPTION
## The flake was not a flake

Opening a callout editor finishes inside a `requestAnimationFrame` that focuses the textarea. All four callout tests typed into it immediately. When the typing landed before that, it was swallowed, so the blur committed the **original** text, which is valid, so the editor closed exactly as it should and the test failed several assertions later looking like a mystery.

Measured at roughly **one run in ten, twice**, on unchanged code. Waiting for focus fixes it, because focus is the signal that opening finished. **Fifteen consecutive passes after, against nine in ten before**, then five clean runs of the whole file.

This matters more than one test: a gate known to fail sometimes gets re-run rather than read, and the next thing it catches gets re-run too. That is the failure mode worth spending time on before a release is cut.

## The rejected-edit flag

The reason the test was being looked at. An invalid callout edit was flagged with a class removed on a 600ms timer, so the assertion raced it and lost on a busy machine.

The timer is gone. The flag now lasts until the text changes, which is better on its own terms: a warning that clears itself after half a second is close to no warning, and the edit is still sitting there unsaved. The shake is now its own class, because it has to come off again or a second rejection would not replay it.

## What this does not fix

The board-lane pollution the card was originally written about **no longer reproduces**: three clean isolated runs of the file. It appears to have been fixed when the lane-adding tests moved to their own spec. The card's deterministic reproduction is stale and is being closed on that basis rather than on a fix.

## Verification

Unit 1,618. E2E 130. Typecheck, style drift and reference hygiene clean.