### PR TITLE
chore: release 0.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
-## Unreleased
-
-**Name:** Foundations
+## 0.11.7: Foundations (2026-08-17)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rundock",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "A visual workspace for your AI agent team. Built for people running their own businesses. Works with your Claude or ChatGPT subscription.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
Version bump and changelog promotion for **0.11.7 Foundations**.

Cut with `npm run release -- 0.11.7`, which asserted the live gate record against HEAD before making this commit. The gate passed on `7e77867` with `live: true`, all 11 steps, 226 seconds. By the script's own design the tagged commit is always one past the gated one: it asserts gate == HEAD, then makes this bump.

**This is going through a PR rather than a direct push because branch protection requires the six checks and has `enforce_admins` on.** The release script pushes straight to main, so the two are structurally incompatible. Carding that separately rather than weakening the protection to suit the script.

Once this merges, `v0.11.7` gets tagged on the merged commit and CI builds, signs, notarises and leaves a draft release.