### PR TITLE
Let the release commit reach main, and nothing else

### DIFF
--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -132,6 +132,34 @@ function buildRecord({ tree, branch, at }) {
   return { tree, branch, at, steps: STEPS.map(s => s.name) };
 }
 
+// The release commit's footprint.
+//
+// scripts/release.js bumps the version, promotes the changelog, and commits
+// directly to main. That is by design and the card plan states the constraint:
+// it is the only thing allowed on top of a gated SHA, release.js checks the
+// gate BEFORE creating it, and it touches these two files and nothing else.
+//
+// The exception is defined by WHAT IS STAGED rather than by an environment
+// variable or the name of the calling process, because a guard any caller can
+// announce its way past is not a guard.
+//
+// RESIDUAL RISK, stated rather than left implicit: this also lets a
+// hand-edited changelog or a hand-edited version reach the default branch
+// without a branch. That is judged acceptable, because neither is code, both
+// are visible in the one place people read before a release, and the
+// alternative is a gate that blocks the release tool it ships beside.
+const RELEASE_FOOTPRINT = ['package.json', 'CHANGELOG.md'];
+
+/** Paths staged for the next commit. */
+function stagedPaths(root = ROOT) {
+  const out = git(['diff', '--cached', '--name-only'], root);
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
+function isReleaseCommit(staged) {
+  return staged.length > 0 && staged.every(p => RELEASE_FOOTPRINT.includes(p));
+}
+
 /**
  * Why a commit may not proceed, or null when it may.
  *
@@ -139,9 +167,11 @@ function buildRecord({ tree, branch, at }) {
  * on: a guard that refuses for the wrong reason is a guard that will refuse
  * for no reason later, and "it failed" is not enough to tell those apart.
  */
-function refusal({ record, tree, branch, mainBranch }) {
+function refusal({ record, tree, branch, mainBranch, staged = [] }) {
   const rerun = 'Run `npm run precommit`, then commit again.';
   if (branch === mainBranch) {
+    // The one commit that belongs here. Everything else branches first.
+    if (isReleaseCommit(staged)) return null;
     return { code: 'on-default-branch', message: `refusing to commit directly to ${mainBranch}. Branch first.` };
   }
   if (!record) {
@@ -205,7 +235,10 @@ function run() {
 
 function verify() {
   const branch = git(['branch', '--show-current']);
-  const why = refusal({ record: readRecord(), tree: currentTree(), branch, mainBranch: defaultBranch() });
+  const why = refusal({
+    record: readRecord(), tree: currentTree(), branch,
+    mainBranch: defaultBranch(), staged: stagedPaths(),
+  });
   if (why) {
     console.error(`[precommit] commit blocked: ${why.message}`);
     process.exit(1);
@@ -217,4 +250,4 @@ if (require.main === module) {
   else run();
 }
 
-module.exports = { refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, workingTreeDrift, RECORD, STEPS };
+module.exports = { refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, workingTreeDrift, stagedPaths, isReleaseCommit, RELEASE_FOOTPRINT, RECORD, STEPS };

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -18,6 +18,7 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const {
   refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch,
+  isReleaseCommit, RELEASE_FOOTPRINT,
 } = require('../../scripts/precommit-gate.js');
 
 const TREE = 'a'.repeat(40);
@@ -360,5 +361,52 @@ describe('the default branch is read from the remote, not assumed', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('the release commit is the one thing allowed on the default branch', () => {
+  // scripts/release.js bumps the version, promotes the changelog and commits
+  // straight to main. That is by design, and on the day this guard merged it
+  // stopped `npm run release` dead: the version was bumped, the changelog
+  // promoted, and the commit refused. A gate that blocks the release tool
+  // shipping beside it is not protecting anything.
+  const onMain = (staged) => refusal({
+    record: null, tree: TREE, branch: MAIN, mainBranch: MAIN, staged,
+  });
+
+  test('the release footprint is admitted', () => {
+    assert.strictEqual(onMain(['package.json', 'CHANGELOG.md']), null);
+    // Either alone is still the release commit's shape.
+    assert.strictEqual(onMain(['package.json']), null);
+    assert.strictEqual(onMain(['CHANGELOG.md']), null);
+  });
+
+  test('anything else alongside it is still refused', () => {
+    // The exception is the footprint, not the presence of a version bump. A
+    // source file riding along is exactly what this guard exists to stop.
+    assert.strictEqual(onMain(['package.json', 'server.js']).code, 'on-default-branch');
+    assert.strictEqual(onMain(['CHANGELOG.md', 'lib/agents/prompt.js']).code, 'on-default-branch');
+    assert.strictEqual(onMain(['server.js']).code, 'on-default-branch');
+  });
+
+  test('an empty staging area is not a release commit', () => {
+    // Nothing staged means nothing to vouch for, and admitting it would let
+    // an empty or amend-shaped commit through on the default branch.
+    assert.strictEqual(onMain([]).code, 'on-default-branch');
+    assert.strictEqual(isReleaseCommit([]), false);
+  });
+
+  test('on a feature branch the footprint still faces the normal checks', () => {
+    // The exception is about the DEFAULT branch. Elsewhere a changelog edit is
+    // an ordinary commit and needs a record like any other.
+    const why = refusal({
+      record: null, tree: TREE, branch: BRANCH, mainBranch: MAIN,
+      staged: ['CHANGELOG.md'],
+    });
+    assert.strictEqual(why.code, 'no-record');
+  });
+
+  test('the footprint is exactly the two files release.js touches', () => {
+    assert.deepStrictEqual([...RELEASE_FOOTPRINT].sort(), ['CHANGELOG.md', 'package.json']);
   });
 });

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -18,7 +18,7 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const {
   refusal, buildRecord, writeRecord, readRecord, currentTree, defaultBranch,
-  isReleaseCommit, RELEASE_FOOTPRINT,
+  isReleaseCommit, RELEASE_FOOTPRINT, stagedPaths,
 } = require('../../scripts/precommit-gate.js');
 
 const TREE = 'a'.repeat(40);
@@ -408,5 +408,76 @@ describe('the release commit is the one thing allowed on the default branch', ()
 
   test('the footprint is exactly the two files release.js touches', () => {
     assert.deepStrictEqual([...RELEASE_FOOTPRINT].sort(), ['CHANGELOG.md', 'package.json']);
+  });
+});
+
+describe('the release commit, through the real entry point on real git', () => {
+  // Everything above hands refusal() a staged array built by hand, which is a
+  // double for what stagedPaths() returns. That proves the decision and not the
+  // wiring, and the wiring is the whole card: if stagedPaths() had wrong flags
+  // or mishandled a path, every test above would stay green while npm run
+  // release failed exactly as it did the night this was written.
+  const PASSING = {
+    test: 'node -e "0"', typecheck: 'node -e "0"',
+    'lint:styles': 'node -e "0"', 'check:refs': 'node -e "0"',
+  };
+
+  function repoOnDefaultBranch() {
+    const { dir, run } = repoWithScripts(PASSING);
+    run('commit', '-q', '-m', 'initial');
+    run('checkout', '-q', '-B', 'main');
+    fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), '# Changelog\n\n## Unreleased\n');
+    fs.writeFileSync(path.join(dir, 'server.js'), '// source\n');
+    run('add', '-A');
+    run('commit', '-q', '-m', 'add changelog and a source file');
+    return { dir, run };
+  }
+
+  test('the real hook admits a release-shaped commit on the default branch', () => {
+    const { dir, run } = repoOnDefaultBranch();
+    try {
+      // What release.js does: bump the version, promote the changelog, stage
+      // exactly those two, commit on main.
+      const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+      pkg.version = '1.0.1';
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
+      fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), '# Changelog\n\n## 1.0.1 (today)\n');
+      run('add', 'package.json', 'CHANGELOG.md');
+
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.strictEqual(code, 0, `the release commit must be admitted, got: ${out}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the real hook refuses a source file riding along with it', () => {
+    const { dir, run } = repoOnDefaultBranch();
+    try {
+      fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), '# Changelog\n\n## 1.0.1 (today)\n');
+      fs.writeFileSync(path.join(dir, 'server.js'), '// snuck in\n');
+      run('add', 'CHANGELOG.md', 'server.js');
+
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.notStrictEqual(code, 0, 'a source file on the default branch is refused');
+      assert.match(out, /refusing to commit directly to main/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('stagedPaths reads the index, and reads it the way refusal expects', () => {
+    // Named separately because a path normalisation bug here would be
+    // invisible above: refusal() compares against bare names, so anything
+    // returning a prefixed or quoted path would silently stop matching.
+    const { dir, run } = repoOnDefaultBranch();
+    try {
+      fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), '# changed\n');
+      run('add', 'CHANGELOG.md');
+      assert.deepStrictEqual(stagedPaths(dir), ['CHANGELOG.md']);
+      assert.strictEqual(isReleaseCommit(stagedPaths(dir)), true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
The pre-commit gate merged hours ago blocked `npm run release` the first time it ran. The version was bumped, the changelog promoted, and then:

```
[precommit] commit blocked: refusing to commit directly to main. Branch first.
[release:push] ERROR: git commit/tag/push failed
```

A gate that blocks the release tool shipping beside it is not protecting anything.

## The exception, and how it is defined

Refusing a card committed straight to main is right and stays. Exactly one commit belongs there, and the card plan already names its shape: `release.js` checks the gate **before** creating it, and it touches `package.json` and `CHANGELOG.md` and nothing else.

So the exception is defined by **what is staged**, not by an environment variable, a flag, or the name of the calling process. A guard any caller can announce its way past is not a guard. `release.js` gains no special standing: that footprint is admitted whoever commits it, and a source file riding alongside is refused whoever commits it.

## Residual risk, stated in the source

This also lets a hand-edited changelog or version reach the default branch without branching. Judged acceptable: neither is code, both are visible in the one file people read before a release, and the alternative is what happened tonight.

## Tests

| Case | |
|---|---|
| `package.json` + `CHANGELOG.md` on main | admitted |
| either alone | admitted |
| `package.json` + `server.js` | refused |
| nothing staged | refused, not a release commit |
| the footprint on a feature branch | still faces the normal record checks |

One fails without the exception.

## How it was found

By running the release. It could not have been found any other way: the release gate makes no commits, so it passed on this same commit an hour earlier.

## Checks

- `npm test`: 1693/1693
- `npm run typecheck`, `npm run check:refs`: clean

Blocking the 0.11.8 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)