### PR TITLE
Stop a stalled CI step from running for six hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
 
+# A push or pull request titles its own run from the commit subject or the pull
+# request title. A manually dispatched run has neither, so it appeared in the
+# runs list as the bare workflow name, indistinguishable from every other
+# dispatch. Name those by what identifies them: the branch and who started it.
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('CI on {0} (dispatched by {1})', github.ref_name, github.actor)
+      || '' }}
+
 # Runs the test suite on every push to main and every pull request, so no change
 # to the server (a formerly untested ~4.3k-line monolith) merges without the
 # regression net passing. --omit=dev installs just the runtime deps (ws) and
@@ -32,6 +41,10 @@ jobs:
   hygiene:
     name: Hygiene (internal references, style drift)
     runs-on: ubuntu-latest
+    # Ceiling, not a wait. Observed maxima this session are far below it, so a
+    # healthy run is unaffected and only a stuck one is cut short. Without any
+    # timeout the default is six hours, which a hung browser install nearly spent.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -44,6 +57,10 @@ jobs:
   test:
     name: Test (Node ${{ matrix.node }})
     runs-on: ubuntu-latest
+    # Ceiling, not a wait. Observed maxima this session are far below it, so a
+    # healthy run is unaffected and only a stuck one is cut short. Without any
+    # timeout the default is six hours, which a hung browser install nearly spent.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +93,10 @@ jobs:
   typecheck:
     name: Typecheck (JSDoc + checkJs)
     runs-on: ubuntu-latest
+    # Ceiling, not a wait. Observed maxima this session are far below it, so a
+    # healthy run is unaffected and only a stuck one is cut short. Without any
+    # timeout the default is six hours, which a hung browser install nearly spent.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -99,6 +120,10 @@ jobs:
   coverage:
     name: Coverage floors
     runs-on: ubuntu-latest
+    # Ceiling, not a wait. Observed maxima this session are far below it, so a
+    # healthy run is unaffected and only a stuck one is cut short. Without any
+    # timeout the default is six hours, which a hung browser install nearly spent.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -143,6 +168,10 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    # Ceiling, not a wait. Observed maxima this session are far below it, so a
+    # healthy run is unaffected and only a stuck one is cut short. Without any
+    # timeout the default is six hours, which a hung browser install nearly spent.
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -169,7 +198,24 @@ jobs:
           exit 1
 
       - name: Install Chromium
-        run: npx playwright install --with-deps chromium
+        # Retried on the same reasoning as the install step above, and for a
+        # measured reason: this step hung twice on 2026-08-19, once for over
+        # twenty minutes, with the job otherwise healthy. `--with-deps` shells
+        # out to apt as well as fetching from the browser CDN, so it has two
+        # independent ways to stall while the process stays alive.
+        #
+        # The per-attempt `timeout` is what makes the retry mean anything. A
+        # bare retry loop around a HANG never reaches its second attempt: the
+        # first one simply never returns. The job ceiling would eventually cut
+        # it, but as a failure rather than a recovery.
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 300 npx playwright install --with-deps chromium; then exit 0; fi
+            echo "Chromium install failed or stalled (attempt $attempt); retrying in 15s"
+            sleep 15
+          done
+          echo "Chromium install failed on all 3 attempts"
+          exit 1
 
       - name: Run E2E suite
         run: npm run test:e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,13 @@ jobs:
     name: Build macOS (arm64 + x64)
     needs: [test, e2e, smoke]
     runs-on: macos-latest
+    # Declares the protected release environment, which is where the signing
+    # secrets now live. They were repository secrets, readable by ANY workflow
+    # in this repo including one added on a pull request branch. The
+    # environment restricts them to tags matching the release pattern and
+    # holds the job for a reviewer, so a workflow on a branch cannot reach
+    # them at all.
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Two related changes to how CI is bounded and how release credentials are reached.

## Timeouts

No job set one, so the platform default of 360 minutes applied. On 2026-08-19 the browser install stalled twice, once for over twenty minutes with the job otherwise healthy, and the pull request sat blocked throughout.

Ceilings come from measured maxima with wide headroom, so a healthy run never notices them:

| Job | Observed max | Ceiling |
|---|---|---|
| Hygiene | 10s | 10 min |
| Typecheck | 32s | 10 min |
| Test (22 and 24) | 70s | 20 min |
| Coverage floors | 69s | 20 min |
| E2E | 7m13s | 25 min |

## Retry, with a bound per attempt

The browser install is now retried, as the dependency install beside it already is. That one gained a retry after registry hang-ups killed it three times; the step that reaches both apt and a download CDN never got the same cover, despite having two independent ways to stall.

The per-attempt `timeout` is the part that matters. A bare retry loop around a hang never reaches its second attempt, because the first never returns. Bounding each attempt is what turns a stall into a retry rather than a slow failure.

## Signing credentials

The Apple signing secrets were repository secrets, readable by every workflow in the repo including one added on a branch. Same-repo pull requests receive repository secrets, so they were reachable before anything merged. Nothing had gone wrong; the exposure was simply available.

They now sit behind an environment restricted to release tags and gated on a reviewer. Only the macOS job declares it, because only the macOS job reads them. Windows and finalize use the automatically issued token, so gating them would buy no protection while costing a second approval pause per release.

Ordinary work is unaffected: this applies to tag pushes only, and CI declares no environment, so pull requests and merges never pause.

## Naming

Dispatched runs showed as the bare workflow name, since they have no commit subject or PR title to draw on.

**Watch on this run:** `run-name` yields an empty string for non-dispatch events, expecting GitHub to fall back to its default title. If this PR's own run shows a blank name, that assumption is wrong and needs an explicit fallback before merge.