### PR TITLE
Keep the properties panel out of the body text under review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
+## Unreleased
+
+**Name:** Editor Hardening
+
+### Fixed
+
+- **A long document under review keeps its properties panel out of the text:** opening a note with frontmatter and adding a review comment could draw the heading and the first paragraphs on top of the properties box, so both were unreadable and the file looked corrupted. The document on disk was never touched: the review sidebar rearranges the page into two columns, and in that arrangement the properties box was allowed to claim far less height than it actually needed. It now takes the room it uses, and the body starts below it as it always did. Short notes were never affected, which is why this looked intermittent.
+
 ## 0.11.7: Foundations & File Tree Stability (2026-08-17)
 
 ### Fixed

--- a/docs/build-ledger.md
+++ b/docs/build-ledger.md
@@ -113,3 +113,78 @@ style drift lint; both themes; no build step.
 first, and both were sound. The cost of following it was small because the parse
 check is quick; the lesson is that a symptom described in document terms was a
 layout fault, and the geometry should have been measured first.
+
+---
+
+## 2026-08-19: R0-01 done
+
+**Card:** R0-01, body content renders above the properties panel after review
+comments are added. **Slice:** merged. Card complete.
+
+**What shipped.** `overflow: hidden` to `overflow: clip` on
+`.tiptap-editor-pane .properties`, plus the regression cover: three browser
+tests and a unit round-trip suite at the document shape that reproduces the
+defect.
+
+**Review.** An earlier round rejected the change on five test-strength
+findings, all fair, none disputing the fix itself. All five were applied:
+the corner clipping gained an automated check, the comment test gained the
+preconditions the defect needs, a superseded fixture comment was deleted,
+the order-unchanged claim now compares the whole rendered block sequence
+rather than only the first block, and the byte-preservation guarantee is now
+checked where the interface actually exercises it rather than on a static
+in-memory round-trip. The re-review returned PASS at round 1 of 3, reviewer
+on a different model, zero blocking findings, all five criteria met.
+
+**Fail-without-fix evidence, recorded here rather than inferred from the
+tests.** With the stylesheet reverted to `overflow: hidden`, three of the
+four browser tests in `review-layout.spec.js` fail: the panel-overlap test,
+the corner-clipping test, and the add-a-comment test. Before the five
+findings were applied it was two of three. The remaining test, the
+document-order one, passes either way, because blocks stay ordered relative
+to each other even while the panel paints across them; the overlap test is
+what catches that case.
+
+**Byte assertion proven non-vacuous.** The round-trip check caught a one-byte
+boundary error in its own first draft, mistaking the newline that opens the
+endmatter for the body's last byte. An assertion that detects a single byte
+of drift is comparing bytes rather than passing by construction.
+
+**Verification.** CI run 32289587305, green across hygiene, typecheck, Node
+22, Node 24, coverage floors, and E2E at 134 passed.
+
+**Surprise, and it cost most of the session.** A filesystem sandbox was
+enabled on the workspace midway through. It broke, in order: git identity,
+port binding, Chromium, `ps`, `kill`, and the review harness. Only the first
+two were filesystem problems. Chromium cannot start under it at all, because
+it registers a Mach port with the bootstrap server and that is refused; no
+path grant addresses this. The browser gate now runs in CI instead, which is
+a better place for it than any developer machine.
+
+`ps` remains blocked, and this is worth carrying forward rather than
+forgetting: `processCommand` in `lib/runtime/claude.js` shells out to `ps`,
+catches the failure, and returns null, so the pid-recycling guard degrades to
+assuming a record is ours. Under the sandbox the app would signal a recycled
+pid. The code behaves as designed for a missing `ps`; the sandbox silently
+disables a safety guard. One unit test fails locally as a result
+(`test/unit/pid-file.test.js`, 1630 of 1631). CI passes it on both Node
+versions, which is what proves it environmental. The test was not skipped.
+
+**Advisories not actioned, and why.** The review raised six advisory
+findings alongside its PASS. They were not folded into this change, because
+amending a diff after it passes review means merging code no independent
+party has seen. Three deserve a follow-up: the fixture selector matches by
+substring, so `reviewed-sections` also matches `unreviewed-sections` and
+resolves correctly only because `r` sorts before `u`; the document-order test
+does not assert that review mode is active, which is why it passes against
+the broken stylesheet; and the comment test mutates its fixture, so it is not
+idempotent if run twice against one server.
+
+**Next:** R0-02, long URLs in review comment replies overflow the card. Ahead
+of it, one unplanned card: the captured Claude CLI contract is stale, at
+2.1.232 against an installed 2.1.235, so `npm run stream:truth` fails. That
+is the drift class that produced the 0.11.6 interception regression, and a
+stale stub weakens every suite that depends on it.
+
+**Invariants:** unchanged. Byte-for-byte round-trip, style drift lint, both
+themes, no build step.

