### PR TITLE
Script the pre-commit sequence so it cannot be skipped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ scripts/screenshots/.banned-tokens.json
 # the form a reader can actually use: the pull request states the verdict, the
 # models and what was judged, in prose.
 .independent-review/
+
+# Local pre-commit gate record: names the tree the checks passed on.
+.precommit-gate.json

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "release": "node scripts/release.js",
     "test:e2e": "playwright test",
     "check:refs": "node scripts/check-internal-refs.js",
+    "precommit": "node scripts/precommit-gate.js",
     "lint:styles": "node test/tools/style-drift.js",
     "typecheck": "tsc -p tsconfig.server.json && tsc -p tsconfig.client.json",
     "screenshots": "node scripts/screenshots/run.mjs",

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -6,3 +6,9 @@ node scripts/check-internal-refs.js || {
   echo "commit blocked: reword the internal references above, then commit again." >&2
   exit 1
 }
+
+# The four steps that three errors in 0.11.7 died at, and a fourth after them:
+# verify the branch, run the checks, read the result, commit. Doing them by
+# habit worked until the work stopped being easy. CI still runs the same checks
+# on every pull request and remains the line that actually holds.
+node scripts/precommit-gate.js --verify || exit 1

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -41,7 +41,13 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const ROOT = path.resolve(__dirname, '..');
+// The repository this acts on. Overridable ONLY so the entry points can be
+// exercised against a throwaway repository: without it, run() and verify()
+// can only ever touch the real checkout, so the wiring around the decision
+// function is untestable and a swapped field would pass every test.
+const ROOT = process.env.PRECOMMIT_GATE_ROOT
+  ? path.resolve(process.env.PRECOMMIT_GATE_ROOT)
+  : path.resolve(__dirname, '..');
 const RECORD = path.join(ROOT, '.precommit-gate.json');
 
 // The checks that belong on a commit: fast, deterministic, and the ones whose
