### PR TITLE
Close three advisories on the review-layout tests

### DIFF
--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -43,6 +43,48 @@ function buildPng() {
   ]);
 }
 
+// The unreviewed sectioned note, as a function rather than a literal, because
+// the browser test that adds a comment MUTATES this file on disk. Run twice
+// against one server it would otherwise read back its own leftovers, so the
+// spec rewrites the file from this definition before it runs. Exported so the
+// spec never carries a second copy of the content to drift against.
+function unreviewedSections(sectionedBody) {
+  return [
+    '---',
+    'title: Unreviewed Sections',
+    'date: 2026-08-18',
+    'status: FROZEN. Amendments only, with named reasons.',
+    'related:',
+    '  - "[[Roadmap-2026]]"',
+    '  - "[[Missing Note]]"',
+    'tags:',
+    '  - product',
+    '  - ux',
+    '---',
+    '',
+    '# Unreviewed Sections',
+    '',
+    'The first paragraph, which sits above the first thematic break.',
+    '',
+    'The second paragraph, still above the first thematic break.',
+    '',
+    ...sectionedBody,
+  ].join('\n');
+}
+
+// The body shared by both sectioned fixtures: four sections, each long enough
+// that the pane must scroll, which is the condition the defect needs.
+function sectionedBodyLines() {
+  const lines = [];
+  for (let s = 1; s <= 4; s += 1) {
+    lines.push('---', '', `## Section ${s}`, '');
+    for (let i = 1; i <= 6; i += 1) {
+      lines.push(`Paragraph ${i} of section ${s}, carrying enough text to give the pane real height to scroll through.`, '');
+    }
+  }
+  return lines;
+}
+
 function buildFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-e2e-'));
   const workspace = path.join(root, 'workspace');
