### PR TITLE
chore: release 0.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
-## Unreleased
-
-**Name:** Editor Hardening
+## 0.11.8: Editor Hardening (2026-08-20)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rundock",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "description": "A visual workspace for your AI agent team. Built for people running their own businesses. Works with your Claude or ChatGPT subscription.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
The release commit for 0.11.8: version bump and changelog promotion, exactly the two files `release.js` produces.

Routed through a pull request because `release.js` pushes this commit **directly to main**, and branch protection requires six status checks that a locally-created commit does not have:

```
remote: - 6 of 6 required status checks are expected.
! [remote rejected] main -> main (protected branch hook declined)
```

The tool's design and the repository's protection rules are in conflict, and tonight is the first time they have been run against each other. The release build triggers on a `v*.*.*` tag rather than on the main push, so tagging the merged commit is sufficient and nothing about the release itself changes.

## Gate

`PASS on 417e21a99 in 284.7s`, all eleven steps including live smoke, live personas and packaging. This commit adds only the version and changelog on top of that gated SHA, which is the one thing the card plan permits there.

## Follow-up

`release.js` needs to produce this commit through a branch and a pull request, so the next release does not hit this. Carded separately rather than fixed inside a release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)