### PR TITLE
Notice a change made outside Rundock

### DIFF
--- a/lib/protocol/handlers/files.js
+++ b/lib/protocol/handlers/files.js
@@ -11,7 +11,7 @@ const { readNormalisedFile } = require('../../agents/discovery.js');
 
 function handleGetFiles(ctx, ws, msg) {
   if (!getWorkspace()) return;
-  try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.getFileTreeCached() })); } catch (e) { console.warn('  File tree failed:', e.message); }
+  try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.fileTreeForSend() })); } catch (e) { console.warn('  File tree failed:', e.message); }
 }
 
 function handleReadFile(ctx, ws, msg) {
@@ -60,7 +60,7 @@ function handleCreatePath(ctx, ws, msg) {
         ctx.workspace.invalidateFileListCache(); ctx.workspace.invalidateFileTreeCache();
         const engine = ctx.store.ensureSearchEngine(); if (engine) { try { engine.noteFileSaved(getWorkspace(), rel); } catch (e) {} }
       }
-      ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.getFileTreeCached() }));
+      ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.fileTreeForSend() }));
       ws.send(JSON.stringify({ type: 'path_created', path: rel, kind: msg.kind }));
     } catch (e) {
       ws.send(JSON.stringify({ type: 'create_error', path: rel, reason: String((e && e.message) || e) }));

--- a/lib/protocol/handlers/files.js
+++ b/lib/protocol/handlers/files.js
@@ -11,7 +11,10 @@ const { readNormalisedFile } = require('../../agents/discovery.js');
 
 function handleGetFiles(ctx, ws, msg) {
   if (!getWorkspace()) return;
-  try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.fileTreeForSend() })); } catch (e) { console.warn('  File tree failed:', e.message); }
+  // Broadcast, not a reply. The record that suppresses the poll is global, so
+  // answering only the asker would leave every other client stale about a
+  // change none of them requested and the poll would stay quiet about it.
+  try { ctx.workspace.broadcastFileTree(); } catch (e) { console.warn('  File tree failed:', e.message); }
 }
 
 function handleReadFile(ctx, ws, msg) {
@@ -60,7 +63,9 @@ function handleCreatePath(ctx, ws, msg) {
         ctx.workspace.invalidateFileListCache(); ctx.workspace.invalidateFileTreeCache();
         const engine = ctx.store.ensureSearchEngine(); if (engine) { try { engine.noteFileSaved(getWorkspace(), rel); } catch (e) {} }
       }
-      ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.fileTreeForSend() }));
+      // Broadcast: a file created here exists for every client, not just the
+      // one that created it. See handleGetFiles above.
+      ctx.workspace.broadcastFileTree();
       ws.send(JSON.stringify({ type: 'path_created', path: rel, kind: msg.kind }));
     } catch (e) {
       ws.send(JSON.stringify({ type: 'create_error', path: rel, reason: String((e && e.message) || e) }));

--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -77,6 +77,19 @@ function handleSetWorkspace(ctx, ws, msg) {
       ctx.workspace.setWorkspaceRoot(previousRoot);
       ctx.agents.invalidateAgentCache();
       ctx.store.clearSearchFailure();
+      // Last, so a throw here cannot skip the rollback steps above: the whole
+      // block shares one catch, and these two are the newest and least proven.
+      //
+      // The open path baselines the tree watcher against the NEW directory
+      // before anything that can throw, so a failed switch would otherwise
+      // leave both the tree cache and the poller's signature describing a
+      // workspace the server is no longer in. Freshness is keyed on absolute
+      // directory paths that still exist, so the stale cache reads as fresh
+      // and the failed workspace's tree would be served as if it were this
+      // one. Invalidate before re-arming: the baseline is built through the
+      // cached getter, which would otherwise hand back the poisoned tree.
+      ctx.workspace.invalidateFileTreeCache();
+      ctx.workspace.armFileTreeWatcher();
     } catch (rollbackErr) { console.warn('  Workspace rollback failed:', rollbackErr.message); }
     ws.send(JSON.stringify({ type: 'workspace_error', message: 'Could not open workspace: ' + e.message }));
   }
@@ -138,7 +151,7 @@ function openWorkspace(ctx, ws, dir) {
   startup.mark('analyze');
   ws.send(JSON.stringify({ type: 'workspace_set', path: getWorkspace(), analysis, isEmpty, workspaceMode: state.workspaceMode, setupComplete: !!state.setupComplete, scaffoldError }));
   ws.send(JSON.stringify({ type: 'agents', agents: agentList }));
-  try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.getFileTreeCached() })); } catch (e) { console.warn('  File tree failed:', e.message); }
+  try { ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.fileTreeForSend() })); } catch (e) { console.warn('  File tree failed:', e.message); }
   startup.mark('tree');
   ctx.signals.reportStartup(`workspace open: ${startup.summary()}`);
   // Warm the search index off the open path (reconcile-on-open);
@@ -209,7 +222,7 @@ function handleCreateWorkspace(ctx, ws, msg) {
 
       ws.send(JSON.stringify({ type: 'workspace_set', path: getWorkspace(), analysis, isEmpty: true, workspaceMode: state.workspaceMode, setupComplete: false, scaffoldError }));
       ws.send(JSON.stringify({ type: 'agents', agents: agentList }));
-      ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.getFileTreeCached() }));
+      ws.send(JSON.stringify({ type: 'file_tree', tree: ctx.workspace.fileTreeForSend() }));
     } catch (e) {
       ws.send(JSON.stringify({ type: 'workspace_error', message: 'Could not create workspace: ' + e.message }));
     }

--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -78,17 +78,13 @@ function handleSetWorkspace(ctx, ws, msg) {
       ctx.agents.invalidateAgentCache();
       ctx.store.clearSearchFailure();
       // Last, so a throw here cannot skip the rollback steps above: the whole
-      // block shares one catch, and these two are the newest and least proven.
+      // block shares one catch, and this is the newest and least proven step.
       //
       // The open path baselines the tree watcher against the NEW directory
       // before anything that can throw, so a failed switch would otherwise
       // leave both the tree cache and the poller's signature describing a
-      // workspace the server is no longer in. Freshness is keyed on absolute
-      // directory paths that still exist, so the stale cache reads as fresh
-      // and the failed workspace's tree would be served as if it were this
-      // one. Invalidate before re-arming: the baseline is built through the
-      // cached getter, which would otherwise hand back the poisoned tree.
-      ctx.workspace.invalidateFileTreeCache();
+      // workspace the server is no longer in. Re-arming clears the cache as
+      // part of arming, so this one call restores both.
       ctx.workspace.armFileTreeWatcher();
     } catch (rollbackErr) { console.warn('  Workspace rollback failed:', rollbackErr.message); }
     ws.send(JSON.stringify({ type: 'workspace_error', message: 'Could not open workspace: ' + e.message }));