@@ -93,13 +135,7 @@ function buildFixture() {
   // several thematic breaks, and a review endmatter block. It is deliberately
   // long: the properties panel only loses its place once the editor pane has
   // more content than it can show at once, so a short note passes either way.
-  const sectionedBody = [];
-  for (let s = 1; s <= 4; s += 1) {
-    sectionedBody.push('---', '', `## Section ${s}`, '');
-    for (let i = 1; i <= 6; i += 1) {
-      sectionedBody.push(`Paragraph ${i} of section ${s}, carrying enough text to give the pane real height to scroll through.`, '');
-    }
-  }
+  const sectionedBody = sectionedBodyLines();
   fs.writeFileSync(path.join(workspace, 'reviewed-sections.md'), [
     '---',
     'title: Reviewed Sections',
@@ -133,28 +169,13 @@ function buildFixture() {
 
   // The same shape with no review data yet, so a test can add the first
   // comment and watch what that does to the rendered order.
-  fs.writeFileSync(path.join(workspace, 'unreviewed-sections.md'), [
-    '---',
-    'title: Unreviewed Sections',
-    'date: 2026-08-18',
-    'status: FROZEN. Amendments only, with named reasons.',
-    'related:',
-    '  - "[[Roadmap-2026]]"',
-    '  - "[[Missing Note]]"',
-    'tags:',
-    '  - product',
-    '  - ux',
-    '---',
-    '',
-    '# Unreviewed Sections',
-    '',
-    'The first paragraph, which sits above the first thematic break.',
-    '',
-    'The second paragraph, still above the first thematic break.',
-    '',
-    ...sectionedBody,
-  ].join('\n'));
-
+  //
+  // Exported rather than written inline, because the test that adds a comment
+  // MUTATES this file. Run twice against one server it would otherwise find
+  // its own leftovers and judge them, so the spec rewrites it from this same
+  // definition before each run. One definition, two readers: duplicating the
+  // content into the spec would create a second source that drifts.
+  fs.writeFileSync(path.join(workspace, 'unreviewed-sections.md'), unreviewedSections(sectionedBody));
   // A briefing-style note: foldable + nested callouts and frontmatter
   // wikilinks.
   fs.writeFileSync(path.join(workspace, 'briefing.md'), [
@@ -295,4 +316,4 @@ function buildFixture() {
   return { root, workspace, home };
 }
 
-module.exports = { buildFixture };
+module.exports = { buildFixture, unreviewedSections, sectionedBodyLines };

--- a/test/e2e/review-layout.spec.js
+++ b/test/e2e/review-layout.spec.js
@@ -10,15 +10,27 @@
 // The defect only appears once the pane has more content than it can show, so
 // these tests use a long note. A short one lays out correctly either way and
 // would pass against the broken stylesheet.
+const fs = require('node:fs');
+const path = require('node:path');
 const { test, expect } = require('@playwright/test');
+const { unreviewedSections, sectionedBodyLines } = require('./fixture.js');
 
 const UNREVIEWED = 'unreviewed-sections.md';
 
-async function openNote(page, name) {
+// Selects by path, not by text. `hasText` is a SUBSTRING match, and these two
+// fixtures are named such that one contains the other: a search for
+// "reviewed-sections" also matches "unreviewed-sections.md". That resolved
+// correctly only because the tree sorts alphabetically and "r" precedes "u",
+// which is not a property any test should rest on.
+//
+// The row carries its own path as a data attribute and owns the click handler,
+// so addressing it that way is exact by construction and does not depend on
+// how the name happens to be rendered.
+async function openNote(page, file) {
   await page.goto('/');
   await expect(page.locator('.convo-item').first()).toBeVisible();
   await page.locator('.nav-item[data-nav="files"]').click();
-  await page.locator('.file-item', { hasText: name }).first().click();
+  await page.locator(`#file-tree .file-item[data-path="${file}"]`).click();
   await expect(page.locator('#tiptap-properties.visible')).toBeVisible();
   await expect(page.locator('.ProseMirror h1')).toBeVisible();
 }
@@ -78,7 +90,7 @@ function expectVisuallyOrdered(blocks) {
 }
 
 test('the body starts below the properties panel while review mode is on', async ({ page }) => {
-  await openNote(page, 'reviewed-sections');
+  await openNote(page, 'reviewed-sections.md');
   const l = await layout(page);
 
   expect(l.reviewActive).toBe(true);
@@ -90,9 +102,14 @@ test('the body starts below the properties panel while review mode is on', async
 });
 
 test('the body stays in document order below the panel', async ({ page }) => {
-  await openNote(page, 'reviewed-sections');
+  await openNote(page, 'reviewed-sections.md');
   const l = await layout(page);
 
+  // Without this the test passes against the broken stylesheet: blocks stay
+  // ordered relative to one another even while the panel paints across them,
+  // so ordering alone never saw the defect. The overlap test is what catches
+  // it, and this assertion is what stops this test claiming credit for that.
+  expect(l.reviewActive).toBe(true);
   expectDefectConditions(l);
   expectVisuallyOrdered(l.blocks);
   expect(l.blocks[0].text).toContain('Reviewed Sections');
@@ -103,7 +120,7 @@ test('the body stays in document order below the panel', async ({ page }) => {
 // which would also drop the corner clipping the panel was given on purpose.
 // This pins both halves: still clipping, still not a scroll container.
 test('the panel still clips to its rounded corners, without scrolling', async ({ page }) => {
-  await openNote(page, 'reviewed-sections');
+  await openNote(page, 'reviewed-sections.md');
   const { panelClip } = await layout(page);
 
   expect(panelClip.radius).toBeGreaterThan(0);
@@ -115,10 +132,23 @@ test('the panel still clips to its rounded corners, without scrolling', async ({
 });
 
 test('adding the first comment does not change the rendered order', async ({ page }) => {
+  // This test WRITES to its fixture, so it has to start from a known state
+  // rather than from whatever a previous run left behind. Restoring it here
+  // makes the test idempotent: run it twice against one server and the second
+  // run judges the fixture, not the first run's comment.
+  //
+  // The content comes from the fixture module rather than a copy pasted into
+  // this file, so there is one definition and nothing to drift.
+  await page.goto('/');
+  const workspace = await page.evaluate(() => currentWorkspacePath);
+  expect(workspace).toBeTruthy();
+  fs.writeFileSync(path.join(workspace, UNREVIEWED),
+    unreviewedSections(sectionedBodyLines()));
+
   // The bytes as authored, before the interface touches the file.
   const onDiskBefore = await (await page.request.get(`/api/file?path=${UNREVIEWED}`)).text();
 
-  await openNote(page, 'unreviewed-sections');
+  await openNote(page, 'unreviewed-sections.md');
   const before = await layout(page);
   expect(before.reviewActive).toBe(false);
   expect(before.overlapping).toEqual([]);


### PR DESCRIPTION
Three findings raised by the independent review that passed the properties panel change. They were left out of that change on purpose: amending a diff after it passes review means merging code no independent party has seen.

**The fixture selector matched by substring.** These two fixtures are named so that one contains the other, so searching for the shorter name also matched the longer file. It resolved correctly only because the tree sorts alphabetically and one letter happens to precede the other. Rows carry their own path as a data attribute and own the click handler, so addressing them that way is exact by construction and independent of how a name is rendered.

**The document-order test never asserted review mode was on.** That is precisely why it passed against the broken stylesheet while the other three failed: blocks stay ordered relative to one another even while the panel paints across them, so ordering alone never saw the defect.

**The comment test writes to its fixture**, so a second run against one server read back the first run's comment and judged that. It now restores the file first, from the fixture module rather than a copy pasted into the spec, so there is one definition and nothing to drift.

The extraction was verified byte-for-byte: both generated notes are identical before and after, so the refactor moved no content.

Local: typecheck, style drift and reference checks clean; unit suite 1,630 of 1,631, the exception being the process-inspection test that cannot pass on a sandboxed machine and passes on both runners here. The browser tests cannot launch locally for a reason no configuration fixes, so this pipeline is where they are proven.