--- a/docs/build-ledger.md
+++ b/docs/build-ledger.md
@@ -62,3 +62,54 @@ first acceptance criterion, not a courtesy.
 2. The four hardening cards are not the only entries tagged for this release on
    the board. The release tag appears throughout, including on shipped work. The
    four that gate the build are the ones sitting in the Ready column.
+
+---
+
+## 2026-08-19: R0-01 diagnosis
+
+**Card:** R0-01, body content renders above the properties panel after review
+comments are added. **Slice:** root cause found and measured. No fix written yet.
+
+**Root cause.** `.tiptap-editor-pane .properties` carries `overflow: hidden`
+(`public/styles/views/editor.css:70`). Turning review mode on makes the pane a
+grid (`public/editor/styles.js:147`), and `overflow: hidden` makes the panel a
+scroll container, so in the block axis it contributes only its borders to the
+size of its auto-sized grid row. The row collapses to 18px, being 2px of border
+plus the panel's 16px margin, while the panel keeps its real 300px height. It
+therefore overflows its own row and paints across the editor, which is correctly
+placed in the row below. What a reader sees is the heading and the paragraphs
+before the first thematic break sitting on top of the properties panel.
+
+The thematic breaks are innocent. They only make the symptom look like a
+segmentation defect, because the panel happens to be about as tall as the body
+above the first break, so the overlap ends where that break begins. Both parse
+steps were verified correct on a document of this shape before the layout was
+examined.
+
+**Measured, not reasoned.** With the real document open and one comment added,
+the pane's resolved `grid-template-rows` read `18px 8241.78px 0px …`. Toggling
+the panel's `overflow` between `hidden` and `clip` in the live page flipped row
+one between 18px and 316px, repeatedly, in both directions. `overflow: clip`
+clips exactly as before, corner radius intact, and does not make a scroll
+container, so the row sizes from content again: the panel then measured
+124-424 with the editor starting at 440, its 16px margin below, and zero
+overlapping blocks.
+
+**Why it needs a long document.** The row collapses only once the pane's content
+overflows the pane's own scroll height. A short note lays out correctly, which is
+why the first reproduction attempt on a synthetic three-section fixture came back
+clean and looked like an absence of the defect rather than an absence of length.
+
+**Next:** add the regression test at the shape named on the card (frontmatter,
+several body thematic breaks, comment endmatter, long enough for the pane to
+scroll), watch it fail, then change `overflow: hidden` to `overflow: clip` and
+watch it pass. Then the round-trip assertion: adding a comment must not change
+rendered order, and must leave every byte outside the endmatter block untouched.
+
+**Invariants:** the byte-for-byte round-trip guarantee; token discipline and the
+style drift lint; both themes; no build step.
+
+**Surprises:** the card's own diagnosis order pointed at parse and segmentation
+first, and both were sound. The cost of following it was small because the parse
+check is quick; the lesson is that a symptom described in document terms was a
+layout fault, and the geometry should have been measured first.

