### PR TITLE
Send strings raw to the GitHub API, so the tag binding stops becoming garbage

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -131,15 +131,31 @@ function requireGatePass(headSha, { root = ROOT } = {}) {
 // ---------------------------------------------------------------------------
 
 // Default GitHub API transport via the gh CLI. `api(method, path, body)`.
-function ghApi(method, apiPath, body) {
+// The gh argument list for one API call. Split out from ghApi so the encoding
+// can be tested without a network call: the bug this exists to prevent was in
+// the encoding, and the publish tests inject a fake transport, so nothing ever
+// exercised the real arguments.
+function ghApiArgs(method, apiPath, body) {
   const args = ['api', '-X', method, apiPath];
   if (body) {
     for (const [key, value] of Object.entries(body)) {
-      // -F preserves JSON types (booleans stay booleans); -f would send strings.
-      args.push('-F', `${key}=${JSON.stringify(value)}`);
+      // Strings go through -f, everything else through -F.
+      //
+      // -F preserves JSON types, which is what booleans need: draft=false has
+      // to arrive as a boolean, not as the word "false". But -F with a
+      // JSON.stringify'd STRING sends the quote marks as part of the value, so
+      // tag_name arrived as "v0.11.7" WITH quotes and the tag binding silently
+      // became garbage. Caught publishing 0.11.7 by the verification below,
+      // which is the only reason it did not ship that way.
+      if (typeof value === 'string') args.push('-f', `${key}=${value}`);
+      else args.push('-F', `${key}=${JSON.stringify(value)}`);
     }
   }
-  const out = execFileSync('gh', args, { cwd: ROOT, encoding: 'utf8' });
+  return args;
+}
+
+function ghApi(method, apiPath, body) {
+  const out = execFileSync('gh', ghApiArgs(method, apiPath, body), { cwd: ROOT, encoding: 'utf8' });
   return out ? JSON.parse(out) : {};
 }
 
@@ -320,4 +336,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { extractChangelogEntry, promoteUnreleasedChangelog, requireGatePass, publishRelease };
+module.exports = { extractChangelogEntry, promoteUnreleasedChangelog, requireGatePass, publishRelease, ghApiArgs };

--- a/test/unit/release-gate.test.js
+++ b/test/unit/release-gate.test.js
@@ -25,7 +25,7 @@ const {
   changelogReady,
   GATE_FILE_NAME,
 } = require('../../scripts/release-gate.js');
-const { requireGatePass, publishRelease } = require('../../scripts/release.js');
+const { requireGatePass, publishRelease, ghApiArgs } = require('../../scripts/release.js');
 
 let root;
 beforeEach(() => {
@@ -284,5 +284,35 @@ describe('publish binds the tag before flipping the draft flag', () => {
     const result = publishRelease('0.11.7', { api });
     assert.strictEqual(result.tag, 'v0.11.7');
     assert.ok(api.calls.some(c => c.method === 'PATCH' && c.body && c.body.draft === false));
+  });
+});
+
+describe('the gh transport encodes values by type', () => {
+  // The publish tests inject a fake api, so nothing exercised the real
+  // argument construction. That is exactly where the bug was: strings were
+  // JSON.stringify'd and passed through -F, so tag_name arrived as "v0.11.7"
+  // WITH quote marks and the release's tag binding became garbage. It was
+  // caught while publishing 0.11.7, by the verification in publishRelease,
+  // which is the only reason it did not ship that way.
+  test('a string is sent raw through -f, not quoted through -F', () => {
+    const args = ghApiArgs('PATCH', 'repos/o/r/releases/1', { tag_name: 'v0.11.7' });
+    assert.ok(args.includes('-f'), 'strings go through -f');
+    assert.ok(args.includes('tag_name=v0.11.7'), `expected a bare value, got: ${args.join(' ')}`);
+    assert.ok(!args.some(a => a.includes('"')), `no argument should carry quote marks: ${args.join(' ')}`);
+  });
+
+  test('a boolean keeps its type through -F', () => {
+    // draft=false has to arrive as a boolean, not as the word "false", or the
+    // release never leaves draft.
+    const args = ghApiArgs('PATCH', 'repos/o/r/releases/1', { draft: false });
+    assert.ok(args.includes('-F'), 'non-strings go through -F');
+    assert.ok(args.includes('draft=false'));
+  });
+
+  test('a mixed body encodes each value by its own type', () => {
+    const args = ghApiArgs('PATCH', 'repos/o/r/releases/1', { tag_name: 'v1.2.3', draft: false });
+    const joined = args.join(' ');
+    assert.match(joined, /-f tag_name=v1\.2\.3/);
+    assert.match(joined, /-F draft=false/);
   });
 });


### PR DESCRIPTION
Publishing 0.11.7 failed with:

```
Binding the tag failed: asked for tag_name v0.11.7, release reports ""v0.11.7""
```

The transport passed every value through `gh`'s `-F` with `JSON.stringify` applied. That is correct for booleans, since `draft=false` must arrive as a boolean rather than the word, and **wrong for strings**: the quote marks became part of the value, so the release's `tag_name` was set to `"v0.11.7"` **with quotes**.

**The publish path's own verification caught it and refused to flip the draft.** That is the only reason a release did not go out bound to a meaningless tag. The guard worked; the thing it was guarding was broken.

## Why it survived

`publishRelease` is tested with an injected `api`, so the tests covered the logic and never the transport. The argument construction is now its own function, `ghApiArgs`, with tests that assert a string arrives bare and a boolean keeps its type. **Reverting the fix fails two of them**, checked rather than assumed.

Suite 1,624 to 1,627.