### PR TITLE
Re-capture the stream grammar against runtime 2.1.232

### DIFF
--- a/scripts/stream-truth/captured-grammar.json
+++ b/scripts/stream-truth/captured-grammar.json
@@ -1,13 +1,18 @@
 {
-  "runtimeVersion": "2.1.227",
-  "capturedAt": "2026-08-11T14:14:29.270Z",
+  "runtimeVersion": "2.1.232",
+  "capturedAt": "2026-08-15T23:02:30.321Z",
   "scenarios": {
     "text-turn": {
       "raw": [
         "system:init",
         "system:status",
+        "rate_limit_event",
         "stream_event:message_start",
         "stream_event:content_block_start(thinking)",
+        "system:thinking_tokens",
+        "stream_event:content_block_delta(thinking_delta)",
+        "system:thinking_tokens",
+        "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",
         "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",
@@ -24,7 +29,6 @@
         "stream_event:content_block_stop",
         "stream_event:message_delta",
         "stream_event:message_stop",
-        "rate_limit_event",
         "result:success"
       ],
       "normalized": [
@@ -62,14 +66,6 @@
         "system:status",
         "stream_event:message_start",
         "stream_event:content_block_start(thinking)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",
         "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",


### PR DESCRIPTION
The release gate refused to validate a candidate against a capture taken from 2.1.227 while 2.1.232 is installed. That is the gate working: a runtime that has moved invalidates the committed model of it, and it failed fast, before any of the expensive live steps.

**The re-capture says the move was harmless.** The normalised grammar is byte-identical for both scenarios, so nothing the server makes decisions on changed between the two versions.

Every difference is in the raw stream: a different number of thinking deltas, and a `rate_limit_event` in a different position. All of it is transport noise that `KNOWN_GAPS` already drops before comparison, and all of it is run-to-run model variance rather than protocol change.

Invariants were verified during capture, and the stub was re-checked against the new capture rather than assumed to still fit.