### PR TITLE
Name 0.11.7 Foundations & File Tree Stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
-## 0.11.7: Foundations (2026-08-17)
+## 0.11.7: Foundations & File Tree Stability (2026-08-17)
 
 ### Fixed
 


### PR DESCRIPTION
Renames the release heading to match the draft.

`Foundations` alone described the two thirds of this release users cannot see and said nothing about what they were downloading. It is also a name worth keeping in reserve, since decomposition, typing and gating recur.

**Stability rather than Polish**, because the tree previously collapsed folders, lost the selection and jumped to the top several times a minute during a busy conversation. That is behaviour, not polish.

The pattern matches the rest of the list: *Team Integrity*, *Window Chrome & Search*, *Long Sessions & Large Workspaces*.

The draft release is already renamed. No rebuild is needed: the `releaseName` baked into `latest.yml` is never read by Rundock's updater, which passes only `version` to the update strip. Checked rather than assumed.