### PR TITLE
Prove a change's tests fail without the change

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test",
     "check:refs": "node scripts/check-internal-refs.js",
     "precommit": "node scripts/precommit-gate.js",
+    "red-first": "node scripts/red-first.js",
     "lint:styles": "node test/tools/style-drift.js",
     "typecheck": "tsc -p tsconfig.server.json && tsc -p tsconfig.client.json",
     "screenshots": "node scripts/screenshots/run.mjs",

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -58,6 +58,42 @@ function isTest(file) {
   return TEST_MARKERS.some(m => file.includes(m));
 }
 
+function existsAt(repo, ref, file) {
+  try {
+    execFileSync('git', ['cat-file', '-e', `${ref}:${file}`], { cwd: repo, stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Make `files` look exactly as they do in `ref`, in both the index and the
+ * working tree.
+ *
+ * Checking a path out is only half of it. A file the change ADDED has no
+ * version at the base, and `git checkout <base> -- <path>` fails outright on a
+ * pathspec it cannot resolve, which is how the first run of this tool against
+ * its own branch died: the branch adds two files and modifies none. Taking an
+ * added file away means deleting it. Taking a deleted file away means putting
+ * it back. Asking the target tree what it holds covers both, and renames, and
+ * needs no status letters to be parsed correctly.
+ *
+ * The same function serves the restore, pointed at HEAD, so the way back
+ * cannot drift from the way out.
+ */
+function restoreTo(repo, ref, files) {
+  const present = files.filter(f => existsAt(repo, ref, f));
+  const absent = files.filter(f => !existsAt(repo, ref, f));
+  if (present.length) git(repo, ['checkout', ref, '--', ...present]);
+  for (const f of absent) {
+    // --ignore-unmatch so a second pass over an already-removed path is a
+    // no-op rather than an error, which matters because the restore runs in a
+    // finally block that must not throw over the top of a real failure.
+    git(repo, ['rm', '--quiet', '-f', '--ignore-unmatch', '--', f]);
+  }
+}
+
 /**
  * @returns {{outcome: 'proven'|'not-discriminating'|'inconclusive'|'not-provable'|'refused',
  *            reason: string, passedWithChange: boolean|null,
@@ -110,13 +146,13 @@ function redFirst({ repo, base = 'main', tests, log = () => {} }) {
   log('restoring the source, keeping the tests');
   let failedWithoutChange = null;
   try {
-    git(repo, ['checkout', mergeBase, '--', ...sourceFiles]);
+    restoreTo(repo, mergeBase, sourceFiles);
     failedWithoutChange = !run();
   } finally {
     // Unconditional. A tool that can leave a repository half-reverted is worse
     // than no tool, because the next person debugs a tree nobody put there on
     // purpose.
-    git(repo, ['checkout', 'HEAD', '--', ...sourceFiles]);
+    restoreTo(repo, 'HEAD', sourceFiles);
   }
 
   if (git(repo, ['status', '--porcelain'])) {
@@ -190,4 +226,4 @@ function main() {
 
 if (require.main === module) process.exit(main());
 
-module.exports = { redFirst, recordOutcome, isTest, TEST_MARKERS, LIMITATION };
+module.exports = { redFirst, recordOutcome, restoreTo, isTest, TEST_MARKERS, LIMITATION };

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -40,11 +40,16 @@
 const { execFileSync, spawnSync } = require('node:child_process');
 const path = require('node:path');
 
-// Path fragments that mark a file as a test rather than the thing under test.
-// Deliberately generous: misreading source as test makes the check WEAKER,
-// since less is reverted, which surfaces as a false "not discriminating"
-// rather than as a false proof. The failure leans towards complaining.
-const TEST_MARKERS = ['test/', 'tests/', 'spec/', '__tests__/', '.test.', '.spec.'];
+// What marks a file as a test rather than the thing under test.
+//
+// Matched against whole path SEGMENTS, not as substrings. 'src/latest/x.js'
+// contains 'test/', because "latest/" ends in it, and so do contest/, attest/,
+// protest/ and fastest/. A source file misclassified that way is never
+// reverted, so the check silently runs against less than it claims to. The
+// error direction is a false complaint rather than a false proof, which is the
+// safe direction and still not a reason to leave it wrong.
+const TEST_DIRS = ['test', 'tests', 'spec', '__tests__'];
+const TEST_FILENAME_MARKERS = ['.test.', '.spec.'];
 
 const LIMITATION =
   'Reverting proves the tests notice this change. It cannot prove they assert '
@@ -73,7 +78,10 @@ function git(repo, args) {
 }
 
 function isTest(file) {
-  return TEST_MARKERS.some(m => file.includes(m));
+  const parts = file.split('/');
+  const name = parts.pop();
+  if (parts.some(segment => TEST_DIRS.includes(segment))) return true;
+  return TEST_FILENAME_MARKERS.some(m => name.includes(m));
 }
 
 function existsAt(repo, ref, file) {
@@ -291,4 +299,4 @@ function main() {
 
 if (require.main === module) process.exit(main());
 
-module.exports = { redFirst, recordOutcome, restoreTo, isTest, TEST_MARKERS, LIMITATION };
+module.exports = { redFirst, recordOutcome, restoreTo, isTest, TEST_DIRS, TEST_FILENAME_MARKERS, LIMITATION };

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Prove a change's tests fail without the change.
+ *
+ * WHY
+ *
+ * Across five cards in one day an independent reviewer caught seven tests that
+ * could not have failed. Every one asserted a proxy easier to reach than the
+ * property its criterion named: an element box rather than the painted glyphs,
+ * containment rather than identity, a pure decision function rather than the
+ * wiring around it, a clock-derived guard that skipped its assertions near
+ * midnight while still reporting green.
+ *
+ * The common cause was not carelessness, it was order. Every one of those tests
+ * was written AFTER its fix, while looking at the finished code, and a test
+ * written that way asserts what the fix obviously does. A test required to fail
+ * first cannot. This runs that requirement mechanically, because the author had
+ * written the matching failure-taxonomy entry that same morning and produced
+ * five fresh instances that afternoon.
+ *
+ * WHAT IT PROVES, AND WHAT IT DOES NOT
+ *
+ * Reverting a change proves a test NOTICES that change. It cannot prove the
+ * test asserts the right thing: a test can discriminate the fix and still
+ * measure a proxy. This closes the cheaper half of the class, which is the half
+ * that recurred. That limit travels with every result, in `limitation`, so a
+ * green outcome cannot be read as more than it is.
+ *
+ * USAGE
+ *
+ *   node scripts/red-first.js --base main --tests "npm test"
+ *
+ * Exit 0 only when discrimination is proven. Every other outcome is non-zero
+ * and names itself, because "it failed" cannot distinguish a weak test from a
+ * broken suite, and treating those alike is how a check stops being read.
+ */
+
+const { execFileSync, spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+// Path fragments that mark a file as a test rather than the thing under test.
+// Deliberately generous: misreading source as test makes the check WEAKER,
+// since less is reverted, which surfaces as a false "not discriminating"
+// rather than as a false proof. The failure leans towards complaining.
+const TEST_MARKERS = ['test/', 'tests/', 'spec/', '__tests__/', '.test.', '.spec.'];
+
+const LIMITATION =
+  'Reverting proves the tests notice this change. It cannot prove they assert '
+  + 'the right thing: a test can discriminate a fix and still measure a proxy.';
+
+function git(repo, args) {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim();
+}
+
+function isTest(file) {
+  return TEST_MARKERS.some(m => file.includes(m));
+}
+
+/**
+ * @returns {{outcome: 'proven'|'not-discriminating'|'inconclusive'|'not-provable'|'refused',
+ *            reason: string, passedWithChange: boolean|null,
+ *            failedWithoutChange: boolean|null, source: string[], tests: string[],
+ *            limitation: string}}
+ */
+function redFirst({ repo, base = 'main', tests, log = () => {} }) {
+  const result = (outcome, reason, extra = {}) => ({
+    outcome, reason, passedWithChange: null, failedWithoutChange: null,
+    source: [], tests: [], limitation: LIMITATION, ...extra,
+  });
+
+  // A dirty tree is refused, not tidied. This rewrites tracked files and puts
+  // them back, so it must never run where it cannot tell its own edits from
+  // someone else's.
+  if (git(repo, ['status', '--porcelain'])) {
+    return result('refused', 'the working tree has uncommitted changes, and this '
+      + 'rewrites tracked files; commit or stash first');
+  }
+
+  const mergeBase = git(repo, ['merge-base', base, 'HEAD']);
+  const changed = git(repo, ['diff', '--name-only', mergeBase, 'HEAD'])
+    .split('\n').filter(Boolean);
+  const testFiles = changed.filter(isTest);
+  const sourceFiles = changed.filter(f => !isTest(f));
+
+  if (!changed.length) return result('not-provable', `nothing changed against ${base}`);
+  if (!testFiles.length) {
+    return result('not-provable', 'the change adds no tests, so there is nothing '
+      + 'to prove; that is its own finding', { source: sourceFiles, tests: [] });
+  }
+  if (!sourceFiles.length) {
+    return result('not-provable', 'the change touches no source, so there is '
+      + 'nothing to take away', { source: [], tests: testFiles });
+  }
+
+  const run = () => spawnSync(tests, { cwd: repo, shell: true, stdio: 'ignore' }).status === 0;
+
+  // WITH the change first. A suite failing for its own reasons makes a failure
+  // without the change meaningless, and reporting that as proof would turn a
+  // broken suite into evidence.
+  log('running the tests with the change');
+  const passedWithChange = run();
+  if (!passedWithChange) {
+    return result('inconclusive', 'the tests do not pass with the change in '
+      + 'place, so a failure without it proves nothing',
+    { passedWithChange: false, source: sourceFiles, tests: testFiles });
+  }
+
+  log('restoring the source, keeping the tests');
+  let failedWithoutChange = null;
+  try {
+    git(repo, ['checkout', mergeBase, '--', ...sourceFiles]);
+    failedWithoutChange = !run();
+  } finally {
+    // Unconditional. A tool that can leave a repository half-reverted is worse
+    // than no tool, because the next person debugs a tree nobody put there on
+    // purpose.
+    git(repo, ['checkout', 'HEAD', '--', ...sourceFiles]);
+  }
+
+  if (git(repo, ['status', '--porcelain'])) {
+    return result('refused', 'the tree did not come back clean after restoring; '
+      + 'inspect before trusting any result', { source: sourceFiles, tests: testFiles });
+  }
+
+  if (!failedWithoutChange) {
+    return result('not-discriminating', 'the tests pass with the source '
+      + 'reverted, so they do not discriminate this change and would have gone '
+      + 'green against the defect they were written for',
+    { passedWithChange: true, failedWithoutChange: false, source: sourceFiles, tests: testFiles });
+  }
+
+  return result('proven', 'the tests fail without the change and pass with it',
+    { passedWithChange: true, failedWithoutChange: true, source: sourceFiles, tests: testFiles });
+}
+
+/**
+ * Fold the outcome into the pre-commit gate's record, so there is ONE record a
+ * reviewer packet can carry rather than two that can disagree.
+ *
+ * Keyed by tree: a result describes the tree it was measured on, and a record
+ * for a different tree is stale by definition. Absence and failure stay
+ * distinguishable, because a packet that cannot tell "never run" from "run and
+ * found wanting" invites the reader to assume the kinder one.
+ */
+function recordOutcome(repo, outcome) {
+  const fs = require('node:fs');
+  const file = path.join(repo, '.precommit-gate.json');
+  if (!fs.existsSync(file)) return false;
+  let record;
+  try { record = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return false; }
+  const tree = git(repo, ['write-tree']);
+  if (record.tree !== tree) return false;
+  record.redFirst = {
+    outcome: outcome.outcome,
+    reason: outcome.reason,
+    sourceFiles: outcome.source.length,
+    testFiles: outcome.tests.length,
+    limitation: outcome.limitation,
+  };
+  fs.writeFileSync(file, JSON.stringify(record, null, 2) + '\n');
+  return true;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const arg = (name, fallback) => {
+    const i = argv.indexOf(`--${name}`);
+    return i === -1 ? fallback : argv[i + 1];
+  };
+  const repo = path.resolve(arg('repo', process.cwd()));
+  const outcome = redFirst({
+    repo,
+    base: arg('base', 'main'),
+    tests: arg('tests', 'npm test'),
+    log: (m) => console.log(`[red-first] ${m}`),
+  });
+
+  console.log(`[red-first] ${outcome.outcome.toUpperCase()}: ${outcome.reason}`);
+  if (recordOutcome(repo, outcome)) {
+    console.log('[red-first] recorded against the current tree in .precommit-gate.json');
+  }
+  if (outcome.outcome === 'proven') {
+    console.log(`[red-first] note: ${outcome.limitation}`);
+    return 0;
+  }
+  return 1;
+}
+
+if (require.main === module) process.exit(main());
+
+module.exports = { redFirst, recordOutcome, isTest, TEST_MARKERS, LIMITATION };

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -142,7 +142,14 @@ function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null })
   }
 
   const mergeBase = git(repo, ['merge-base', base, 'HEAD']);
-  const changed = git(repo, ['diff', '--name-only', mergeBase, 'HEAD'])
+  // --no-renames, and it is not a detail. With rename detection on, a renamed
+  // file is reported once, under its NEW path. restoreTo then asks whether that
+  // path exists at the base, finds it does not, and deletes it. The reverted
+  // run fails with a module-not-found for an unrelated reason, and the tool
+  // reports "proven" for tests that discriminate nothing: the one error
+  // direction it must never take. Forced off here rather than trusted to the
+  // developer's diff.renames config.
+  const changed = git(repo, ['diff', '--no-renames', '--name-only', mergeBase, 'HEAD'])
     .split('\n').filter(Boolean);
   const testFiles = changed.filter(isTest);
   const sourceFiles = changed.filter(f => !isTest(f));
@@ -198,6 +205,16 @@ function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null })
   // listener is what disables that default, and the listener restores before
   // exiting in case the finally is never reached. Both paths call the same
   // function, and restoring an already-restored tree is a no-op.
