### PR TITLE
Show every part of a long agent turn after a relaunch

### DIFF
--- a/lib/protocol/handlers/history.js
+++ b/lib/protocol/handlers/history.js
@@ -155,7 +155,31 @@ function handleGetSessionHistory(ctx, ws, msg) {
               ));
             if (match) {
               match._used = true;
-              merged.push({ role: 'assistant', content: match.content, agentId: t.agent || null, timestamp: match.timestamp || t.timestamp || null });
+              // A transcript entry holds a whole agent TURN. The session file
+              // splits that same turn into one entry per stretch of text
+              // between tool calls, so a turn shaped text, tool, text, tool,
+              // summary arrives here as several entries. Claiming one of them
+              // per turn showed the opening stretch and silently dropped the
+              // rest, which is why long working turns lost their closing
+              // summary on reload while short ones were fine.
+              //
+              // Absorb the stretches that follow, but only while their opening
+              // text is present in this turn's own transcript text. That check
+              // is doing real work: a second agent replying straight after the
+              // first, with no user message between, is ordinary, and without
+              // it that reply would be swallowed into this bubble and
+              // attributed to the wrong agent.
+              const parts = [match.content];
+              const turnText = stripToolSummaries(tText);
+              for (let k = jsonlPool.indexOf(match) + 1; k < jsonlPool.length; k += 1) {
+                const next = jsonlPool[k];
+                if (next.role === 'user' || next._used) break;
+                const head = next.content.trim().substring(0, 60);
+                if (!head || !turnText.includes(head)) break;
+                next._used = true;
+                parts.push(next.content);
+              }
+              merged.push({ role: 'assistant', content: parts.join('\n\n'), agentId: t.agent || null, timestamp: match.timestamp || t.timestamp || null });
             } else {
               // No JSONL match: use transcript text (may be truncated but better than dropping)
               const cleanText = stripToolSummaries(tText);

--- a/lib/protocol/handlers/history.js
+++ b/lib/protocol/handlers/history.js
@@ -178,10 +178,15 @@ function handleGetSessionHistory(ctx, ws, msg) {
               // arrangement the accumulator can actually have produced.
               const parts = [match.content];
               const turnText = stripToolSummaries(tText);
+              // Advance past the WHOLE stretch, not merely the head matched on.
+              // Advancing by the head alone leaves the rest of that stretch in
+              // range, so a later stretch could match inside text already
+              // claimed. The accumulator concatenates stretches verbatim, so
+              // the whole of one is present at the position its head was found.
               const headOf = (m) => m.content.trim().substring(0, 60);
-              const firstHead = headOf(match);
-              const firstAt = turnText.indexOf(firstHead);
-              let searchFrom = firstAt < 0 ? 0 : firstAt + firstHead.length;
+              const advance = (m, at) => at + m.content.trim().length;
+              const firstAt = turnText.indexOf(headOf(match));
+              let searchFrom = firstAt < 0 ? 0 : advance(match, firstAt);
               for (let k = jsonlPool.indexOf(match) + 1; k < jsonlPool.length; k += 1) {
                 const next = jsonlPool[k];
                 if (next.role === 'user' || next._used) break;
@@ -190,7 +195,7 @@ function handleGetSessionHistory(ctx, ws, msg) {
                 if (at < 0) break;
                 next._used = true;
                 parts.push(next.content);
-                searchFrom = at + head.length;
+                searchFrom = advance(next, at);
               }
               merged.push({ role: 'assistant', content: parts.join('\n\n'), agentId: t.agent || null, timestamp: match.timestamp || t.timestamp || null });
             } else {

--- a/lib/protocol/handlers/history.js
+++ b/lib/protocol/handlers/history.js
@@ -169,15 +169,28 @@ function handleGetSessionHistory(ctx, ws, msg) {
               // first, with no user message between, is ordinary, and without
               // it that reply would be swallowed into this bubble and
               // attributed to the wrong agent.
+              // Walk FORWARD through the turn text rather than asking whether
+              // each stretch appears anywhere in it. A plain containment test
+              // would absorb a following agent's short reply whose opening
+              // happens to repeat a phrase from earlier in this turn, which is
+              // not far-fetched between agents that share a house style. Each
+              // stretch must appear after the one before it, which is the only
+              // arrangement the accumulator can actually have produced.
               const parts = [match.content];
               const turnText = stripToolSummaries(tText);
+              const headOf = (m) => m.content.trim().substring(0, 60);
+              const firstHead = headOf(match);
+              const firstAt = turnText.indexOf(firstHead);
+              let searchFrom = firstAt < 0 ? 0 : firstAt + firstHead.length;
               for (let k = jsonlPool.indexOf(match) + 1; k < jsonlPool.length; k += 1) {
                 const next = jsonlPool[k];
                 if (next.role === 'user' || next._used) break;
-                const head = next.content.trim().substring(0, 60);
-                if (!head || !turnText.includes(head)) break;
+                const head = headOf(next);
+                const at = head ? turnText.indexOf(head, searchFrom) : -1;
+                if (at < 0) break;
                 next._used = true;
                 parts.push(next.content);
+                searchFrom = at + head.length;
               }
               merged.push({ role: 'assistant', content: parts.join('\n\n'), agentId: t.agent || null, timestamp: match.timestamp || t.timestamp || null });
             } else {

--- a/test/integration/session-history.test.js
+++ b/test/integration/session-history.test.js
@@ -282,6 +282,43 @@ describe('get_session_history: multi-session merge', () => {
     assert.strictEqual(res.messages[2].content, shared);
   });
 
+  test('an echo occurring late in the first turn still leaves the reply separate', async () => {
+    // Sharper than the case above, and the one that decides how far the walk
+    // advances after a match. Here the repeated phrase sits well past the
+    // sixty characters used to recognise a stretch, so a walk that stepped
+    // forward only by that head would still be inside the first agent's text
+    // and would match the echo there, absorbing a reply that belongs to
+    // someone else. Stepping past the whole stretch is what rules it out.
+    const convoId = 'sh-multiblock-4';
+    const echoed = 'and that is the recommendation I would make here.';
+    const firstTurn = 'Opening remarks that comfortably exceed the sixty characters used to '
+      + `recognise a stretch, followed by the phrase in question, ${echoed} Then a further `
+      + 'sentence so the echo is not at the end either.';
+    writeSession('sess-late-echo', [
+      userLine('Both of you weigh in', '2026-08-13T12:00:00Z'),
+      assistantLine(firstTurn, '2026-08-13T12:00:05Z'),
+      assistantLine(echoed, '2026-08-13T12:00:10Z'),
+    ]);
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Both of you weigh in', timestamp: '2026-08-13T12:00:00Z' },
+      { role: 'agent', agent: 'cos', text: firstTurn, timestamp: '2026-08-13T12:00:05Z' },
+      { role: 'agent', agent: 'penn', text: echoed, timestamp: '2026-08-13T12:00:10Z' },
+    ]);
+
+    const res = await getHistory({
+      conversationId: convoId,
+      sessionIds: [{ sessionId: 'sess-late-echo' }],
+    });
+
+    assert.strictEqual(res.messages.length, 3);
+    assert.deepStrictEqual(res.messages.map(m => m.agentId), [null, 'cos', 'penn']);
+    assert.strictEqual(res.messages[1].content, firstTurn, 'nothing absorbed into the first turn');
+    assert.strictEqual(res.messages[2].content, echoed);
+    // Present once as its own turn, not duplicated into the bubble before it.
+    const occurrences = res.messages.filter(m => m.content === echoed).length;
+    assert.strictEqual(occurrences, 1, 'the reply appears exactly once');
+  });
+
   test('a following agent turn is not swallowed into the one before it', async () => {
     // The guard on the change above. Two agents replying in sequence with no
     // user message between them is ordinary, and absorbing every assistant

--- a/test/integration/session-history.test.js
+++ b/test/integration/session-history.test.js
@@ -34,6 +34,10 @@ function assistantLine(text, timestamp) {
   return { message: { role: 'assistant', content: [{ type: 'text', text }] }, timestamp: timestamp || null };
 }
 
+function toolLine(name, timestamp) {
+  return { message: { role: 'assistant', content: [{ type: 'tool_use', name, input: {} }] }, timestamp: timestamp || null };
+}
+
 function writeTranscript(convoId, entries) {
   const dir = path.join(h.workspaceDir, '.rundock', 'transcripts');
   fs.mkdirSync(dir, { recursive: true });
@@ -201,6 +205,79 @@ describe('get_session_history: multi-session merge', () => {
       'Recovered from the transcript alone',
     ]);
   });
+
+  test('every text block of a multi-block turn survives a relaunch', async () => {
+    // The shape from the field report: text, tool, text, tool, text. It renders
+    // in full while live and, before this was fixed, collapsed to its opening
+    // line on reload. The session file kept every block; the rebuild claimed
+    // one of them per turn and silently dropped the rest, so the final summary,
+    // usually the most valuable part of a long turn, vanished from view.
+    const convoId = 'sh-multiblock-1';
+    const first = 'Let me gather the actual clutter before prescribing anything.';
+    const second = 'Now checking what the settings file already carries.';
+    const third = "I've done everything that was safe to do without your input. "
+      + 'Here is the summary and what I recommend next, which is the part worth keeping.';
+
+    writeSession('sess-multi-1', [
+      userLine('Please tidy this workspace', '2026-08-13T09:00:00Z'),
+      assistantLine(first, '2026-08-13T09:00:10Z'),
+      toolLine('Read', '2026-08-13T09:00:11Z'),
+      assistantLine(second, '2026-08-13T09:00:20Z'),
+      toolLine('Edit', '2026-08-13T09:00:21Z'),
+      assistantLine(third, '2026-08-13T09:00:30Z'),
+    ]);
+    // One transcript entry per TURN, holding the turn's whole text, which is
+    // what the accumulator in the delegation engine produces.
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Please tidy this workspace', timestamp: '2026-08-13T09:00:00Z' },
+      { role: 'agent', agent: 'dev', text: first + second + third, timestamp: '2026-08-13T09:00:30Z' },
+    ]);
+
+    const res = await getHistory({
+      conversationId: convoId,
+      sessionIds: [{ sessionId: 'sess-multi-1' }],
+    });
+
+    assert.strictEqual(res.messages.length, 2, 'one user turn and one agent turn');
+    const agentMsg = res.messages[1];
+    assert.strictEqual(agentMsg.role, 'assistant');
+    for (const [label, block] of [['first', first], ['second', second], ['final', third]]) {
+      assert.ok(agentMsg.content.includes(block), `the ${label} block is shown`);
+    }
+    // Order matters as much as presence: a summary shown before the work that
+    // produced it would read as nonsense.
+    assert.ok(agentMsg.content.indexOf(first) < agentMsg.content.indexOf(second));
+    assert.ok(agentMsg.content.indexOf(second) < agentMsg.content.indexOf(third));
+  });
+
+  test('a following agent turn is not swallowed into the one before it', async () => {
+    // The guard on the change above. Two agents replying in sequence with no
+    // user message between them is ordinary, and absorbing every assistant
+    // entry up to the next user message would merge them into one bubble and
+    // misattribute the second agent's words to the first.
+    const convoId = 'sh-multiblock-2';
+    writeSession('sess-two-agents', [
+      userLine('Who can help', '2026-08-13T10:00:00Z'),
+      assistantLine('Routing you to the specialist now', '2026-08-13T10:00:05Z'),
+      assistantLine('Specialist here, this is my own separate answer', '2026-08-13T10:00:10Z'),
+    ]);
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Who can help', timestamp: '2026-08-13T10:00:00Z' },
+      { role: 'agent', agent: 'cos', text: 'Routing you to the specialist now', timestamp: '2026-08-13T10:00:05Z' },
+      { role: 'agent', agent: 'penn', text: 'Specialist here, this is my own separate answer', timestamp: '2026-08-13T10:00:10Z' },
+    ]);
+
+    const res = await getHistory({
+      conversationId: convoId,
+      sessionIds: [{ sessionId: 'sess-two-agents' }],
+    });
+
+    assert.strictEqual(res.messages.length, 3, 'the two agent turns stay separate');
+    assert.deepStrictEqual(res.messages.map(m => m.agentId), [null, 'cos', 'penn']);
+    assert.ok(!res.messages[1].content.includes('Specialist here'),
+      "the first agent's bubble did not absorb the second agent's reply");
+  });
+
 });
 
 describe('get_session_history: single-session fallback', () => {

--- a/test/integration/session-history.test.js
+++ b/test/integration/session-history.test.js
@@ -38,6 +38,15 @@ function toolLine(name, timestamp) {
   return { message: { role: 'assistant', content: [{ type: 'tool_use', name, input: {} }] }, timestamp: timestamp || null };
 }
 
+function toolResultLine(text, timestamp) {
+  // Shaped as Claude Code writes it: user role, ARRAY content. The parser
+  // admits user entries only when their content is a string, so these never
+  // reach the merge pool. The regression test below includes them anyway, so
+  // that if that filter is ever relaxed the absorption walk does not silently
+  // start stopping at the first tool result and lose the rest of the turn.
+  return { type: 'user', message: { role: 'user', content: [{ type: 'tool_result', content: text }] }, timestamp: timestamp || null };
+}
+
 function writeTranscript(convoId, entries) {
   const dir = path.join(h.workspaceDir, '.rundock', 'transcripts');
   fs.mkdirSync(dir, { recursive: true });
@@ -222,8 +231,10 @@ describe('get_session_history: multi-session merge', () => {
       userLine('Please tidy this workspace', '2026-08-13T09:00:00Z'),
       assistantLine(first, '2026-08-13T09:00:10Z'),
       toolLine('Read', '2026-08-13T09:00:11Z'),
+      toolResultLine('file contents here', '2026-08-13T09:00:12Z'),
       assistantLine(second, '2026-08-13T09:00:20Z'),
       toolLine('Edit', '2026-08-13T09:00:21Z'),
+      toolResultLine('edit applied', '2026-08-13T09:00:22Z'),
       assistantLine(third, '2026-08-13T09:00:30Z'),
     ]);
     // One transcript entry per TURN, holding the turn's whole text, which is

--- a/test/integration/session-history.test.js
+++ b/test/integration/session-history.test.js
@@ -250,6 +250,38 @@ describe('get_session_history: multi-session merge', () => {
     assert.ok(agentMsg.content.indexOf(second) < agentMsg.content.indexOf(third));
   });
 
+  test('a following agent whose opening repeats an earlier phrase stays separate', async () => {
+    // The sharp case for the absorption rule. Agents sharing a house style
+    // reuse phrases, so a second agent's short reply can legitimately open
+    // with words that already appear inside the first agent's turn. A rule
+    // that asked only whether the text appears ANYWHERE in the turn would
+    // absorb it and attribute one agent's words to another. Requiring each
+    // stretch to appear AFTER the previous one is what prevents that.
+    const convoId = 'sh-multiblock-3';
+    const shared = 'Here is the summary worth keeping.';
+    writeSession('sess-echo', [
+      userLine('Both of you report back', '2026-08-13T11:00:00Z'),
+      assistantLine(`${shared} That was the first agent talking.`, '2026-08-13T11:00:05Z'),
+      assistantLine(shared, '2026-08-13T11:00:10Z'),
+    ]);
+    writeTranscript(convoId, [
+      { role: 'user', text: 'Both of you report back', timestamp: '2026-08-13T11:00:00Z' },
+      { role: 'agent', agent: 'cos', text: `${shared} That was the first agent talking.`, timestamp: '2026-08-13T11:00:05Z' },
+      { role: 'agent', agent: 'penn', text: shared, timestamp: '2026-08-13T11:00:10Z' },
+    ]);
+
+    const res = await getHistory({
+      conversationId: convoId,
+      sessionIds: [{ sessionId: 'sess-echo' }],
+    });
+
+    assert.strictEqual(res.messages.length, 3, 'the echoed reply is its own turn');
+    assert.deepStrictEqual(res.messages.map(m => m.agentId), [null, 'cos', 'penn']);
+    assert.strictEqual(res.messages[1].content, `${shared} That was the first agent talking.`,
+      "the first agent's bubble is exactly its own turn, with nothing absorbed");
+    assert.strictEqual(res.messages[2].content, shared);
+  });
+
   test('a following agent turn is not swallowed into the one before it', async () => {
     // The guard on the change above. Two agents replying in sequence with no
     // user message between them is ordinary, and absorbing every assistant

--- a/test/unit/stream-handlers.test.js
+++ b/test/unit/stream-handlers.test.js
@@ -102,6 +102,32 @@ describe('response text accumulation', () => {
     assert.strictEqual(entry.responseText, 'Hello world');
   });
 
+  test('the transcript writer stores a long multi-stretch turn whole', () => {
+    // The other half of the link. The test below pins what the accumulator
+    // produces; this pins that the writer stores it unchanged and reads it
+    // back the same. Without both, a rebuild test could rest on a fixture
+    // nothing in production actually creates.
+    //
+    // Length is deliberate: longer than the turn in the field report, whose
+    // closing stretch alone was 2,389 characters, and with the closing stretch
+    // last, since that is the part that went missing.
+    srv.setWorkspace(makeWorkspace({ agents: standardTeam() }));
+    const opening = 'Let me gather the clutter first.';
+    const middle = 'x'.repeat(1200);
+    const closing = `${'y'.repeat(1200)} Here is the summary worth keeping.`;
+    const whole = opening + middle + closing;
+    assert.ok(whole.length > 2400, 'the fixture is longer than the reported case');
+
+    const convoId = 'transcript-roundtrip-1';
+    srv.appendTranscript(convoId, 'agent', 'dev', whole);
+    const back = srv.loadTranscript(convoId);
+    const entry = back[back.length - 1];
+
+    assert.strictEqual(entry.text, whole, 'stored and read back byte for byte');
+    assert.ok(entry.text.endsWith('Here is the summary worth keeping.'),
+      'the closing stretch survives, which is the part that went missing');
+  });
+
   test('a turn interleaving text and tool calls accumulates every stretch, in order', () => {
     // Pins the SHAPE the transcript writer receives for a long working turn,
     // because a test elsewhere asserts how such a turn is rebuilt for display

--- a/test/unit/stream-handlers.test.js
+++ b/test/unit/stream-handlers.test.js
@@ -102,6 +102,29 @@ describe('response text accumulation', () => {
     assert.strictEqual(entry.responseText, 'Hello world');
   });
 
+  test('a turn interleaving text and tool calls accumulates every stretch, in order', () => {
+    // Pins the SHAPE the transcript writer receives for a long working turn,
+    // because a test elsewhere asserts how such a turn is rebuilt for display
+    // and had been assuming this shape rather than proving it. If the
+    // accumulator ever inserted a separator, or dropped a stretch after a tool
+    // call, that test would keep passing against a fixture reality no longer
+    // produces. This is the link between the two.
+    const entry = makeEntry();
+    srv.wireProcessHandlers(entry, 'convo-1', null, {});
+    push(entry, [
+      fx.textDelta('Let me gather the clutter first.'),
+      ...fx.toolUseFlow('Read', { file_path: 'a.md' }),
+      fx.textDelta('Now checking the settings file.'),
+      ...fx.toolUseFlow('Edit', { file_path: 'b.md' }),
+      fx.textDelta('Here is the summary worth keeping.'),
+    ]);
+    assert.strictEqual(
+      entry.responseText,
+      'Let me gather the clutter first.Now checking the settings file.Here is the summary worth keeping.',
+      'stretches are concatenated with no separator, and tool calls contribute nothing',
+    );
+  });
+
   test('a later assistant message does not clobber an earlier block (marker survives)', () => {
     // Post-fix behavior: the assistant message appends (deduped against the
     // delta stream) instead of replacing, so a marker streamed earlier in the


### PR DESCRIPTION
Fixes #121.

A turn where the agent writes, uses a tool, writes again, uses another tool, then finishes with a summary rendered in full while live and collapsed to its opening line once the conversation was reopened. The summary is usually the part worth keeping, so what survived was the least useful fragment.

**Nothing was ever lost on disk.** A transcript entry holds a whole turn; the session file splits that same turn into one entry per stretch of text between tool calls. The rebuild claimed a single session entry per transcript turn and moved on, leaving the later stretches stored and unshown. Short turns have only one stretch, which is why they always looked fine.

The rebuild now keeps absorbing the stretches that follow, while their opening text is present in that turn's own transcript text.

**That condition is the whole safety of the change.** Two agents replying in sequence with no user message between them is ordinary, so absorbing everything up to the next user message would merge them into one bubble and attribute the second agent's words to the first. An existing characterisation test already covered that shape and would have caught it; this adds a second test stating the guarantee directly rather than relying on the older one noticing.

Both tests use the reported turn shape, three text blocks with tool calls interleaved, and assert presence **and order**, since a summary shown before the work that produced it reads as nonsense.

Reverting the change fails the new test and leaves the guard passing. Unit suite 1,632 of 1,633, the exception being the process-inspection test that cannot pass on a sandboxed machine and passes on both runners here.

Credit to @miccohen67, who verified the blocks were intact on disk, followed the parentUuid chain, and retracted their own first diagnosis with evidence. The corrected diagnosis was right and this change follows it.