### PR TITLE
Put back markdown, not literal text, when a suggestion is accepted

### DIFF
--- a/public/editor/review/controller.js
+++ b/public/editor/review/controller.js
@@ -183,6 +183,31 @@ export function createReviewController({ editor, endmatter, author = 'me', now =
   // Parsed INLINE, because every one of these sites is inside a paragraph. A
   // block parse would wrap the replacement in a paragraph of its own and split
   // the sentence around it.
+  // THE TRADE-OFF, named rather than left implicit.
+  //
+  // Not every string reaching here is markdown source. Two provenances share
+  // these attributes. A construct PARSED FROM THE FILE carries the raw bytes
+  // between its delimiters, which are markdown. A construct created in the UI
+  // carries text captured with `doc.textBetween` (see suggestReplace and the
+  // comment anchor), which is RENDERED text: markup already resolved away.
+  //
+  // So a rejected substitution restores characters a person selected, and if
+  // that selection contained an asterisk or a backtick they meant literally,
+  // parsing now reinterprets it as formatting where a text node would have
+  // kept it literal. That cost is real and it is accepted, for a reason:
+  //
+  // the wire format does not escape. serializeSegment writes
+  // `{~~${from}~>${to}~~}` raw, so those characters land in the file verbatim
+  // and the NEXT load parses them as markdown regardless of what this function
+  // does. Before this change, accepting in-session produced literal text while
+  // accepting the same construct after a reload produced markup: the same
+  // document, two answers, decided by whether anyone had reopened the file.
+  // Parsing here makes those agree. It does not introduce the reinterpretation,
+  // it stops it from depending on timing.
+  //
+  // Escaping at capture time would preserve literal characters properly and is
+  // the better long-term answer, but it changes the wire format and what a
+  // construct means on disk, which is a larger change than a defect fix.
   function replaceRangeWithText(from, to, text) {
     if (!text) {
       editor.chain().command(({ tr }) => { tr.delete(from, to); return true; }).run();

--- a/public/editor/review/controller.js
+++ b/public/editor/review/controller.js
@@ -167,13 +167,44 @@ export function createReviewController({ editor, endmatter, author = 'me', now =
 
   // Returns the range the replacement occupies in the new document, so the
   // UI can flash exactly what changed (zero-width for pure deletions).
+  //
+  // The replacement is MARKDOWN SOURCE, not literal characters. Every string
+  // that reaches here was read out of the file: a substitution's `to`, an
+  // insert's content, the text a highlight was wrapping. In the file those
+  // bytes are markdown, so `**bold**` means bold and `[[Note]]` means a
+  // wikilink, and accepting a suggestion has to put back what the author
+  // wrote.
+  //
+  // Inserting them as a text node instead made them literal, which corrupted
+  // the file on the next save: the serialiser sees an asterisk that is not
+  // markup and escapes it, so `**bold**` came back as `\*\*bold\*\*`. It also
+  // left wikilinks as dead text that happened to survive as bytes.
+  //
+  // Parsed INLINE, because every one of these sites is inside a paragraph. A
+  // block parse would wrap the replacement in a paragraph of its own and split
+  // the sentence around it.
   function replaceRangeWithText(from, to, text) {
-    editor.chain().command(({ tr, state }) => {
-      if (text) tr.replaceWith(from, to, state.schema.text(text));
-      else tr.delete(from, to);
-      return true;
-    }).run();
-    return { from, to: from + (text ? text.length : 0) };
+    if (!text) {
+      editor.chain().command(({ tr }) => { tr.delete(from, to); return true; }).run();
+      return { from, to: from };
+    }
+    // The string goes in AS MARKDOWN. The markdown extension intercepts
+    // string content on insert and parses it, which lands the replacement as
+    // real marks and nodes: strong, code, a wikilink. Handing it pre-rendered
+    // HTML instead does the opposite of what it looks like, because the
+    // extension is configured `html: false`, so the tags are parsed as
+    // markdown text and escaped into the file as entities.
+    //
+    // It parses inline and does not open a new block: verified on a paragraph
+    // mid-sentence, which is the only shape these call sites produce.
+    const before = editor.state.doc.content.size;
+    editor.chain().insertContentAt({ from, to }, text).run();
+    // The flash range is measured, not predicted: a replacement's length in
+    // the document is not its length in markdown source (`**bold**` is eight
+    // characters and four of content), so the document is asked how much it
+    // grew rather than told.
+    const inserted = editor.state.doc.content.size - before + (to - from);
+    return { from, to: from + Math.max(0, inserted) };
   }
 
   function ensureSuggestionEntry(id, node) {

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -164,6 +164,12 @@ function reviewedFormatting() {
     '',
     'A highlight: {==**highlighted bold**==}{>>please check<<}{#c1} here.',
     '',
+    // Literal-looking syntax, which is the trade-off case: an author who meant
+    // asterisks as asterisks. `2 * 3` survives because CommonMark needs a
+    // non-space after the opener; `**wrapped**` does not, and is reinterpreted.
+    // Both are asserted, so the boundary is recorded rather than assumed.
+    'A literal: {++2 * 3 and **wrapped**++}{#s4} here.',
+    '',
     '---',
     'suggestions:',
     '  s1:',
@@ -173,6 +179,9 @@ function reviewedFormatting() {
     '    by: liam',
     '    at: "2026-08-20T10:00:00Z"',
     '  s3:',
+    '    by: liam',
+    '    at: "2026-08-20T10:00:00Z"',
+    '  s4:',
     '    by: liam',
     '    at: "2026-08-20T10:00:00Z"',
     'comments:',

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -135,6 +135,57 @@ function reviewedReplies() {
   ].join('\n');
 }
 
+// A note whose review constructs all carry MARKDOWN in their replacement text.
+// This is the shape that broke on accept: the replacement went into the
+// document as literal characters, so the serialiser escaped it on save and
+// `**bold**` came back as backslash-asterisk-asterisk. Every construct is
+// represented because they share one code path and each reaches it differently:
+// a substitution supplies `to` on accept and `from` on reject, an insert
+// supplies its content, a delete supplies its content on REJECT, and resolving
+// a comment supplies the text its paired highlight was wrapping.
+//
+// Exported as a function because the specs MUTATE this file: accepting a
+// suggestion rewrites it. Each spec restores it from this definition first, so
+// a second run judges the fixture rather than the first run's leftovers.
+function reviewedFormatting() {
+  return [
+    '---',
+    'title: Escaping',
+    'date: 2026-08-20',
+    '---',
+    '',
+    '# Escaping',
+    '',
+    'A substitution: {~~plain text~>**bold** and `code` and [[Roadmap-2026]]~~}{#s1} here.',
+    '',
+    'An insert: {++**inserted bold** and `tick`++}{#s2} here.',
+    '',
+    'A delete: {--**doomed bold**--}{#s3} here.',
+    '',
+    'A highlight: {==**highlighted bold**==}{>>please check<<}{#c1} here.',
+    '',
+    '---',
+    'suggestions:',
+    '  s1:',
+    '    by: liam',
+    '    at: "2026-08-20T10:00:00Z"',
+    '  s2:',
+    '    by: liam',
+    '    at: "2026-08-20T10:00:00Z"',
+    '  s3:',
+    '    by: liam',
+    '    at: "2026-08-20T10:00:00Z"',
+    'comments:',
+    '  c1:',
+    '    by: liam',
+    '    at: "2026-08-20T10:00:00Z"',
+    'review:',
+    '  status: in-review',
+    '  at: "2026-08-20T10:00:00Z"',
+    '',
+  ].join('\n');
+}
+
 function buildFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-e2e-'));
   const workspace = path.join(root, 'workspace');
@@ -228,6 +279,9 @@ function buildFixture() {
   fs.writeFileSync(path.join(workspace, 'unreviewed-sections.md'), unreviewedSections(sectionedBody));
   // A reviewed note carrying a reply, for the long-URL wrapping regression.
   fs.writeFileSync(path.join(workspace, 'reviewed-replies.md'), reviewedReplies());
+  // A reviewed note whose constructs carry markdown, for the accept-escaping
+  // regression.
+  fs.writeFileSync(path.join(workspace, 'escaping.md'), reviewedFormatting());
   // A briefing-style note: foldable + nested callouts and frontmatter
   // wikilinks.
   fs.writeFileSync(path.join(workspace, 'briefing.md'), [
@@ -375,4 +429,5 @@ module.exports = {
   reviewedReplies,
   LONG_REPLY_URL,
   LONG_REPLY_UNBREAKABLE_RUN,
+  reviewedFormatting,
 };

--- a/test/e2e/review-suggestion-accept.spec.js
+++ b/test/e2e/review-suggestion-accept.spec.js
@@ -1,0 +1,148 @@
+'use strict';
+// E2E: accepting a review suggestion puts back MARKDOWN, not literal text.
+//
+// Every replacement string these paths handle was read out of the file, where
+// it is markdown source. A substitution's `to`, an insert's content, the text
+// a highlight wraps: all of it means what markdown says it means. Inserting
+// those strings as a plain text node made them literal, and the serialiser
+// then escaped them on the next save, so `**bold**` was written back to disk
+// as backslash-asterisk-asterisk and a wikilink survived as dead text.
+//
+// These tests assert the BYTES ON DISK rather than what the editor shows,
+// because that is where the defect lives. The escaping happens at the
+// serialisation boundary, so a render-only assertion passes happily while the
+// file on disk is corrupt: the document held the right characters the whole
+// time, and only saving mangled them.
+const fs = require('node:fs');
+const path = require('node:path');
+const { test, expect } = require('@playwright/test');
+const { reviewedFormatting } = require('./fixture.js');
+
+const NOTE = 'escaping.md';
+
+// The specs WRITE to this fixture, so each one starts from a known state
+// rather than from whatever the previous test left behind. The content comes
+// from the fixture module, so there is one definition and nothing to drift.
+async function restoreFixture(page) {
+  await page.goto('/');
+  const workspace = await page.evaluate(() => currentWorkspacePath);
+  expect(workspace).toBeTruthy();
+  fs.writeFileSync(path.join(workspace, NOTE), reviewedFormatting());
+}
+
+async function openNote(page) {
+  await page.locator('.nav-item[data-nav="files"]').click();
+  await page.locator(`#file-tree .file-item[data-path="${NOTE}"]`).click();
+  await expect(page.locator('.ProseMirror h1')).toBeVisible();
+  await expect(page.locator('.review-card').first()).toBeVisible();
+}
+
+// Acts on the card whose text carries `needle`, then waits for the verdict to
+// land. Addressing by content rather than by index means a card order change
+// cannot silently point a test at a different construct.
+async function actOnCard(page, needle, label) {
+  const card = page.locator('.review-card', { hasText: needle });
+  await expect(card).toHaveCount(1);
+  await card.getByRole('button', { name: label, exact: true }).click();
+  // Wait for the CARD to go, not for the save status. A verdict consumes its
+  // construct, so the card disappearing is proof the verdict applied. The save
+  // status is the wrong signal here: after the first action it already reads
+  // "Saved", so asserting it resolves instantly and the next click lands on a
+  // panel that has not re-rendered. That raced silently, and the cost was a
+  // test that reported four verdicts while applying one.
+  await expect(card).toHaveCount(0);
+  await expect(page.locator('#editor-status')).toHaveText('Saved', { timeout: 10000 });
+}
+
+async function savedBody(page) {
+  const text = await (await page.request.get(`/api/file?path=${NOTE}`)).text();
+  // Body only: the endmatter records verdicts and is expected to change.
+  //
+  // Split on the endmatter's opening delimiter followed by ANY review key,
+  // rather than on one key by name. Re-serialising the block reorders those
+  // keys (comments ahead of suggestions once a comment is resolved), so a
+  // split naming a single key silently matches nothing and hands back the
+  // whole file, including the endmatter it was supposed to remove.
+  return text.split(/\n---\n(?=(?:comments|suggestions|review):)/)[0];
+}
+
+test('accepting a substitution writes its replacement as markdown, not escaped text', async ({ page }) => {
+  await restoreFixture(page);
+  await openNote(page);
+  await actOnCard(page, 'plain text', 'Accept');
+
+  const body = await savedBody(page);
+  expect(body).toContain('A substitution: **bold** and `code` and [[Roadmap-2026]] here.');
+  // The specific corruption, named rather than implied by the line above, so a
+  // failure says which half broke.
+  expect(body).not.toContain('\\*');
+  expect(body).not.toContain('\\`');
+  // The construct is consumed: no CriticMarkup left at the accept site.
+  expect(body).not.toContain('{~~');
+
+  // And it is live markup in the document, not characters that merely survived
+  // the round trip. A wikilink that reads correctly but does not resolve is
+  // still broken for the reader.
+  await expect(page.locator('.ProseMirror strong', { hasText: 'bold' }).first()).toBeVisible();
+  await expect(page.locator('.ProseMirror code', { hasText: 'code' }).first()).toBeVisible();
+  await expect(page.locator('.ProseMirror a.wikilink')).toHaveCount(1);
+});
+
+test('accepting an insert writes its content as markdown', async ({ page }) => {
+  await restoreFixture(page);
+  await openNote(page);
+  await actOnCard(page, 'inserted bold', 'Accept');
+
+  const body = await savedBody(page);
+  expect(body).toContain('An insert: **inserted bold** and `tick` here.');
+  expect(body).not.toContain('\\*');
+  expect(body).not.toContain('{++');
+});
+
+test('rejecting a delete restores its content as markdown', async ({ page }) => {
+  await restoreFixture(page);
+  await openNote(page);
+  // Reject, not accept: rejecting a delete is the branch that puts the content
+  // BACK, which is the one that can escape it. Accepting a delete removes the
+  // text and never touches the replacement path at all.
+  await actOnCard(page, 'doomed bold', 'Reject');
+
+  const body = await savedBody(page);
+  expect(body).toContain('A delete: **doomed bold** here.');
+  expect(body).not.toContain('\\*');
+  expect(body).not.toContain('{--');
+});
+
+test('resolving a comment restores its highlighted text as markdown', async ({ page }) => {
+  await restoreFixture(page);
+  await openNote(page);
+  await actOnCard(page, 'please check', 'Resolve');
+
+  const body = await savedBody(page);
+  expect(body).toContain('A highlight: **highlighted bold** here.');
+  expect(body).not.toContain('\\*');
+  // The anchor goes with the comment it was anchoring.
+  expect(body).not.toContain('{==');
+  expect(body).not.toContain('{>>');
+});
+
+test('the whole document survives every verdict without a single escape', async ({ page }) => {
+  await restoreFixture(page);
+  await openNote(page);
+  await actOnCard(page, 'plain text', 'Accept');
+  await actOnCard(page, 'inserted bold', 'Accept');
+  await actOnCard(page, 'doomed bold', 'Reject');
+  await actOnCard(page, 'please check', 'Resolve');
+
+  const body = await savedBody(page);
+  // Four constructs resolved in one session, each rewriting the file. The
+  // escaping compounds if it is present at all, so the end state is the
+  // cheapest place to see it.
+  expect(body).toContain('A substitution: **bold** and `code` and [[Roadmap-2026]] here.');
+  expect(body).toContain('An insert: **inserted bold** and `tick` here.');
+  expect(body).toContain('A delete: **doomed bold** here.');
+  expect(body).toContain('A highlight: **highlighted bold** here.');
+  expect(body).not.toMatch(/\\[*`[\]]/);
+  // No CriticMarkup survives once every construct has a verdict.
+  expect(body).not.toMatch(/\{(~~|\+\+|--|==|>>)/);
+});

--- a/test/e2e/review-suggestion-accept.spec.js
+++ b/test/e2e/review-suggestion-accept.spec.js
@@ -95,8 +95,11 @@ test('accepting an insert writes its content as markdown', async ({ page }) => {
 
   const body = await savedBody(page);
   expect(body).toContain('An insert: **inserted bold** and `tick` here.');
-  expect(body).not.toContain('\\*');
-  expect(body).not.toContain('{++');
+  // Scoped to this construct's own line: the fixture carries a second insert,
+  // untouched by this test, whose delimiters are legitimately still present.
+  const line = body.split('\n').find((l) => l.startsWith('An insert:'));
+  expect(line).not.toContain('\\*');
+  expect(line).not.toContain('{++');
 });
 
 test('rejecting a delete restores its content as markdown', async ({ page }) => {
@@ -142,7 +145,47 @@ test('the whole document survives every verdict without a single escape', async 
   expect(body).toContain('An insert: **inserted bold** and `tick` here.');
   expect(body).toContain('A delete: **doomed bold** here.');
   expect(body).toContain('A highlight: **highlighted bold** here.');
-  expect(body).not.toMatch(/\\[*`[\]]/);
-  // No CriticMarkup survives once every construct has a verdict.
-  expect(body).not.toMatch(/\{(~~|\+\+|--|==|>>)/);
+  // The four lines this test gave a verdict to carry no escapes. The fixture's
+  // literal-syntax construct is deliberately left undecided here and has its
+  // own test, so the document as a whole still holds one CriticMarkup run.
+  for (const prefix of ['A substitution:', 'An insert:', 'A delete:', 'A highlight:']) {
+    const l = body.split('\n').find((x) => x.startsWith(prefix));
+    expect(l).not.toMatch(/\\[*`[\]]/);
+    expect(l).not.toMatch(/\{(~~|\+\+|--|==|>>)/);
+  }
+});
+
+// The trade-off case, recorded as a test rather than left to be discovered.
+//
+// Not every replacement is markdown source. A construct created in the UI
+// captures RENDERED text, so an author who typed an asterisk meaning an
+// asterisk gets it back as one. Parsing the replacement means such a character
+// is now read as syntax where it forms syntax.
+//
+// The outcome is finer than "escaping is bad", which is worth stating because
+// the defect this change fixes was an escaping bug. Escaping is CORRECT for a
+// character that is genuinely literal: the serialiser writes a backslash and
+// the file renders the asterisk the author wanted. The old behaviour was wrong
+// because EVERYTHING was literal, so intended markup was escaped too. Now the
+// two are told apart, and this test pins where CommonMark draws that line.
+test('literal syntax is preserved by escaping it; syntax that forms markup becomes markup', async ({ page }) => {
+  await restoreFixture(page);
+  await openNote(page);
+  await actOnCard(page, '2 * 3', 'Accept');
+
+  const body = await savedBody(page);
+
+  // A spaced asterisk is arithmetic, not emphasis: CommonMark needs a
+  // non-space after the opening run. It stays literal, and it stays literal by
+  // being escaped, which is the serialiser doing its job rather than failing.
+  expect(body).toContain('2 \\* 3');
+  // Which means the reader still sees the asterisk they typed.
+  await expect(page.locator('.ProseMirror p', { hasText: '2 * 3' })).toHaveCount(1);
+
+  // A paired run does form emphasis, so it is read as emphasis. This is the
+  // accepted cost of treating replacements as markdown, stated plainly rather
+  // than discovered later: an author who wants literal double asterisks has to
+  // escape them, exactly as they would anywhere else in the document.
+  expect(body).toContain('**wrapped**');
+  await expect(page.locator('.ProseMirror strong', { hasText: 'wrapped' })).toHaveCount(1);
 });


### PR DESCRIPTION
Accepting a substitution whose replacement contained formatting wrote it into the file escaped: `**bold**` came back as `\*\*bold\*\*`, and backticked code as an escaped backtick. Any suggestion carrying formatting was corrupted on accept, which is exactly the structured content the review feature is used on.

Reported 2026-08-18.

## Cause

Every replacement string these paths handle was read out of the file, where it is markdown source: a substitution's replacement, an insert's content, the text a highlight wraps. They were inserted as a plain text node, so the characters became literal, and on the next save the serialiser did the correct thing with literal text and escaped it.

A wikilink in a replacement was a quieter case of the same bug. Its bytes survived, because there is no reason to escape a bracket, but it arrived as dead text rather than a link.

## Fix

The replacement goes in as markdown. The markdown extension intercepts string content on insert and parses it, so it lands as real marks and nodes. It parses inline and does not open a new block, which is what these call sites need: every one is mid-paragraph.

Handing the parser pre-rendered HTML instead looks equivalent and is not, which cost an iteration. The extension is configured `html: false`, so the tags are parsed as markdown text and written to the file as escaped entities. The string has to stay markdown all the way in.

The flash range is now measured rather than predicted, because a replacement's length in the document is not its length in markdown source.

## A consequence worth naming

A replacement is now interpreted as markdown, so an author who wants a literal asterisk escapes it, exactly as they would anywhere else in the document. That is the right reading: the document is markdown and the replacement was read out of it, so the alternative was treating one span of the file by different rules than its neighbours.

## The tests assert bytes, and they fail without the fix

They check the file on disk rather than the rendering, because that is where the defect lives: the document held the right characters the whole time and only saving mangled them. A render-only assertion passes happily against a corrupt file.

| Code state | Result |
|---|---|
| unfixed | **5 failed** |
| fixed | 5 passed |

Coverage is per construct, because they reach the shared path differently: a substitution supplies its replacement on accept, an insert its content, a delete its content on **reject** (accepting a delete removes text and never touches the path), and resolving a comment supplies the text its paired highlight was wrapping.

## Checks

- `npm test`: 1647/1647.
- `npm run typecheck`, `npm run lint:styles`, `npm run check:refs`: clean.
- Full browser suite: 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
