### PR TITLE
Normalise the agent body read so skill matching works on Windows

### DIFF
--- a/server.js
+++ b/server.js
@@ -1604,7 +1604,11 @@ function discoverSkills(existingAgents) {
   const agentBody = {};
   for (const agent of agents.filter(a => a.status === 'onTeam' && a.fileName)) {
     try {
-      const content = fs.readFileSync(path.join(agentsDir, agent.fileName), 'utf-8');
+      // Normalised, like every other read in discovery. A raw read here meant
+      // the newline-only frontmatter pattern below missed on a CRLF checkout,
+      // so the body came back empty and this whole pass silently matched
+      // nothing on Windows while explicit assignments carried on working.
+      const content = readNormalisedFile(path.join(agentsDir, agent.fileName));
       const bodyMatch = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)/);
       agentBody[agent.id] = bodyMatch ? bodyMatch[1].toLowerCase() : '';
     } catch (e) { agentBody[agent.id] = ''; }

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -300,6 +300,29 @@ describe('parseSkillFile / discoverSkills', () => {
     assert.strictEqual(bySlug['hook-generator'].status, 'assigned');
   });
 
+  test('body-text skill matching survives a CRLF checkout', () => {
+    // Every other read in discovery goes through readNormalisedFile. The body
+    // read for this second pass did not, and matched frontmatter with a
+    // newline-only pattern, so on a Windows checkout the match failed, the
+    // body came back empty, and body-text matching silently assigned nothing.
+    // Explicit `skills:` entries kept working, which is what made it invisible:
+    // a Windows contributor sees half the mechanism work and no error at all.
+    useWorkspace({
+      agents: {
+        'content-lead': agentFile({
+          name: 'content-lead', displayName: 'Penn', type: 'specialist', order: 1,
+          body: 'Penn reaches for content-linter when a draft needs checking.',
+        }).replace(/\n/g, '\r\n'),
+      },
+      skills: {
+        'content-linter': '---\ndescription: Lints content\n---\nbody',
+      },
+    });
+    const bySlug = Object.fromEntries(srv.discoverSkills().map(s => [s.slug, s]));
+    assert.deepStrictEqual(bySlug['content-linter'].assignedAgents.map(a => a.id), ['content-lead']);
+    assert.strictEqual(bySlug['content-linter'].status, 'assigned');
+  });
+
   test('discoverSkills: rundock-* skills only assign to platform agents and vice versa', () => {
     useWorkspace({
       agents: {


### PR DESCRIPTION
Skill assignment has two passes: explicit frontmatter entries, then a scan of the agent's body text for skill names.

The second pass read the file raw and matched frontmatter with a newline-only pattern, so on a CRLF checkout the match failed, the body came back empty, and the pass assigned nothing. Nothing errored and nothing logged. A Windows contributor saw explicit assignments work and body matching silently do nothing.

Every other read in discovery already goes through `readNormalisedFile`. This one now does too.

Promoted into 0.11.7 because the packaged Windows app is about to be tested against this release, and this sits directly in that path.

**Test:** CRLF fixture, red before the change. Unit 1,618 to 1,619.