### PR TITLE
Declare bash for the Windows install step, which PowerShell could not parse

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,13 @@ jobs:
         # that npm's own fetch retries do not cover; registry socket hang-ups
         # have killed this step three times. Retry the whole install with a
         # clean node_modules between attempts.
+        # shell: bash is REQUIRED here and nowhere else in this file. Windows
+        # runners default to PowerShell, which cannot parse a bash for-loop:
+        # it fails with "Missing opening '(' after keyword 'for'" before npm
+        # is ever reached. This retry wrapper was added to make CI steadier and
+        # instead broke the Windows build outright, which stayed invisible
+        # because this is the only workflow that builds Windows.
+        shell: bash
         run: |
           for attempt in 1 2 3; do
             if npm ci; then exit 0; fi


### PR DESCRIPTION
The 0.11.7 Windows build failed **before npm was ever reached**:

```
ParserError: Missing opening '(' after keyword 'for'
```

Windows runners default to PowerShell, and the `npm ci` retry wrapper is a bash for-loop. **The wrapper was added to make CI steadier against registry socket hang-ups and instead broke the Windows build outright.**

It stayed invisible because the release workflow is the only one that builds Windows, so nothing exercised it until a tag was pushed. On the same run, the test job, E2E, the packaged-app smoke and the macOS build all passed.

**The fix is proved by its own neighbour.** The very next step in the same job already declares `shell: bash`, with a comment noting bash is available on Windows runners. The retry wrapper never inherited it.

I scanned every workflow for the same class of mistake rather than fixing only the instance that bit us. This step was the only one missing the declaration: `test-windows-bootstrap.yml` correctly uses `shell: pwsh` for its PowerShell, and the other Windows step here already has `shell: bash`.