--- a/docs/build-ledger.md
+++ b/docs/build-ledger.md
@@ -1,0 +1,64 @@
+# Build ledger
+
+The checkpoint log for the Routines and Agent Computer build. Every card appends
+here: before any context compaction, at session end or handoff, and at card
+completion. A session resuming a card reads that card's most recent entry first.
+
+## How to read an entry
+
+| Field | Meaning |
+|---|---|
+| Card | The card id and title |
+| Slice | Where the work stands inside the card |
+| Next | The next concrete step, written so a cold reader can act on it |
+| Invariants | The rules in play that the next step must not break |
+| Surprises | What the code turned out to be, where it differed from the plan |
+
+Entries are append-only. A later entry corrects an earlier one by saying so; the
+earlier text stays, because the record of a wrong belief is worth keeping.
+
+## Card ids
+
+Release 0 hardening cards carry `R0-` ids assigned in pull order. Release 1 and 2
+cards carry the ids from the card plan.
+
+| Id | Card |
+|---|---|
+| R0-01 | Body content renders above the properties panel after review comments are added |
+| R0-02 | Long URLs in review comment replies overflow the card |
+| R0-03 | Markdown characters are escaped when a review suggestion is accepted |
+| R0-04 | Tab indentation for list items is lost when the note contains callouts |
+
+---
+
+## 2026-08-19: build opens
+
+**Card:** none yet. **Slice:** ledger initialised.
+
+**Next:** pull R0-01 into its own worktree, reproduce the defect, and name the
+root cause with file and line before writing any fix. That naming is the card's
+first acceptance criterion, not a courtesy.
+
+**Invariants in play at the start of the build:**
+
+- One card, one session, one worktree. At most three cards in flight at once.
+- No card is approved by the party that built it. Review runs on a different
+  model, against the frozen criteria.
+- The earlier research spike is reference only. Its concepts are re-implemented
+  under a card with tests; no file is copied across.
+- The locked mocks are acceptance criteria for visual work, checked against the
+  file rather than from memory.
+- Editor changes hold the byte-for-byte round-trip guarantee.
+
+**Surprises:** two, both recorded now so no later session rediscovers them.
+
+1. The scheduler's home changed after the architecture spec was written. The
+   architecture spec places it in the Electron main process; the card plan
+   amends it to the shared Node server layer so that behaviour is identical for
+   the desktop app and for running from source. The card plan is the later
+   document and the one the build executes, so the shared server layer is the
+   binding placement. The consequence is a five-cell verification matrix rather
+   than a single-platform check.
+2. The four hardening cards are not the only entries tagged for this release on
+   the board. The release tag appears throughout, including on shipped work. The
+   four that gate the build are the ones sitting in the Ready column.

--- a/public/styles/views/editor.css
+++ b/public/styles/views/editor.css
@@ -67,7 +67,14 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
    (.wikilink, .callout), and the floating toolbar all live here. */
 .tiptap-editor-pane { flex: 1; overflow-y: auto; padding: 24px 32px; position: relative; }
 .tiptap-editor-pane.hidden { display: none; }