@@ -126,7 +132,7 @@ function refusal({ record, tree, branch, mainBranch }) {
 }
 
 function run() {
-  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const branch = git(['branch', '--show-current']);
   const mainBranch = defaultBranch();
   if (branch === mainBranch) {
     console.error(`[precommit] refusing to run on ${mainBranch}: branch first, then run this again.`);
@@ -164,7 +170,7 @@ function run() {
 }
 
 function verify() {
-  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const branch = git(['branch', '--show-current']);
   const why = refusal({ record: readRecord(), tree: currentTree(), branch, mainBranch: defaultBranch() });
   if (why) {
     console.error(`[precommit] commit blocked: ${why.message}`);

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -85,6 +85,31 @@ function currentTree(root = ROOT) {
   return git(['write-tree'], root);
 }
 
+/**
+ * Content the checks would read but the record would not name.
+ *
+ * The checks run against the WORKING DIRECTORY; the record hashes the INDEX.
+ * Those are the same tree only while nothing is unstaged. Stage a file, edit it
+ * again without staging, and the checks validate the newer content while the
+ * record names the older staged tree. `git commit` then commits the index, and
+ * verify() admits it, because the index has not moved. The gate would have
+ * certified a tree it never checked, which is the exact guarantee it exists to
+ * provide.
+ *
+ * So refuse when they diverge rather than hashing one and testing the other.
+ * Untracked files count: a new test file the checks would happily run is not in
+ * the index and would not be in the record.
+ *
+ * Returns the offending paths, empty when the two agree.
+ */
+function workingTreeDrift(root = ROOT) {
+  const lines = git(['status', '--porcelain'], root).split('\n').filter(Boolean);
+  return lines
+    // Column two is the working tree against the index; '??' is untracked.
+    .filter(line => line.startsWith('??') || (line[1] && line[1] !== ' '))
+    .map(line => line.slice(3));
+}
+
 function readRecord(file = RECORD) {
   if (!fs.existsSync(file)) return null;
   try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
@@ -139,6 +164,15 @@ function run() {
     process.exit(1);
   }
 
+  const drift = workingTreeDrift();
+  if (drift.length) {
+    console.error('[precommit] refusing: the working tree does not match what is staged, so the checks');
+    console.error('           would read one tree and the record would name another. Stage or stash:');
+    for (const file of drift.slice(0, 10)) console.error(`             ${file}`);
+    if (drift.length > 10) console.error(`             ...and ${drift.length - 10} more`);
+    process.exit(1);
+  }
+
   for (const step of STEPS) {
     process.stdout.write(`[precommit] ${step.name}... `);
     try {
@@ -183,4 +217,4 @@ if (require.main === module) {
   else run();
 }
 
-module.exports = { refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, RECORD, STEPS };
+module.exports = { refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, workingTreeDrift, RECORD, STEPS };

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Pre-commit gate: the four steps, as a command rather than a habit.
+ *
+ * Three errors in the 0.11.7 run died at the same four steps: verify the
+ * branch, run the checks, read the result, commit. A fourth followed the same
+ * week, a pull request pushed without the unit suite having been run, with CI
+ * going red on a failure thirty seconds locally would have caught. Doing them
+ * by hand worked for thirty-four merges and stopped working once the work had
+ * no instruments of its own. A habit that holds only while the work is easy is
+ * not a control.
+ *
+ * The shape is borrowed rather than invented. `scripts/release-gate.js` solves
+ * this one level up: run the gauntlet, write a record stamped with the SHA it
+ * passed on, and refuse to tag unless the record matches the exact current
+ * HEAD. This is the same contract for the per-commit checks.
+ *
+ * WHAT IDENTIFIES THE TREE. The record names the hash `git write-tree`
+ * produces for the current index, which is the exact content a commit would
+ * capture. A working-directory timestamp would not do: it cannot tell a passing
+ * tree from the same tree with one more edit staged on top, which is the case
+ * the guard exists for.
+ *
+ * Usage, and the order matters:
+ *   git add -A                 # stage first: the record names the STAGED tree
+ *   npm run precommit          # run the checks, write the record
+ *   git commit                 # the hook refuses unless the record matches
+ *
+ * Running the checks before staging records the tree as it was, which the hook
+ * then correctly rejects as stale. That is the guard working rather than
+ * misfiring: what was checked is not what would go in.
+ *
+ * This is a local convenience and not the enforcement. CI runs the same checks
+ * on every pull request and is the line that actually holds; a developer who
+ * has not installed the hooks is not bypassing anything that protects main.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const RECORD = path.join(ROOT, '.precommit-gate.json');
+
+// The checks that belong on a commit: fast, deterministic, and the ones whose
+// absence has actually cost a red pipeline. The browser suite and the live
+// smoke stay in the release gate, where their cost is affordable.
+const STEPS = [
+  { name: 'test', args: ['test'] },
+  { name: 'typecheck', args: ['run', 'typecheck'] },
+  { name: 'lint:styles', args: ['run', 'lint:styles'] },
+  { name: 'check:refs', args: ['run', 'check:refs'] },
+];
+
+function git(args) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' }).trim();
+}
+
+/** The default branch, read from the remote rather than assumed to be `main`. */
+function defaultBranch() {
+  try {
+    return git(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']).replace(/^origin\//, '');
+  } catch {
+    return 'main';
+  }
+}
+
+/**
+ * The hash of the tree a commit would capture right now.
+ *
+ * `write-tree` requires the index to be current, so refresh it first: without
+ * that, a file touched but unchanged can report as modified and produce a
+ * different hash for identical content.
+ */
+function currentTree() {
+  try { execFileSync('git', ['update-index', '-q', '--refresh'], { cwd: ROOT, stdio: 'ignore' }); } catch { /* refresh is best effort */ }
+  return git(['write-tree']);
+}
+
+function readRecord() {
+  if (!fs.existsSync(RECORD)) return null;
+  try { return JSON.parse(fs.readFileSync(RECORD, 'utf8')); } catch { return null; }
+}
+
+/**
+ * Why a commit may not proceed, or null when it may.
+ *
+ * Returns a reason CODE alongside the message. The code is what tests assert
+ * on: a guard that refuses for the wrong reason is a guard that will refuse
+ * for no reason later, and "it failed" is not enough to tell those apart.
+ */
+function refusal({ record, tree, branch, mainBranch }) {
+  const rerun = 'Run `npm run precommit`, then commit again.';
+  if (branch === mainBranch) {
+    return { code: 'on-default-branch', message: `refusing to commit directly to ${mainBranch}. Branch first.` };
+  }
+  if (!record) {
+    return { code: 'no-record', message: `the checks have not been run against this tree. ${rerun}` };
+  }
+  if (record.branch !== branch) {
+    return { code: 'wrong-branch', message: `the record is for branch "${record.branch}" but you are on "${branch}". ${rerun}` };
+  }
+  if (record.tree !== tree) {
+    return { code: 'stale-record', message: `the record is for a different tree, so something changed after the checks ran. ${rerun}` };
+  }
+  return null;
+}
+
+function run() {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const mainBranch = defaultBranch();
+  if (branch === mainBranch) {
+    console.error(`[precommit] refusing to run on ${mainBranch}: branch first, then run this again.`);
+    process.exit(1);
+  }
+
+  for (const step of STEPS) {
+    process.stdout.write(`[precommit] ${step.name}... `);
+    try {
+      execFileSync('npm', step.args, { cwd: ROOT, stdio: ['ignore', 'ignore', 'pipe'] });
+      console.log('ok');
+    } catch (err) {
+      console.log('FAILED');
+      const detail = err.stderr ? String(err.stderr).trim().split('\n').slice(-12).join('\n') : '';
+      if (detail) console.error(detail);
+      console.error(`[precommit] ${step.name} failed. No record written, so the commit stays blocked.`);
+      process.exit(1);
+    }
+  }
+
+  // Written only after every step passed, so the record's existence IS the
+  // result being read. There is no separate "did you look at it" step to skip.
+  const record = { tree: currentTree(), branch, at: new Date().toISOString(), steps: STEPS.map(s => s.name) };
+  fs.writeFileSync(RECORD, JSON.stringify(record, null, 2) + '\n');
+  console.log(`[precommit] PASS. Record written for tree ${record.tree.slice(0, 12)} on ${branch}.`);
+}
+
+function verify() {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const why = refusal({ record: readRecord(), tree: currentTree(), branch, mainBranch: defaultBranch() });
+  if (why) {
+    console.error(`[precommit] commit blocked: ${why.message}`);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  if (process.argv.includes('--verify')) verify();
+  else run();
+}
+
+module.exports = { refusal, RECORD };

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -54,14 +54,14 @@ const STEPS = [
   { name: 'check:refs', args: ['run', 'check:refs'] },
 ];
 
-function git(args) {
-  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' }).trim();
+function git(args, root = ROOT) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
 }
 
 /** The default branch, read from the remote rather than assumed to be `main`. */
-function defaultBranch() {
+function defaultBranch(root = ROOT) {
   try {
-    return git(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']).replace(/^origin\//, '');
+    return git(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], root).replace(/^origin\//, '');
   } catch {
     return 'main';
   }
@@ -74,14 +74,31 @@ function defaultBranch() {
  * that, a file touched but unchanged can report as modified and produce a
  * different hash for identical content.
  */
-function currentTree() {
-  try { execFileSync('git', ['update-index', '-q', '--refresh'], { cwd: ROOT, stdio: 'ignore' }); } catch { /* refresh is best effort */ }
-  return git(['write-tree']);
+function currentTree(root = ROOT) {
+  try { execFileSync('git', ['update-index', '-q', '--refresh'], { cwd: root, stdio: 'ignore' }); } catch { /* refresh is best effort */ }
+  return git(['write-tree'], root);
 }
 
-function readRecord() {
-  if (!fs.existsSync(RECORD)) return null;
-  try { return JSON.parse(fs.readFileSync(RECORD, 'utf8')); } catch { return null; }
+function readRecord(file = RECORD) {
+  if (!fs.existsSync(file)) return null;
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+/**
+ * The record, written by the one path that writes it.
+ *
+ * Extracted so tests exercise the SAME writer the gate uses. A test that
+ * hand-builds the JSON proves the reader can read the test's idea of a record,
+ * which is not the claim: a field renamed on one side only would leave such a
+ * test green while the guard silently stopped matching anything.
+ */
+function writeRecord(record, file = RECORD) {
+  fs.writeFileSync(file, JSON.stringify(record, null, 2) + '\n');
+}
+
+/** The record `run()` would write for this tree and branch. */
+function buildRecord({ tree, branch, at }) {
+  return { tree, branch, at, steps: STEPS.map(s => s.name) };
 }
 
 /**
@@ -119,12 +136,21 @@ function run() {
   for (const step of STEPS) {
     process.stdout.write(`[precommit] ${step.name}... `);
     try {
-      execFileSync('npm', step.args, { cwd: ROOT, stdio: ['ignore', 'ignore', 'pipe'] });
+      execFileSync('npm', step.args, { cwd: ROOT, stdio: ['ignore', 'pipe', 'pipe'] });
       console.log('ok');
     } catch (err) {
       console.log('FAILED');
-      const detail = err.stderr ? String(err.stderr).trim().split('\n').slice(-12).join('\n') : '';
-      if (detail) console.error(detail);
+      // BOTH streams. The node test runner writes which test failed and why to
+      // STDOUT, and tsc writes its diagnostics there too; stderr carries only
+      // npm's "lifecycle script failed" boilerplate. Capturing stderr alone
+      // left the developer with a bare "test failed" and nothing to act on,
+      // which removes the read-the-result step on the one path where reading
+      // the result is the entire point.
+      const detail = [err.stdout, err.stderr]
+        .map(stream => (stream ? String(stream).trim() : ''))
+        .filter(Boolean)
+        .join('\n');
+      if (detail) console.error(detail.split('\n').slice(-25).join('\n'));
       console.error(`[precommit] ${step.name} failed. No record written, so the commit stays blocked.`);
       process.exit(1);
     }
@@ -132,8 +158,8 @@ function run() {
 
   // Written only after every step passed, so the record's existence IS the
   // result being read. There is no separate "did you look at it" step to skip.
-  const record = { tree: currentTree(), branch, at: new Date().toISOString(), steps: STEPS.map(s => s.name) };
-  fs.writeFileSync(RECORD, JSON.stringify(record, null, 2) + '\n');
+  const record = buildRecord({ tree: currentTree(), branch, at: new Date().toISOString() });
+  writeRecord(record);
   console.log(`[precommit] PASS. Record written for tree ${record.tree.slice(0, 12)} on ${branch}.`);
 }
 
@@ -151,4 +177,4 @@ if (require.main === module) {
   else run();
 }
 
-module.exports = { refusal, RECORD };
+module.exports = { refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, RECORD, STEPS };

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -17,7 +17,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const {
-  refusal, buildRecord, writeRecord, readRecord, currentTree,
+  refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch,
 } = require('../../scripts/precommit-gate.js');
 
 const TREE = 'a'.repeat(40);
@@ -321,6 +321,42 @@ describe('the tree that was checked is the tree that gets recorded', () => {
       const { code, out } = spawnGate(['--verify'], dir);
       assert.notStrictEqual(code, 0);
       assert.match(out, /is for branch "fix\/card"/, 'the refusal names the branch the record belongs to');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the default branch is read from the remote, not assumed', () => {
+  // Every other repository here is a bare `git init` with no origin, so only
+  // the catch-fallback ran and the remote-reading line was dead to the suite:
+  // replacing it with `return 'main'` would have left every test passing. A
+  // project whose default branch is not called main would have been told to
+  // "branch first" while already on a branch, or worse, allowed to commit
+  // straight to its trunk.
+  test('a remote HEAD pointing at trunk resolves to trunk, not main', () => {
+    const { dir, run } = tempRepo();
+    try {
+      run('commit', '-q', '-m', 'initial');
+      // A remote that exists locally is enough: the lookup reads the
+      // remote-tracking ref, and never talks to a server.
+      run('remote', 'add', 'origin', dir);
+      run('update-ref', 'refs/remotes/origin/trunk', 'HEAD');
+      run('symbolic-ref', 'refs/remotes/origin/HEAD', 'refs/remotes/origin/trunk');
+
+      assert.strictEqual(defaultBranch(dir), 'trunk',
+        'the remote HEAD is read, and the origin/ prefix stripped');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('with no remote at all it falls back to main', () => {
+    // The other half, kept explicit so the fallback is a stated behaviour
+    // rather than the only one anything ever reached.
+    const { dir } = tempRepo();
+    try {
+      assert.strictEqual(defaultBranch(dir), 'main');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -12,7 +12,13 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
-const { refusal } = require('../../scripts/precommit-gate.js');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const {
+  refusal, buildRecord, writeRecord, readRecord, currentTree,
+} = require('../../scripts/precommit-gate.js');
 
 const TREE = 'a'.repeat(40);
 const OTHER_TREE = 'b'.repeat(40);
@@ -67,6 +73,79 @@ describe('the pre-commit gate', () => {
     ];
     for (const why of cases) {
       assert.match(why.message, /npm run precommit/, `${why.code} names the command that fixes it`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The mechanism, against real git
+// ---------------------------------------------------------------------------
+
+// The tests above drive the pure decision with hand-built values, which proves
+// the decision and nothing else. The claim this guard actually rests on lives
+// in the parts that touch reality: that a record written by the gate is read
+// back as the same record, and that the tree hash MOVES when something is
+// staged on top of a checked tree. A field renamed on one side only, or a
+// write-tree taken before the index refresh, would leave every test above green
+// while the guard quietly matched nothing. So this exercises the real functions
+// against a real repository.
+function tempRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'precommit-gate-'));
+  const run = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  run('init', '-q');
+  run('config', 'user.email', 'test@example.com');
+  run('config', 'user.name', 'Test');
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'first\n');
+  run('add', '-A');
+  return { dir, run };
+}
+
+describe('the record and the tree hash, against a real repository', () => {
+  test('a record written by the gate reads back as the same record', () => {
+    const { dir } = tempRepo();
+    const file = path.join(dir, '.precommit-gate.json');
+    try {
+      const written = buildRecord({ tree: currentTree(dir), branch: 'fix/card', at: '2026-08-20T00:00:00.000Z' });
+      writeRecord(written, file);
+      assert.deepStrictEqual(readRecord(file), written);
+      // Named explicitly: these are the fields refusal() compares, and a
+      // rename on one side is the failure this test exists for.
+      assert.ok(readRecord(file).tree);
+      assert.ok(readRecord(file).branch);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('staging a further edit changes the tree, so the record goes stale', () => {
+    const { dir, run } = tempRepo();
+    try {
+      const before = currentTree(dir);
+      const record = buildRecord({ tree: before, branch: 'fix/card', at: '2026-08-20T00:00:00.000Z' });
+      // The same tree, unchanged: the gate admits it.
+      assert.strictEqual(
+        refusal({ record, tree: currentTree(dir), branch: 'fix/card', mainBranch: 'main' }),
+        null,
+      );
+
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'second\n');
+      run('add', '-A');
+      const after = currentTree(dir);
+
+      assert.notStrictEqual(after, before, 'write-tree moves when content is staged on top');
+      const why = refusal({ record, tree: after, branch: 'fix/card', mainBranch: 'main' });
+      assert.strictEqual(why.code, 'stale-record');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a missing record file reads as no record, rather than throwing', () => {
+    const { dir } = tempRepo();
+    try {
+      assert.strictEqual(readRecord(path.join(dir, 'nope.json')), null);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -149,3 +149,111 @@ describe('the record and the tree hash, against a real repository', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// The entry points, spawned for real
+// ---------------------------------------------------------------------------
+
+// Everything above tests the decision and the git primitives. Neither is what
+// npm and the git hook actually call. run() and verify() are the wiring, and
+// wiring is where a swapped field or a record read from the wrong path lives:
+// both would leave every test above green while the guard admitted anything.
+// So these spawn the real script against a throwaway repository.
+const GATE = path.join(__dirname, '..', '..', 'scripts', 'precommit-gate.js');
+
+function spawnGate(args, root) {
+  const res = require('node:child_process').spawnSync(
+    process.execPath, [GATE, ...args],
+    { env: { ...process.env, PRECOMMIT_GATE_ROOT: root }, encoding: 'utf8' },
+  );
+  return { code: res.status, out: `${res.stdout || ''}${res.stderr || ''}` };
+}
+
+function repoWithScripts(scripts) {
+  const { dir, run } = tempRepo();
+  run('checkout', '-q', '-b', 'fix/card');
+  fs.writeFileSync(path.join(dir, 'package.json'),
+    JSON.stringify({ name: 'tmp', version: '1.0.0', scripts }, null, 2));
+  run('add', '-A');
+  return { dir, run };
+}
+
+describe('the entry points, against a throwaway repository', () => {
+  test('a failing step writes no record and exits non-zero', () => {
+    // The branch that matters most: a check failed, so nothing may vouch for
+    // this tree. If the loop stopped short-circuiting, the record would be
+    // written anyway and the guard would wave through an unverified commit.
+    const { dir } = repoWithScripts({
+      test: 'node -e "process.exit(1)"',
+      typecheck: 'node -e "0"', 'lint:styles': 'node -e "0"', 'check:refs': 'node -e "0"',
+    });
+    try {
+      const { code } = spawnGate([], dir);
+      assert.notStrictEqual(code, 0, 'a failing check fails the gate');
+      assert.ok(!fs.existsSync(path.join(dir, '.precommit-gate.json')),
+        'no record is written when a step failed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('all steps passing writes a record for this tree and branch', () => {
+    const { dir } = repoWithScripts({
+      test: 'node -e "0"', typecheck: 'node -e "0"',
+      'lint:styles': 'node -e "0"', 'check:refs': 'node -e "0"',
+    });
+    try {
+      const { code } = spawnGate([], dir);
+      assert.strictEqual(code, 0);
+      const record = readRecord(path.join(dir, '.precommit-gate.json'));
+      assert.ok(record, 'a record is written');
+      assert.strictEqual(record.branch, 'fix/card');
+      assert.strictEqual(record.tree, currentTree(dir), 'and it names the tree that was checked');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--verify admits a commit when the record matches', () => {
+    const { dir } = repoWithScripts({
+      test: 'node -e "0"', typecheck: 'node -e "0"',
+      'lint:styles': 'node -e "0"', 'check:refs': 'node -e "0"',
+    });
+    try {
+      assert.strictEqual(spawnGate([], dir).code, 0, 'gate passes first');
+      assert.strictEqual(spawnGate(['--verify'], dir).code, 0, 'and the commit is admitted');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--verify refuses, and says why, when the tree moved after the checks', () => {
+    const { dir, run } = repoWithScripts({
+      test: 'node -e "0"', typecheck: 'node -e "0"',
+      'lint:styles': 'node -e "0"', 'check:refs': 'node -e "0"',
+    });
+    try {
+      assert.strictEqual(spawnGate([], dir).code, 0);
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'changed after the checks\n');
+      run('add', '-A');
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.notStrictEqual(code, 0, 'a moved tree is refused');
+      assert.match(out, /something changed after the checks ran/,
+        'and the refusal names which of the three it was');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--verify refuses when the checks have never been run', () => {
+    const { dir } = repoWithScripts({ test: 'node -e "0"' });
+    try {
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.notStrictEqual(code, 0);
+      assert.match(out, /have not been run/);
+      assert.match(out, /npm run precommit/, 'and names the command that fixes it');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -1,0 +1,72 @@
+'use strict';
+// The pre-commit gate refuses for a NAMED reason.
+//
+// Three errors in the 0.11.7 run died at the same four steps: verify the
+// branch, run the checks, read the result, commit. This turns those steps into
+// a record and a refusal.
+//
+// Every test asserts the refusal CODE, not merely that something was refused.
+// A guard that blocks for the wrong reason blocks for no reason eventually,
+// and "it failed" cannot tell those apart. That distinction is the whole
+// difference between a control and a tripwire nobody trusts.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { refusal } = require('../../scripts/precommit-gate.js');
+
+const TREE = 'a'.repeat(40);
+const OTHER_TREE = 'b'.repeat(40);
+const BRANCH = 'fix/some-card';
+const MAIN = 'main';
+
+const ok = { tree: TREE, branch: BRANCH, at: '2026-08-20T00:00:00.000Z', steps: ['test'] };
+
+describe('the pre-commit gate', () => {
+  test('admits a commit when the record matches this tree on this branch', () => {
+    const why = refusal({ record: ok, tree: TREE, branch: BRANCH, mainBranch: MAIN });
+    assert.strictEqual(why, null);
+  });
+
+  test('refuses a commit made directly to the default branch', () => {
+    // The first of the four steps. Checked before the record, because a valid
+    // record on the wrong branch is still the mistake this catches.
+    const why = refusal({ record: ok, tree: TREE, branch: MAIN, mainBranch: MAIN });
+    assert.strictEqual(why.code, 'on-default-branch');
+    assert.match(why.message, /Branch first/);
+  });
+
+  test('refuses when the checks have never been run', () => {
+    const why = refusal({ record: null, tree: TREE, branch: BRANCH, mainBranch: MAIN });
+    assert.strictEqual(why.code, 'no-record');
+    assert.match(why.message, /npm run precommit/);
+  });
+
+  test('refuses a record left behind by a different branch', () => {
+    const why = refusal({
+      record: { ...ok, branch: 'fix/a-different-card' },
+      tree: TREE, branch: BRANCH, mainBranch: MAIN,
+    });
+    assert.strictEqual(why.code, 'wrong-branch');
+    assert.match(why.message, /a-different-card/);
+  });
+
+  test('refuses a record whose tree is not the tree being committed', () => {
+    // The case a timestamp cannot catch: the checks passed, then something was
+    // staged on top. The record is honest about a tree that is no longer the
+    // one going in.
+    const why = refusal({ record: ok, tree: OTHER_TREE, branch: BRANCH, mainBranch: MAIN });
+    assert.strictEqual(why.code, 'stale-record');
+    assert.match(why.message, /something changed after the checks ran/);
+  });
+
+  test('every refusal says what to do next', () => {
+    const cases = [
+      refusal({ record: null, tree: TREE, branch: BRANCH, mainBranch: MAIN }),
+      refusal({ record: { ...ok, branch: 'other' }, tree: TREE, branch: BRANCH, mainBranch: MAIN }),
+      refusal({ record: ok, tree: OTHER_TREE, branch: BRANCH, mainBranch: MAIN }),
+    ];
+    for (const why of cases) {
+      assert.match(why.message, /npm run precommit/, `${why.code} names the command that fixes it`);
+    }
+  });
+});

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -257,3 +257,72 @@ describe('the entry points, against a throwaway repository', () => {
     }
   });
 });
+
+describe('the tree that was checked is the tree that gets recorded', () => {
+  const PASSING = {
+    test: 'node -e "0"', typecheck: 'node -e "0"',
+    'lint:styles': 'node -e "0"', 'check:refs': 'node -e "0"',
+  };
+
+  test('an unstaged edit is refused, because the checks would read a different tree', () => {
+    // The gap this closes: STEPS run against the working directory while the
+    // record hashes the index. Stage, edit again without staging, and the
+    // checks validate content the record does not name. Committing then puts
+    // the older staged version in, and verify() admits it because the index
+    // never moved: a tree certified without ever being checked.
+    const { dir } = repoWithScripts(PASSING);
+    try {
+      fs.writeFileSync(path.join(dir, 'a.txt'), 'edited after staging\n');
+      const { code, out } = spawnGate([], dir);
+      assert.notStrictEqual(code, 0, 'drift between working tree and index is refused');
+      assert.match(out, /does not match what is staged/);
+      assert.match(out, /a\.txt/, 'and it names the file');
+      assert.ok(!fs.existsSync(path.join(dir, '.precommit-gate.json')), 'no record is written');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an untracked file is refused too: the checks would read it, the record would not name it', () => {
+    const { dir } = repoWithScripts(PASSING);
+    try {
+      fs.writeFileSync(path.join(dir, 'new-test.js'), '// never staged\n');
+      const { code, out } = spawnGate([], dir);
+      assert.notStrictEqual(code, 0);
+      assert.match(out, /new-test\.js/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the real entry point refuses to run on the default branch', () => {
+    // run() carries its own branch check, separate from refusal()'s. Covering
+    // only the shared decision left this copy untested.
+    const { dir, run } = repoWithScripts(PASSING);
+    try {
+      run('commit', '-q', '-m', 'initial');
+      run('checkout', '-q', '-B', 'main');
+      const { code, out } = spawnGate([], dir);
+      assert.notStrictEqual(code, 0, 'the gate refuses on the default branch');
+      assert.match(out, /refusing to run on main/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a record written on one branch is refused after switching to another', () => {
+    // The wrong-branch case, end to end rather than hand-built: a real record,
+    // a real checkout, and the refusal the fixture only assumed.
+    const { dir, run } = repoWithScripts(PASSING);
+    try {
+      assert.strictEqual(spawnGate([], dir).code, 0, 'record written on fix/card');
+      run('commit', '-q', '-m', 'initial');
+      run('checkout', '-q', '-b', 'fix/other-card');
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.notStrictEqual(code, 0);
+      assert.match(out, /is for branch "fix\/card"/, 'the refusal names the branch the record belongs to');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Three errors in the 0.11.7 run died at the same four steps: verify the branch, run the checks, read the result, commit. A fourth followed the same week, a pull request pushed without the unit suite having been run, with CI going red on a failure thirty seconds locally would have caught. Doing them by hand worked for thirty-four merges and stopped working once the work had no instruments of its own.

## The shape is borrowed, not invented

`scripts/release-gate.js` solves this one level up: run the gauntlet, write a record stamped with the SHA it passed on, and refuse to tag unless the record matches the exact current HEAD. This applies the same contract to the per-commit checks, so the repository has one mechanism rather than two.

## What identifies the tree

The record names the hash `git write-tree` produces for the index, which is the exact content a commit would capture. A timestamp would not do: it cannot tell a passing tree from the same tree with one more edit staged on top, which is precisely the case the guard exists for.

Writing the record **only after every step passes** is also what makes "read the result" unskippable. The record's existence is the result; there is no separate acknowledgement step available to skip.

Order matters, and the script says so: stage, then run the checks, then commit. Running them before staging records the tree as it was, which the hook then rejects as stale. That is the guard working, not misfiring.

## Refusals are named

Each refusal carries a reason code (`on-default-branch`, `no-record`, `wrong-branch`, `stale-record`) and every message names the command that fixes it. The tests assert on the **code**, not on failure: a guard that refuses for the wrong reason will refuse for no reason eventually, and "it failed" cannot tell those apart.

## Two limits stated rather than engineered around

The hook stays opt-in exactly as the existing ones are, and **CI remains the line that actually holds**. A developer without hooks installed is not bypassing anything that protects `main`.

And on a machine where the suite has an environmental failure, this blocks every commit. That is the guard being honest about an unverified tree, but it does mean a broken environment has to be fixed rather than tolerated. Worth naming, because a guard people disable is worse than no guard.

## Checks

- `npm test`: 1653/1653.
- `npm run typecheck`, `npm run lint:styles`, `npm run check:refs`: clean.
- Proven on itself: this branch's commit was admitted by the hook against a record written for its own staged tree, and refused beforehand when the record named a pre-staging tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
