### PR TITLE
Stop the runner warning on every build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,12 @@ jobs:
       # every run, pass or fail.
       - name: Upload lcov for floor diagnosis
         if: always()
-        uses: actions/upload-artifact@v4
+        # v7 rather than v4: v4 targets Node 20, which the runners now force
+        # onto Node 24 and warn about on every run. A warning nobody can act on
+        # trains people to ignore the warnings that matter. The inputs used
+        # here are unchanged across the majors between; what changed is
+        # artifact merging and overwrite behaviour, neither of which this uses.
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov
           path: coverage.lcov


### PR DESCRIPTION
The artifact upload action targeted Node 20, which the runners now force onto Node 24 while warning about it on **every run of every pull request**.

A warning nobody can act on is not free. It teaches people to skim past the warnings that do matter.

`checkout` and `setup-node` were already moved to their current majors. This one was missed, so it was the only action left behind.

**Why the jump is safe.** The four inputs this step uses (`name`, `path`, `if-no-files-found`, `retention-days`) are all still supported, verified against the action definition at that tag rather than assumed. What changed across the majors in between is artifact merging and overwrite behaviour; this uploads a single file under a fixed name and uses neither.

**It verifies itself.** If the bump were wrong, the step uploading the coverage report would fail on this pull request.