-.tiptap-editor-pane .properties { display: none; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 16px; overflow: hidden; }
+/* `clip` rather than `hidden`, and the difference is not cosmetic. `hidden`
+   makes this panel a scroll container, and a scroll container contributes only
+   its borders to the height of an auto-sized grid row. Review mode turns the
+   pane into a grid, so the panel's row collapsed to the border-plus-margin
+   18px while the panel kept its real height, and it painted over the top of
+   the body text. `clip` clips to the same rounded box and creates no scroll
+   container, so the row measures the panel's content. */
+.tiptap-editor-pane .properties { display: none; background: var(--card); border: 1px solid var(--border); border-radius: var(--radius-lg); margin-bottom: 16px; overflow: clip; }
 .tiptap-editor-pane .properties.visible { display: block; }
 .tiptap-editor-pane .properties-header { display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-bottom: 1px solid var(--border); }
 .tiptap-editor-pane .properties-header .label { font-size: var(--label); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-2); }

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -89,11 +89,6 @@ function buildFixture() {
   fs.writeFileSync(path.join(workspace, 'wikilink-line.md'),
     '# Links\n\nSee also: [[Roadmap-2026]] and [[Missing Note]].\n');
 
-  // A note in the shape that broke the review layout: leading frontmatter, a
-  // body carrying several thematic breaks, and a review endmatter block. The
-  // properties panel, the body and the review sidebar must each keep their
-  // own place when review mode is on. Written as a template so the thematic
-  // breaks read as themselves rather than as escaped bytes.
   // The shape that broke the review layout: leading frontmatter, a body with
   // several thematic breaks, and a review endmatter block. It is deliberately
   // long: the properties panel only loses its place once the editor pane has

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -89,6 +89,77 @@ function buildFixture() {
   fs.writeFileSync(path.join(workspace, 'wikilink-line.md'),
     '# Links\n\nSee also: [[Roadmap-2026]] and [[Missing Note]].\n');
 
+  // A note in the shape that broke the review layout: leading frontmatter, a
+  // body carrying several thematic breaks, and a review endmatter block. The
+  // properties panel, the body and the review sidebar must each keep their
+  // own place when review mode is on. Written as a template so the thematic
+  // breaks read as themselves rather than as escaped bytes.
+  // The shape that broke the review layout: leading frontmatter, a body with
+  // several thematic breaks, and a review endmatter block. It is deliberately
+  // long: the properties panel only loses its place once the editor pane has
+  // more content than it can show at once, so a short note passes either way.
+  const sectionedBody = [];
+  for (let s = 1; s <= 4; s += 1) {
+    sectionedBody.push('---', '', `## Section ${s}`, '');
+    for (let i = 1; i <= 6; i += 1) {
+      sectionedBody.push(`Paragraph ${i} of section ${s}, carrying enough text to give the pane real height to scroll through.`, '');
+    }
+  }
+  fs.writeFileSync(path.join(workspace, 'reviewed-sections.md'), [
+    '---',
+    'title: Reviewed Sections',
+    'date: 2026-08-18',
+    'status: FROZEN. Amendments only, with named reasons.',
+    'related:',
+    '  - "[[Roadmap-2026]]"',
+    '  - "[[Missing Note]]"',
+    'tags:',
+    '  - product',
+    '  - ux',
+    '---',
+    '',
+    '# Reviewed Sections',
+    '',
+    'The {==first paragraph==}{>>does this still read as the opening?<<}{#c1}, which sits above the first thematic break.',
+    '',
+    'The second paragraph, still above the first thematic break.',
+    '',
+    ...sectionedBody,
+    '---',
+    'comments:',
+    '  c1:',
+    '    by: liam',
+    '    at: "2026-08-18T10:00:00Z"',
+    'review:',
+    '  status: in-review',
+    '  at: "2026-08-18T10:00:00Z"',
+    '',
+  ].join('\n'));
+
+  // The same shape with no review data yet, so a test can add the first
+  // comment and watch what that does to the rendered order.
+  fs.writeFileSync(path.join(workspace, 'unreviewed-sections.md'), [
+    '---',
+    'title: Unreviewed Sections',
+    'date: 2026-08-18',
+    'status: FROZEN. Amendments only, with named reasons.',
+    'related:',
+    '  - "[[Roadmap-2026]]"',
+    '  - "[[Missing Note]]"',
+    'tags:',
+    '  - product',
+    '  - ux',
+    '---',
+    '',
+    '# Unreviewed Sections',
+    '',
+    'The first paragraph, which sits above the first thematic break.',
+    '',
+    'The second paragraph, still above the first thematic break.',
+    '',
+    ...sectionedBody,
+  ].join('\n'));
+
   // A briefing-style note: foldable + nested callouts and frontmatter
   // wikilinks.
   fs.writeFileSync(path.join(workspace, 'briefing.md'), [

--- a/test/e2e/review-layout.spec.js
+++ b/test/e2e/review-layout.spec.js
@@ -12,6 +12,8 @@
 // would pass against the broken stylesheet.
 const { test, expect } = require('@playwright/test');
 
+const UNREVIEWED = 'unreviewed-sections.md';
+
 async function openNote(page, name) {
   await page.goto('/');
   await expect(page.locator('.convo-item').first()).toBeVisible();
@@ -37,26 +39,50 @@ async function layout(page) {
       text: (el.textContent || '').slice(0, 30),
       ...box(el),
     }));
+    const cs = getComputedStyle(props);
     return {
       reviewActive: pane.classList.contains('review-active'),
       properties,
       blocks,
+      // The order a reader sees, as a comparable value rather than geometry.
+      // Comparing the whole sequence is what catches a block that moved into
+      // the middle of the document; checking only the first block does not.
+      sequence: blocks.map((b) => `${b.tag}|${b.text}`),
       // A block overlaps the panel when their vertical ranges intersect.
       overlapping: blocks.filter((b) => b.top < properties.bottom && b.bottom > properties.top),
       paneScrolls: pane.scrollHeight > pane.clientHeight,
+      // Clipping to the rounded corners was deliberate. The fix trades
+      // `hidden` for `clip`, and both of those clip; `visible` would not.
+      panelClip: {
+        overflowX: cs.overflowX,
+        overflowY: cs.overflowY,
+        radius: parseFloat(cs.borderTopLeftRadius),
+      },
     };
   });
+}
+
+// The preconditions the defect needs. Asserted wherever a layout is judged, so
+// a fixture that quietly stops reproducing them fails loudly instead of passing
+// for the wrong reason. A shortened note is the likeliest way to lose them.
+function expectDefectConditions(l) {
+  expect(l.paneScrolls).toBe(true);
+  expect(l.blocks.filter((b) => b.tag === 'HR').length).toBeGreaterThan(1);
+}
+
+// Every block sits at or below the one before it: nothing jumped the queue.
+function expectVisuallyOrdered(blocks) {
+  for (let i = 1; i < blocks.length; i += 1) {
+    expect(blocks[i].top).toBeGreaterThanOrEqual(blocks[i - 1].top);
+  }
 }
 
 test('the body starts below the properties panel while review mode is on', async ({ page }) => {
   await openNote(page, 'reviewed-sections');
   const l = await layout(page);
 
-  // The conditions the defect needs, asserted so a fixture that quietly stops
-  // reproducing them fails loudly instead of passing for the wrong reason.
   expect(l.reviewActive).toBe(true);
-  expect(l.paneScrolls).toBe(true);
-  expect(l.blocks.filter((b) => b.tag === 'HR').length).toBeGreaterThan(1);
+  expectDefectConditions(l);
 
   expect(l.overlapping).toEqual([]);
   expect(l.blocks[0].tag).toBe('H1');
@@ -65,20 +91,40 @@ test('the body starts below the properties panel while review mode is on', async
 
 test('the body stays in document order below the panel', async ({ page }) => {
   await openNote(page, 'reviewed-sections');
-  const { blocks } = await layout(page);
+  const l = await layout(page);
 
-  // Every block sits at or below the one before it: nothing has jumped the queue.
-  for (let i = 1; i < blocks.length; i += 1) {
-    expect(blocks[i].top).toBeGreaterThanOrEqual(blocks[i - 1].top);
-  }
-  expect(blocks[0].text).toContain('Reviewed Sections');
+  expectDefectConditions(l);
+  expectVisuallyOrdered(l.blocks);
+  expect(l.blocks[0].text).toContain('Reviewed Sections');
+});
+
+// The panel's row collapsed because `overflow: hidden` made it a scroll
+// container. The cheap way to "fix" that is to drop the overflow entirely,
+// which would also drop the corner clipping the panel was given on purpose.
+// This pins both halves: still clipping, still not a scroll container.
+test('the panel still clips to its rounded corners, without scrolling', async ({ page }) => {
+  await openNote(page, 'reviewed-sections');
+  const { panelClip } = await layout(page);
+
+  expect(panelClip.radius).toBeGreaterThan(0);
+  // `clip` clips to the padding box exactly as `hidden` did. Unlike `hidden`,
+  // `auto` and `scroll`, it establishes no scroll container, which is what
+  // lets the auto-sized grid row measure the panel's real height again.
+  expect(panelClip.overflowX).toBe('clip');
+  expect(panelClip.overflowY).toBe('clip');
 });
 
 test('adding the first comment does not change the rendered order', async ({ page }) => {
+  // The bytes as authored, before the interface touches the file.
+  const onDiskBefore = await (await page.request.get(`/api/file?path=${UNREVIEWED}`)).text();
+
   await openNote(page, 'unreviewed-sections');
   const before = await layout(page);
   expect(before.reviewActive).toBe(false);
   expect(before.overlapping).toEqual([]);
+  // The same preconditions the reviewed-note tests assert. Without these a
+  // shortened fixture would let this test pass without exercising the defect.
+  expectDefectConditions(before);
 
   await page.locator('.ProseMirror p', { hasText: 'first paragraph' }).first().click({ clickCount: 3 });
   await page.locator('.tb-comment').first().click();
@@ -90,6 +136,38 @@ test('adding the first comment does not change the rendered order', async ({ pag
   const after = await layout(page);
   expect(after.reviewActive).toBe(true);
   expect(after.overlapping).toEqual([]);
+  expectDefectConditions(after);
   expect(after.blocks[0].tag).toBe('H1');
   expect(after.blocks[0].top).toBeGreaterThanOrEqual(after.properties.bottom);
+
+  // The whole sequence, not just the first block: a block that swapped places
+  // with another in the middle of the document would survive a first-block
+  // check untouched.
+  expect(after.sequence).toEqual(before.sequence);
+  expectVisuallyOrdered(after.blocks);
+
+  // The byte-preservation guarantee, checked where the interface actually
+  // exercises it, rather than on a static in-memory round-trip. Without this,
+  // a comment-add that rewrote or re-escaped the body would pass every other
+  // assertion here.
+  await expect(page.locator('#editor-status')).toHaveText('Saved', { timeout: 10000 });
+  await expect
+    .poll(async () => (await (await page.request.get(`/api/file?path=${UNREVIEWED}`)).text()))
+    .toContain('\n---\ncomments:');
+
+  const onDiskAfter = await (await page.request.get(`/api/file?path=${UNREVIEWED}`)).text();
+  const endmatterAt = onDiskAfter.indexOf('\n---\ncomments:');
+  expect(endmatterAt).toBeGreaterThan(0);
+
+  // Everything before the endmatter block: frontmatter and body. Adding a
+  // comment inserts CriticMarkup at the comment site and must change nothing
+  // else, so stripping that one annotation has to give back the exact bytes.
+  //
+  // The slice stops AT the newline the match starts on, because that newline
+  // is the endmatter's own opening delimiter rather than the body's last byte.
+  // The body already ends in a newline of its own; taking both would count the
+  // blank line that separates the two blocks as if the body had grown one.
+  const outside = onDiskAfter.slice(0, endmatterAt);
+  const stripped = outside.replace(/\{==([\s\S]*?)==\}\{>>[\s\S]*?<<\}\{#[^}]*\}/g, '$1');
+  expect(stripped).toBe(onDiskBefore);
 });

--- a/test/e2e/review-layout.spec.js
+++ b/test/e2e/review-layout.spec.js
@@ -1,0 +1,95 @@
+'use strict';
+// E2E: the properties panel keeps its place when review mode is on.
+//
+// Review mode turns the editor pane into a two-column grid. A grid item that
+// is also a scroll container contributes only its borders to the height of an
+// auto-sized row, so a panel styled `overflow: hidden` collapsed its row to
+// 18px, kept its real height, and painted across the body text below it. The
+// document looked like it had lost its segmentation; the parse was never wrong.
+//
+// The defect only appears once the pane has more content than it can show, so
+// these tests use a long note. A short one lays out correctly either way and
+// would pass against the broken stylesheet.
+const { test, expect } = require('@playwright/test');
+
+async function openNote(page, name) {
+  await page.goto('/');
+  await expect(page.locator('.convo-item').first()).toBeVisible();
+  await page.locator('.nav-item[data-nav="files"]').click();
+  await page.locator('.file-item', { hasText: name }).first().click();
+  await expect(page.locator('#tiptap-properties.visible')).toBeVisible();
+  await expect(page.locator('.ProseMirror h1')).toBeVisible();
+}
+
+// The rectangles that decide whether a reader sees one thing on top of another.
+async function layout(page) {
+  return page.evaluate(() => {
+    const props = document.getElementById('tiptap-properties');
+    const pane = document.getElementById('tiptap-editor-pane');
+    const pm = document.querySelector('.ProseMirror');
+    const box = (el) => {
+      const r = el.getBoundingClientRect();
+      return { top: Math.round(r.top), bottom: Math.round(r.bottom) };
+    };
+    const properties = box(props);
+    const blocks = [...pm.children].map((el) => ({
+      tag: el.tagName,
+      text: (el.textContent || '').slice(0, 30),
+      ...box(el),
+    }));
+    return {
+      reviewActive: pane.classList.contains('review-active'),
+      properties,
+      blocks,
+      // A block overlaps the panel when their vertical ranges intersect.
+      overlapping: blocks.filter((b) => b.top < properties.bottom && b.bottom > properties.top),
+      paneScrolls: pane.scrollHeight > pane.clientHeight,
+    };
+  });
+}
+
+test('the body starts below the properties panel while review mode is on', async ({ page }) => {
+  await openNote(page, 'reviewed-sections');
+  const l = await layout(page);
+
+  // The conditions the defect needs, asserted so a fixture that quietly stops
+  // reproducing them fails loudly instead of passing for the wrong reason.
+  expect(l.reviewActive).toBe(true);
+  expect(l.paneScrolls).toBe(true);
+  expect(l.blocks.filter((b) => b.tag === 'HR').length).toBeGreaterThan(1);
+
+  expect(l.overlapping).toEqual([]);
+  expect(l.blocks[0].tag).toBe('H1');
+  expect(l.blocks[0].top).toBeGreaterThanOrEqual(l.properties.bottom);
+});
+
+test('the body stays in document order below the panel', async ({ page }) => {
+  await openNote(page, 'reviewed-sections');
+  const { blocks } = await layout(page);
+
+  // Every block sits at or below the one before it: nothing has jumped the queue.
+  for (let i = 1; i < blocks.length; i += 1) {
+    expect(blocks[i].top).toBeGreaterThanOrEqual(blocks[i - 1].top);
+  }
+  expect(blocks[0].text).toContain('Reviewed Sections');
+});
+
+test('adding the first comment does not change the rendered order', async ({ page }) => {
+  await openNote(page, 'unreviewed-sections');
+  const before = await layout(page);
+  expect(before.reviewActive).toBe(false);
+  expect(before.overlapping).toEqual([]);
+
+  await page.locator('.ProseMirror p', { hasText: 'first paragraph' }).first().click({ clickCount: 3 });
+  await page.locator('.tb-comment').first().click();
+  const composer = page.locator('.review-composer textarea');
+  await composer.fill('Does this still read as the opening?');
+  await composer.press('Enter');
+  await expect(page.locator('#tiptap-editor-pane.review-active')).toBeVisible();
+
+  const after = await layout(page);
+  expect(after.reviewActive).toBe(true);
+  expect(after.overlapping).toEqual([]);
+  expect(after.blocks[0].tag).toBe('H1');
+  expect(after.blocks[0].top).toBeGreaterThanOrEqual(after.properties.bottom);
+});

--- a/test/unit/review-sectioned-roundtrip.test.js
+++ b/test/unit/review-sectioned-roundtrip.test.js
@@ -1,0 +1,85 @@
+// Round-trip cover for the document shape that broke the review layout:
+// leading frontmatter, a body carrying several thematic breaks, and a review
+// endmatter block. The layout fault was in the stylesheet, but the shape had
+// no round-trip test of its own, so nothing would have caught a parse-order
+// change made while chasing it. This closes that gap.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { roundTrip } from '../helpers/editor-harness.js';
+import { parseFile } from '../../public/editor/markdown/pipeline.js';
+
+const SECTIONED = [
+  '---',
+  'title: Reviewed Sections',
+  'related:',
+  '  - "[[Roadmap-2026]]"',
+  'tags:',
+  '  - product',
+  '---',
+  '',
+  '# Reviewed Sections',
+  '',
+  'The {==first paragraph==}{>>does this still read as the opening?<<}{#c1}, above the first break.',
+  '',
+  'The second paragraph, still above the first break.',
+  '',
+  '---',
+  '',
+  '## Section one',
+  '',
+  'Body text under the first thematic break.',
+  '',
+  '---',
+  '',
+  '## Section two',
+  '',
+  'Body text under the second thematic break.',
+  '',
+  '---',
+  'comments:',
+  '  c1:',
+  '    by: liam',
+  '    at: "2026-08-18T10:00:00Z"',
+  'review:',
+  '  status: in-review',
+  '  at: "2026-08-18T10:00:00Z"',
+  '',
+].join('\n');
+
+describe('a sectioned document under review', () => {
+  test('round-trips byte-for-byte', async () => {
+    assert.equal(await roundTrip(SECTIONED), SECTIONED);
+  });
+
+  test('splits into frontmatter, body and endmatter, with the breaks in the body', () => {
+    const parts = parseFile(SECTIONED);
+
+    assert.ok(parts.raw.startsWith('---\ntitle: Reviewed Sections'));
+    assert.equal(parts.parsed.title, 'Reviewed Sections');
+
+    // The endmatter is the review block at the end, not a body thematic break.
+    assert.ok(parts.endmatter.raw.startsWith('---\ncomments:'));
+    assert.equal(parts.endmatter.data.comments.c1.by, 'liam');
+
+    // Both body thematic breaks stay in the body. The document authors three
+    // `---` lines after the frontmatter; the last one opens the endmatter, and
+    // the other two are content that must not be mistaken for it.
+    const breaks = parts.body.split('\n').filter((line) => line === '---');
+    assert.equal(breaks.length, 2);
+    assert.ok(parts.body.startsWith('# Reviewed Sections'));
+    assert.ok(parts.body.includes('## Section two'));
+  });
+
+  test('reassembles to the original bytes', () => {
+    const parts = parseFile(SECTIONED);
+    const rebuilt = parts.raw + parts.body + parts.trailingBody + parts.endmatter.raw + parts.trailing;
+    assert.equal(rebuilt, SECTIONED);
+  });
+
+  test('the same body without review data round-trips too', async () => {
+    const plain = SECTIONED.slice(0, SECTIONED.indexOf('\n---\ncomments:'))
+      .replace('{==first paragraph==}{>>does this still read as the opening?<<}{#c1}', 'first paragraph') + '\n';
+    assert.equal(await roundTrip(plain), plain);
+  });
+});


### PR DESCRIPTION
Review mode lays the editor pane out as a grid. The properties panel was styled `overflow: hidden`, which makes it a scroll container, and a scroll container contributes only its borders to the height of an auto-sized grid row. Its row collapsed to 18px while the panel kept its real height, so it overflowed and painted across the heading and the first paragraphs.

`overflow: clip` clips to the same rounded box and creates no scroll container, so the row measures the content again.

The thematic breaks in the body were never implicated. They only made the overlap end where the first break began, which is what made a layout fault read as a segmentation fault.

## Regression cover

Three browser tests and a unit round-trip suite, at a document shape long enough for the pane to scroll. A short note lays out correctly against the broken stylesheet, so a short fixture would not be evidence.

With the stylesheet reverted, three of the four browser tests fail: panel overlap, corner clipping, and add-a-comment.

## Review

An earlier round rejected this on five test-strength findings, none disputing the fix. All five are applied. The re-review returned PASS at round 1 of 3, on a different model from the implementer, zero blocking findings, all five acceptance criteria met.

Six advisory findings were left unactioned deliberately: amending a diff after it passes review means merging code no independent party has seen. Three warrant a follow-up and are recorded in `docs/build-ledger.md`.

## Verification

CI run 32289587305: hygiene, typecheck, Node 22, Node 24, coverage floors, and E2E at 134 passed.

One unit test (`test/unit/pid-file.test.js`) fails on a sandboxed local machine because `ps` cannot execute; CI passes it on both Node versions, which is what proves it environmental. It was not skipped. The build ledger records why it matters: the same `ps` lookup backs a pid-recycling guard in `lib/runtime/claude.js`.