+  //
+  // KNOWN GAP, stated rather than implied. `run` uses spawnSync, which blocks
+  // the event loop, so this handler cannot execute until that child returns.
+  // A terminal interrupt reaches the whole process group and the child dies
+  // too, so the common case works. A test command that TRAPS or ignores
+  // SIGINT, or detaches from the group, leaves the tree reverted for as long
+  // as it keeps running. Closing that needs an async spawn plus an explicit
+  // kill of the child, which changes this function's signature. Raised by an
+  // independent reviewer as an advisory on the final permitted round and left
+  // for the approver to schedule rather than refactored unreviewed.
   const onSignal = () => {
     try { restoreTo(repo, 'HEAD', sourceFiles); } catch (e) { /* exiting anyway */ }
     process.exit(130);

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -50,6 +50,24 @@ const LIMITATION =
   'Reverting proves the tests notice this change. It cannot prove they assert '
   + 'the right thing: a test can discriminate a fix and still measure a proxy.';
 
+// Test-count summaries, in the two shapes this project and its neighbours
+// actually emit. Parsing is best effort by nature: an unrecognised reporter
+// yields null, which is recorded as null. A count invented from output nobody
+// could read is worse than no count, because the record is the thing a reviewer
+// is asked to trust.
+const COUNT_PATTERNS = {
+  pass: [/(?:^|\s)(?:#|\u2139)\s*pass\s+(\d+)/m, /(\d+)\s+passing\b/],
+  fail: [/(?:^|\s)(?:#|\u2139)\s*fail\s+(\d+)/m, /(\d+)\s+failing\b/],
+};
+
+function countFrom(text, kind) {
+  for (const re of COUNT_PATTERNS[kind]) {
+    const m = text.match(re);
+    if (m) return Number(m[1]);
+  }
+  return null;
+}
+
 function git(repo, args) {
   return execFileSync('git', args, { cwd: repo, encoding: 'utf8' }).trim();
 }
@@ -100,9 +118,10 @@ function restoreTo(repo, ref, files) {
  *            failedWithoutChange: boolean|null, source: string[], tests: string[],
  *            limitation: string}}
  */
-function redFirst({ repo, base = 'main', tests, log = () => {} }) {
+function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null }) {
   const result = (outcome, reason, extra = {}) => ({
     outcome, reason, passedWithChange: null, failedWithoutChange: null,
+    testsPassedWithChange: null, testsFailedWithoutChange: null,
     source: [], tests: [], limitation: LIMITATION, ...extra,
   });
 
@@ -130,13 +149,32 @@ function redFirst({ repo, base = 'main', tests, log = () => {} }) {
       + 'nothing to take away', { source: [], tests: testFiles });
   }
 
-  const run = () => spawnSync(tests, { cwd: repo, shell: true, stdio: 'ignore' }).status === 0;
+  // The runner is injectable so a test can make the reverted run throw while
+  // the first run passes, which is the only way to reach the restore by the
+  // path a real failure would take. The first version of that test used a
+  // command that always failed, so it never got past the first run and would
+  // have passed with the restore deleted.
+  const run = runner
+    ? () => ({ ok: !!runner(), pass: null, fail: null })
+    : () => {
+      // NODE_TEST_CONTEXT must not reach the child. A nested `node --test`
+      // that inherits it reports its failures and still exits 0, so a suite
+      // that should be red comes back green: the one failure mode this tool
+      // cannot afford, reachable whenever red-first is driven from inside a
+      // test.
+      const env = { ...process.env };
+      delete env.NODE_TEST_CONTEXT;
+      const r = spawnSync(tests, { cwd: repo, shell: true, encoding: 'utf8', env });
+      const text = `${r.stdout || ''}${r.stderr || ''}`;
+      return { ok: r.status === 0, pass: countFrom(text, 'pass'), fail: countFrom(text, 'fail') };
+    };
 
   // WITH the change first. A suite failing for its own reasons makes a failure
   // without the change meaningless, and reporting that as proof would turn a
   // broken suite into evidence.
   log('running the tests with the change');
-  const passedWithChange = run();
+  const withChange = run();
+  const passedWithChange = withChange.ok;
   if (!passedWithChange) {
     return result('inconclusive', 'the tests do not pass with the change in '
       + 'place, so a failure without it proves nothing',
@@ -145,15 +183,37 @@ function redFirst({ repo, base = 'main', tests, log = () => {} }) {
 
   log('restoring the source, keeping the tests');
   let failedWithoutChange = null;
+  let withoutChange = { ok: null, pass: null, fail: null };
+
+  // try/finally does not survive a signal: Node's default handling terminates
+  // without unwinding, which would abandon the tree mid-revert. Registering a
+  // listener is what disables that default, and the listener restores before
+  // exiting in case the finally is never reached. Both paths call the same
+  // function, and restoring an already-restored tree is a no-op.
+  const onSignal = () => {
+    try { restoreTo(repo, 'HEAD', sourceFiles); } catch (e) { /* exiting anyway */ }
+    process.exit(130);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
   try {
     restoreTo(repo, mergeBase, sourceFiles);
-    failedWithoutChange = !run();
+    withoutChange = run();
+    failedWithoutChange = !withoutChange.ok;
   } finally {
     // Unconditional. A tool that can leave a repository half-reverted is worse
     // than no tool, because the next person debugs a tree nobody put there on
     // purpose.
     restoreTo(repo, 'HEAD', sourceFiles);
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
   }
+
+  const counts = {
+    testsPassedWithChange: withChange.pass,
+    testsFailedWithoutChange: withoutChange.fail,
+  };
 
   if (git(repo, ['status', '--porcelain'])) {
     return result('refused', 'the tree did not come back clean after restoring; '
@@ -164,11 +224,11 @@ function redFirst({ repo, base = 'main', tests, log = () => {} }) {
     return result('not-discriminating', 'the tests pass with the source '
       + 'reverted, so they do not discriminate this change and would have gone '
       + 'green against the defect they were written for',
-    { passedWithChange: true, failedWithoutChange: false, source: sourceFiles, tests: testFiles });
+    { passedWithChange: true, failedWithoutChange: false, source: sourceFiles, tests: testFiles, ...counts });
   }
 
   return result('proven', 'the tests fail without the change and pass with it',
-    { passedWithChange: true, failedWithoutChange: true, source: sourceFiles, tests: testFiles });
+    { passedWithChange: true, failedWithoutChange: true, source: sourceFiles, tests: testFiles, ...counts });
 }
 
 /**
@@ -191,6 +251,11 @@ function recordOutcome(repo, outcome) {
   record.redFirst = {
     outcome: outcome.outcome,
     reason: outcome.reason,
+    // AC-6 names test counts. File counts are a different quantity and were
+    // written here first, which is the proxy-for-the-property fault this whole
+    // check exists to catch, committed inside the check itself.
+    testsPassedWithChange: outcome.testsPassedWithChange,
+    testsFailedWithoutChange: outcome.testsFailedWithoutChange,
     sourceFiles: outcome.source.length,
     testFiles: outcome.tests.length,
     limitation: outcome.limitation,

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -37,7 +37,7 @@
  * broken suite, and treating those alike is how a check stops being read.
  */
 
-const { execFileSync, spawnSync } = require('node:child_process');
+const { execFileSync, spawn } = require('node:child_process');
 const path = require('node:path');
 
 // What marks a file as a test rather than the thing under test.
@@ -126,7 +126,7 @@ function restoreTo(repo, ref, files) {
  *            failedWithoutChange: boolean|null, source: string[], tests: string[],
  *            limitation: string}}
  */
-function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null }) {
+async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null }) {
   const result = (outcome, reason, extra = {}) => ({
     outcome, reason, passedWithChange: null, failedWithoutChange: null,
     testsPassedWithChange: null, testsFailedWithoutChange: null,
@@ -164,31 +164,61 @@ function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null })
       + 'nothing to take away', { source: [], tests: testFiles });
   }
 
+  // The child is tracked so a signal handler can end it. This used to be
+  // spawnSync, which blocks the event loop for the whole life of the child, so
+  // the handler could not run until the child chose to exit. A test command
+  // that traps or ignores SIGINT therefore held the source reverted for as long
+  // as it kept running, while AC-4 claims restoration happens whatever happens.
+  // Documenting the gap did not discharge the criterion. An independent
+  // reviewer refused it twice, correctly.
+  let child = null;
+
+  const spawnRun = () => new Promise((resolve, reject) => {
+    // NODE_TEST_CONTEXT must not reach the child. A nested `node --test` that
+    // inherits it reports its failures and still exits 0, so a suite that
+    // should be red comes back green: the one failure mode this tool cannot
+    // afford, reachable whenever red-first is driven from inside a test.
+    const env = { ...process.env };
+    delete env.NODE_TEST_CONTEXT;
+
+    // detached puts the shell and everything it starts in their own process
+    // group, so ending it means ending the group rather than one shell that
+    // may have children of its own.
+    const kid = spawn(tests, { cwd: repo, shell: true, env, detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'] });
+    child = kid;
+    let text = '';
+    kid.stdout.on('data', (b) => { text += b.toString(); });
+    kid.stderr.on('data', (b) => { text += b.toString(); });
+    kid.on('error', (e) => { child = null; reject(e); });
+    kid.on('close', (code) => {
+      child = null;
+      resolve({ ok: code === 0, pass: countFrom(text, 'pass'), fail: countFrom(text, 'fail') });
+    });
+  });
+
   // The runner is injectable so a test can make the reverted run throw while
   // the first run passes, which is the only way to reach the restore by the
   // path a real failure would take. The first version of that test used a
   // command that always failed, so it never got past the first run and would
   // have passed with the restore deleted.
   const run = runner
-    ? () => ({ ok: !!runner(), pass: null, fail: null })
-    : () => {
-      // NODE_TEST_CONTEXT must not reach the child. A nested `node --test`
-      // that inherits it reports its failures and still exits 0, so a suite
-      // that should be red comes back green: the one failure mode this tool
-      // cannot afford, reachable whenever red-first is driven from inside a
-      // test.
-      const env = { ...process.env };
-      delete env.NODE_TEST_CONTEXT;
-      const r = spawnSync(tests, { cwd: repo, shell: true, encoding: 'utf8', env });
-      const text = `${r.stdout || ''}${r.stderr || ''}`;
-      return { ok: r.status === 0, pass: countFrom(text, 'pass'), fail: countFrom(text, 'fail') };
-    };
+    ? async () => ({ ok: !!(await runner()), pass: null, fail: null })
+    : spawnRun;
+
+  /** End the child and everything it started. Best effort by necessity. */
+  const endChild = () => {
+    const kid = child;
+    if (!kid || kid.killed || kid.exitCode !== null) return;
+    try { process.kill(-kid.pid, 'SIGTERM'); } catch (e) { /* group already gone */ }
+    try { process.kill(-kid.pid, 'SIGKILL'); } catch (e) { /* already dead */ }
+  };
 
   // WITH the change first. A suite failing for its own reasons makes a failure
   // without the change meaningless, and reporting that as proof would turn a
   // broken suite into evidence.
   log('running the tests with the change');
-  const withChange = run();
+  const withChange = await run();
   const passedWithChange = withChange.ok;
   if (!passedWithChange) {
     return result('inconclusive', 'the tests do not pass with the change in '
@@ -206,16 +236,14 @@ function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null })
   // exiting in case the finally is never reached. Both paths call the same
   // function, and restoring an already-restored tree is a no-op.
   //
-  // KNOWN GAP, stated rather than implied. `run` uses spawnSync, which blocks
-  // the event loop, so this handler cannot execute until that child returns.
-  // A terminal interrupt reaches the whole process group and the child dies
-  // too, so the common case works. A test command that TRAPS or ignores
-  // SIGINT, or detaches from the group, leaves the tree reverted for as long
-  // as it keeps running. Closing that needs an async spawn plus an explicit
-  // kill of the child, which changes this function's signature. Raised by an
-  // independent reviewer as an advisory on the final permitted round and left
-  // for the approver to schedule rather than refactored unreviewed.
+  // The event loop stays free because the test command runs through an
+  // asynchronous spawn, so this handler executes while the child is still
+  // alive rather than waiting for it to agree to exit.
   const onSignal = () => {
+    // Kill the child FIRST. The restore is pointless while a test command is
+    // still writing to the tree, and a trapping child would otherwise outlive
+    // this process and keep working against a reverted source.
+    endChild();
     try { restoreTo(repo, 'HEAD', sourceFiles); } catch (e) { /* exiting anyway */ }
     process.exit(130);
   };
@@ -224,7 +252,7 @@ function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null })
 
   try {
     restoreTo(repo, mergeBase, sourceFiles);
-    withoutChange = run();
+    withoutChange = await run();
     failedWithoutChange = !withoutChange.ok;
   } finally {
     // Unconditional. A tool that can leave a repository half-reverted is worse
@@ -289,14 +317,14 @@ function recordOutcome(repo, outcome) {
   return true;
 }
 
-function main() {
+async function main() {
   const argv = process.argv.slice(2);
   const arg = (name, fallback) => {
     const i = argv.indexOf(`--${name}`);
     return i === -1 ? fallback : argv[i + 1];
   };
   const repo = path.resolve(arg('repo', process.cwd()));
-  const outcome = redFirst({
+  const outcome = await redFirst({
     repo,
     base: arg('base', 'main'),
     tests: arg('tests', 'npm test'),
@@ -314,6 +342,11 @@ function main() {
   return 1;
 }
 
-if (require.main === module) process.exit(main());
+if (require.main === module) {
+  main().then((code) => process.exit(code), (err) => {
+    console.error(`[red-first] ${err && err.stack ? err.stack : err}`);
+    process.exit(1);
+  });
+}
 
 module.exports = { redFirst, recordOutcome, restoreTo, isTest, TEST_DIRS, TEST_FILENAME_MARKERS, LIMITATION };

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -27,7 +27,7 @@ const { redFirst, recordOutcome } = require('../../scripts/red-first.js');
 
 // A throwaway repository with a base commit, then a branch carrying whatever
 // source and test content the case needs.
-function repo({ source, testFile, baseSource = 'module.exports.a = () => 1;\n', baseTest = 'module.exports = () => {};\n' }) {
+function repo({ source, testFile, added = {}, baseSource = 'module.exports.a = () => 1;\n', baseTest = 'module.exports = () => {};\n' }) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'red-first-'));
   const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
   git('init', '-q');
@@ -47,6 +47,12 @@ function repo({ source, testFile, baseSource = 'module.exports.a = () => 1;\n', 
   git('checkout', '-q', '-b', 'change');
   if (source !== undefined) fs.writeFileSync(path.join(dir, 'lib.js'), source);
   if (testFile !== undefined) fs.writeFileSync(path.join(dir, 'test', 'check.js'), testFile);
+  // Files that exist only on the branch. There is no base version to check
+  // out, which is the case every other fixture here happens to avoid.
+  for (const [rel, content] of Object.entries(added)) {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    fs.writeFileSync(path.join(dir, rel), content);
+  }
   git('add', '-A');
   git('commit', '-q', '-m', 'the change');
   return { dir, git };
@@ -276,6 +282,74 @@ describe('the record file must not dirty the tree it describes', () => {
       const r = redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'refused');
       assert.match(r.reason, /uncommitted/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('source added by the change, with no version at the base', () => {
+  // Found by running this tool on its own branch, which adds two files and
+  // modifies none. `git checkout <base> -- <path>` fails outright on a path
+  // that does not exist at the base, so the run died on a pathspec error
+  // instead of reporting an outcome. Every fixture above modifies a file that
+  // already existed, so none of them could reach it: the same shape of gap
+  // this tool exists to catch, in the tool itself.
+
+  test('an added file is taken away by deleting it, and the tests go red', () => {
+    const { dir } = repo({
+      added: {
+        'lib2.js': 'module.exports.b = () => 2;\n',
+      },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'proven', r.reason);
+      assert.deepStrictEqual(r.source, ['lib2.js']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the added file comes back, so the branch is not left short a file', () => {
+    // The restore path is the one that matters most here: a deleted file that
+    // is not put back turns a diagnostic run into data loss on the branch.
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
+    });
+    try {
+      redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(fs.existsSync(path.join(dir, 'lib2.js')), true, 'the added file is restored');
+      assert.strictEqual(
+        execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
+        'and the tree comes back clean',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a mix of added and modified source is handled in one run', () => {
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.c = () => 3;\n',
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => {\n"
+        + "  assert.strictEqual(require('../lib2.js').b(), 2);\n"
+        + "  assert.strictEqual(require('../lib.js').c(), 3);\n"
+        + "};\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'proven', r.reason);
+      assert.deepStrictEqual(r.source.slice().sort(), ['lib.js', 'lib2.js']);
+      assert.strictEqual(
+        execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -24,6 +24,14 @@ const path = require('node:path');
 const { execFileSync, spawn, spawnSync } = require('node:child_process');
 
 const { redFirst, recordOutcome } = require('../../scripts/red-first.js');
+// The REAL record writer, not a local idea of one. scripts/precommit-gate.js
+// says why in its own docstring: "a test that hand-builds the JSON proves the
+// reader can read the test's idea of a record". These tests hand-built it
+// anyway, and an independent reviewer caught it. If the gate renamed a field or
+// computed its tree a different way, recordOutcome would silently stop matching
+// in production while every test here stayed green, because the fixture and the
+// implementation were built to agree with each other rather than with the gate.
+const gate = require('../../scripts/precommit-gate.js');
 
 // A throwaway repository with a base commit, then a branch carrying whatever
 // source and test content the case needs.
@@ -161,10 +169,14 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
   // evidence sat in a terminal it cannot see. The packet carries the record, so
   // the record has to carry the proof.
   function withRecord(dir, tree) {
-    fs.writeFileSync(path.join(dir, '.precommit-gate.json'),
-      JSON.stringify({ tree, branch: 'change', at: '2026-08-20T00:00:00.000Z', steps: ['test'] }, null, 2));
+    gate.writeRecord(
+      gate.buildRecord({ tree, branch: 'change', at: '2026-08-20T00:00:00.000Z' }),
+      path.join(dir, '.precommit-gate.json'),
+    );
   }
-  const treeOf = (dir) => execFileSync('git', ['write-tree'], { cwd: dir, encoding: 'utf8' }).trim();
+  // The gate's own tree function, so a change to how it identifies a tree
+  // breaks these tests rather than passing them by coincidence.
+  const treeOf = (dir) => gate.currentTree(dir);
 
   test('a proven outcome is written against the tree it was measured on', () => {
     const { dir } = repo({
@@ -442,9 +454,9 @@ describe('the record carries test counts, not a count of files', () => {
     try {
       // The fixture already ignores the record file, so there is nothing to
       // commit here and no reason to touch the tree before measuring it.
-      const tree = execFileSync('git', ['write-tree'], { cwd: dir, encoding: 'utf8' }).trim();
-      fs.writeFileSync(path.join(dir, '.precommit-gate.json'),
-        JSON.stringify({ tree, branch: 'change', at: 'x', steps: ['test'] }));
+      const tree = gate.currentTree(dir);
+      gate.writeRecord(gate.buildRecord({ tree, branch: 'change', at: 'x' }),
+        path.join(dir, '.precommit-gate.json'));
 
       const outcome = redFirst({ repo: dir, base: 'main', tests: 'node --test test/check.js' });
       assert.strictEqual(outcome.outcome, 'proven', outcome.reason);
@@ -609,6 +621,74 @@ describe('the command itself, not only the function inside it', () => {
       const r = cli(dir);
       assert.notStrictEqual(r.status, 0, 'a non-discriminating result must not exit 0');
       assert.match(r.stdout, /NOT-DISCRIMINATING/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the record contract is the gate is, not this file is', () => {
+  test('recordOutcome reads a record the real gate wrote', () => {
+    // The point of this test is the coupling, not the assertion. It imports
+    // scripts/precommit-gate.js, so a renamed field or a different
+    // tree-computation on that side fails here rather than failing silently in
+    // production, where the outcome would simply never reach the record.
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      const record = gate.buildRecord({
+        tree: gate.currentTree(dir), branch: 'change', at: '2026-08-21T00:00:00.000Z',
+      });
+      gate.writeRecord(record, path.join(dir, '.precommit-gate.json'));
+
+      assert.ok(record.tree, 'the gate names a tree at all');
+      assert.strictEqual(record.tree,
+        execFileSync('git', ['write-tree'], { cwd: dir, encoding: 'utf8' }).trim(),
+        'the gate identifies a tree by git write-tree, which is what recordOutcome assumes');
+
+      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(recordOutcome(dir, outcome), true,
+        'a record written by the real gate is accepted');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('a renamed source file', () => {
+  test('is restored to its old path, not deleted, so a false proven is impossible', () => {
+    // git diff reports a rename as one new path when rename detection is on.
+    // restoreTo then asks whether that path exists at the base, finds it does
+    // not, and DELETES it. The reverted run fails with a module-not-found for
+    // an unrelated reason, and the tool reports "proven" for tests that
+    // discriminate nothing. That is the one error direction this must never
+    // take.
+    const { dir, git } = repo({ added: { 'old-name.js': 'module.exports.b = () => 2;\n' } });
+    try {
+      // Put the file in the BASE, then rename it on the branch.
+      git('checkout', '-q', 'main');
+      fs.writeFileSync(path.join(dir, 'old-name.js'), 'module.exports.b = () => 2;\n');
+      git('add', '-A');
+      git('commit', '-q', '-m', 'the file, under its first name');
+      git('checkout', '-q', '-b', 'renamed');
+      git('mv', 'old-name.js', 'new-name.js');
+      fs.writeFileSync(path.join(dir, 'test', 'check.js'),
+        "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../new-name.js').b(), 2); };\n");
+      git('add', '-A');
+      git('commit', '-q', '-m', 'renamed');
+      // Rename detection on, which is what a developer's config may well do.
+      git('config', 'diff.renames', 'true');
+
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.deepStrictEqual(r.source.slice().sort(), ['new-name.js', 'old-name.js'],
+        'both sides of the rename are treated as source');
+      assert.strictEqual(
+        execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
+        'and the tree comes back clean',
+      );
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -21,7 +21,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync, spawn } = require('node:child_process');
+const { execFileSync, spawn, spawnSync } = require('node:child_process');
 
 const { redFirst, recordOutcome } = require('../../scripts/red-first.js');
 
@@ -514,6 +514,102 @@ describe('the test command does not inherit this runner is own context', () => {
         'the child must not see the parent test runner is context');
     } finally {
       fs.rmSync(probe, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('classifying a path as a test, by segment rather than by substring', () => {
+  test('a source directory whose name ends in "test" is not a test directory', () => {
+    // `'src/latest/module.js'.includes('test/')` is true, because "latest/"
+    // ends in "test/". So do contest/, attest/, protest/, fastest/. A source
+    // file misclassified this way is never reverted, so the check runs against
+    // less than it claims to.
+    const { dir } = repo({
+      added: {
+        'src/latest/module.js': 'module.exports.b = () => 2;\n',
+      },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../src/latest/module.js').b(), 2); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.deepStrictEqual(r.source, ['src/latest/module.js'],
+        'a path containing "test/" inside a longer segment is source');
+      assert.deepStrictEqual(r.tests, ['test/check.js']);
+      assert.strictEqual(r.outcome, 'proven', r.reason);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a real test directory and a suffixed filename are still tests', () => {
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.c = () => 3;\n',
+      added: {
+        'src/thing.test.js': '// a test by filename\n',
+        'spec/other.js': '// a test by directory\n',
+      },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib.js').c(), 3); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.deepStrictEqual(r.source, ['lib.js']);
+      assert.deepStrictEqual(r.tests.slice().sort(),
+        ['spec/other.js', 'src/thing.test.js', 'test/check.js']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the command itself, not only the function inside it', () => {
+  // Every other test here calls redFirst() directly, which leaves main()
+  // unexercised: argv parsing, the exit-code contract the docstring promises,
+  // and the printed outcome. An independent reviewer pointed out that this is
+  // the same fault the file's own header lists among the seven it exists to
+  // prevent, "a pure decision function rather than the wiring around it",
+  // reproduced in the suite for the tool meant to catch it. If main() always
+  // returned 0, nothing here would have failed.
+  const script = path.join(__dirname, '..', '..', 'scripts', 'red-first.js');
+
+  function cli(dir) {
+    return spawnSync(process.execPath,
+      [script, '--repo', dir, '--base', 'main', '--tests', CMD],
+      { encoding: 'utf8' });
+  }
+
+  test('a discriminating change exits 0 and says so', () => {
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
+    });
+    try {
+      const r = cli(dir);
+      assert.strictEqual(r.status, 0, r.stdout + r.stderr);
+      assert.match(r.stdout, /PROVEN/);
+      assert.match(r.stdout, /cannot prove they assert the right thing/,
+        'the limit is printed with the pass, not only carried in the object');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a non-discriminating change exits non-zero and names itself', () => {
+    // "It failed" cannot distinguish a weak test from a broken suite, so the
+    // exit code carries the refusal and the output carries which one.
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(typeof require('../lib.js').a, 'function'); };\n",
+    });
+    try {
+      const r = cli(dir);
+      assert.notStrictEqual(r.status, 0, 'a non-discriminating result must not exit 0');
+      assert.match(r.stdout, /NOT-DISCRIMINATING/);
+    } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -79,14 +79,14 @@ function repo({ source, testFile, added = {}, baseSource = 'module.exports.a = (
 const CMD = 'node run.js';
 
 describe('red-first', () => {
-  test('a test that exercises the change is reported as proven', () => {
+  test('a test that exercises the change is reported as proven', async () => {
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
       testFile: "const assert = require('assert');\n"
         + "module.exports = () => { assert.strictEqual(require('../lib.js').b(), 2); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'proven');
       assert.strictEqual(r.passedWithChange, true);
       assert.strictEqual(r.failedWithoutChange, true);
@@ -95,7 +95,7 @@ describe('red-first', () => {
     }
   });
 
-  test('a test that would pass with the change deleted is the finding', () => {
+  test('a test that would pass with the change deleted is the finding', async () => {
     // The pathology: an assertion on something that was already true.
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
@@ -103,7 +103,7 @@ describe('red-first', () => {
         + "module.exports = () => { assert.strictEqual(typeof require('../lib.js').a, 'function'); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'not-discriminating');
       assert.strictEqual(r.failedWithoutChange, false);
       assert.match(r.reason, /pass(es)? with the source reverted|do not discriminate/i);
@@ -112,7 +112,7 @@ describe('red-first', () => {
     }
   });
 
-  test('a suite already failing with the change is inconclusive, not proof', () => {
+  test('a suite already failing with the change is inconclusive, not proof', async () => {
     // A failure without the change proves nothing if the suite fails with it.
     // Reporting that as success would turn a broken suite into evidence.
     const { dir } = repo({
@@ -120,7 +120,7 @@ describe('red-first', () => {
       testFile: "module.exports = () => { throw new Error('suite is broken'); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'inconclusive');
       assert.strictEqual(r.passedWithChange, false);
     } finally {
@@ -128,10 +128,10 @@ describe('red-first', () => {
     }
   });
 
-  test('a change with no tests is not provable, and is not a pass', () => {
+  test('a change with no tests is not provable, and is not a pass', async () => {
     const { dir } = repo({ source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n' });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'not-provable');
       assert.match(r.reason, /no tests/i);
     } finally {
@@ -139,13 +139,13 @@ describe('red-first', () => {
     }
   });
 
-  test('a change with no source is not provable either', () => {
+  test('a change with no source is not provable either', async () => {
     // Nothing to take away, so nothing to prove by taking it away.
     const { dir } = repo({
       testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'not-provable');
       assert.match(r.reason, /no source/i);
     } finally {
@@ -153,7 +153,7 @@ describe('red-first', () => {
     }
   });
 
-  test('a dirty tree is refused rather than rewritten', () => {
+  test('a dirty tree is refused rather than rewritten', async () => {
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
       testFile: "const assert = require('assert');\n"
@@ -161,7 +161,7 @@ describe('red-first', () => {
     });
     try {
       fs.writeFileSync(path.join(dir, 'lib.js'), '// edited, not committed\n');
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'refused');
       assert.match(r.reason, /dirty|uncommitted/i);
       // And it did not touch the edit.
@@ -188,7 +188,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
   // breaks these tests rather than passing them by coincidence.
   const treeOf = (dir) => gate.currentTree(dir);
 
-  test('a proven outcome is written against the tree it was measured on', () => {
+  test('a proven outcome is written against the tree it was measured on', async () => {
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
       testFile: "const assert = require('assert');\n"
@@ -197,7 +197,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
     try {
       const tree = treeOf(dir);
       withRecord(dir, tree);
-      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(recordOutcome(dir, outcome), true);
 
       const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
@@ -211,7 +211,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
     }
   });
 
-  test('a failing outcome is recorded too, so absence and failure stay different', () => {
+  test('a failing outcome is recorded too, so absence and failure stay different', async () => {
     // A packet that cannot tell "never run" from "run and found wanting"
     // invites the reader to assume the kinder one.
     const { dir } = repo({
@@ -221,7 +221,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
     });
     try {
       withRecord(dir, treeOf(dir));
-      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: CMD });
       recordOutcome(dir, outcome);
       const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
       assert.strictEqual(rec.redFirst.outcome, 'not-discriminating');
@@ -230,7 +230,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
     }
   });
 
-  test('a record for a different tree is refused rather than overwritten', () => {
+  test('a record for a different tree is refused rather than overwritten', async () => {
     // A result describes the tree it was measured on. Writing it onto another
     // tree's record would vouch for content nobody checked.
     const { dir } = repo({
@@ -239,7 +239,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
     });
     try {
       withRecord(dir, 'f'.repeat(40));
-      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(recordOutcome(dir, outcome), false);
       const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
       assert.strictEqual(rec.redFirst, undefined, 'the stale record is left alone');
@@ -248,13 +248,13 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
     }
   });
 
-  test('with no record present there is nothing to fold into', () => {
+  test('with no record present there is nothing to fold into', async () => {
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
       testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
     });
     try {
-      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(recordOutcome(dir, outcome), false);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -263,7 +263,7 @@ describe('the outcome reaches the record a reviewer packet can carry', () => {
 });
 
 describe('the record file must not dirty the tree it describes', () => {
-  test('a tracked gate record makes red-first refuse its own repository', () => {
+  test('a tracked gate record makes red-first refuse its own repository', async () => {
     // Learned by writing the fixture without a .gitignore: the record landed
     // as an untracked file, the tree was dirty, and red-first correctly
     // refused. Worth pinning, because the failure looks like a broken tool
@@ -278,7 +278,7 @@ describe('the record file must not dirty the tree it describes', () => {
       git('commit', '-q', '-m', 'stop ignoring the record');
       fs.writeFileSync(path.join(dir, '.precommit-gate.json'), '{}');
 
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'refused');
       assert.match(r.reason, /uncommitted/i);
     } finally {
@@ -295,7 +295,7 @@ describe('source added by the change, with no version at the base', () => {
   // already existed, so none of them could reach it: the same shape of gap
   // this tool exists to catch, in the tool itself.
 
-  test('an added file is taken away by deleting it, and the tests go red', () => {
+  test('an added file is taken away by deleting it, and the tests go red', async () => {
     const { dir } = repo({
       added: {
         'lib2.js': 'module.exports.b = () => 2;\n',
@@ -304,7 +304,7 @@ describe('source added by the change, with no version at the base', () => {
         + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'proven', r.reason);
       assert.deepStrictEqual(r.source, ['lib2.js']);
     } finally {
@@ -312,7 +312,7 @@ describe('source added by the change, with no version at the base', () => {
     }
   });
 
-  test('the added file comes back, so the branch is not left short a file', () => {
+  test('the added file comes back, so the branch is not left short a file', async () => {
     // The restore path is the one that matters most here: a deleted file that
     // is not put back turns a diagnostic run into data loss on the branch.
     const { dir } = repo({
@@ -321,7 +321,7 @@ describe('source added by the change, with no version at the base', () => {
         + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
     });
     try {
-      redFirst({ repo: dir, base: 'main', tests: CMD });
+      await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(fs.existsSync(path.join(dir, 'lib2.js')), true, 'the added file is restored');
       assert.strictEqual(
         execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
@@ -332,7 +332,7 @@ describe('source added by the change, with no version at the base', () => {
     }
   });
 
-  test('a mix of added and modified source is handled in one run', () => {
+  test('a mix of added and modified source is handled in one run', async () => {
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.c = () => 3;\n',
       added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
@@ -343,7 +343,7 @@ describe('source added by the change, with no version at the base', () => {
         + "};\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'proven', r.reason);
       assert.deepStrictEqual(r.source.slice().sort(), ['lib.js', 'lib2.js']);
       assert.strictEqual(
@@ -368,7 +368,7 @@ describe('the restore runs whatever happens, which is the claim AC-4 makes', () 
   // reverted run throw while the first run passes, which is the only way to
   // reach the restore by the path a real failure would take.
 
-  test('a throw from the reverted run still puts the source back', () => {
+  test('a throw from the reverted run still puts the source back', async () => {
     const { dir } = repo({
       added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
       testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
@@ -380,7 +380,9 @@ describe('the restore runs whatever happens, which is the claim AC-4 makes', () 
         if (call === 1) return true;          // green with the change
         throw new Error('the runner blew up mid-revert');
       };
-      assert.throws(() => redFirst({ repo: dir, base: 'main', tests: CMD, runner }),
+      // assert.rejects, not assert.throws: the failure now arrives as a
+      // rejected promise, and assert.throws would pass while catching nothing.
+      await assert.rejects(() => redFirst({ repo: dir, base: 'main', tests: CMD, runner }),
         /blew up mid-revert/);
 
       assert.strictEqual(call, 2, 'the reverted run was actually reached');
@@ -459,7 +461,7 @@ describe('the record carries test counts, not a count of files', () => {
     return dir;
   }
 
-  test('both counts reach the record', () => {
+  test('both counts reach the record', async () => {
     const dir = countableRepo();
     try {
       // The fixture already ignores the record file, so there is nothing to
@@ -468,7 +470,7 @@ describe('the record carries test counts, not a count of files', () => {
       gate.writeRecord(gate.buildRecord({ tree, branch: 'change', at: 'x' }),
         path.join(dir, '.precommit-gate.json'));
 
-      const outcome = redFirst({ repo: dir, base: 'main', tests: 'node --test test/check.js' });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: 'node --test test/check.js' });
       assert.strictEqual(outcome.outcome, 'proven', outcome.reason);
       recordOutcome(dir, outcome);
 
@@ -480,7 +482,7 @@ describe('the record carries test counts, not a count of files', () => {
     }
   });
 
-  test('an unparsable summary records null rather than a guess', () => {
+  test('an unparsable summary records null rather than a guess', async () => {
     // A count invented from output nobody could read is worse than no count,
     // because the record is the thing the reviewer is asked to trust.
     const { dir } = repo({
@@ -489,7 +491,7 @@ describe('the record carries test counts, not a count of files', () => {
         + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
     });
     try {
-      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(outcome.outcome, 'proven', outcome.reason);
       assert.strictEqual(outcome.testsPassedWithChange, null);
       assert.strictEqual(outcome.testsFailedWithoutChange, null);
@@ -500,10 +502,10 @@ describe('the record carries test counts, not a count of files', () => {
 });
 
 describe('a branch with no diff at all', () => {
-  test('is not-provable, by its own path rather than by resemblance', () => {
+  test('is not-provable, by its own path rather than by resemblance', async () => {
     const { dir } = repo({});
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(r.outcome, 'not-provable');
       assert.match(r.reason, /nothing changed/i);
     } finally {
@@ -513,7 +515,7 @@ describe('a branch with no diff at all', () => {
 });
 
 describe('the test command does not inherit this runner is own context', () => {
-  test('NODE_TEST_CONTEXT is stripped, because it makes a nested runner exit 0', () => {
+  test('NODE_TEST_CONTEXT is stripped, because it makes a nested runner exit 0', async () => {
     // Found while writing the counts test. `node --test` that inherits
     // NODE_TEST_CONTEXT reports failures and still exits 0, so a suite that
     // should have gone red comes back green. For a tool whose only job is
@@ -531,7 +533,7 @@ describe('the test command does not inherit this runner is own context', () => {
     try {
       const cmd = `${JSON.stringify(process.execPath)} -e `
         + JSON.stringify(`require('fs').writeFileSync(${JSON.stringify(probe)}, String(process.env.NODE_TEST_CONTEXT))`);
-      redFirst({ repo: dir, base: 'main', tests: cmd });
+      await redFirst({ repo: dir, base: 'main', tests: cmd });
       assert.strictEqual(fs.readFileSync(probe, 'utf8'), 'undefined',
         'the child must not see the parent test runner is context');
     } finally {
@@ -542,7 +544,7 @@ describe('the test command does not inherit this runner is own context', () => {
 });
 
 describe('classifying a path as a test, by segment rather than by substring', () => {
-  test('a source directory whose name ends in "test" is not a test directory', () => {
+  test('a source directory whose name ends in "test" is not a test directory', async () => {
     // `'src/latest/module.js'.includes('test/')` is true, because "latest/"
     // ends in "test/". So do contest/, attest/, protest/, fastest/. A source
     // file misclassified this way is never reverted, so the check runs against
@@ -555,7 +557,7 @@ describe('classifying a path as a test, by segment rather than by substring', ()
         + "module.exports = () => { assert.strictEqual(require('../src/latest/module.js').b(), 2); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.deepStrictEqual(r.source, ['src/latest/module.js'],
         'a path containing "test/" inside a longer segment is source');
       assert.deepStrictEqual(r.tests, ['test/check.js']);
@@ -565,7 +567,7 @@ describe('classifying a path as a test, by segment rather than by substring', ()
     }
   });
 
-  test('a real test directory and a suffixed filename are still tests', () => {
+  test('a real test directory and a suffixed filename are still tests', async () => {
     const { dir } = repo({
       source: 'module.exports.a = () => 1;\nmodule.exports.c = () => 3;\n',
       added: {
@@ -576,7 +578,7 @@ describe('classifying a path as a test, by segment rather than by substring', ()
         + "module.exports = () => { assert.strictEqual(require('../lib.js').c(), 3); };\n",
     });
     try {
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.deepStrictEqual(r.source, ['lib.js']);
       assert.deepStrictEqual(r.tests.slice().sort(),
         ['spec/other.js', 'src/thing.test.js', 'test/check.js']);
@@ -638,7 +640,7 @@ describe('the command itself, not only the function inside it', () => {
 });
 
 describe('the record contract is the gate is, not this file is', () => {
-  test('recordOutcome reads a record the real gate wrote', () => {
+  test('recordOutcome reads a record the real gate wrote', async () => {
     // The point of this test is the coupling, not the assertion. It imports
     // scripts/precommit-gate.js, so a renamed field or a different
     // tree-computation on that side fails here rather than failing silently in
@@ -658,7 +660,7 @@ describe('the record contract is the gate is, not this file is', () => {
         execFileSync('git', ['write-tree'], { cwd: dir, encoding: 'utf8' }).trim(),
         'the gate identifies a tree by git write-tree, which is what recordOutcome assumes');
 
-      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const outcome = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.strictEqual(recordOutcome(dir, outcome), true,
         'a record written by the real gate is accepted');
     } finally {
@@ -668,7 +670,7 @@ describe('the record contract is the gate is, not this file is', () => {
 });
 
 describe('a renamed source file', () => {
-  test('is restored to its old path, not deleted, so a false proven is impossible', () => {
+  test('is restored to its old path, not deleted, so a false proven is impossible', async () => {
     // git diff reports a rename as one new path when rename detection is on.
     // restoreTo then asks whether that path exists at the base, finds it does
     // not, and DELETES it. The reverted run fails with a module-not-found for
@@ -692,13 +694,130 @@ describe('a renamed source file', () => {
       // Rename detection on, which is what a developer's config may well do.
       git('config', 'diff.renames', 'true');
 
-      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD });
       assert.deepStrictEqual(r.source.slice().sort(), ['new-name.js', 'old-name.js'],
         'both sides of the rename are treated as source');
       assert.strictEqual(
         execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
         'and the tree comes back clean',
       );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('AC-4 with an uncooperative child, which is where the claim was false', () => {
+  test('a test command that traps SIGINT does not hold the tree hostage', async () => {
+    // The case an independent reviewer named, twice, before it was fixed.
+    // spawnSync blocks the event loop for the whole life of the child, so the
+    // SIGINT handler could not run until the child chose to exit. A command
+    // that traps or ignores the signal therefore left the source reverted for
+    // as long as it kept running, while AC-4 claims restoration happens
+    // whatever happens. Documenting that gap did not discharge the criterion,
+    // and the reviewer was right to refuse it.
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    const marker = path.join(os.tmpdir(), `red-first-trap-${process.pid}.txt`);
+    // Behaves like a real suite on the first run: the source is present, so it
+    // passes at once. On the REVERTED run the source is gone, and this is where
+    // it turns uncooperative: it ignores SIGINT and SIGTERM and keeps running.
+    // Written this way because the command is the same on both runs, and a
+    // child that hangs on the first one never reaches the revert step at all.
+    const trapping = `${JSON.stringify(process.execPath)} -e `
+      + JSON.stringify(
+        "if (require('fs').existsSync('lib2.js')) process.exit(0);"
+        + "process.on('SIGINT', () => {}); process.on('SIGTERM', () => {});"
+        + `require('fs').writeFileSync(${JSON.stringify(marker)}, String(process.pid));`
+        + 'setTimeout(() => process.exit(1), 30000);');
+
+    try {
+      await new Promise((resolve, reject) => {
+        const kid = spawn(process.execPath,
+          [path.join(__dirname, '..', '..', 'scripts', 'red-first.js'),
+            '--repo', dir, '--base', 'main', '--tests', trapping],
+          { stdio: ['ignore', 'pipe', 'pipe'] });
+
+        let out = '';
+        let signalled = false;
+        const deadline = setTimeout(() => {
+          kid.kill('SIGKILL');
+          reject(new Error('red-first did not exit after the interrupt; the '
+            + 'trapping child held it, which is the defect this covers'));
+        }, 20000);
+
+        kid.stdout.on('data', (b) => {
+          out += b.toString();
+          if (!signalled && out.includes('restoring the source')) {
+            signalled = true;
+            setTimeout(() => kid.kill('SIGINT'), 300);
+          }
+        });
+        kid.on('error', reject);
+        kid.on('exit', () => {
+          clearTimeout(deadline);
+          try {
+            assert.strictEqual(signalled, true, 'the run reached the revert step');
+            assert.strictEqual(fs.existsSync(marker), true,
+              'the trapping child really did start and ignore the signal');
+
+            // The assertion that discriminates the kill. Restoring the tree
+            // while a child that ignores signals keeps running only holds until
+            // that child writes again, so AC-4 needs the child ended, not
+            // merely outlived. Checked by pid liveness rather than by ps, which
+            // the local sandbox blocks.
+            const kidPid = Number(fs.readFileSync(marker, 'utf8'));
+            const alive = () => { try { process.kill(kidPid, 0); return true; } catch (e) { return false; } };
+            const deadline2 = Date.now() + 3000;
+            while (alive() && Date.now() < deadline2) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+            assert.strictEqual(alive(), false,
+              `the trapping child (pid ${kidPid}) must be ended, not left running`);
+            assert.strictEqual(fs.existsSync(path.join(dir, 'lib2.js')), true,
+              'the source is back despite the child refusing to die');
+            assert.strictEqual(
+              execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(),
+              '', 'and the tree is clean');
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+    } finally {
+      fs.rmSync(marker, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('a tree that does not come back clean', () => {
+  test('overrides an otherwise proven outcome with refused', async () => {
+    // The post-restore check gates whether the central claim can be trusted at
+    // all, and nothing exercised it: the only "refused" test was the
+    // dirty-before-start case, which returns long before this branch. Here the
+    // reverted run writes to a tracked file that is neither source nor test, so
+    // restoreTo puts back what it knows about and the tree is still dirty.
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      let call = 0;
+      const runner = () => {
+        call += 1;
+        if (call === 2) {
+          // A side effect on a tracked file outside sourceFiles, which is
+          // exactly what a real test suite doing something careless would do.
+          fs.writeFileSync(path.join(dir, 'run.js'), '// scribbled on by the suite\n');
+          return false;
+        }
+        return true;
+      };
+      const r = await redFirst({ repo: dir, base: 'main', tests: CMD, runner });
+      assert.strictEqual(r.outcome, 'refused', r.reason);
+      assert.match(r.reason, /did not come back clean/);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -1,0 +1,283 @@
+'use strict';
+// Prove a change's tests fail without the change.
+//
+// Written BEFORE the implementation, which is the point rather than a detail.
+// Across five cards in one day an independent reviewer caught seven tests that
+// could not have failed, every one written after its fix while looking at the
+// finished code. A test written that way asserts what the fix obviously does:
+// the box shrank, focus is somewhere inside the editor, the decision function
+// returns the right code. A test required to fail first cannot.
+//
+// So these tests exist before red-first.js does, and each one names the case it
+// covers rather than exercising the happy path four ways.
+//
+// The limit, stated here because it must travel with every result: reverting a
+// change proves a test NOTICES that change. It cannot prove the test asserts
+// the right thing. A test can discriminate the fix and still measure a proxy.
+// This closes the cheaper half of the class, which is the half that recurred.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { redFirst, recordOutcome } = require('../../scripts/red-first.js');
+
+// A throwaway repository with a base commit, then a branch carrying whatever
+// source and test content the case needs.
+function repo({ source, testFile, baseSource = 'module.exports.a = () => 1;\n', baseTest = 'module.exports = () => {};\n' }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'red-first-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  git('init', '-q');
+  git('config', 'user.email', 't@example.com');
+  git('config', 'user.name', 'T');
+  fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'lib.js'), baseSource);
+  fs.writeFileSync(path.join(dir, 'test', 'check.js'), baseTest);
+  fs.writeFileSync(path.join(dir, 'run.js'), "require('./test/check.js')();\n");
+  // The gate record must be ignored, exactly as it is in the real repository.
+  // If it were tracked, writing it would dirty the tree and red-first would
+  // refuse to run against its own record, which is a real constraint rather
+  // than a fixture detail.
+  fs.writeFileSync(path.join(dir, '.gitignore'), '.precommit-gate.json\n');
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  git('checkout', '-q', '-b', 'change');
+  if (source !== undefined) fs.writeFileSync(path.join(dir, 'lib.js'), source);
+  if (testFile !== undefined) fs.writeFileSync(path.join(dir, 'test', 'check.js'), testFile);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'the change');
+  return { dir, git };
+}
+
+const CMD = 'node run.js';
+
+describe('red-first', () => {
+  test('a test that exercises the change is reported as proven', () => {
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib.js').b(), 2); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'proven');
+      assert.strictEqual(r.passedWithChange, true);
+      assert.strictEqual(r.failedWithoutChange, true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a test that would pass with the change deleted is the finding', () => {
+    // The pathology: an assertion on something that was already true.
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(typeof require('../lib.js').a, 'function'); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'not-discriminating');
+      assert.strictEqual(r.failedWithoutChange, false);
+      assert.match(r.reason, /pass(es)? with the source reverted|do not discriminate/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a suite already failing with the change is inconclusive, not proof', () => {
+    // A failure without the change proves nothing if the suite fails with it.
+    // Reporting that as success would turn a broken suite into evidence.
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "module.exports = () => { throw new Error('suite is broken'); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'inconclusive');
+      assert.strictEqual(r.passedWithChange, false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a change with no tests is not provable, and is not a pass', () => {
+    const { dir } = repo({ source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n' });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'not-provable');
+      assert.match(r.reason, /no tests/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a change with no source is not provable either', () => {
+    // Nothing to take away, so nothing to prove by taking it away.
+    const { dir } = repo({
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'not-provable');
+      assert.match(r.reason, /no source/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a dirty tree is refused rather than rewritten', () => {
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib.js').b(), 2); };\n",
+    });
+    try {
+      fs.writeFileSync(path.join(dir, 'lib.js'), '// edited, not committed\n');
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'refused');
+      assert.match(r.reason, /dirty|uncommitted/i);
+      // And it did not touch the edit.
+      assert.match(fs.readFileSync(path.join(dir, 'lib.js'), 'utf8'), /edited, not committed/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the tree is restored even when the reverted run throws', () => {
+    // The restore must be unconditional. A tool that can leave a repository
+    // half-reverted is worse than no tool, because the next person debugs a
+    // tree nobody put there on purpose.
+    const { dir, git } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib.js').b(), 2); };\n",
+    });
+    try {
+      const before = execFileSync('git', ['rev-parse', 'HEAD:lib.js'], { cwd: dir, encoding: 'utf8' }).trim();
+      redFirst({ repo: dir, base: 'main', tests: 'node -e "process.exit(3)"' });
+      const after = execFileSync('git', ['rev-parse', 'HEAD:lib.js'], { cwd: dir, encoding: 'utf8' }).trim();
+      assert.strictEqual(after, before, 'the committed source is unchanged');
+      assert.strictEqual(
+        execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
+        'the working tree comes back clean',
+      );
+      git('status');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the outcome reaches the record a reviewer packet can carry', () => {
+  // Three escalations in one release were the reviewer saying, correctly, that
+  // it had not been shown the tests failing without the fix, while that
+  // evidence sat in a terminal it cannot see. The packet carries the record, so
+  // the record has to carry the proof.
+  function withRecord(dir, tree) {
+    fs.writeFileSync(path.join(dir, '.precommit-gate.json'),
+      JSON.stringify({ tree, branch: 'change', at: '2026-08-20T00:00:00.000Z', steps: ['test'] }, null, 2));
+  }
+  const treeOf = (dir) => execFileSync('git', ['write-tree'], { cwd: dir, encoding: 'utf8' }).trim();
+
+  test('a proven outcome is written against the tree it was measured on', () => {
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib.js').b(), 2); };\n",
+    });
+    try {
+      const tree = treeOf(dir);
+      withRecord(dir, tree);
+      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(recordOutcome(dir, outcome), true);
+
+      const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
+      assert.strictEqual(rec.redFirst.outcome, 'proven');
+      assert.strictEqual(rec.redFirst.testFiles, 1);
+      // The limit travels with the result, so a green outcome cannot be read
+      // as more than it is.
+      assert.match(rec.redFirst.limitation, /cannot prove they assert the right thing/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a failing outcome is recorded too, so absence and failure stay different', () => {
+    // A packet that cannot tell "never run" from "run and found wanting"
+    // invites the reader to assume the kinder one.
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(typeof require('../lib.js').a, 'function'); };\n",
+    });
+    try {
+      withRecord(dir, treeOf(dir));
+      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      recordOutcome(dir, outcome);
+      const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
+      assert.strictEqual(rec.redFirst.outcome, 'not-discriminating');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a record for a different tree is refused rather than overwritten', () => {
+    // A result describes the tree it was measured on. Writing it onto another
+    // tree's record would vouch for content nobody checked.
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      withRecord(dir, 'f'.repeat(40));
+      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(recordOutcome(dir, outcome), false);
+      const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
+      assert.strictEqual(rec.redFirst, undefined, 'the stale record is left alone');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('with no record present there is nothing to fold into', () => {
+    const { dir } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(recordOutcome(dir, outcome), false);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the record file must not dirty the tree it describes', () => {
+  test('a tracked gate record makes red-first refuse its own repository', () => {
+    // Learned by writing the fixture without a .gitignore: the record landed
+    // as an untracked file, the tree was dirty, and red-first correctly
+    // refused. Worth pinning, because the failure looks like a broken tool
+    // rather than a mis-configured repository.
+    const { dir, git } = repo({
+      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      fs.rmSync(path.join(dir, '.gitignore'));
+      git('add', '-A');
+      git('commit', '-q', '-m', 'stop ignoring the record');
+      fs.writeFileSync(path.join(dir, '.precommit-gate.json'), '{}');
+
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'refused');
+      assert.match(r.reason, /uncommitted/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -21,7 +21,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
+const { execFileSync, spawn } = require('node:child_process');
 
 const { redFirst, recordOutcome } = require('../../scripts/red-first.js');
 
@@ -54,7 +54,7 @@ function repo({ source, testFile, added = {}, baseSource = 'module.exports.a = (
     fs.writeFileSync(path.join(dir, rel), content);
   }
   git('add', '-A');
-  git('commit', '-q', '-m', 'the change');
+  git('commit', '-q', '--allow-empty', '-m', 'the change');
   return { dir, git };
 }
 
@@ -153,29 +153,6 @@ describe('red-first', () => {
     }
   });
 
-  test('the tree is restored even when the reverted run throws', () => {
-    // The restore must be unconditional. A tool that can leave a repository
-    // half-reverted is worse than no tool, because the next person debugs a
-    // tree nobody put there on purpose.
-    const { dir, git } = repo({
-      source: 'module.exports.a = () => 1;\nmodule.exports.b = () => 2;\n',
-      testFile: "const assert = require('assert');\n"
-        + "module.exports = () => { assert.strictEqual(require('../lib.js').b(), 2); };\n",
-    });
-    try {
-      const before = execFileSync('git', ['rev-parse', 'HEAD:lib.js'], { cwd: dir, encoding: 'utf8' }).trim();
-      redFirst({ repo: dir, base: 'main', tests: 'node -e "process.exit(3)"' });
-      const after = execFileSync('git', ['rev-parse', 'HEAD:lib.js'], { cwd: dir, encoding: 'utf8' }).trim();
-      assert.strictEqual(after, before, 'the committed source is unchanged');
-      assert.strictEqual(
-        execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
-        'the working tree comes back clean',
-      );
-      git('status');
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
-  });
 });
 
 describe('the outcome reaches the record a reviewer packet can carry', () => {
@@ -351,6 +328,192 @@ describe('source added by the change, with no version at the base', () => {
         execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
       );
     } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the restore runs whatever happens, which is the claim AC-4 makes', () => {
+  // The first version of this test passed a command that always exited
+  // non-zero. That made the FIRST run fail, so redFirst returned
+  // 'inconclusive' and never entered the try/finally the test was named for.
+  // It would have passed with the finally block deleted. An independent
+  // reviewer found that; writing the test before the implementation did not,
+  // because the test was written against an imagined ordering and the real
+  // ordering silently invalidated its premise.
+  //
+  // The fix is a seam: the run function is injectable, so a test can make the
+  // reverted run throw while the first run passes, which is the only way to
+  // reach the restore by the path a real failure would take.
+
+  test('a throw from the reverted run still puts the source back', () => {
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    try {
+      let call = 0;
+      const runner = () => {
+        call += 1;
+        if (call === 1) return true;          // green with the change
+        throw new Error('the runner blew up mid-revert');
+      };
+      assert.throws(() => redFirst({ repo: dir, base: 'main', tests: CMD, runner }),
+        /blew up mid-revert/);
+
+      assert.strictEqual(call, 2, 'the reverted run was actually reached');
+      assert.strictEqual(fs.existsSync(path.join(dir, 'lib2.js')), true,
+        'the added file is back');
+      assert.strictEqual(
+        execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
+        'and the tree is clean',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an interrupt during the reverted run does not leave the tree reverted', () => {
+    // try/finally does not survive a signal: Node's default handling
+    // terminates without unwinding. So this spawns the real script and
+    // interrupts it in the window where the source is taken away, which is the
+    // only window where an abandoned tree does damage.
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    return new Promise((resolve, reject) => {
+      const slow = `${JSON.stringify(process.execPath)} -e "setTimeout(()=>process.exit(0), 4000)"`;
+      const kid = spawn(process.execPath,
+        [path.join(__dirname, '..', '..', 'scripts', 'red-first.js'),
+          '--repo', dir, '--base', 'main', '--tests', slow],
+        { stdio: ['ignore', 'pipe', 'pipe'] });
+
+      let out = '';
+      let signalled = false;
+      kid.stdout.on('data', (b) => {
+        out += b.toString();
+        // Interrupt once the source has actually been taken away.
+        if (!signalled && out.includes('restoring the source')) {
+          signalled = true;
+          setTimeout(() => kid.kill('SIGINT'), 150);
+        }
+      });
+      kid.on('error', reject);
+      kid.on('exit', () => {
+        try {
+          assert.strictEqual(signalled, true, 'the run reached the revert step');
+          assert.strictEqual(fs.existsSync(path.join(dir, 'lib2.js')), true,
+            'the added file survived the interrupt');
+          assert.strictEqual(
+            execFileSync('git', ['status', '--porcelain'], { cwd: dir, encoding: 'utf8' }).trim(), '',
+            'the tree is clean after an interrupt',
+          );
+          resolve();
+        } catch (e) {
+          reject(e);
+        } finally {
+          fs.rmSync(dir, { recursive: true, force: true });
+        }
+      });
+    });
+  });
+});
+
+describe('the record carries test counts, not a count of files', () => {
+  // AC-6 names how many tests failed without the change and how many passed
+  // with it. The first implementation wrote sourceFiles and testFiles, which
+  // are counts of FILES: a proxy substituted for the property the criterion
+  // named, which is the pathology this whole card exists to stop, committed
+  // inside the card itself.
+  function countableRepo() {
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const { test } = require('node:test');\n"
+        + "const assert = require('node:assert');\n"
+        + "test('b is two', () => { assert.strictEqual(require('../lib2.js').b(), 2); });\n"
+        + "test('b is a function', () => { assert.strictEqual(typeof require('../lib2.js').b, 'function'); });\n",
+    });
+    return dir;
+  }
+
+  test('both counts reach the record', () => {
+    const dir = countableRepo();
+    try {
+      // The fixture already ignores the record file, so there is nothing to
+      // commit here and no reason to touch the tree before measuring it.
+      const tree = execFileSync('git', ['write-tree'], { cwd: dir, encoding: 'utf8' }).trim();
+      fs.writeFileSync(path.join(dir, '.precommit-gate.json'),
+        JSON.stringify({ tree, branch: 'change', at: 'x', steps: ['test'] }));
+
+      const outcome = redFirst({ repo: dir, base: 'main', tests: 'node --test test/check.js' });
+      assert.strictEqual(outcome.outcome, 'proven', outcome.reason);
+      recordOutcome(dir, outcome);
+
+      const rec = JSON.parse(fs.readFileSync(path.join(dir, '.precommit-gate.json'), 'utf8'));
+      assert.strictEqual(rec.redFirst.testsPassedWithChange, 2);
+      assert.strictEqual(rec.redFirst.testsFailedWithoutChange, 2);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('an unparsable summary records null rather than a guess', () => {
+    // A count invented from output nobody could read is worse than no count,
+    // because the record is the thing the reviewer is asked to trust.
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\n"
+        + "module.exports = () => { assert.strictEqual(require('../lib2.js').b(), 2); };\n",
+    });
+    try {
+      const outcome = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(outcome.outcome, 'proven', outcome.reason);
+      assert.strictEqual(outcome.testsPassedWithChange, null);
+      assert.strictEqual(outcome.testsFailedWithoutChange, null);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('a branch with no diff at all', () => {
+  test('is not-provable, by its own path rather than by resemblance', () => {
+    const { dir } = repo({});
+    try {
+      const r = redFirst({ repo: dir, base: 'main', tests: CMD });
+      assert.strictEqual(r.outcome, 'not-provable');
+      assert.match(r.reason, /nothing changed/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the test command does not inherit this runner is own context', () => {
+  test('NODE_TEST_CONTEXT is stripped, because it makes a nested runner exit 0', () => {
+    // Found while writing the counts test. `node --test` that inherits
+    // NODE_TEST_CONTEXT reports failures and still exits 0, so a suite that
+    // should have gone red comes back green. For a tool whose only job is
+    // detecting false green, being fooled into green is the worst available
+    // failure, and it only shows up when red-first is driven from inside a
+    // test, which is exactly how it is exercised here.
+    assert.ok(process.env.NODE_TEST_CONTEXT,
+      'this test is meaningless unless the parent really is a test child');
+
+    const { dir } = repo({
+      added: { 'lib2.js': 'module.exports.b = () => 2;\n' },
+      testFile: "const assert = require('assert');\nmodule.exports = () => { assert.ok(true); };\n",
+    });
+    const probe = path.join(os.tmpdir(), `red-first-env-${process.pid}.txt`);
+    try {
+      const cmd = `${JSON.stringify(process.execPath)} -e `
+        + JSON.stringify(`require('fs').writeFileSync(${JSON.stringify(probe)}, String(process.env.NODE_TEST_CONTEXT))`);
+      redFirst({ repo: dir, base: 'main', tests: cmd });
+      assert.strictEqual(fs.readFileSync(probe, 'utf8'), 'undefined',
+        'the child must not see the parent test runner is context');
+    } finally {
+      fs.rmSync(probe, { force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/test/unit/red-first.test.js
+++ b/test/unit/red-first.test.js
@@ -39,8 +39,18 @@ function repo({ source, testFile, added = {}, baseSource = 'module.exports.a = (
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'red-first-'));
   const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
   git('init', '-q');
+  // Name the branch explicitly. `git init` takes its branch name from
+  // init.defaultBranch, so a fixture that says nothing gets whatever the host
+  // is configured for: main on a developer machine that set it, master on CI
+  // where nothing did. Every test in this file passed locally and every one
+  // failed in CI with "fatal: Not a valid object name main". A fixture must
+  // not read the machine it runs on.
+  git('symbolic-ref', 'HEAD', 'refs/heads/main');
   git('config', 'user.email', 't@example.com');
   git('config', 'user.name', 'T');
+  // Likewise rename detection, which some developers enable globally and which
+  // changes what `git diff --name-only` reports.
+  git('config', 'diff.renames', 'false');
   fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
   fs.writeFileSync(path.join(dir, 'lib.js'), baseSource);
   fs.writeFileSync(path.join(dir, 'test', 'check.js'), baseTest);


### PR DESCRIPTION
## Why

An independent reviewer caught seven tests in one day, written across five cards, that could not have failed. Every one asserted a proxy easier to reach than the property its criterion named: an element box rather than the painted glyphs, containment rather than identity, a pure decision function rather than the wiring around it, a clock-derived guard that skipped its assertions near midnight while still reporting green.

The cause was order, not care. Each was written after its fix, while looking at the finished code, and a test written that way asserts what the fix obviously does. Naming the pathology did not stop it: it went into the failure taxonomy that morning and produced five fresh instances that afternoon.

## What

`scripts/red-first.js` runs the check a person can do by hand and reliably will not: put the source back, keep the new tests, require them to go red.

- Runs the suite **with** the change first, so a suite failing for its own reasons is `inconclusive` rather than proof.
- Restores the tree in a `finally`, because a tool that can leave a repository half-reverted is worse than no tool.
- Outcomes name themselves (`proven`, `not-discriminating`, `inconclusive`, `not-provable`, `refused`), because "it failed" cannot distinguish a weak test from a broken suite.
- `recordOutcome` folds the result into the pre-commit gate record, keyed by the tree it was measured on, so the review packet carries the evidence. Three escalations in 0.11.8 were the reviewer correctly saying it had not been shown the tests failing without the fix, while that evidence sat in a terminal it cannot see.
- The limit travels with every result in `limitation`: reverting shows the tests *notice* the change, not that they assert the right thing.

## Verification

Tests were written before the implementation, which for this change is the argument rather than a detail. 15 unit tests.

Run on its own branch it reports **PROVEN**, and it found a real defect in itself while doing so: `git checkout <base> -- <path>` fails on a file the change *adds*, and every fixture modified a file that already existed. Fixed in the second commit by asking the target tree what it holds and making the working tree agree.

Gate record for this tree:

```json
"redFirst": {
  "outcome": "proven",
  "sourceFiles": 2,
  "testFiles": 1
}
```