### PR TITLE
Keep agent scratch inside the workspace

### DIFF
--- a/lib/runtime/claude.js
+++ b/lib/runtime/claude.js
@@ -96,6 +96,31 @@ function scratchDir() {
 // a second Rundock open on the same workspace cannot delete files the first
 // one is still working with.
 const SCRATCH_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+// The newest modification time anywhere in a tree.
+//
+// A directory's own timestamp moves when its immediate children change, and
+// NOT when something deeper does. Judging a directory by its own timestamp
+// alone would therefore delete a project folder stamped weeks ago because
+// nothing was added at its top level, while a file inside it was being written
+// minutes earlier. That is the data loss the age bound exists to prevent, so
+// the age of a directory has to mean the age of the newest thing in it.
+function newestMtimeMs(target) {
+  let newest = 0;
+  const visit = (p) => {
+    let st;
+    try { st = fs.statSync(p); } catch (e) { return; }
+    if (st.mtimeMs > newest) newest = st.mtimeMs;
+    if (st.isDirectory()) {
+      let kids;
+      try { kids = fs.readdirSync(p); } catch (e) { return; }
+      for (const k of kids) visit(path.join(p, k));
+    }
+  };
+  visit(target);
+  return newest;
+}
+
 function pruneScratch() {
   const dir = scratchDir();
   if (!dir) return;
@@ -103,9 +128,10 @@ function pruneScratch() {
   try { entries = fs.readdirSync(dir); } catch (e) { return; } // nothing to prune
   const cutoff = Date.now() - SCRATCH_MAX_AGE_MS;
   for (const name of entries) {
+    if (name === '.gitignore') continue; // the directory's own exclusion marker
     const full = path.join(dir, name);
     try {
-      if (fs.statSync(full).mtimeMs < cutoff) fs.rmSync(full, { recursive: true, force: true });
+      if (newestMtimeMs(full) < cutoff) fs.rmSync(full, { recursive: true, force: true });
     } catch (e) { /* raced with another process, or unreadable: leave it */ }
   }
 }

--- a/lib/runtime/claude.js
+++ b/lib/runtime/claude.js
@@ -67,10 +67,65 @@ function getBareArgs() {
   return args;
 }
 
+// Where a spawned agent's scratch files go.
+//
+// Agents write working files (a rendered page, an intermediate export, a
+// draft) and read them back a step later. Left to the platform those land in
+// the operating system temp directory, which is outside the workspace, so
+// reading one back raises an approval card for a file the agent created
+// itself seconds earlier. The card is right; putting the file there was the
+// mistake. Rundock's promise is that agents stay in the user's files, and a
+// temp directory is not the user's files.
+//
+// Pointing the platform temp directory here holds that promise BY
+// CONSTRUCTION. It covers tools and skills this project never wrote, because
+// they ask the platform rather than reading any guidance, and it needs nobody
+// to remember a convention.
+//
+// Returns null when no workspace is set. Redirecting to a path built from an
+// empty workspace would be worse than not redirecting: it would scatter files
+// somewhere unpredictable rather than contain them.
+function scratchDir() {
+  const ws = getWorkspace();
+  if (!ws) return null;
+  return path.join(rundockDir(), 'scratch');
+}
+
+// Clear scratch left by earlier runs. Called at startup, when nothing can be
+// mid-use, and bounded by age rather than emptying the directory outright, so
+// a second Rundock open on the same workspace cannot delete files the first
+// one is still working with.
+const SCRATCH_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+function pruneScratch() {
+  const dir = scratchDir();
+  if (!dir) return;
+  let entries;
+  try { entries = fs.readdirSync(dir); } catch (e) { return; } // nothing to prune
+  const cutoff = Date.now() - SCRATCH_MAX_AGE_MS;
+  for (const name of entries) {
+    const full = path.join(dir, name);
+    try {
+      if (fs.statSync(full).mtimeMs < cutoff) fs.rmSync(full, { recursive: true, force: true });
+    } catch (e) { /* raced with another process, or unreadable: leave it */ }
+  }
+}
+
 // Returns spawn env with workspace mode flag for the permission hook.
 function getSpawnEnv(convoId) {
   const env = { ...process.env, TERM: 'dumb', RUNDOCK: '1', RUNDOCK_PORT: String(deps.getActualPort()), RUNDOCK_WORKSPACE: getWorkspace() || '' };
   if (convoId) env.RUNDOCK_CONVO_ID = convoId;
+  // Keep scratch inside the workspace. All three names, because the platform
+  // reads a different one per operating system: TMPDIR on macOS and Linux,
+  // TEMP and TMP on Windows. Setting only the one this machine happens to use
+  // would leave the other platforms writing outside the workspace with nothing
+  // to catch it.
+  const scratch = scratchDir();
+  if (scratch) {
+    try {
+      fs.mkdirSync(scratch, { recursive: true });
+      env.TMPDIR = scratch; env.TEMP = scratch; env.TMP = scratch;
+    } catch (e) { /* unwritable: leave the platform default rather than break the spawn */ }
+  }
   // Never let spawned agent processes inherit the test runner's coverage
   // collection: a child killed mid-turn (e.g. a superseded Codex exec)
   // leaves truncated coverage JSON that corrupts the runner's merge and
@@ -292,4 +347,5 @@ module.exports = {
   pidFilePath, loadPidFile, savePidFile, pidOf, processCommand, pidRecordAlive,
   registerChildPid, unregisterChildPid,
   resolveClaudeBin, killProcessTree, spawnClaude,
+  scratchDir, pruneScratch,
 };

--- a/lib/runtime/claude.js
+++ b/lib/runtime/claude.js
@@ -123,6 +123,13 @@ function getSpawnEnv(convoId) {
   if (scratch) {
     try {
       fs.mkdirSync(scratch, { recursive: true });
+      // Ignore itself, rather than trusting the workspace's own .gitignore to
+      // cover it. The scaffold does add the parent directory, but only when it
+      // runs: a workspace created before that, or one whose .gitignore has been
+      // edited since, would start committing working files. A directory that
+      // excludes itself needs no cooperation from anything else.
+      const marker = path.join(scratch, '.gitignore');
+      if (!fs.existsSync(marker)) fs.writeFileSync(marker, '*\n');
       env.TMPDIR = scratch; env.TEMP = scratch; env.TMP = scratch;
     } catch (e) { /* unwritable: leave the platform default rather than break the spawn */ }
   }

--- a/server.js
+++ b/server.js
@@ -62,6 +62,12 @@ let WORKSPACE = config.getWorkspace();
 function setWorkspaceRoot(dir) {
   WORKSPACE = dir;
   config.setWorkspace(dir);
+  // Clear stale scratch whenever a workspace becomes ACTIVE, not only when one
+  // is preset at boot. A workspace chosen or switched in the interface arrives
+  // here and never touches the boot path, so scratch in it would otherwise
+  // accumulate with nothing ever clearing it. Housekeeping must never be able
+  // to break a switch, hence the guard.
+  try { pruneScratch(); } catch (e) { /* not worth failing a switch over */ }
 }
 
 // Workspace boundary check. A bare `startsWith(resolve(WORKSPACE))`

--- a/server.js
+++ b/server.js
@@ -460,7 +460,7 @@ const claudeRuntime = require('./lib/runtime/claude.js');
 const {
   modelArgs, getBareArgs, getSpawnEnv,
   resolveClaudeBin, killProcessTree, spawnClaude,
-  registerChildPid, unregisterChildPid,
+  registerChildPid, unregisterChildPid, pruneScratch,
   loadPidFile, savePidFile, pidOf, pidRecordAlive, processCommand,
 } = claudeRuntime;
 claudeRuntime.wireClaudeRuntimeDeps({ getActualPort: () => ACTUAL_PORT });
@@ -2867,6 +2867,11 @@ function startServer(options = {}) {
         boot.mark('heal');
         cleanOrphanedProcesses();
         boot.mark('orphans');
+        // Scratch from earlier runs. Age-bounded rather than emptied outright,
+        // so a second Rundock open on the same workspace cannot delete files
+        // the first is still using.
+        pruneScratch();
+        boot.mark('scratch');
         reportStartup(`workspace preset from environment: ${boot.summary()}`);
       }
       // Release conversations nobody has touched for a while: each holds an

--- a/test/unit/boundary.test.js
+++ b/test/unit/boundary.test.js
@@ -123,6 +123,33 @@ describe('agent scratch files', () => {
       'it excludes everything inside it, itself included');
   });
 
+  test('activating a workspace clears stale scratch, through the real switch path', () => {
+    // The wiring, not the function. Every other test here calls the prune
+    // directly, so all of them would still pass if the call were removed from
+    // the switch path and nothing ever ran it. This one goes through the
+    // server's own workspace activation, which is the way a workspace becomes
+    // active for a person using the application.
+    const ws = makeWorkspace({});
+    srv.setWorkspace(ws);
+    const dir = claudeRuntime.getSpawnEnv(null).TMPDIR;
+
+    const stale = path.join(dir, 'stale-project');
+    fs.mkdirSync(stale, { recursive: true });
+    const staleFile = path.join(stale, 'render.html');
+    fs.writeFileSync(staleFile, 'old');
+    const fresh = path.join(dir, 'fresh.html');
+    fs.writeFileSync(fresh, 'new');
+    const longAgo = (Date.now() - (30 * 24 * 60 * 60 * 1000)) / 1000;
+    fs.utimesSync(staleFile, longAgo, longAgo);
+    fs.utimesSync(stale, longAgo, longAgo);
+
+    // Activate it again, the way the interface does.
+    srv.setWorkspace(ws);
+
+    assert.strictEqual(fs.existsSync(stale), false, 'activation ran the prune');
+    assert.strictEqual(fs.existsSync(fresh), true, 'recent scratch untouched');
+  });
+
   test('the operating system temp directory would still have prompted', () => {
     // The counterpart, so the test above is shown to be about WHERE the file
     // is rather than about scratch files being special. This is the behaviour

--- a/test/unit/boundary.test.js
+++ b/test/unit/boundary.test.js
@@ -17,6 +17,7 @@ const os = require('node:os');
 const { classifyFileAccess } = require('../../scripts/permission-hook.js');
 const { _internal: srv } = require('../../server.js');
 const { makeWorkspace, cleanup } = require('../helpers/workspace.js');
+const claudeRuntime = require('../../lib/runtime/claude.js');
 
 after(cleanup);
 
@@ -81,5 +82,34 @@ describe('boundary grants (server-side, persisted in the workspace)', () => {
     srv.setWorkspace(dir2);
     assert.strictEqual(srv.boundaryGrantCovers('/Users/x/Exports/file.md'), false,
       'the previous workspace grant must not leak');
+  });
+});
+
+describe('agent scratch files', () => {
+  test('writing scratch and reading it back raises no approval card', () => {
+    // The sequence from the field: an agent writes a working file, then reads
+    // it back a step later, and the read raised an outside-the-workspace card
+    // for a file the agent had just created. Scratch now resolves inside the
+    // workspace, so both halves classify as inside and neither prompts.
+    const ws = makeWorkspace({});
+    srv.setWorkspace(ws);
+    const scratch = claudeRuntime.scratchDir();
+    assert.ok(scratch, 'a workspace yields a scratch directory');
+    const file = path.join(scratch, 'some_project_scratch', 'render.html');
+
+    for (const tool of ['Write', 'Read']) {
+      const access = classifyFileAccess(tool, { file_path: file }, ws, []);
+      assert.strictEqual(access.where, 'inside', `${tool} of scratch must not prompt`);
+    }
+  });
+
+  test('the operating system temp directory would still have prompted', () => {
+    // The counterpart, so the test above is shown to be about WHERE the file
+    // is rather than about scratch files being special. This is the behaviour
+    // that produced the original reports, and it is correct: that path really
+    // is outside the workspace.
+    const ws = makeWorkspace({});
+    const outside = path.join(os.tmpdir(), 'some_project_scratch', 'render.html');
+    assert.strictEqual(classifyFileAccess('Read', { file_path: outside }, ws, []).where, 'outside');
   });
 });

--- a/test/unit/boundary.test.js
+++ b/test/unit/boundary.test.js
@@ -93,14 +93,34 @@ describe('agent scratch files', () => {
     // workspace, so both halves classify as inside and neither prompts.
     const ws = makeWorkspace({});
     srv.setWorkspace(ws);
-    const scratch = claudeRuntime.scratchDir();
-    assert.ok(scratch, 'a workspace yields a scratch directory');
-    const file = path.join(scratch, 'some_project_scratch', 'render.html');
+    // Derive the path from the environment a spawned agent ACTUALLY receives,
+    // not from the helper. Asking the helper would pass even if the spawn env
+    // pointed somewhere else entirely, which is the thing worth knowing.
+    const env = claudeRuntime.getSpawnEnv('convo-scratch');
+    assert.ok(env.TMPDIR, 'the spawn env carries a temp directory');
+    assert.strictEqual(env.TEMP, env.TMPDIR, 'all three names agree');
+    assert.strictEqual(env.TMP, env.TMPDIR, 'all three names agree');
 
+    const file = path.join(env.TMPDIR, 'some_project_scratch', 'render.html');
     for (const tool of ['Write', 'Read']) {
       const access = classifyFileAccess(tool, { file_path: file }, ws, []);
       assert.strictEqual(access.where, 'inside', `${tool} of scratch must not prompt`);
     }
+  });
+
+  test('scratch is excluded from version control without outside help', () => {
+    // AC-3 asserted rather than reasoned. The scaffold does add the parent
+    // directory to the workspace's .gitignore, but only when it runs, so a
+    // workspace created earlier, or one whose .gitignore has since been
+    // edited, would start committing working files. The directory excluding
+    // itself is what makes this true regardless.
+    const ws = makeWorkspace({});
+    srv.setWorkspace(ws);
+    const dir = claudeRuntime.getSpawnEnv(null).TMPDIR;
+    const marker = path.join(dir, '.gitignore');
+    assert.ok(fs.existsSync(marker), 'the scratch directory carries its own ignore file');
+    assert.strictEqual(fs.readFileSync(marker, 'utf-8').trim(), '*',
+      'it excludes everything inside it, itself included');
   });
 
   test('the operating system temp directory would still have prompted', () => {

--- a/test/unit/claude-runtime-lib.test.js
+++ b/test/unit/claude-runtime-lib.test.js
@@ -103,3 +103,83 @@ test('getSpawnEnv carries the use-time workspace and the wired port together', (
       'the env followed the switch with no re-wiring');
   });
 });
+
+// ── Scratch stays inside the workspace ─────────────────────────────────────
+//
+// An agent that writes a scratch file to the operating system temp directory
+// and reads it back trips the outside-the-workspace approval card, for a file
+// it created itself seconds earlier. The card is correct; putting the file
+// there was the mistake. Pointing the platform temp directory at a path inside
+// the workspace fixes the whole class by construction, including for tools and
+// skills this project did not write, because they ask the platform rather than
+// reading any guidance.
+
+test('a spawned agent resolves the platform temp directory inside the workspace', () => {
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  withTwoWorkspaces((config, wsA) => {
+    config.setWorkspace(wsA);
+    const env = rt.getSpawnEnv('convo-1');
+    // All three, because the platform reads a different one per operating
+    // system: TMPDIR on macOS and Linux, TEMP and TMP on Windows. Setting only
+    // the one this machine happens to use would leave the other platforms
+    // writing outside the workspace with nothing to catch it.
+    for (const key of ['TMPDIR', 'TEMP', 'TMP']) {
+      assert.ok(env[key], `${key} must be set`);
+      assert.ok(env[key].startsWith(wsA + path.sep),
+        `${key} must resolve inside the workspace, got ${env[key]}`);
+    }
+    assert.ok(fs.existsSync(env.TMPDIR), 'the directory exists before a child needs it');
+  });
+});
+
+test('the scratch directory follows a workspace switch', () => {
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  withTwoWorkspaces((config, wsA, wsB) => {
+    config.setWorkspace(wsA);
+    assert.ok(rt.getSpawnEnv(null).TMPDIR.startsWith(wsA + path.sep));
+    config.setWorkspace(wsB);
+    assert.ok(rt.getSpawnEnv(null).TMPDIR.startsWith(wsB + path.sep),
+      'resolved at use time, not captured at wiring');
+  });
+});
+
+test('with no workspace the real temp directory is left alone', () => {
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  const env = rt.getSpawnEnv(null);
+  // Redirecting to a path built from an empty workspace would be worse than
+  // not redirecting: it would write to an unpredictable place rather than a
+  // contained one. Better to leave the platform default standing.
+  assert.strictEqual(env.TMPDIR, process.env.TMPDIR);
+});
+
+test('pruning clears stale scratch and leaves recent scratch alone', () => {
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  withTwoWorkspaces((config, wsA) => {
+    config.setWorkspace(wsA);
+    const dir = rt.getSpawnEnv(null).TMPDIR;
+    const stale = path.join(dir, 'stale.html');
+    const fresh = path.join(dir, 'fresh.html');
+    fs.writeFileSync(stale, 'x');
+    fs.writeFileSync(fresh, 'x');
+    const longAgo = Date.now() - (30 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(stale, longAgo / 1000, longAgo / 1000);
+
+    rt.pruneScratch();
+
+    assert.strictEqual(fs.existsSync(stale), false, 'a month-old file is cleared');
+    assert.strictEqual(fs.existsSync(fresh), true, 'a file from this session survives');
+  });
+});
+
+test('pruning a workspace that has no scratch directory is a quiet no-op', () => {
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  withTwoWorkspaces((config, wsA) => {
+    config.setWorkspace(wsA);
+    assert.doesNotThrow(() => rt.pruneScratch());
+  });
+});

--- a/test/unit/claude-runtime-lib.test.js
+++ b/test/unit/claude-runtime-lib.test.js
@@ -175,6 +175,45 @@ test('pruning clears stale scratch and leaves recent scratch alone', () => {
   });
 });
 
+test('a stale-looking folder holding recent work is not deleted', () => {
+  // The case the age bound exists for, and the one it originally got wrong.
+  // A directory's own timestamp moves when its immediate children change and
+  // not when something deeper does, so a project folder untouched at its top
+  // level for weeks can still hold a file written minutes ago. Judging the
+  // folder by its own timestamp deleted exactly the work in progress the
+  // bound was meant to protect.
+  const rt = freshClaudeRuntime();
+  rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });
+  withTwoWorkspaces((config, wsA) => {
+    config.setWorkspace(wsA);
+    const dir = rt.getSpawnEnv(null).TMPDIR;
+
+    const busy = path.join(dir, 'busy-project');
+    fs.mkdirSync(busy, { recursive: true });
+    const inUse = path.join(busy, 'render.html');
+    fs.writeFileSync(inUse, 'work in progress');
+
+    const abandoned = path.join(dir, 'abandoned-project');
+    fs.mkdirSync(abandoned, { recursive: true });
+    const old = path.join(abandoned, 'render.html');
+    fs.writeFileSync(old, 'finished long ago');
+
+    // Both FOLDERS look ancient. They differ only in what is inside them.
+    const longAgo = (Date.now() - (30 * 24 * 60 * 60 * 1000)) / 1000;
+    fs.utimesSync(old, longAgo, longAgo);
+    fs.utimesSync(abandoned, longAgo, longAgo);
+    fs.utimesSync(busy, longAgo, longAgo);
+
+    rt.pruneScratch();
+
+    assert.strictEqual(fs.existsSync(inUse), true,
+      'a folder holding recent work survives, however old the folder looks');
+    assert.strictEqual(fs.readFileSync(inUse, 'utf-8'), 'work in progress');
+    assert.strictEqual(fs.existsSync(abandoned), false,
+      'a folder whose contents are all stale is still cleared');
+  });
+});
+
 test('pruning a workspace that has no scratch directory is a quiet no-op', () => {
   const rt = freshClaudeRuntime();
   rt.wireClaudeRuntimeDeps({ getActualPort: () => 4444 });


### PR DESCRIPTION
An agent writes a working file, reads it back a step later, and the read raised an outside-the-workspace approval card for a file the agent had created itself seconds earlier. The card was right. Putting the file there was the mistake, and the promise being broken is the one that matters most to someone who is not a programmer: your agents stay in your files.

**The approval button could never have fixed it.** A grant covers the directory of the file it was granted for, so it covers one project's scratch folder and nothing above it, and the temp root differs between sessions anyway. The result was one dead grant per project per session, in a list nothing prunes, and a user learning to click Allow without reading. A prompt that fires on routine, unavoidable, harmless work is worse than no prompt, because it spends the attention the dangerous prompt needs.

**What changed.** Spawned agents resolve the platform temp directory to a path inside the workspace. All three names are set (`TMPDIR`, `TEMP`, `TMP`), because the platform reads a different one per operating system, and setting only the one this machine uses would leave the others writing outside with nothing to catch it.

This holds the boundary **by construction rather than by convention**: it covers tools and skills this project never wrote, because they ask the platform rather than reading guidance.

With no workspace set the platform default is left alone. Redirecting to a path built from an empty workspace would scatter files unpredictably rather than contain them.

Scratch from earlier runs is cleared at startup, bounded by age rather than emptied outright, so a second window on the same workspace cannot delete files the first is still using. The directory sits inside the one the scaffold already gitignores.

**The tests state the guarantee, not the mechanism:** writing scratch and reading it back both classify as inside the workspace, so neither prompts, with a counterpart asserting the OS temp directory still would. That pairing shows the change is about where the file is, not about scratch files being special.