### PR TITLE
Re-capture the runtime contract against 2.1.237

### DIFF
--- a/scripts/stream-truth/captured-grammar.json
+++ b/scripts/stream-truth/captured-grammar.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "2.1.236",
-  "capturedAt": "2026-08-19T22:57:10.773Z",
+  "runtimeVersion": "2.1.237",
+  "capturedAt": "2026-08-20T21:04:55.592Z",
   "scenarios": {
     "text-turn": {
       "invariants": [


### PR DESCRIPTION
The release gate refuses a candidate whose capture came from a different runtime than the one installed, and it is right to: a runtime change invalidates the capture, and the stub is only trustworthy against a runtime someone has actually checked.

## The contract did not move

Stream invariants hold on both scenarios against the real 2.1.237, and the stub still matches the new capture. That is the check that exists because 0.11.6 shipped a draft with delegation interception dead on real streams while 1,333 stub-shaped tests stayed green.

## The diff is two lines

This is the first re-capture since the churn fix merged, and it is the outcome that card claimed, now observed against a real runtime change rather than a fixture.

The raw stream genuinely varied between runs: 26 and 46 grammar tokens, where the previous capture saw 20 and 40. Every stored section came out **byte-identical**.

| Scenario | invariants | normalized |
|---|---|---|
| text-turn | 9 to 9, identical | 7 to 7, identical |
| tool-turn | 17 to 17, identical | 13 to 13, identical |

```
-  "runtimeVersion": "2.1.236",
-  "capturedAt": "2026-08-19T22:57:10.773Z",
+  "runtimeVersion": "2.1.237",
+  "capturedAt": "2026-08-20T21:04:55.592Z",
```

Before today the same re-capture would have rewritten the stored sections with a difference carrying no information, which is what trained the reader to skim the one artifact whose purpose is to be read.

## Checks

- `npm run stream:truth`: PASS, stub matches the 2.1.237 capture.
- `npm test`: 1681/1681.

Needed before the 0.11.8 cut: the release gate runs `stream:truth` third and would otherwise stop there.
