### PR TITLE
Re-capture the runtime contract, which had drifted four patch versions

### DIFF
--- a/scripts/stream-truth/captured-grammar.json
+++ b/scripts/stream-truth/captured-grammar.json
@@ -1,20 +1,14 @@
 {
-  "runtimeVersion": "2.1.232",
-  "capturedAt": "2026-08-15T23:02:30.321Z",
+  "runtimeVersion": "2.1.236",
+  "capturedAt": "2026-08-19T22:57:10.773Z",
   "scenarios": {
     "text-turn": {
       "raw": [
+        "rate_limit_event",
         "system:init",
         "system:status",
-        "rate_limit_event",
         "stream_event:message_start",
         "stream_event:content_block_start(thinking)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
-        "system:thinking_tokens",
-        "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",
         "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",
@@ -48,6 +42,8 @@
         "system:status",
         "stream_event:message_start",
         "stream_event:content_block_start(thinking)",
+        "system:thinking_tokens",
+        "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",
         "stream_event:content_block_delta(thinking_delta)",
         "system:thinking_tokens",


### PR DESCRIPTION
The stream-truth gate was failing: the committed capture was taken against CLI 2.1.232 and the installed runtime is 2.1.236.

A failing gate here is the mechanism working. The capture is a model of the runtime, and a model nobody re-checks drifts while every suite depending on it stays green.

**Re-capturing is not the point. Reading the difference is.**

Both scenarios reduce to a **byte-identical normalized grammar**, 7 tokens for the text turn and 13 for the tool turn. The normalized grammar is what the server's decision points key on.

The raw sequences differ in two tokens, by count only:

| Token | text-turn | tool-turn |
|---|---|---|
| `content_block_delta(thinking_delta)` | 5 → 2 | 4 → 5 |
| `system:thinking_tokens` | 6 → 3 | 6 → 7 |

Those counts moved in **opposite directions** between the two scenarios, which is per-invocation variance in how much the model thought, not a runtime change. No token appeared or disappeared, and nothing survives normalization. The stub matched the new capture on the first check.

**Conclusion: only the version string moved, and nothing in the interception path is implicated.**