### PR TITLE
A polling predicate that throws means "not yet", not "stop"

### DIFF
--- a/scripts/smoke/personas.mjs
+++ b/scripts/smoke/personas.mjs
@@ -32,6 +32,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { waitFor } from './wait-for.mjs';
 
 const require = createRequire(import.meta.url);
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -52,15 +53,6 @@ function record(step, ok, detail) {
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${step}${detail ? `  (${detail})` : ''}`);
 }
 
-async function waitFor(pred, timeout = 30000, interval = 200) {
-  const deadline = Date.now() + timeout;
-  for (;;) {
-    const v = await pred();
-    if (v) return v;
-    if (Date.now() >= deadline) return null;
-    await new Promise(r => setTimeout(r, interval));
-  }
-}
 
 function readState(workspace) {
   try { return JSON.parse(fs.readFileSync(path.join(workspace, '.rundock', 'state.json'), 'utf8')); }

--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -24,6 +24,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import { waitFor } from './wait-for.mjs';
 
 const require = createRequire(import.meta.url);
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -97,15 +98,6 @@ function readEvents(workspace) {
   return out;
 }
 
-async function waitFor(pred, timeout = 30000, interval = 200) {
-  const deadline = Date.now() + timeout;
-  for (;;) {
-    const v = await pred();
-    if (v) return v;
-    if (Date.now() >= deadline) return null;
-    await new Promise(r => setTimeout(r, interval));
-  }
-}
 
 // ── Boot ────────────────────────────────────────────────────────────────
 const workspace = buildWorkspace();

--- a/scripts/smoke/wait-for.mjs
+++ b/scripts/smoke/wait-for.mjs
@@ -1,0 +1,37 @@
+// Poll until a condition holds, or the deadline passes.
+//
+// A predicate that THROWS means the condition is not met yet, not that the
+// caller should stop. These harnesses poll for things a server is still
+// producing, so a predicate routinely runs before the thing exists:
+// `fs.readdirSync` on a directory scaffolding has not created yet throws
+// ENOENT, while `existsSync` returns false. Both mean "not yet", and only one
+// of them used to be survivable.
+//
+// It cost two release gate runs on 2026-08-20. A persona journey aborted on
+// ENOENT and reported 5 of 14 checks; the same suite standalone passed 16 of 16
+// on the same commit. The difference was load: inside the gate that step
+// follows a 140-second browser suite, scaffolding is slower, and the first poll
+// landed before the directory existed. A suite that fails for reasons unrelated
+// to the change teaches people to stop reading it.
+//
+// The catch belongs here rather than around the one predicate that tripped it.
+// A helper safe only for the predicates it happened to be given leaves the trap
+// set for the next one, and the other predicates in these files are safe by
+// accident rather than by design.
+//
+// It lives in its own module because both harnesses had their own copy, and
+// fixing this meant patching the same eight lines twice.
+export async function waitFor(pred, timeout = 30000, interval = 200) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    let v = null;
+    try {
+      v = await pred();
+    } catch {
+      v = null; // not yet
+    }
+    if (v) return v;
+    if (Date.now() >= deadline) return null;
+    await new Promise(r => setTimeout(r, interval));
+  }
+}

--- a/test/unit/wait-for.test.js
+++ b/test/unit/wait-for.test.js
@@ -1,0 +1,75 @@
+'use strict';
+// The smoke harnesses' polling helper.
+//
+// It polls for things a server is still producing, so a predicate routinely
+// runs before the thing it looks for exists. `existsSync` returns false there;
+// `readdirSync` throws ENOENT. Both mean "not yet", and until 2026-08-20 only
+// one of them was survivable: a throwing predicate propagated out of the poll
+// loop and aborted the whole journey.
+//
+// That cost two release gate runs in one afternoon. A persona journey died on
+// ENOENT and reported 5 of 14 checks, while the same suite standalone passed
+// 16 of 16 on the same commit. The difference was load: inside the gate the
+// step follows a long browser suite, scaffolding is slower, and the first poll
+// landed before the directory existed.
+//
+// These tests are the reason the helper now has one home rather than a copy in
+// each harness: the same eight lines had to be fixed twice.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+let waitFor;
+test('load the module', async () => {
+  ({ waitFor } = await import('../../scripts/smoke/wait-for.mjs'));
+  assert.strictEqual(typeof waitFor, 'function');
+});
+
+describe('waitFor', () => {
+  test('a predicate that throws, then succeeds, resolves rather than aborting', async () => {
+    // The exact shape that killed the gate: read a directory that does not
+    // exist yet, then does.
+    let calls = 0;
+    const result = await waitFor(() => {
+      calls += 1;
+      if (calls < 3) throw new Error('ENOENT: no such file or directory, scandir');
+      return 'found';
+    }, 2000, 10);
+
+    assert.strictEqual(result, 'found');
+    assert.ok(calls >= 3, 'it kept polling past the throws');
+  });
+
+  test('a predicate that only ever throws times out instead of propagating', async () => {
+    // A condition that never becomes true must be reported as a timeout, not
+    // raised as an exception. Otherwise one unmet condition takes down every
+    // check that would have run after it, which is what turned a single missing
+    // directory into nine skipped assertions.
+    const result = await waitFor(() => { throw new Error('always'); }, 60, 10);
+    assert.strictEqual(result, null);
+  });
+
+  test('a rejected promise counts as not yet, the same as a throw', async () => {
+    let calls = 0;
+    const result = await waitFor(async () => {
+      calls += 1;
+      if (calls < 2) return Promise.reject(new Error('not ready'));
+      return 'ready';
+    }, 2000, 10);
+    assert.strictEqual(result, 'ready');
+  });
+
+  test('a successful predicate returns its value, not merely true', async () => {
+    // Callers use the returned value, so swallowing it into a boolean would
+    // break them quietly.
+    const result = await waitFor(() => ({ agents: 2 }), 1000, 10);
+    assert.deepStrictEqual(result, { agents: 2 });
+  });
+
+  test('a falsey predicate still times out to null', async () => {
+    const started = Date.now();
+    const result = await waitFor(() => false, 60, 10);
+    assert.strictEqual(result, null);
+    assert.ok(Date.now() - started >= 50, 'it waited for the deadline');
+  });
+});


### PR DESCRIPTION
Two release gate runs were lost on 2026-08-20 to harness flakiness, and this was the second. A persona journey aborted with `ENOENT` scanning `.claude/agents` and reported 5 of 14 checks. The same suite standalone passed 16 of 16 on the same commit.

## Cause

`waitFor` called its predicate and never caught. These harnesses poll for things a server is still producing, so a predicate routinely runs before the thing exists: `existsSync` returns false there, `readdirSync` throws `ENOENT`. Both mean "not yet", and only one of them was survivable. One missing directory took down the nine checks that would have run after it.

**Load is what made it visible.** Inside the gate the step follows a 140-second browser suite, scaffolding is slower, and the first poll lands before the directory exists. Standalone it exists by the first poll and the bug cannot be seen, which is the worst property a flake can have: it fails only in the expensive place, at the end of the longest sequence in the repository.

## The fix is in the helper, not the caller

Guarding the one predicate that tripped it would leave the trap set. Every other predicate in those files is safe by accident rather than by design.

Both harnesses carried their own copy of the same eight lines, so fixing this meant patching it twice. It now lives in one module, which is also what makes it testable.

## Tests

| Case | |
|---|---|
| throws, then succeeds | keeps polling, resolves |
| only ever throws | times out to `null`, does not propagate |
| rejected promise | counts as not yet |
| succeeds | returns its **value**, not a boolean |
| falsey | waits for the deadline |

Against the unfixed helper, three of the six fail.

## Checks

- `npm test`: 1688/1688
- `npm run smoke`: 20/20 · `npm run smoke:personas`: 16/16
- `npm run typecheck`, `npm run check:refs`: clean

No persona check changes what it asserts. This fixes how the suite waits.

Blocking the 0.11.8 cut: the gate cannot pass reliably until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)