--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -90,6 +90,7 @@ function openWorkspace(ctx, ws, dir) {
   ctx.runtime.killAllChildren();
   ctx.workspace.setWorkspaceRoot(dir);
   ctx.agents.armAgentsDirWatcher();
+  ctx.workspace.armFileTreeWatcher();
   // Before anything reads state that may have come from another path.
   ctx.workspace.healWorkspaceIfMoved(dir);
   // A workspace switch (including re-selecting the same one) is the
@@ -186,6 +187,7 @@ function handleCreateWorkspace(ctx, ws, msg) {
       ctx.runtime.killAllChildren();
       ctx.workspace.setWorkspaceRoot(dir);
       ctx.agents.armAgentsDirWatcher();
+      ctx.workspace.armFileTreeWatcher();
       loadRoutineState();
       ctx.workspace.saveRecentWorkspace(dir);
 

--- a/server.js
+++ b/server.js
@@ -1941,6 +1941,17 @@ function fileTreeForSend() {
 function armFileTreeWatcher() {
   if (_treeWatchTimer) { clearInterval(_treeWatchTimer); _treeWatchTimer = null; }
   if (!WORKSPACE) return;
+  // Drop the cache before baselining, because every caller has just pointed
+  // the server at a workspace and the cache still describes the previous one.
+  // Freshness re-stats the ABSOLUTE directory paths it recorded and never
+  // checks which workspace they belong to, so a previous workspace still
+  // sitting untouched on disk reads as fresh: the baseline would be taken
+  // from the wrong tree and the interval would go on stat-checking the wrong
+  // directories, unable to see any change in the workspace it is supposed to
+  // be watching. Arming is always a workspace boundary, so this is always the
+  // right thing to do here, and it belongs here rather than at each call site
+  // where the next one added would forget it.
+  invalidateFileTreeCache();
   // Baseline against what is on disk right now, so entering a workspace is
   // never itself reported as an external change.
   _lastSentTreeSig = JSON.stringify(getFileTreeCached());

--- a/server.js
+++ b/server.js
@@ -1159,7 +1159,7 @@ const wsHandlerContext = {
     setWorkspaceRoot, healWorkspaceIfMoved, saveRecentWorkspace, loadRecentWorkspaces,
     discoverWorkspaces, isInsideWorkspace, isSafeCreatePath, getFileTreeCached,
     invalidateFileListCache, invalidateFileTreeCache, watchOpenFile,
-    fileTreeForSend, armFileTreeWatcher,
+    fileTreeForSend, broadcastFileTree, armFileTreeWatcher,
   },
   runtime: { getRuntimeStatus, killAllChildren, cleanOrphanedProcesses },
   signals: { reportStartup, phaseTimer },         // startup telemetry (recordEvent is lib-owned)
@@ -1934,13 +1934,35 @@ let _lastSentTreeSig = null;
 let _lastSeenTree = null;
 
 // The tree, plus a record that this is what clients have now been told. Every
-// site that sends a file_tree must go through here, or the poll will send it
-// again.
+// site that sends a file_tree must go through here or through
+// broadcastFileTree, or the poll will send it again.
+//
+// Use this one only where the send genuinely concerns the requester alone.
+// The record it writes is process-global, so a send that reaches ONE client
+// while claiming the tree is delivered starves every other client of the
+// poll's broadcast: see broadcastFileTree.
 function fileTreeForSend() {
   const tree = getFileTreeCached();
   _lastSeenTree = tree;
   _lastSentTreeSig = JSON.stringify(tree);
   return tree;
+}
+
+// The tree, delivered to EVERY connected client, and recorded as delivered.
+//
+// The record that suppresses the poll is process-global, but a reply on one
+// socket is not. So a per-connection reply that recorded the tree as sent
+// would tell the poll to stay quiet about a change the other clients never
+// received, and they would sit stale until some later change happened to
+// occur. They made no request of their own, which is exactly the case the
+// poll exists to serve.
+//
+// The file tree is shared state: one server, one workspace, one tree. Every
+// client wants the same answer, so the send that records it as answered has
+// to be the send that reaches all of them. A client that did not ask
+// reconciles the push to zero operations and nothing moves on its screen.
+function broadcastFileTree() {
+  safeSend(JSON.stringify({ type: 'file_tree', tree: fileTreeForSend() }));
 }
 
 function armFileTreeWatcher() {
@@ -3030,7 +3052,7 @@ module.exports._internal = {
   setWorkspace(dir) { setWorkspaceRoot(dir); invalidateAgentCache(); armAgentsDirWatcher(); armFileTreeWatcher(); },
   getWorkspace() { return WORKSPACE; },
   // file tree external-change poll
-  armFileTreeWatcher, fileTreeForSend,
+  armFileTreeWatcher, fileTreeForSend, broadcastFileTree,
   flatFileListCached, invalidateFileListCache,
   // scheduler
   getNextRun, executeRoutine, routineState, startScheduler,

--- a/server.js
+++ b/server.js
@@ -1159,6 +1159,7 @@ const wsHandlerContext = {
     setWorkspaceRoot, healWorkspaceIfMoved, saveRecentWorkspace, loadRecentWorkspaces,
     discoverWorkspaces, isInsideWorkspace, isSafeCreatePath, getFileTreeCached,
     invalidateFileListCache, invalidateFileTreeCache, watchOpenFile,
+    fileTreeForSend, armFileTreeWatcher,
   },
   runtime: { getRuntimeStatus, killAllChildren, cleanOrphanedProcesses },
   signals: { reportStartup, phaseTimer },         // startup telemetry (recordEvent is lib-owned)
@@ -1872,6 +1873,89 @@ function getFileTreeCached() {
   try { dirs.set(WORKSPACE, fs.statSync(WORKSPACE).mtimeMs); } catch (e) {}
   _treeCache = { tree, dirs };
   return tree;
+}
+
+// ── External-change poll ───────────────────────────────────────────────────
+// Nothing else watches the filesystem on the tree's behalf. The client asks
+// for the tree in exactly three places and all three mean "Rundock did
+// something": workspace open, after a file-writing tool call, and after an
+// agent turn. So a file written by anything else (a CLI agent session, an
+// editor, git, a sync client) never reached the sidebar until a restart,
+// while search saw it within seconds through its own TTL-gated reconcile.
+//
+// A self-owned POLLER, not fs.watch, for the reasons already written up at
+// the agents-directory watcher: event-based watching is where the 0.11.5
+// live-refresh data-loss bug lived, and fs.watch delivery differs across
+// platforms and Node versions. Detection is the tree cache's own freshness
+// pass, which is a directory-only stat walk, so a quiet workspace costs one
+// stat per directory and reads none of them.
+//
+// TWO GUARDS, because a push that fights the reconcile diff would undo the
+// no-flicker work that card bought.
+//
+// The first is freshness: an unchanged workspace returns before anything is
+// built or sent, so nothing reaches the wire at all. Not a push that
+// reconciles to zero operations, which would still cost a serialisation on
+// every tick, forever, on the thread driving the window.
+//
+// That check is deliberately REDUNDANT with the one inside getFileTreeCached,
+// and the redundancy is the point rather than an oversight. Without it a
+// quiet tick still returns the cached tree correctly, but only after
+// serialising the whole thing to compare it, which on a large vault is
+// hundreds of kilobytes every two seconds for no result. The price is one
+// extra directory-stat pass on ticks that DO find a change, which is
+// negligible beside the walk those ticks are about to do anyway. No test
+// discriminates this line: deleting it leaves every assertion green, because
+// what it saves is serialisation rather than directory reads. It is kept on
+// the cost argument alone, which is stated here so the next reader does not
+// have to rediscover it before deleting it.
+//
+// The second is the signature, and it is the one that is easy to get wrong.
+// Cache invalidation is NOT evidence of an external change: every in-app save
+// and create calls invalidateFileTreeCache(), which makes treeCacheIsFresh()
+// false on the very next tick. Keying the push off freshness alone therefore
+// duplicates every tree the handlers already sent, and re-walks after every
+// content save. Comparing against the last tree actually SENT distinguishes
+// the two: the handlers record theirs through fileTreeForSend, so work that
+// went out through a handler is already accounted for by the time the poll
+// looks. Tree nodes carry only type, name, path and kind, never mtime or
+// size, so a content edit cannot move the signature on its own.
+//
+// One consequence worth naming: changing a note's frontmatter to a board DOES
+// move the signature, so the poll happens to close the fileKind gap recorded
+// against the cache above. That is a side effect of comparing trees rather
+// than an intended feature, and nothing should depend on it.
+const TREE_WATCH_POLL_MS = parseInt(process.env.RUNDOCK_TREE_POLL_MS || '', 10) || 2000;
+let _treeWatchTimer = null;
+let _lastSentTreeSig = null;
+
+// The tree, plus a record that this is what clients have now been told. Every
+// site that sends a file_tree must go through here, or the poll will send it
+// again.
+function fileTreeForSend() {
+  const tree = getFileTreeCached();
+  _lastSentTreeSig = JSON.stringify(tree);
+  return tree;
+}
+
+function armFileTreeWatcher() {
+  if (_treeWatchTimer) { clearInterval(_treeWatchTimer); _treeWatchTimer = null; }
+  if (!WORKSPACE) return;
+  // Baseline against what is on disk right now, so entering a workspace is
+  // never itself reported as an external change.
+  _lastSentTreeSig = JSON.stringify(getFileTreeCached());
+  _treeWatchTimer = setInterval(() => {
+    if (!WORKSPACE) return;
+    if (treeCacheIsFresh()) return;
+    const tree = getFileTreeCached();
+    const sig = JSON.stringify(tree);
+    if (sig === _lastSentTreeSig) return;
+    _lastSentTreeSig = sig;
+    safeSend(JSON.stringify({ type: 'file_tree', tree }));
+    console.log('[FileTree] workspace changed on disk; pushed a refreshed tree');
+  }, TREE_WATCH_POLL_MS);
+  // Never hold shutdown open for a sidebar refresh.
+  if (_treeWatchTimer.unref) _treeWatchTimer.unref();
 }
 
 // ===== PROCESS CLEANUP (S4) =====
@@ -2860,6 +2944,7 @@ async function runUniversalSearch(msg) {
 
 function startServer(options = {}) {
   armAgentsDirWatcher();
+  armFileTreeWatcher();
   const port = options.port != null ? options.port : PORT;
   return new Promise((resolve) => {
     server.listen(port, () => {
@@ -2924,8 +3009,10 @@ module.exports = { startServer };
 // tests can point the module-level WORKSPACE at a temp fixture directory.
 module.exports._internal = {
   // workspace pointer (test fixture wiring only)
-  setWorkspace(dir) { setWorkspaceRoot(dir); invalidateAgentCache(); armAgentsDirWatcher(); },
+  setWorkspace(dir) { setWorkspaceRoot(dir); invalidateAgentCache(); armAgentsDirWatcher(); armFileTreeWatcher(); },
   getWorkspace() { return WORKSPACE; },
+  // file tree external-change poll
+  armFileTreeWatcher, fileTreeForSend,
   // scheduler
   getNextRun, executeRoutine, routineState, startScheduler,
   loadRoutineState, saveRoutineState, recordRoutineRun,

--- a/server.js
+++ b/server.js
@@ -1893,22 +1893,24 @@ function getFileTreeCached() {
 // TWO GUARDS, because a push that fights the reconcile diff would undo the
 // no-flicker work that card bought.
 //
-// The first is freshness: an unchanged workspace returns before anything is
-// built or sent, so nothing reaches the wire at all. Not a push that
-// reconciles to zero operations, which would still cost a serialisation on
-// every tick, forever, on the thread driving the window.
+// The first is identity, and it must NOT be a freshness check. _treeCache is
+// shared by every caller of getFileTreeCached, not only by the poll and the
+// handlers: the search file list and the grep file list both rebuild it on
+// their own expiry. So a search running between an external write and the
+// next tick rebuilds the cache to match the already-changed disk and marks it
+// fresh, without touching _lastSentTreeSig. A tick guarded on freshness then
+// returns before it ever compares signatures, and that external change is
+// never pushed at all: the sidebar stays stale until some unrelated change
+// happens to occur. An earlier revision of this poll had exactly that bug,
+// defended with a cost argument that assumed the poll and the handlers were
+// the only writers of the cache. They are not.
 //
-// That check is deliberately REDUNDANT with the one inside getFileTreeCached,
-// and the redundancy is the point rather than an oversight. Without it a
-// quiet tick still returns the cached tree correctly, but only after
-// serialising the whole thing to compare it, which on a large vault is
-// hundreds of kilobytes every two seconds for no result. The price is one
-// extra directory-stat pass on ticks that DO find a change, which is
-// negligible beside the walk those ticks are about to do anyway. No test
-// discriminates this line: deleting it leaves every assertion green, because
-// what it saves is serialisation rather than directory reads. It is kept on
-// the cost argument alone, which is stated here so the next reader does not
-// have to rediscover it before deleting it.
+// Comparing the tree OBJECT instead is both correct and cheap. A fresh cache
+// hands back the same array every time, so an idle tick matches on identity
+// and returns without serialising anything. A cache rebuilt by anyone at all
+// hands back a new array, which fails identity and falls through to the
+// signature comparison, where a genuine change is caught and a rebuild that
+// changed nothing costs one serialisation and is dropped.
 //
 // The second is the signature, and it is the one that is easy to get wrong.
 // Cache invalidation is NOT evidence of an external change: every in-app save
@@ -1928,12 +1930,15 @@ function getFileTreeCached() {
 const TREE_WATCH_POLL_MS = parseInt(process.env.RUNDOCK_TREE_POLL_MS || '', 10) || 2000;
 let _treeWatchTimer = null;
 let _lastSentTreeSig = null;
+// The exact array last compared. Identity only: never read for its contents.
+let _lastSeenTree = null;
 
 // The tree, plus a record that this is what clients have now been told. Every
 // site that sends a file_tree must go through here, or the poll will send it
 // again.
 function fileTreeForSend() {
   const tree = getFileTreeCached();
+  _lastSeenTree = tree;
   _lastSentTreeSig = JSON.stringify(tree);
   return tree;
 }
@@ -1954,11 +1959,13 @@ function armFileTreeWatcher() {
   invalidateFileTreeCache();
   // Baseline against what is on disk right now, so entering a workspace is
   // never itself reported as an external change.
-  _lastSentTreeSig = JSON.stringify(getFileTreeCached());
+  _lastSeenTree = getFileTreeCached();
+  _lastSentTreeSig = JSON.stringify(_lastSeenTree);
   _treeWatchTimer = setInterval(() => {
     if (!WORKSPACE) return;
-    if (treeCacheIsFresh()) return;
     const tree = getFileTreeCached();
+    if (tree === _lastSeenTree) return;
+    _lastSeenTree = tree;
     const sig = JSON.stringify(tree);
     if (sig === _lastSentTreeSig) return;
     _lastSentTreeSig = sig;
@@ -3024,6 +3031,7 @@ module.exports._internal = {
   getWorkspace() { return WORKSPACE; },
   // file tree external-change poll
   armFileTreeWatcher, fileTreeForSend,
+  flatFileListCached, invalidateFileListCache,
   // scheduler
   getNextRun, executeRoutine, routineState, startScheduler,
   loadRoutineState, saveRoutineState, recordRoutineRun,

--- a/test/integration/external-tree-changes.test.js
+++ b/test/integration/external-tree-changes.test.js
@@ -21,7 +21,9 @@
 // freshness. The remaining
 // tests are guard criteria of the form "and it must not also do X" (the two
 // quiet cases, the in-app create, the in-app save, and the post-switch save),
-// so with no poller at all they pass vacuously. They
+// so with no poller at all they pass vacuously. One more covers a second
+// connected client, which the rest of the file cannot see because it drives
+// only one. They
 // earn their place once the poller is in, where they are the only thing
 // standing between a working push and one that fights the reconcile diff or
 // duplicates work Rundock did itself.
@@ -185,6 +187,52 @@ describe('a change made outside Rundock reaches the file tree', () => {
       treePaths(msg.tree).includes('written-then-searched.md'),
       'a search must not be able to absorb an external change on the tree\'s behalf'
     );
+  });
+
+  test('a second client is not starved by the first client asking', async () => {
+    // The record that suppresses the poll is process-global. The dangerous
+    // ordering is the external write landing FIRST: the other client's own
+    // get_files then absorbs the change into that global record, and a poll
+    // keyed on it stays quiet about a change this client never received.
+    //
+    // Note the ordering. With the request first, the write still moves the
+    // signature afterwards and the poll broadcasts anyway, so a test written
+    // that way passes whether or not the send reaches everybody.
+    const second = await h.connect();
+    await h.delay(POLL_MS * 2);
+
+    const watching = second.messages.length;
+    fs.writeFileSync(path.join(h.workspaceDir, 'seen-by-both.md'), '# External\n');
+    client.send({ type: 'get_files' });
+
+    const { msg } = await second.waitFor(m => m.type === 'file_tree', {
+      since: watching,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'file_tree reaching the client that never asked for one',
+    });
+    assert.ok(
+      treePaths(msg.tree).includes('seen-by-both.md'),
+      'a client that made no request must still be told about an external change'
+    );
+    // Same starvation, other send site: a file created by one client exists
+    // for every client. Without a broadcast the creator's own reply records
+    // the tree as delivered, the poll finds nothing new to say, and the other
+    // client never learns the file exists.
+    const created = second.messages.length;
+    client.send({ type: 'create_path', path: 'made-for-both.md', kind: 'note', content: '# Shared\n' });
+
+    const { msg: afterCreate } = await second.waitFor(m => m.type === 'file_tree', {
+      since: created,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'file_tree reaching the other client after an in-app create',
+    });
+    assert.ok(
+      treePaths(afterCreate.tree).includes('made-for-both.md'),
+      'a file created by one client must reach the others'
+    );
+
+    second.close();
+    await h.delay(POLL_MS);
   });
 
   test('an untouched workspace produces no pushes at all', async () => {

--- a/test/integration/external-tree-changes.test.js
+++ b/test/integration/external-tree-changes.test.js
@@ -159,6 +159,34 @@ describe('a change made outside Rundock reaches the file tree', () => {
     );
   });
 
+  test('a search rebuilding the shared cache does not swallow the change', async () => {
+    // _treeCache is shared by every caller of getFileTreeCached, not only by
+    // the poll and the handlers. The search file list rebuilds it on its own
+    // expiry, which marks it fresh against already-changed disk WITHOUT
+    // recording anything as sent. A poll guarded on freshness returns before
+    // it compares signatures, and the change is never pushed: the sidebar
+    // stays stale until some unrelated change happens to occur.
+    //
+    // Reproduced here by driving the search path between the write and the
+    // tick. h.internal reaches the same function the search handlers use.
+    const since = client.messages.length;
+    fs.writeFileSync(path.join(h.workspaceDir, 'written-then-searched.md'), '# External\n');
+
+    // Rebuild the shared cache the way a search would, before the poll looks.
+    h.internal.invalidateFileListCache();
+    h.internal.flatFileListCached();
+
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested push after a search rebuilt the cache first',
+    });
+    assert.ok(
+      treePaths(msg.tree).includes('written-then-searched.md'),
+      'a search must not be able to absorb an external change on the tree\'s behalf'
+    );
+  });
+
   test('an untouched workspace produces no pushes at all', async () => {
     // Not "a push that reconciles to zero operations": nothing on the wire.
     const since = client.messages.length;

--- a/test/integration/external-tree-changes.test.js
+++ b/test/integration/external-tree-changes.test.js
@@ -14,10 +14,14 @@
 //
 // HONESTY NOTE ON WHAT EACH TEST PROVES, measured by reverting rather than
 // assumed. THREE tests go red when the poll is removed, and they are the ones
-// that prove the mechanism exists: external create, external mkdir, external
-// delete. The remaining tests are guard criteria of the form "and it must not
-// also do X" (the two quiet cases, the in-app create, the in-app save, and
-// the workspace switch), so with no poller at all they pass vacuously. They
+// that prove the mechanism exists at boot: external create, external mkdir,
+// external delete. Three more cover the workspace boundary: that the open and
+// create paths arm a poll when none is running, which is what a fresh install
+// is, and that creating a workspace does not inherit the previous one's
+// freshness. The remaining
+// tests are guard criteria of the form "and it must not also do X" (the two
+// quiet cases, the in-app create, the in-app save, and the post-switch save),
+// so with no poller at all they pass vacuously. They
 // earn their place once the poller is in, where they are the only thing
 // standing between a working push and one that fights the reconcile diff or
 // duplicates work Rundock did itself.
@@ -243,51 +247,143 @@ describe('a change made outside Rundock reaches the file tree', () => {
     );
   });
 
-  // LAST ON PURPOSE: this repoints the server at another directory, so any
-  // test after it would be measuring a workspace it did not set up.
-  test('opening a workspace does not leave the poll believing it missed a change', async () => {
-    // Opening a workspace scaffolds into it, which changes the tree AFTER the
-    // watcher has taken its baseline. If the tree that open sends is not
-    // recorded as sent, the baseline still describes the pre-scaffold
-    // directory, and the next cache invalidation that changes nothing
-    // structural (a content save) makes the poll compare against it and
-    // announce Rundock's own scaffolding as an external change.
+  // LAST ON PURPOSE: these repoint the server at another directory and clear
+  // the workspace to construct their starting state, so any test after them
+  // would be measuring a workspace it did not set up.
+
+  test('opening a workspace arms the poll when nothing had armed it', async () => {
+    // The case the arming call in the open path exists for, and the only one
+    // that can prove it: the server running with NO workspace, which is what
+    // a fresh install is, and what a recent workspace that has gone away
+    // leaves behind. Nothing has started a poll, so detection for the rest of
+    // the session depends entirely on the open path arming one.
+    //
+    // Without this setup the test cannot discriminate, and that was checked
+    // rather than assumed: the interval reads the workspace at TICK time, so
+    // the one armed at boot keeps working across a switch and deleting the
+    // open path's arming call leaves every other assertion in this file
+    // green.
+    h.internal.setWorkspace(null);
+    await h.delay(POLL_MS * 2);
+
     const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-open-'));
     const since = client.messages.length;
     client.send({ type: 'set_workspace', path: fresh });
 
     await client.waitFor(m => m.type === 'workspace_set', {
-      since,
-      timeout: 15000,
-      label: 'workspace_set for the freshly opened workspace',
+      since, timeout: 15000, label: 'workspace_set for the switched-to workspace',
     });
     const opened = await client.waitFor(m => m.type === 'file_tree', {
-      since,
-      timeout: 15000,
-      label: 'file_tree for the freshly opened workspace',
+      since, timeout: 15000, label: 'file_tree for the switched-to workspace',
     });
-
-    // Let the scaffold settle, then invalidate WITHOUT sending a tree. It has
-    // to be a content save: create_path rebuilds and records on its way out,
-    // which repairs a stale baseline and hides exactly the defect under test.
     await h.delay(POLL_MS * 4);
 
+    const external = client.messages.length;
+    fs.writeFileSync(path.join(fresh, 'after-the-switch.md'), '# External\n');
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since: external,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested push after an external write to the switched-to workspace',
+    });
+    assert.ok(
+      treePaths(msg.tree).includes('after-the-switch.md'),
+      'the push must describe the workspace switched to, not the one booted'
+    );
+
+    // And the switch must not have left the poll believing it missed the
+    // scaffold. It has to be a content save: create_path rebuilds and records
+    // on its way out, which repairs a stale baseline and hides the defect.
     const scaffolded = treeFiles(opened.msg.tree);
-    assert.ok(scaffolded.length > 0, 'opening a workspace must scaffold at least one visible file to save');
+    assert.ok(scaffolded.length > 0, 'opening a workspace must scaffold at least one visible file');
 
     const quiet = client.messages.length;
     client.send({ type: 'save_file', path: scaffolded[0], content: '# Edited after open\n' });
     await client.waitFor(m => m.type === 'file_saved', {
-      since: quiet,
-      timeout: 8000,
-      label: 'file_saved in the freshly opened workspace',
+      since: quiet, timeout: 8000, label: 'file_saved in the switched-to workspace',
     });
     await h.delay(POLL_MS * 6);
 
     const pushes = pushesSince(quiet);
     assert.strictEqual(
       pushes.length, 0,
-      `a content save after a workspace open must produce zero file_tree pushes, saw ${pushes.length}`
+      `a content save after a workspace switch must produce zero pushes, saw ${pushes.length}`
+    );
+  });
+
+  test('creating a workspace arms the poll when nothing had armed it', async () => {
+    // Same construction as the test above, and for the same reason: with a
+    // poll already running from an earlier workspace this cannot fail.
+    //
+    // The create path also never cleared the tree cache of its own accord.
+    // Freshness re-stats absolute directory paths without checking which
+    // workspace they belong to, so with an earlier workspace still on disk
+    // the cache reads as fresh and the poll goes on watching it, and an
+    // external write to the NEW workspace is never seen. Arming clears the
+    // cache, which is why that now holds for every entry point rather than
+    // for the ones somebody remembered.
+    h.internal.setWorkspace(null);
+    await h.delay(POLL_MS * 2);
+
+    const name = 'poll-armed-on-create';
+    const created = path.join(process.env.HOME, 'Documents', 'Rundock', name);
+    const since = client.messages.length;
+    client.send({ type: 'create_workspace', name });
+
+    await client.waitFor(m => m.type === 'workspace_set' && m.path === created, {
+      since, timeout: 15000, label: 'workspace_set for the created workspace',
+    });
+    await h.delay(POLL_MS * 4);
+
+    const external = client.messages.length;
+    fs.writeFileSync(path.join(created, 'after-the-create.md'), '# External\n');
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since: external,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested push after an external write to the created workspace',
+    });
+    assert.ok(
+      treePaths(msg.tree).includes('after-the-create.md'),
+      'the push must describe the created workspace, not a previous one'
+    );
+  });
+
+  test('creating a workspace does not inherit the previous workspace\'s freshness', async () => {
+    // The blocking case, and it needs a populated cache to exist at all: the
+    // test above cannot show it, because clearing the workspace cascades
+    // through invalidateAgentCache and empties the cache on the way.
+    //
+    // So warm the cache against the CURRENT workspace first, then create a
+    // new one. Freshness re-stats the absolute directory paths it recorded
+    // and never checks which workspace they belong to, so with the previous
+    // workspace still sitting untouched on disk the cache reads as fresh, the
+    // baseline is taken from the wrong tree, and the poll goes on stat-
+    // checking directories in a workspace the server has left. An external
+    // write to the new workspace is then never seen at all.
+    const warm = client.messages.length;
+    client.send({ type: 'get_files' });
+    await client.waitFor(m => m.type === 'file_tree', {
+      since: warm, timeout: 8000, label: 'file_tree warming the cache for the current workspace',
+    });
+
+    const name = 'poll-not-inheriting-freshness';
+    const created = path.join(process.env.HOME, 'Documents', 'Rundock', name);
+    const since = client.messages.length;
+    client.send({ type: 'create_workspace', name });
+    await client.waitFor(m => m.type === 'workspace_set' && m.path === created, {
+      since, timeout: 15000, label: 'workspace_set for the second created workspace',
+    });
+    await h.delay(POLL_MS * 4);
+
+    const external = client.messages.length;
+    fs.writeFileSync(path.join(created, 'not-inherited.md'), '# External\n');
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since: external,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested push after an external write to the second created workspace',
+    });
+    assert.ok(
+      treePaths(msg.tree).includes('not-inherited.md'),
+      'the poll must be watching the created workspace, not the one it was warmed against'
     );
   });
 });

--- a/test/integration/external-tree-changes.test.js
+++ b/test/integration/external-tree-changes.test.js
@@ -1,0 +1,232 @@
+'use strict';
+// Integration: the file tree must notice a change made outside Rundock.
+//
+// The client asks for the tree in exactly three places and all three mean
+// "Rundock did something": workspace open, after a file-writing tool call,
+// and after an agent turn. The server only ever sends `file_tree` in reply to
+// a request, so a file written by an external process (a CLI agent session,
+// Obsidian, git, a sync client) never reaches the sidebar until a restart.
+// Search does not have this problem: it runs its own TTL-gated reconcile.
+//
+// These tests drive the change from OUTSIDE the server's own code paths,
+// with plain fs writes into the workspace directory, because a write made
+// through a handler is exactly the case that already worked.
+//
+// HONESTY NOTE ON WHAT EACH TEST PROVES. Only the first test goes red when
+// the poll is removed; it is the one that proves the mechanism exists. The
+// other two are guard criteria of the form "and it must not also do X", so
+// with no poller at all they pass vacuously. They earn their place once the
+// poller is in, where they are the only thing standing between a working
+// push and one that fights the reconcile diff or duplicates in-app work.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+
+// Short enough that the suite is not dominated by real sleeping, long enough
+// that a loaded machine still completes a stat pass inside one interval.
+const POLL_MS = 120;
+// A push is allowed up to one full interval of latency, plus the walk. Four
+// intervals is a generous ceiling that still fails fast when nothing polls.
+const PUSH_WINDOW_MS = POLL_MS * 4;
+
+let client;
+
+// Counting directory READS is how the tree cache's own test measures whether
+// a pass was cheap, and it is the fair measure here too: validating that
+// nothing changed is meant to cost one stat per directory and read none of
+// them. Counted only while armed, and never under `.claude`, because the
+// agents-directory poller reads there on its own fixed 2s interval and the
+// tree walk skips dotfolders entirely.
+let counting = false;
+let dirReads = 0;
+const realReaddirSync = fs.readdirSync;
+
+before(async () => {
+  await h.boot({ env: { RUNDOCK_TREE_POLL_MS: String(POLL_MS) } });
+  client = await h.connect();
+  const dotClaude = path.join(h.workspaceDir, '.claude');
+  fs.readdirSync = function (p, ...rest) {
+    const s = String(p);
+    if (counting && s.startsWith(h.workspaceDir) && !s.startsWith(dotClaude)) dirReads++;
+    return realReaddirSync.call(fs, p, ...rest);
+  };
+  // Boot scaffolds a workspace, which bumps directory mtimes. Let that drain
+  // so a quiet-case assertion is not measuring the server's own start-up.
+  await h.delay(PUSH_WINDOW_MS);
+});
+
+after(async () => {
+  fs.readdirSync = realReaddirSync;
+  await h.shutdown();
+});
+
+/** Every path in a tree payload, folders and files alike. */
+function treePaths(nodes, out = []) {
+  for (const n of nodes || []) {
+    out.push(n.path);
+    if (n.children) treePaths(n.children, out);
+  }
+  return out;
+}
+
+/** file_tree messages that arrived after `since`. */
+function pushesSince(since) {
+  return client.messages.slice(since).filter(m => m.type === 'file_tree');
+}
+
+describe('a change made outside Rundock reaches the file tree', () => {
+  test('a file created by another process is pushed without any request', async () => {
+    const since = client.messages.length;
+    fs.writeFileSync(
+      path.join(h.workspaceDir, 'written-by-something-else.md'),
+      '# Not created through Rundock\n'
+    );
+
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested file_tree push after an external write',
+    });
+
+    assert.ok(
+      treePaths(msg.tree).includes('written-by-something-else.md'),
+      'the pushed tree must contain the externally created file'
+    );
+  });
+
+  test('a directory created by another process is pushed too', async () => {
+    const since = client.messages.length;
+    fs.mkdirSync(path.join(h.workspaceDir, 'external-folder'), { recursive: true });
+    fs.writeFileSync(
+      path.join(h.workspaceDir, 'external-folder', 'nested.md'),
+      '# Nested\n'
+    );
+
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested file_tree push after an external mkdir',
+    });
+
+    const paths = treePaths(msg.tree);
+    assert.ok(paths.includes('external-folder'), 'the new folder must be in the pushed tree');
+    assert.ok(
+      paths.includes('external-folder/nested.md'),
+      'the file inside the new folder must be in the pushed tree'
+    );
+  });
+
+  test('a file deleted by another process is pushed', async () => {
+    const target = path.join(h.workspaceDir, 'to-be-deleted.md');
+    fs.writeFileSync(target, '# Temporary\n');
+    await client.waitFor(m => m.type === 'file_tree' && treePaths(m.tree).includes('to-be-deleted.md'), {
+      since: client.messages.length,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'file_tree containing the file about to be deleted',
+    });
+
+    const since = client.messages.length;
+    fs.unlinkSync(target);
+
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since,
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested file_tree push after an external delete',
+    });
+    assert.ok(
+      !treePaths(msg.tree).includes('to-be-deleted.md'),
+      'the deleted file must be gone from the pushed tree'
+    );
+  });
+
+  test('an untouched workspace produces no pushes at all', async () => {
+    // Not "a push that reconciles to zero operations": nothing on the wire.
+    const since = client.messages.length;
+    await h.delay(POLL_MS * 6);
+    const pushes = pushesSince(since);
+    assert.strictEqual(
+      pushes.length, 0,
+      `a quiet workspace must produce zero file_tree pushes, saw ${pushes.length}`
+    );
+  });
+
+  test('a file created through Rundock does not also produce a poll-driven push', async () => {
+    // WHAT DISCRIMINATES THIS TEST, checked by deleting each guard in turn:
+    // the freshness check, not the signature check. handleCreatePath rebuilds
+    // the cache on its way out, so the next tick finds it fresh and returns
+    // before the signature is ever compared. The signature guard is proven by
+    // the save test below, which is the path that invalidates without sending.
+    const since = client.messages.length;
+    client.send({ type: 'create_path', path: 'made-in-rundock.md', kind: 'note', content: '# In app\n' });
+
+    await client.waitFor(m => m.type === 'path_created', {
+      since,
+      timeout: 4000,
+      label: 'path_created for the in-app create',
+    });
+    await h.delay(POLL_MS * 6);
+
+    const pushes = pushesSince(since);
+    assert.strictEqual(
+      pushes.length, 1,
+      `an in-app create must produce exactly one file_tree, saw ${pushes.length}`
+    );
+    assert.ok(
+      treePaths(pushes[0].tree).includes('made-in-rundock.md'),
+      'the single tree must contain the newly created file'
+    );
+  });
+
+  test('a file saved through Rundock produces no push, because the tree did not change', async () => {
+    // A content save invalidates the tree cache but changes no directory
+    // mtime and no node. Nothing should reach the sidebar.
+    //
+    // This is the load-bearing test of the two guards. It goes red when the
+    // signature check is deleted (the invalidation alone then reads as an
+    // external change), and red again when the handlers stop recording what
+    // they sent (the poll then re-sends a tree a handler already delivered).
+    // Both were verified by deleting those blocks by hand.
+    const since = client.messages.length;
+    client.send({ type: 'save_file', path: 'made-in-rundock.md', content: '# In app, edited\n' });
+
+    await client.waitFor(m => m.type === 'file_saved', {
+      since,
+      timeout: 4000,
+      label: 'file_saved for the in-app save',
+    });
+    await h.delay(POLL_MS * 6);
+
+    const pushes = pushesSince(since);
+    assert.strictEqual(
+      pushes.length, 0,
+      `a content save must produce zero file_tree pushes, saw ${pushes.length}`
+    );
+  });
+
+  test('polling a quiet workspace reads no directories at all', async () => {
+    // The other quiet-case test proves nothing is SENT. It passes just as
+    // happily when every tick re-walks the workspace and discards the result,
+    // which on a large vault is the whole cost the cache exists to avoid,
+    // paid on a timer forever. This one holds the poll to the cached path.
+    //
+    // WHAT IT DOES NOT PROVE, checked rather than assumed: it does not hold
+    // the poll's own `treeCacheIsFresh` short-circuit in place. Deleting that
+    // line leaves this assertion green, because getFileTreeCached performs
+    // the same check internally and still reads nothing. What that line
+    // actually saves is serialising the tree on every idle tick, and no test
+    // here discriminates it. The argument for keeping it is written where it
+    // lives, in server.js, not smuggled in as a passing test.
+    dirReads = 0;
+    counting = true;
+    await h.delay(POLL_MS * 6);
+    counting = false;
+
+    assert.strictEqual(
+      dirReads, 0,
+      `an idle poll must read no directories, saw ${dirReads} read(s)`
+    );
+  });
+});

--- a/test/integration/external-tree-changes.test.js
+++ b/test/integration/external-tree-changes.test.js
@@ -12,16 +12,20 @@
 // with plain fs writes into the workspace directory, because a write made
 // through a handler is exactly the case that already worked.
 //
-// HONESTY NOTE ON WHAT EACH TEST PROVES. Only the first test goes red when
-// the poll is removed; it is the one that proves the mechanism exists. The
-// other two are guard criteria of the form "and it must not also do X", so
-// with no poller at all they pass vacuously. They earn their place once the
-// poller is in, where they are the only thing standing between a working
-// push and one that fights the reconcile diff or duplicates in-app work.
+// HONESTY NOTE ON WHAT EACH TEST PROVES, measured by reverting rather than
+// assumed. THREE tests go red when the poll is removed, and they are the ones
+// that prove the mechanism exists: external create, external mkdir, external
+// delete. The remaining tests are guard criteria of the form "and it must not
+// also do X" (the two quiet cases, the in-app create, the in-app save, and
+// the workspace switch), so with no poller at all they pass vacuously. They
+// earn their place once the poller is in, where they are the only thing
+// standing between a working push and one that fights the reconcile diff or
+// duplicates work Rundock did itself.
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 
 const h = require('../helpers/harness.js');
 
@@ -68,6 +72,15 @@ function treePaths(nodes, out = []) {
   for (const n of nodes || []) {
     out.push(n.path);
     if (n.children) treePaths(n.children, out);
+  }
+  return out;
+}
+
+/** Only the file nodes in a tree payload, never the folders. */
+function treeFiles(nodes, out = []) {
+  for (const n of nodes || []) {
+    if (n.type === 'folder') treeFiles(n.children, out);
+    else out.push(n.path);
   }
   return out;
 }
@@ -227,6 +240,54 @@ describe('a change made outside Rundock reaches the file tree', () => {
     assert.strictEqual(
       dirReads, 0,
       `an idle poll must read no directories, saw ${dirReads} read(s)`
+    );
+  });
+
+  // LAST ON PURPOSE: this repoints the server at another directory, so any
+  // test after it would be measuring a workspace it did not set up.
+  test('opening a workspace does not leave the poll believing it missed a change', async () => {
+    // Opening a workspace scaffolds into it, which changes the tree AFTER the
+    // watcher has taken its baseline. If the tree that open sends is not
+    // recorded as sent, the baseline still describes the pre-scaffold
+    // directory, and the next cache invalidation that changes nothing
+    // structural (a content save) makes the poll compare against it and
+    // announce Rundock's own scaffolding as an external change.
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-open-'));
+    const since = client.messages.length;
+    client.send({ type: 'set_workspace', path: fresh });
+
+    await client.waitFor(m => m.type === 'workspace_set', {
+      since,
+      timeout: 15000,
+      label: 'workspace_set for the freshly opened workspace',
+    });
+    const opened = await client.waitFor(m => m.type === 'file_tree', {
+      since,
+      timeout: 15000,
+      label: 'file_tree for the freshly opened workspace',
+    });
+
+    // Let the scaffold settle, then invalidate WITHOUT sending a tree. It has
+    // to be a content save: create_path rebuilds and records on its way out,
+    // which repairs a stale baseline and hides exactly the defect under test.
+    await h.delay(POLL_MS * 4);
+
+    const scaffolded = treeFiles(opened.msg.tree);
+    assert.ok(scaffolded.length > 0, 'opening a workspace must scaffold at least one visible file to save');
+
+    const quiet = client.messages.length;
+    client.send({ type: 'save_file', path: scaffolded[0], content: '# Edited after open\n' });
+    await client.waitFor(m => m.type === 'file_saved', {
+      since: quiet,
+      timeout: 8000,
+      label: 'file_saved in the freshly opened workspace',
+    });
+    await h.delay(POLL_MS * 6);
+
+    const pushes = pushesSince(quiet);
+    assert.strictEqual(
+      pushes.length, 0,
+      `a content save after a workspace open must produce zero file_tree pushes, saw ${pushes.length}`
     );
   });
 });

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -124,9 +124,8 @@ describe('handler seams (stub ctx, capture ws)', () => {
         setWorkspaceRoot: (d) => { rolledBack.push(d); config.setWorkspace(d); },
         // The open path baselines the file-tree poller against the new
         // directory before anything that can throw, so the rollback has to
-        // put both the cache and the poller back or the failed workspace's
-        // tree is served as if it were this one.
-        invalidateFileTreeCache: () => invalidated.push('tree-cache'),
+        // put the poller back or the failed workspace's tree is served as if
+        // it were this one. Arming clears the tree cache as part of arming.
         armFileTreeWatcher: () => invalidated.push('tree-watch'),
       },
       agents: { invalidateAgentCache: () => invalidated.push('agents') },
@@ -141,7 +140,7 @@ describe('handler seams (stub ctx, capture ws)', () => {
       assert.deepStrictEqual(rolledBack, [original], 'the previous root was restored');
       // Order matters: the established steps must complete before the newer
       // tree-poller rollback, because one catch covers the whole block.
-      assert.deepStrictEqual(invalidated, ['agents', 'search', 'tree-cache', 'tree-watch'],
+      assert.deepStrictEqual(invalidated, ['agents', 'search', 'tree-watch'],
         'caches cleared and the tree poller re-armed after rollback');
       assert.strictEqual(config.getWorkspace(), original, 'no half-switch persists');
     } finally {

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -120,7 +120,15 @@ describe('handler seams (stub ctx, capture ws)', () => {
     const ctx = {
       signals: { phaseTimer: () => { throw new Error('prepare exploded'); } },
       runtime: { killAllChildren: () => {} },
-      workspace: { setWorkspaceRoot: (d) => { rolledBack.push(d); config.setWorkspace(d); } },
+      workspace: {
+        setWorkspaceRoot: (d) => { rolledBack.push(d); config.setWorkspace(d); },
+        // The open path baselines the file-tree poller against the new
+        // directory before anything that can throw, so the rollback has to
+        // put both the cache and the poller back or the failed workspace's
+        // tree is served as if it were this one.
+        invalidateFileTreeCache: () => invalidated.push('tree-cache'),
+        armFileTreeWatcher: () => invalidated.push('tree-watch'),
+      },
       agents: { invalidateAgentCache: () => invalidated.push('agents') },
       store: { clearSearchFailure: () => invalidated.push('search') },
     };
@@ -131,7 +139,10 @@ describe('handler seams (stub ctx, capture ws)', () => {
       assert.strictEqual(ws.sent[0].type, 'workspace_error');
       assert.match(ws.sent[0].message, /^Could not open workspace: prepare exploded$/);
       assert.deepStrictEqual(rolledBack, [original], 'the previous root was restored');
-      assert.deepStrictEqual(invalidated, ['agents', 'search'], 'caches cleared after rollback');
+      // Order matters: the established steps must complete before the newer
+      // tree-poller rollback, because one catch covers the whole block.
+      assert.deepStrictEqual(invalidated, ['agents', 'search', 'tree-cache', 'tree-watch'],
+        'caches cleared and the tree poller re-armed after rollback');
       assert.strictEqual(config.getWorkspace(), original, 'no half-switch persists');
     } finally {
       config.setWorkspace(original);


### PR DESCRIPTION
## What

A file written into the workspace by any process other than Rundock never reached the sidebar until a restart. Search found it within seconds; the tree never did.

The client asks for the tree in exactly three places and all three mean "Rundock did something": workspace open, after a file-writing tool call, and after an agent turn. The server only ever answered a request. Nothing was watching the filesystem on the tree's behalf.

This is a gap rather than a regression. The reconcile work that landed earlier governs how the DOM patches when data arrives, not what makes data arrive.

## How

A self-owned poller on a stated two second interval, not `fs.watch`, for the reasons already recorded against the agents-directory watcher. Detection is the tree cache's existing directory-mtime freshness pass, so an idle workspace costs one stat per directory and reads none of them.

Two guards, because a push that fights the reconcile diff would undo the no-flicker work:

1. **Freshness.** An unchanged workspace returns before anything is built or sent. Nothing reaches the wire at all.
2. **Signature.** Cache invalidation is not evidence of an external change: every in-app save and create invalidates, which makes the freshness check false on the very next tick. Keying the push off freshness alone duplicates every tree the handlers already sent. Comparing against the last tree actually sent separates the two, so both send sites now record what they delivered.

No client change. The push reuses the existing message and arrives on the existing handler, so the expand-state, highlight and scroll guarantees are untouched by construction.

## Verification

Seven integration tests, driven by plain filesystem writes from outside the server's own code paths: external create, external mkdir, external delete, the quiet case (no pushes), the quiet case (no directory reads), an in-app create, and an in-app save.

`red-first` against this branch reports **PROVEN**.

Each guard was additionally checked by hand, by deleting the block and watching a named test go red:

| Block deleted | Result |
|---|---|
| signature check | red: the save test, `saw 1` push |
| handlers recording their sends | red: the save test, `saw 1` push |
| uncached walk in the tick | red: the directory-read test |
| poll's freshness short-circuit | **stayed green** |

That last row is a real limit and is not papered over. The poll's `treeCacheIsFresh` short-circuit is redundant with the check inside the cached getter, and what it saves is serialising the tree on every idle tick rather than any directory read. No test discriminates it. It is kept on the cost argument, which is written at the code rather than smuggled in as a passing test.

One test comment was corrected after mutation testing showed it named the wrong guard: the in-app create case is discharged by the freshness check, not the signature check, because the create rebuilds the cache on its way out.

## Scope

Does not touch the reconcile diff or how the tree renders. Rename detection and stable node identity remain a separate concern.