### PR TITLE
Give routines a data model that can be written back

### DIFF
--- a/lib/agents/discovery.js
+++ b/lib/agents/discovery.js
@@ -16,7 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const { getWorkspace, DEFAULT_MODEL } = require('../config.js');
-const { parseRoutineBlocks, normalizeRoutine } = require('./routines.js');
+const { parseRoutineBlocks, normalizeRoutine, migrateAgentRoutines } = require('./routines.js');
 
 let _agentCache = null;
 let _agentCacheTime = 0;
@@ -74,7 +74,13 @@ function discoverAgents() {
         }
 
         const caps = parseCapabilities(fmText);
-        const routines = parseRoutines(fmText, { owner: isDefault ? 'default' : id });
+        const owner = isDefault ? 'default' : id;
+        // Routines migrate lazily on read, like the conversation store: the
+        // returned content carries the new representation whether or not the
+        // file could be rewritten to match.
+        const migrated = migrateAgentRoutines(path.join(agentsDir, file), content, { owner });
+        const routines = parseRoutines(migrated === content ? fmText : extractFrontmatterText(migrated), { owner });
+
         const prompts = parsePrompts(fmText);
         const skills = parseSkills(fmText);
 

--- a/lib/agents/discovery.js
+++ b/lib/agents/discovery.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const { getWorkspace, DEFAULT_MODEL } = require('../config.js');
+const { parseRoutineBlocks, normalizeRoutine } = require('./routines.js');
 
 let _agentCache = null;
 let _agentCacheTime = 0;
@@ -73,7 +74,7 @@ function discoverAgents() {
         }
 
         const caps = parseCapabilities(fmText);
-        const routines = parseRoutines(fmText);
+        const routines = parseRoutines(fmText, { owner: isDefault ? 'default' : id });
         const prompts = parsePrompts(fmText);
         const skills = parseSkills(fmText);
 
@@ -292,23 +293,13 @@ function parseCapabilities(fmText) {
   return Object.keys(caps).length > 0 ? caps : null;
 }
 
-function parseRoutines(fmText) {
-  const routines = [];
-  const match = fmText.match(/routines:\n((?:  - [\s\S]*?)(?=\n\w|\n$|$))/);
-  if (!match) return routines;
-
-  // Split into individual routine blocks by "  - name:"
-  const blocks = match[1].split(/(?=  - name:)/);
-  for (const block of blocks) {
-    if (!block.trim()) continue;
-    const routine = {};
-    for (const line of block.split('\n')) {
-      const kv = line.match(/^\s+-?\s*(\w+):\s*(.*)/);
-      if (kv) routine[kv[1]] = kv[2].trim();
-    }
-    if (routine.name) routines.push(routine);
-  }
-  return routines;
+// Routines parse to the typed representation in lib/agents/routines.js. The
+// block scan itself lives there too, because the writer needs the same idea of
+// where a block starts and stops and two copies of that would drift.
+// `opts.owner` is the id of the agent whose file declares the routine, which
+// is what an undeclared owner has always meant.
+function parseRoutines(fmText, opts = {}) {
+  return parseRoutineBlocks(fmText).map(raw => normalizeRoutine(raw, opts));
 }
 
 function parsePrompts(fmText) {

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -1,0 +1,214 @@
+'use strict';
+/**
+ * The routine data model: the typed representation of a routine, and the only
+ * path that writes one back into an agent file.
+ *
+ * WHY A WRITER EXISTS AT ALL. Routines have always been readable and never
+ * writable. The frontmatter format is hand-rolled, there is no YAML library in
+ * the server path, and the only other frontmatter writes in the codebase are
+ * targeted regex replacements on single scalar lines. So this file edits
+ * LINES rather than re-serialising a parsed document: a routine block is
+ * located, the named keys in it are replaced or appended, and every other byte
+ * of the file is carried through untouched. Re-serialising would mean deciding
+ * how to render every key an author ever wrote, and the keys this module has
+ * never heard of are exactly the ones it must not lose.
+ *
+ * WHY THE PARSER TYPES ANYTHING. The block parser copies whatever `key: value`
+ * it finds, as a string, with no whitelist. New fields therefore parse for
+ * free and arrive as the wrong type, so `enabled: false` read back as the
+ * string 'false', which is truthy. Typing is the work; parsing was never the
+ * problem.
+ */
+
+// Where a routine runs. `local` is the only value that runs anything in this
+// release. `agent-computer` is a RECOGNISED token rather than an accepted one:
+// it is kept verbatim through a round trip so an author who wrote it does not
+// silently lose it, and it is excluded from the supported set so nothing
+// treats it as runnable yet.
+const RUN_ON_SUPPORTED = ['local'];
+const RUN_ON_RESERVED = ['agent-computer'];
+const RUN_ON_DEFAULT = 'local';
+
+function isRunOnSupported(runOn) {
+  return RUN_ON_SUPPORTED.includes(runOn);
+}
+
+// Quotes are stripped only from the fields this module types. Stripping them
+// from `prompt` or `schedule` too would change what the scheduler already
+// sends to the CLI, which is a different card's decision.
+function unquote(value) {
+  return String(value).trim().replace(/^"(.*)"$/, '$1').replace(/^'(.*)'$/, '$1').trim();
+}
+
+function readString(raw, key) {
+  const value = raw[key];
+  if (value === undefined || value === null) return null;
+  const text = unquote(value);
+  return text === '' ? null : text;
+}
+
+// Unrecognised values fall back to the default rather than being kept, so a
+// frontmatter typo cannot leave a routine in a state nothing knows how to
+// read. This mirrors how the agent `runtime` field already behaves.
+function readBoolean(raw, key, fallback) {
+  const value = raw[key];
+  if (typeof value === 'boolean') return value;
+  if (value === undefined || value === null) return fallback;
+  const text = unquote(value).toLowerCase();
+  if (text === 'true') return true;
+  if (text === 'false') return false;
+  return fallback;
+}
+
+function readRunOn(raw) {
+  const text = readString(raw, 'runOn');
+  if (!text) return RUN_ON_DEFAULT;
+  const token = text.toLowerCase();
+  if (RUN_ON_SUPPORTED.includes(token) || RUN_ON_RESERVED.includes(token)) return token;
+  return RUN_ON_DEFAULT;
+}
+
+/**
+ * Turn one raw block into the typed representation.
+ *
+ * Unknown keys are carried through untouched: a key this module does not
+ * understand still belongs to whoever wrote it. `owner` falls back to the id
+ * of the agent whose file declares the routine, which is what ownership has
+ * always meant here (it was positional and unwritten), so a file with no
+ * owner keeps exactly the meaning it has today.
+ */
+function normalizeRoutine(raw, opts = {}) {
+  return {
+    ...raw,
+    name: readString(raw, 'name'),
+    schedule: raw.schedule === undefined ? null : raw.schedule,
+    prompt: raw.prompt === undefined ? null : raw.prompt,
+    skill: readString(raw, 'skill'),
+    runOn: readRunOn(raw),
+    owner: readString(raw, 'owner') || opts.owner || null,
+    enabled: readBoolean(raw, 'enabled', true),
+    paused: readBoolean(raw, 'paused', false),
+    planHash: readString(raw, 'planHash'),
+    planApprovedAt: readString(raw, 'planApprovedAt'),
+  };
+}
+
+// ===== BLOCK LOCATION =====
+// Both the reader and the writer need the same idea of where a routine block
+// starts and stops, so they share one locator rather than two regexes that
+// can drift apart.
+
+const ROUTINES_KEY = /^routines:[ \t]*$/;
+const ROUTINE_ITEM = /^[ \t]*-[ \t]*name:/;
+
+// The `routines:` section runs from the key to the first line that is neither
+// indented nor blank, i.e. the next top-level key.
+function locateSection(lines) {
+  const start = lines.findIndex(l => ROUTINES_KEY.test(l));
+  if (start === -1) return null;
+  let end = start + 1;
+  while (end < lines.length && (lines[end].trim() === '' || /^[ \t]/.test(lines[end]))) end++;
+  return { start, end };
+}
+
+// Item ranges within the section, one per `- name:` line.
+function locateItems(lines, section) {
+  const items = [];
+  for (let i = section.start + 1; i < section.end; i++) {
+    if (ROUTINE_ITEM.test(lines[i])) {
+      if (items.length) items[items.length - 1].end = i;
+      items.push({ start: i, end: section.end });
+    }
+  }
+  return items;
+}
+
+function parseRoutineBlocks(fmText) {
+  const lines = fmText.split('\n');
+  const section = locateSection(lines);
+  if (!section) return [];
+  const routines = [];
+  for (const item of locateItems(lines, section)) {
+    const routine = {};
+    for (let i = item.start; i < item.end; i++) {
+      const kv = lines[i].match(/^[ \t]*-?[ \t]*(\w+):[ \t]*(.*)$/);
+      if (kv) routine[kv[1]] = kv[2].trim();
+    }
+    if (routine.name) routines.push(routine);
+  }
+  return routines;
+}
+
+// ===== THE WRITE PATH =====
+
+function formatValue(key, value) {
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  const text = String(value);
+  // A newline in a value would silently split one key into two and corrupt
+  // every routine below it. Refuse loudly rather than write a broken file.
+  if (/[\r\n]/.test(text)) {
+    throw new Error(`routine field "${key}" cannot contain a line break`);
+  }
+  return text;
+}
+
+// The indent authors actually used for this block's keys, so an appended key
+// lines up with the ones already there. Falls back to the position implied by
+// the `- ` marker when the block has nothing but a name.
+function keyIndent(lines, item) {
+  for (let i = item.start + 1; i < item.end; i++) {
+    const m = lines[i].match(/^([ \t]+)\w+:/);
+    if (m) return m[1];
+  }
+  const dash = lines[item.start].match(/^([ \t]*)-([ \t]*)/);
+  return ' '.repeat(dash[1].length + 1 + dash[2].length);
+}
+
+/**
+ * Replace or append the given keys inside one routine block, leaving every
+ * other byte of the file alone. Values of `undefined` are skipped, so a caller
+ * can pass a whole routine and update only the parts it means to.
+ */
+function updateRoutineBlock(content, name, updates) {
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return content;
+  const fmText = fmMatch[1];
+  const lines = fmText.split('\n');
+  const section = locateSection(lines);
+  if (!section) return content;
+
+  const items = locateItems(lines, section);
+  const target = items.find(item => {
+    const m = lines[item.start].match(/^[ \t]*-[ \t]*name:[ \t]*(.*)$/);
+    return m && unquote(m[1]) === name;
+  });
+  if (!target) return content;
+
+  const indent = keyIndent(lines, target);
+  const appended = [];
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    const formatted = formatValue(key, value);
+    const existing = findKeyLine(lines, target, key);
+    if (existing === -1) appended.push(`${indent}${key}: ${formatted}`);
+    else lines[existing] = lines[existing].replace(
+      new RegExp(`^([ \\t]*-?[ \\t]*${key}:[ \\t]*).*$`), `$1${formatted}`);
+  }
+  // Appended keys go at the end of the block, which is where a hand edit would
+  // put them and which keeps the author's existing key order intact.
+  lines.splice(target.end, 0, ...appended);
+
+  const nextFm = lines.join('\n');
+  return content.slice(0, 4) + nextFm + content.slice(4 + fmText.length);
+}
+
+function findKeyLine(lines, item, key) {
+  const re = new RegExp(`^[ \\t]*-?[ \\t]*${key}:`);
+  for (let i = item.start; i < item.end; i++) if (re.test(lines[i])) return i;
+  return -1;
+}
+
+module.exports = {
+  RUN_ON_SUPPORTED, RUN_ON_RESERVED, RUN_ON_DEFAULT, isRunOnSupported,
+  normalizeRoutine, parseRoutineBlocks, updateRoutineBlock,
+};

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -170,8 +170,17 @@ function keyIndent(lines, item) {
 
 /**
  * Replace or append the given keys inside one routine block, leaving every
- * other byte of the file alone. Values of `undefined` are skipped, so a caller
- * can pass a whole routine and update only the parts it means to.
+ * other byte of the file alone.
+ *
+ * ABSENT VALUES ARE SKIPPED, BOTH null AND undefined. A caller is meant to be
+ * able to hand this a whole routine, and the reader produces null for every
+ * field a file does not declare, so writing those through would put the four
+ * letters n-u-l-l in the file. The next read hands back a string that is not
+ * null, is truthy, and hashes differently, which is the worst of the three.
+ * Skipping leaves any existing line for that key exactly as it was.
+ *
+ * To CLEAR a field, pass an empty string: `key: ` with nothing after it reads
+ * back as null, which is the same absence the file started with.
  */
 function updateRoutineBlock(content, name, updates) {
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
@@ -191,7 +200,7 @@ function updateRoutineBlock(content, name, updates) {
   const indent = keyIndent(lines, target);
   const appended = [];
   for (const [key, value] of Object.entries(updates)) {
-    if (value === undefined) continue;
+    if (value === undefined || value === null) continue;
     const formatted = formatValue(key, value);
     const existing = findKeyLine(lines, target, key);
     if (existing === -1) appended.push(`${indent}${key}: ${formatted}`);

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -20,6 +20,8 @@
  * problem.
  */
 
+const crypto = require('crypto');
+
 // Where a routine runs. `local` is the only value that runs anything in this
 // release. `agent-computer` is a RECOGNISED token rather than an accepted one:
 // it is kept verbatim through a round trip so an author who wrote it does not
@@ -208,7 +210,27 @@ function findKeyLine(lines, item, key) {
   return -1;
 }
 
+// ===== THE PLAN HASH =====
+
+// What a routine DOES: the instruction, the skill it runs, where it runs, and
+// which agent it runs as. Deliberately not the schedule, because a routine
+// moved by ten minutes is the same plan and re-approving it would make
+// approval worthless. Deliberately not enabled or paused either: turning a
+// routine off changes whether it happens, not what happens when it does.
+// Read by name from a normalised routine, so the order the fields appear in
+// the file cannot reach the hash.
+const PLAN_FIELDS = ['prompt', 'skill', 'runOn', 'owner'];
+
+function computePlanHash(routine) {
+  const plan = PLAN_FIELDS.map(field => {
+    const value = routine[field];
+    return value === undefined || value === null ? null : String(value);
+  });
+  return crypto.createHash('sha256').update(JSON.stringify(plan)).digest('hex');
+}
+
 module.exports = {
   RUN_ON_SUPPORTED, RUN_ON_RESERVED, RUN_ON_DEFAULT, isRunOnSupported,
   normalizeRoutine, parseRoutineBlocks, updateRoutineBlock,
+  PLAN_FIELDS, computePlanHash,
 };

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -145,6 +145,18 @@ function parseRoutineBlocks(fmText) {
 
 // ===== THE WRITE PATH =====
 
+// The parser reads back `\w+` keys and nothing else, so a key outside that
+// shape could never survive a round trip anyway. Refusing it here also means
+// the pattern built from it below is made only of word characters, which is
+// what keeps a caller-supplied key from becoming a pattern of its own.
+const FIELD_NAME = /^\w+$/;
+
+function assertFieldName(key) {
+  if (!FIELD_NAME.test(key)) {
+    throw new Error(`"${key}" is not a routine field name`);
+  }
+}
+
 function formatValue(key, value) {
   if (typeof value === 'boolean') return value ? 'true' : 'false';
   const text = String(value);
@@ -186,6 +198,10 @@ function keyIndent(lines, item) {
  * is an ordinary thing to find in one, so `occurrence` picks which block of
  * that name to edit. It defaults to the first, which is what a caller holding
  * a name and no index means.
+ *
+ * VALUES ARE TEXT, NEVER PATTERNS. A value is inserted literally, and a key
+ * outside `\w+` is refused rather than compiled. The name is compared with
+ * `===` against what the item line captured, so it is not a pattern either.
  */
 function updateRoutineBlock(content, name, updates, occurrence = 0) {
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
@@ -205,11 +221,21 @@ function updateRoutineBlock(content, name, updates, occurrence = 0) {
   const appended = [];
   for (const [key, value] of Object.entries(updates)) {
     if (value === undefined || value === null) continue;
+    assertFieldName(key);
     const formatted = formatValue(key, value);
     const existing = findKeyLine(lines, target, key);
-    if (existing === -1) appended.push(`${indent}${key}: ${formatted}`);
-    else lines[existing] = lines[existing].replace(
-      new RegExp(`^([ \\t]*-?[ \\t]*${key}:[ \\t]*).*$`), `$1${formatted}`);
+    if (existing === -1) {
+      appended.push(`${indent}${key}: ${formatted}`);
+    } else {
+      // Keep the author's exact prefix and concatenate the value onto it,
+      // rather than splicing it in as a replacement string. A value is text
+      // somebody wrote, and a prompt saying "$1 per run" is ordinary; through
+      // a replacement template those two characters become the captured
+      // prefix, and $&, $` and $' pull in the surrounding line. The value
+      // would be corrupted silently, with no error to notice.
+      const prefix = lines[existing].match(keyLinePattern(key))[0];
+      lines[existing] = prefix + formatted;
+    }
   }
   // Appended keys go at the end of the block, which is where a hand edit would
   // put them and which keeps the author's existing key order intact.
@@ -219,8 +245,15 @@ function updateRoutineBlock(content, name, updates, occurrence = 0) {
   return content.slice(0, 4) + nextFm + content.slice(4 + fmText.length);
 }
 
+// The prefix of a key's line: leading space, an optional item marker, the key
+// and its colon, and the space after it. Built from a key already checked to
+// be word characters only.
+function keyLinePattern(key) {
+  return new RegExp(`^[ \\t]*-?[ \\t]*${key}:[ \\t]*`);
+}
+
 function findKeyLine(lines, item, key) {
-  const re = new RegExp(`^[ \\t]*-?[ \\t]*${key}:`);
+  const re = keyLinePattern(key);
   for (let i = item.start; i < item.end; i++) if (re.test(lines[i])) return i;
   return -1;
 }

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -181,8 +181,13 @@ function keyIndent(lines, item) {
  *
  * To CLEAR a field, pass an empty string: `key: ` with nothing after it reads
  * back as null, which is the same absence the file started with.
+ *
+ * Nothing makes a routine name unique within a file, and a copy-pasted block
+ * is an ordinary thing to find in one, so `occurrence` picks which block of
+ * that name to edit. It defaults to the first, which is what a caller holding
+ * a name and no index means.
  */
-function updateRoutineBlock(content, name, updates) {
+function updateRoutineBlock(content, name, updates, occurrence = 0) {
   const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) return content;
   const fmText = fmMatch[1];
@@ -190,11 +195,10 @@ function updateRoutineBlock(content, name, updates) {
   const section = locateSection(lines);
   if (!section) return content;
 
-  const items = locateItems(lines, section);
-  const target = items.find(item => {
+  const target = locateItems(lines, section).filter(item => {
     const m = lines[item.start].match(/^[ \t]*-[ \t]*name:[ \t]*(.*)$/);
     return m && unquote(m[1]) === name;
-  });
+  })[occurrence];
   if (!target) return content;
 
   const indent = keyIndent(lines, target);
@@ -288,19 +292,27 @@ function needsMigration(rawRoutine) {
 function migrateAgentRoutines(filePath, content, opts = {}) {
   const fm = content.match(/^---\n([\s\S]*?)\n---/);
   if (!fm) return content;
-  const pending = parseRoutineBlocks(fm[1]).filter(needsMigration);
-  if (!pending.length) return content;
+  const blocks = parseRoutineBlocks(fm[1]);
+  if (!blocks.some(needsMigration)) return content;
 
   let next = content;
   let migrated = 0;
-  for (const block of pending) {
+  // Count every block of a given name, not just the ones being migrated, so
+  // the index handed to the writer is the block's real position among its
+  // namesakes. Appending keys never reorders items, so the count stays valid
+  // as the text is rewritten under it.
+  const seen = new Map();
+  for (const block of blocks) {
+    const occurrence = seen.get(block.name) || 0;
+    seen.set(block.name, occurrence + 1);
+    if (!needsMigration(block)) continue;
     const routine = normalizeRoutine(block, opts);
     const updates = {};
     for (const key of MIGRATED_KEYS) {
       if (block[key] !== undefined) continue;
       updates[key] = key === 'planHash' ? computePlanHash(routine) : routine[key];
     }
-    next = updateRoutineBlock(next, routine.name, updates);
+    next = updateRoutineBlock(next, routine.name, updates, occurrence);
     migrated++;
   }
   try {

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -21,6 +21,8 @@
  */
 
 const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 
 // Where a routine runs. `local` is the only value that runs anything in this
 // release. `agent-computer` is a RECOGNISED token rather than an accepted one:
@@ -229,7 +231,78 @@ function computePlanHash(routine) {
   return crypto.createHash('sha256').update(JSON.stringify(plan)).digest('hex');
 }
 
+// ===== MIGRATION =====
+
+// The keys a migrated routine carries. There is no schema version anywhere:
+// whether a file has been migrated is a question the data answers, the same
+// way the conversation store decides, so nothing has to keep a marker honest.
+// `owner` is deliberately absent. Ownership was positional and unwritten, and
+// writing it into every file that never named an owner would turn an implicit
+// meaning into an explicit one that is then free to drift from the file it
+// lives in.
+const MIGRATED_KEYS = ['runOn', 'enabled', 'paused', 'planHash'];
+const BACKUP_SUFFIX = '.pre-routine-model-backup';
+
+function needsMigration(rawRoutine) {
+  return MIGRATED_KEYS.some(key => rawRoutine[key] === undefined);
+}
+
+/**
+ * Bring one agent file's routines up to the new representation, lazily, on
+ * read. Returns the migrated file content, and persists it best effort.
+ *
+ * The migrated content is computed BEFORE anything is written, and returned
+ * whether or not the write lands. That is the whole reason a workspace nobody
+ * can write to still runs: the caller's routines are migrated in memory, and
+ * persisting is only how that is remembered for next time.
+ *
+ * Idempotent by construction: a file with nothing pending returns the content
+ * it was given, having touched no disk and said nothing.
+ */
+function migrateAgentRoutines(filePath, content, opts = {}) {
+  const fm = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return content;
+  const pending = parseRoutineBlocks(fm[1]).filter(needsMigration);
+  if (!pending.length) return content;
+
+  let next = content;
+  let migrated = 0;
+  for (const block of pending) {
+    const routine = normalizeRoutine(block, opts);
+    const updates = {};
+    for (const key of MIGRATED_KEYS) {
+      if (block[key] !== undefined) continue;
+      updates[key] = key === 'planHash' ? computePlanHash(routine) : routine[key];
+    }
+    next = updateRoutineBlock(next, routine.name, updates);
+    migrated++;
+  }
+  if (next === content) return content;
+
+  try {
+    // Write only when the file on disk is byte for byte what was read. That
+    // covers two cases at once: a file someone edited since the read, which
+    // must not be clobbered to record four keys, and a checkout with Windows
+    // line endings, which differs from the newline-normalised text every
+    // editor here works on and would otherwise be rewritten line by line.
+    if (fs.readFileSync(filePath, 'utf-8') === content) {
+      // Snapshot the file once, before the first migrating write, so a manual
+      // recovery path exists. Every later attempt skips it: the copy worth
+      // keeping is the one taken before anything touched the file.
+      const backup = filePath + BACKUP_SUFFIX;
+      if (!fs.existsSync(backup)) fs.copyFileSync(filePath, backup);
+      fs.writeFileSync(filePath, next);
+      console.log(`[migrate] ${path.basename(filePath)}: ${migrated} routines gained the new representation`);
+    }
+  } catch (err) {
+    // Safe to retry: the next read attempts the same write again.
+    console.error('[migrate] routine persist failed:', err && err.message ? err.message : err);
+  }
+  return next;
+}
+
 module.exports = {
+  MIGRATED_KEYS, BACKUP_SUFFIX, migrateAgentRoutines,
   RUN_ON_SUPPORTED, RUN_ON_RESERVED, RUN_ON_DEFAULT, isRunOnSupported,
   normalizeRoutine, parseRoutineBlocks, updateRoutineBlock,
   PLAN_FIELDS, computePlanHash,

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -277,8 +277,6 @@ function migrateAgentRoutines(filePath, content, opts = {}) {
     next = updateRoutineBlock(next, routine.name, updates);
     migrated++;
   }
-  if (next === content) return content;
-
   try {
     // Write only when the file on disk is byte for byte what was read. That
     // covers two cases at once: a file someone edited since the read, which

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -223,14 +223,31 @@ function findKeyLine(lines, item, key) {
 
 // ===== THE PLAN HASH =====
 
-// What a routine DOES: the instruction, the skill it runs, where it runs, and
-// which agent it runs as. Deliberately not the schedule, because a routine
-// moved by ten minutes is the same plan and re-approving it would make
-// approval worthless. Deliberately not enabled or paused either: turning a
-// routine off changes whether it happens, not what happens when it does.
+// What a routine DOES: the instruction, the skill it runs, and where it runs.
+//
+// Deliberately not the schedule, because a routine moved by ten minutes is
+// the same plan and re-approving it would make approval worthless. Not
+// enabled or paused either: turning a routine off changes whether it happens,
+// not what happens when it does.
+//
+// And deliberately not the owner, which is the subtler case. Files declare an
+// owner only rarely, so for almost every routine it is resolved by the caller
+// from the agent file's name and its position on the roster. Hashing it would
+// mean that renaming an agent file, or an agent gaining or losing order zero
+// and so answering to the id `default`, silently invalidated an approval while
+// every byte of the routine stayed exactly where it was. That is the schedule
+// problem arriving by a different road. The rule that closes the whole class:
+// the hash reads only what the routine itself declares, never a value the
+// caller supplies.
+//
+// The cost, named rather than hidden: changing a DECLARED owner no longer
+// invalidates an approval. Owner is a field in its own right, so an approval
+// flow can compare it directly, and it does not need smuggling through a hash
+// to be noticed.
+//
 // Read by name from a normalised routine, so the order the fields appear in
-// the file cannot reach the hash.
-const PLAN_FIELDS = ['prompt', 'skill', 'runOn', 'owner'];
+// the file cannot reach the hash either.
+const PLAN_FIELDS = ['prompt', 'skill', 'runOn'];
 
 function computePlanHash(routine) {
   const plan = PLAN_FIELDS.map(field => {

--- a/test/helpers/workspace.js
+++ b/test/helpers/workspace.js
@@ -81,6 +81,12 @@ function agentFile({ name, displayName, role, type, order, reportsTo, model, run
       lines.push(`  - name: ${r.name}`);
       if (r.schedule) lines.push(`    schedule: ${r.schedule}`);
       if (r.prompt) lines.push(`    prompt: ${r.prompt}`);
+      // Any other key an author might write, so a fixture can declare the
+      // routine fields this helper predates without knowing about each one.
+      for (const [k, v] of Object.entries(r)) {
+        if (k === 'name' || k === 'schedule' || k === 'prompt') continue;
+        lines.push(`    ${k}: ${v}`);
+      }
     }
   }
   lines.push('---', '');

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -86,10 +86,25 @@ describe('nested frontmatter block parsers', () => {
     assert.strictEqual(srv.parseCapabilities('name: x'), null);
   });
 
-  test('parseRoutines extracts each routine with fields', () => {
+  // The shape gained typed fields with the routine data model. A file that
+  // declares none of them still means what it always meant: it runs locally,
+  // it is enabled, it is not paused, and its owner is settled by the caller
+  // that knows which agent file this frontmatter came from.
+  test('parseRoutines extracts each routine with fields, typed', () => {
     const routines = srv.parseRoutines(fm);
     assert.strictEqual(routines.length, 2);
-    assert.deepStrictEqual(routines[0], { name: 'morning-digest', schedule: 'every day at 08:00', prompt: 'Run the digest' });
+    assert.deepStrictEqual(routines[0], {
+      name: 'morning-digest',
+      schedule: 'every day at 08:00',
+      prompt: 'Run the digest',
+      skill: null,
+      runOn: 'local',
+      owner: null,
+      enabled: true,
+      paused: false,
+      planHash: null,
+      planApprovedAt: null,
+    });
     assert.strictEqual(routines[1].name, 'weekly-review');
     assert.deepStrictEqual(srv.parseRoutines('name: x'), []);
   });

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -16,7 +16,7 @@ const { parseRoutines, extractFrontmatterText } = require('../../lib/agents/disc
 const { _internal: srv } = require('../../server.js');
 const { makeWorkspace, agentFile, cleanup } = require('../helpers/workspace.js');
 const {
-  updateRoutineBlock, normalizeRoutine, isRunOnSupported,
+  updateRoutineBlock, normalizeRoutine, isRunOnSupported, computePlanHash,
 } = require('../../lib/agents/routines.js');
 
 const FIXTURE = [
@@ -193,5 +193,70 @@ describe('ownership', () => {
     const penn = srv.discoverAgents().find(a => a.id === 'content-lead');
     assert.strictEqual(penn.routines[0].owner, 'content-lead');
     assert.strictEqual(penn.routines[1].owner, 'executive-assistant');
+  });
+});
+
+describe('plan hash', () => {
+  const plan = (fields) => computePlanHash(normalizeRoutine({
+    name: 'morning-digest', prompt: 'Run the digest', skill: 'content-linter', ...fields,
+  }, { owner: 'penn' }));
+
+  // The unchanged cases are the ones that matter. A hash that moved when the
+  // schedule moved would invalidate an approval every time someone shifted a
+  // routine by ten minutes, which makes approval worthless.
+  test('changing only the schedule leaves the hash unchanged', () => {
+    assert.strictEqual(
+      plan({ schedule: 'every day at 08:00' }),
+      plan({ schedule: 'every friday at 16:00' }));
+  });
+
+  test('changing enabled or paused leaves the hash unchanged', () => {
+    const base = plan({});
+    assert.strictEqual(plan({ enabled: 'false' }), base);
+    assert.strictEqual(plan({ paused: 'true' }), base);
+  });
+
+  test('changing what the routine does changes the hash', () => {
+    const base = plan({});
+    assert.notStrictEqual(plan({ prompt: 'Run something else' }), base);
+    assert.notStrictEqual(plan({ skill: 'voice-editor' }), base);
+    assert.notStrictEqual(plan({ runOn: 'agent-computer' }), base);
+    assert.notStrictEqual(plan({ owner: 'executive-assistant' }), base);
+  });
+
+  test('the hash does not depend on the order the fields appear in the file', () => {
+    const ordered = [
+      'routines:',
+      '  - name: morning-digest',
+      '    schedule: every day at 08:00',
+      '    prompt: Run the digest',
+      '    skill: content-linter',
+      '    runOn: local',
+    ].join('\n');
+    const shuffled = [
+      'routines:',
+      '  - name: morning-digest',
+      '    runOn: local',
+      '    skill: content-linter',
+      '    prompt: Run the digest',
+      '    schedule: every day at 08:00',
+    ].join('\n');
+    const hashOf = (fm) => computePlanHash(parseRoutines(fm, { owner: 'penn' })[0]);
+    assert.strictEqual(hashOf(shuffled), hashOf(ordered));
+  });
+
+  test('the hash is stable across a write-then-read cycle', () => {
+    const source = parseRoutines(extractFrontmatterText(FIXTURE), { owner: 'penn' })
+      .find(r => r.name === 'morning-digest');
+    const before = computePlanHash(source);
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', {
+      planHash: before, planApprovedAt: '2026-08-21T09:00:00.000Z',
+    });
+    const readBack = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' })
+      .find(r => r.name === 'morning-digest');
+    // Both halves: the stored value survives, and recomputing from what came
+    // back off disk lands on the same hash.
+    assert.strictEqual(readBack.planHash, before);
+    assert.strictEqual(computePlanHash(readBack), before);
   });
 });

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -11,6 +11,8 @@
 // the parts nobody thought to preserve.
 const { test, describe, after } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { parseRoutines, extractFrontmatterText } = require('../../lib/agents/discovery.js');
 const { _internal: srv } = require('../../server.js');
@@ -258,5 +260,110 @@ describe('plan hash', () => {
     // back off disk lands on the same hash.
     assert.strictEqual(readBack.planHash, before);
     assert.strictEqual(computePlanHash(readBack), before);
+  });
+});
+
+describe('migration of existing routines', () => {
+  after(cleanup);
+
+  const AGENT = 'content-lead';
+  function legacyWorkspace() {
+    const dir = makeWorkspace({
+      agents: {
+        [AGENT]: agentFile({
+          name: AGENT, displayName: 'Penn', role: 'Content Lead',
+          type: 'specialist', order: 2,
+          routines: [{ name: 'morning-digest', schedule: 'every day at 08:00', prompt: 'Run the digest' }],
+          body: 'You are Penn.\n\nA body the migration is not allowed to touch.',
+        }),
+      },
+    });
+    srv.setWorkspace(dir);
+    return { dir, file: path.join(dir, '.claude', 'agents', `${AGENT}.md`) };
+  }
+
+  function reread() {
+    srv.invalidateAgentCache();
+    return srv.discoverAgents();
+  }
+
+  test('an existing routine gains the new representation, detected without a version marker', () => {
+    const { file } = legacyWorkspace();
+    const original = fs.readFileSync(file, 'utf-8');
+    const agents = reread();
+
+    const written = fs.readFileSync(file, 'utf-8');
+    assert.ok(written.includes('    runOn: local'), 'runOn not written');
+    assert.ok(written.includes('    enabled: true'), 'enabled not written');
+    assert.ok(written.includes('    paused: false'), 'paused not written');
+
+    const routine = agents.find(a => a.id === AGENT).routines[0];
+    assert.ok(written.includes(`    planHash: ${routine.planHash}`), 'planHash not written');
+    assert.strictEqual(routine.planHash, computePlanHash(routine));
+
+    // Nothing stamps a schema version anywhere: the data says whether it has
+    // been migrated, the same way the conversation store decides.
+    assert.ok(!/version/i.test(written), 'a version marker was written');
+
+    // Ownership stays positional unless it was declared, so a file that never
+    // named an owner still means what it meant.
+    assert.ok(!written.includes('owner:'), 'an owner was written into a file that declared none');
+
+    // And the parts the migration was never told about survive.
+    assert.strictEqual(splitFile(written).body, splitFile(original).body);
+    assert.strictEqual(
+      splitFile(written).frontmatter.split('\n').slice(0, 5).join('\n'),
+      splitFile(original).frontmatter.split('\n').slice(0, 5).join('\n'));
+  });
+
+  test('running the migration twice changes nothing on the second run', () => {
+    const { file } = legacyWorkspace();
+    reread();
+    const afterFirst = fs.readFileSync(file, 'utf-8');
+    reread();
+    assert.strictEqual(fs.readFileSync(file, 'utf-8'), afterFirst);
+  });
+
+  test('the pre-migration backup is written once and never overwritten', () => {
+    const { file } = legacyWorkspace();
+    const original = fs.readFileSync(file, 'utf-8');
+    reread();
+
+    const backup = `${file}.pre-routine-model-backup`;
+    assert.ok(fs.existsSync(backup), 'no backup was written');
+    assert.strictEqual(fs.readFileSync(backup, 'utf-8'), original);
+
+    // A second routine, declared later and un-migrated, forces another
+    // migrating write. The backup must still hold the ORIGINAL file.
+    fs.writeFileSync(file, fs.readFileSync(file, 'utf-8').replace(
+      '    prompt: Run the digest\n',
+      '    prompt: Run the digest\n  - name: handover\n    schedule: every friday at 16:00\n    prompt: Hand over\n'));
+    reread();
+    assert.ok(fs.readFileSync(file, 'utf-8').includes('  - name: handover'), 'the second routine was lost');
+    assert.strictEqual(fs.readFileSync(backup, 'utf-8'), original, 'the backup was overwritten');
+  });
+
+  test('a failed migrating write is logged and leaves the read usable', () => {
+    const { file } = legacyWorkspace();
+    const before = fs.readFileSync(file, 'utf-8');
+    fs.chmodSync(file, 0o444);
+    const errors = [];
+    const realError = console.error;
+    console.error = (...args) => errors.push(args.join(' '));
+    try {
+      const agents = reread();
+      const routine = agents.find(a => a.id === AGENT).routines[0];
+      // The read still returns the new representation: it is built in memory
+      // and the write is only how it is remembered for next time.
+      assert.strictEqual(routine.runOn, 'local');
+      assert.strictEqual(routine.enabled, true);
+      assert.strictEqual(routine.paused, false);
+      assert.strictEqual(typeof routine.planHash, 'string');
+    } finally {
+      console.error = realError;
+      fs.chmodSync(file, 0o644);
+    }
+    assert.strictEqual(fs.readFileSync(file, 'utf-8'), before, 'the unwritable file changed');
+    assert.ok(errors.some(e => /routine/i.test(e)), `nothing was logged, saw: ${JSON.stringify(errors)}`);
   });
 });

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -320,8 +320,31 @@ describe('migration of existing routines', () => {
     const { file } = legacyWorkspace();
     reread();
     const afterFirst = fs.readFileSync(file, 'utf-8');
-    reread();
+
+    const logs = [];
+    const realLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try { reread(); } finally { console.log = realLog; }
+
     assert.strictEqual(fs.readFileSync(file, 'utf-8'), afterFirst);
+    // Identical bytes are not enough on their own: a second pass that rewrites
+    // the same content and announces it has still done something. Nothing at
+    // all should happen.
+    assert.deepStrictEqual(logs.filter(l => l.includes('[migrate]')), []);
+  });
+
+  test('a file with Windows line endings is read migrated and left alone on disk', () => {
+    const { file } = legacyWorkspace();
+    const crlf = fs.readFileSync(file, 'utf-8').replace(/\n/g, '\r\n');
+    fs.writeFileSync(file, crlf);
+
+    const routine = reread().find(a => a.id === AGENT).routines[0];
+    assert.strictEqual(routine.runOn, 'local');
+    assert.strictEqual(routine.enabled, true);
+    assert.strictEqual(typeof routine.planHash, 'string');
+    // Rewriting every line in the file to record four keys is not a trade a
+    // migration gets to make, so the file keeps its line endings and waits.
+    assert.strictEqual(fs.readFileSync(file, 'utf-8'), crlf);
   });
 
   test('the pre-migration backup is written once and never overwritten', () => {

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -91,6 +91,32 @@ describe('routine write path', () => {
     assert.strictEqual(typeof r.planApprovedAt, 'string');
   });
 
+  // The test above writes the values normalizeRoutine invents when a key is
+  // absent or unreadable, so for runOn, enabled, paused and owner it cannot
+  // tell "survived the cycle" from "was defaulted": a writer that dropped
+  // those keys entirely would still pass it. These are the same fields with
+  // values nothing defaults to.
+  test('non-default values survive the cycle, so a dropped key cannot pass as a default', () => {
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', {
+      runOn: 'agent-computer',
+      enabled: false,
+      paused: true,
+      owner: 'executive-assistant',
+    });
+    const r = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' })
+      .find(x => x.name === 'morning-digest');
+
+    assert.strictEqual(r.runOn, 'agent-computer');
+    assert.strictEqual(r.enabled, false);
+    assert.strictEqual(r.paused, true);
+    assert.strictEqual(r.owner, 'executive-assistant');
+
+    assert.strictEqual(typeof r.runOn, 'string');
+    assert.strictEqual(typeof r.enabled, 'boolean');
+    assert.strictEqual(typeof r.paused, 'boolean');
+    assert.strictEqual(typeof r.owner, 'string');
+  });
+
   test('writing a routine leaves every other frontmatter key byte for byte', () => {
     const updated = updateRoutineBlock(FIXTURE, 'morning-digest', written);
     const before = splitFile(FIXTURE).frontmatter.split('\n');
@@ -244,6 +270,9 @@ describe('plan hash', () => {
       '    schedule: every day at 08:00',
     ].join('\n');
     const hashOf = (fm) => computePlanHash(parseRoutines(fm, { owner: 'penn' })[0]);
+    // Two hashes of nothing are also equal, so prove both files parsed first.
+    assert.strictEqual(parseRoutines(shuffled, { owner: 'penn' })[0].skill, 'content-linter');
+    assert.strictEqual(parseRoutines(ordered, { owner: 'penn' })[0].skill, 'content-linter');
     assert.strictEqual(hashOf(shuffled), hashOf(ordered));
   });
 
@@ -339,9 +368,13 @@ describe('migration of existing routines', () => {
     fs.writeFileSync(file, crlf);
 
     const routine = reread().find(a => a.id === AGENT).routines[0];
+    // runOn and enabled here equal what the reader invents for an absent key,
+    // so they cannot tell a migrated read from an unmigrated one. The plan
+    // hash can: nothing defaults it, and a routine the migration never saw
+    // comes back with it null.
+    assert.strictEqual(routine.planHash, computePlanHash(routine));
     assert.strictEqual(routine.runOn, 'local');
     assert.strictEqual(routine.enabled, true);
-    assert.strictEqual(typeof routine.planHash, 'string');
     // Rewriting every line in the file to record four keys is not a trade a
     // migration gets to make, so the file keeps its line endings and waits.
     assert.strictEqual(fs.readFileSync(file, 'utf-8'), crlf);
@@ -378,10 +411,12 @@ describe('migration of existing routines', () => {
       const routine = agents.find(a => a.id === AGENT).routines[0];
       // The read still returns the new representation: it is built in memory
       // and the write is only how it is remembered for next time.
+      // Again the plan hash is the assertion that discriminates: the other
+      // three are what the reader would invent even if migration did nothing.
+      assert.strictEqual(routine.planHash, computePlanHash(routine));
       assert.strictEqual(routine.runOn, 'local');
       assert.strictEqual(routine.enabled, true);
       assert.strictEqual(routine.paused, false);
-      assert.strictEqual(typeof routine.planHash, 'string');
     } finally {
       console.error = realError;
       fs.chmodSync(file, 0o644);

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -419,6 +419,86 @@ describe('migration of existing routines', () => {
     assert.strictEqual(fs.readFileSync(backup, 'utf-8'), original, 'the backup was overwritten');
   });
 
+  // A copy-pasted routine block is an ordinary thing to find in a hand-edited
+  // file, and nothing makes a name unique. Addressing a block by its name
+  // sent both sets of updates into the first block: the second never got its
+  // own hash, still needed migrating on every read, and so rewrote and
+  // announced the file on every cache miss, which is the opposite of what
+  // running twice is supposed to do.
+  test('two routines sharing a name are each migrated in their own block', () => {
+    const dir = makeWorkspace({
+      agents: {
+        [AGENT]: agentFile({
+          name: AGENT, displayName: 'Penn', role: 'Content Lead',
+          type: 'specialist', order: 2,
+          routines: [
+            { name: 'morning-digest', schedule: 'every day at 08:00', prompt: 'Run the digest' },
+            { name: 'morning-digest', schedule: 'every day at 09:00', prompt: 'Run it again' },
+          ],
+        }),
+      },
+    });
+    srv.setWorkspace(dir);
+    const file = path.join(dir, '.claude', 'agents', `${AGENT}.md`);
+
+    const routines = reread().find(a => a.id === AGENT).routines;
+    assert.strictEqual(routines.length, 2);
+    assert.strictEqual(routines[0].planHash, computePlanHash(routines[0]));
+    assert.strictEqual(routines[1].planHash, computePlanHash(routines[1]));
+    assert.notStrictEqual(routines[0].planHash, routines[1].planHash,
+      'the two blocks do different things and must not share a hash');
+
+    const afterFirst = fs.readFileSync(file, 'utf-8');
+    const logs = [];
+    const realLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try { reread(); } finally { console.log = realLog; }
+    assert.strictEqual(fs.readFileSync(file, 'utf-8'), afterFirst);
+    assert.deepStrictEqual(logs.filter(l => l.includes('[migrate]')), []);
+  });
+
+  // The case above cannot see whether the block index counts every namesake
+  // or only the ones being migrated, because in it every block needs
+  // migrating and the two counts agree. Here the first block is already done,
+  // so a counter that skipped it would send the second block's updates into
+  // the first, overwrite a hash that was already correct, and leave the
+  // second block unmigrated for the next read to find again.
+  test('an already-migrated namesake still holds its place in the count', () => {
+    const settled = computePlanHash(normalizeRoutine(
+      { name: 'morning-digest', prompt: 'Run the digest' }, { owner: AGENT }));
+    const dir = makeWorkspace({
+      agents: {
+        [AGENT]: agentFile({
+          name: AGENT, displayName: 'Penn', role: 'Content Lead',
+          type: 'specialist', order: 2,
+          routines: [
+            {
+              name: 'morning-digest', schedule: 'every day at 08:00', prompt: 'Run the digest',
+              runOn: 'local', enabled: true, paused: false, planHash: settled,
+            },
+            { name: 'morning-digest', schedule: 'every day at 09:00', prompt: 'Run it again' },
+          ],
+        }),
+      },
+    });
+    srv.setWorkspace(dir);
+    const file = path.join(dir, '.claude', 'agents', `${AGENT}.md`);
+
+    const routines = reread().find(a => a.id === AGENT).routines;
+    assert.strictEqual(routines[0].prompt, 'Run the digest');
+    assert.strictEqual(routines[1].prompt, 'Run it again');
+    assert.strictEqual(routines[0].planHash, settled, 'the settled block was written over');
+    assert.strictEqual(routines[1].planHash, computePlanHash(routines[1]));
+
+    const afterFirst = fs.readFileSync(file, 'utf-8');
+    const logs = [];
+    const realLog = console.log;
+    console.log = (...args) => logs.push(args.join(' '));
+    try { reread(); } finally { console.log = realLog; }
+    assert.strictEqual(fs.readFileSync(file, 'utf-8'), afterFirst);
+    assert.deepStrictEqual(logs.filter(l => l.includes('[migrate]')), []);
+  });
+
   test('a failed migrating write is logged and leaves the read usable', () => {
     const { file } = legacyWorkspace();
     const before = fs.readFileSync(file, 'utf-8');

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -423,3 +423,27 @@ describe('the writer at its edges', () => {
       /cannot contain a line break/);
   });
 });
+
+describe('writing a whole routine back', () => {
+  // The writer's contract invites a caller to hand it a routine and let it
+  // work out what to change, which means it is handed the nulls the reader
+  // produces for every field a file does not declare. Writing those through
+  // as text puts the four letters n-u-l-l in the file, and the next read hands
+  // back a string that is not null, is truthy, and hashes differently.
+  test('a routine with no skill round-trips unchanged, nulls and all', () => {
+    const parsed = parseRoutines(extractFrontmatterText(FIXTURE), { owner: 'penn' })
+      .find(r => r.name === 'morning-digest');
+    assert.strictEqual(parsed.skill, null, 'the fixture routine is supposed to declare no skill');
+    const before = computePlanHash(parsed);
+
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', parsed);
+    const readBack = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' })
+      .find(r => r.name === 'morning-digest');
+
+    assert.strictEqual(readBack.skill, null);
+    assert.strictEqual(readBack.planHash, null);
+    assert.strictEqual(readBack.planApprovedAt, null);
+    assert.ok(!updated.includes('null'), 'the text "null" reached the file');
+    assert.strictEqual(computePlanHash(readBack), before, 'the plan hash moved across a round trip');
+  });
+});

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -1,0 +1,197 @@
+'use strict';
+// The routine data model: typed fields, and the write path back into an agent
+// file.
+//
+// The write path is the spine. Routines have always been readable and never
+// writable, so "a field round-trips" is a claim about code that did not exist
+// rather than about a parser that already accepted anything. The fixture below
+// deliberately carries a frontmatter key, a key inside the routine block, a
+// second routine, and a body that the writer is never told about, because the
+// risk in a hand-rolled frontmatter format with no library behind it is losing
+// the parts nobody thought to preserve.
+const { test, describe, after } = require('node:test');
+const assert = require('node:assert');
+
+const { parseRoutines, extractFrontmatterText } = require('../../lib/agents/discovery.js');
+const { _internal: srv } = require('../../server.js');
+const { makeWorkspace, agentFile, cleanup } = require('../helpers/workspace.js');
+const {
+  updateRoutineBlock, normalizeRoutine, isRunOnSupported,
+} = require('../../lib/agents/routines.js');
+
+const FIXTURE = [
+  '---',
+  'name: penn',
+  'displayName: Penn',
+  'aKeyThisCardNeverHeardOf: keep me exactly',
+  'routines:',
+  '  - name: morning-digest',
+  '    schedule: every day at 08:00',
+  '    prompt: Run the digest',
+  '    aRoutineKeyTheWriterDoesNotKnow: keep me too',
+  '  - name: weekly-review',
+  '    schedule: every friday at 16:00',
+  '    prompt: Review the week',
+  'trailingKey: still here',
+  '---',
+  '',
+  '# Penn',
+  '',
+  'Body text the writer knows nothing about.',
+  '',
+  '- a list item',
+  '',
+].join('\n');
+
+// Split on the frontmatter fences by index so a body containing its own fence
+// cannot confuse the split.
+function splitFile(content) {
+  const end = content.indexOf('\n---\n', 4);
+  return { frontmatter: content.slice(4, end), body: content.slice(end + 5) };
+}
+
+describe('routine write path', () => {
+  const written = {
+    runOn: 'local',
+    skill: 'content-linter',
+    owner: 'penn',
+    enabled: true,
+    paused: false,
+    planHash: 'f00dcafe',
+    planApprovedAt: '2026-08-21T09:00:00.000Z',
+  };
+
+  test('every field survives a write-then-read cycle with its value and its type', () => {
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', written);
+    const routines = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' });
+    const r = routines.find(x => x.name === 'morning-digest');
+
+    // Values, field by field, named so a failure says which one moved.
+    assert.strictEqual(r.name, 'morning-digest');
+    assert.strictEqual(r.schedule, 'every day at 08:00');
+    assert.strictEqual(r.prompt, 'Run the digest');
+    assert.strictEqual(r.runOn, 'local');
+    assert.strictEqual(r.skill, 'content-linter');
+    assert.strictEqual(r.owner, 'penn');
+    assert.strictEqual(r.enabled, true);
+    assert.strictEqual(r.paused, false);
+    assert.strictEqual(r.planHash, 'f00dcafe');
+    assert.strictEqual(r.planApprovedAt, '2026-08-21T09:00:00.000Z');
+
+    // Types, because the parser this replaces returned a string for every
+    // value, so a boolean asserted only by value would pass on 'true'.
+    assert.strictEqual(typeof r.enabled, 'boolean');
+    assert.strictEqual(typeof r.paused, 'boolean');
+    assert.strictEqual(typeof r.runOn, 'string');
+    assert.strictEqual(typeof r.skill, 'string');
+    assert.strictEqual(typeof r.owner, 'string');
+    assert.strictEqual(typeof r.planHash, 'string');
+    assert.strictEqual(typeof r.planApprovedAt, 'string');
+  });
+
+  test('writing a routine leaves every other frontmatter key byte for byte', () => {
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', written);
+    const before = splitFile(FIXTURE).frontmatter.split('\n');
+    const after = splitFile(updated).frontmatter.split('\n');
+
+    // A writer that does nothing preserves everything, so prove the write
+    // happened before claiming it was careful.
+    assert.ok(after.includes('    runOn: local'), 'the write never landed');
+
+    // Everything above the edited block.
+    const head = before.indexOf('  - name: morning-digest');
+    assert.deepStrictEqual(after.slice(0, head), before.slice(0, head));
+
+    // Everything from the next routine onward, which covers the second
+    // routine and the top-level key that follows the block.
+    const tailBefore = before.slice(before.indexOf('  - name: weekly-review'));
+    const tailAfter = after.slice(after.indexOf('  - name: weekly-review'));
+    assert.deepStrictEqual(tailAfter, tailBefore);
+
+    // The unknown key inside the edited block itself.
+    assert.ok(after.includes('    aRoutineKeyTheWriterDoesNotKnow: keep me too'),
+      'an unknown key inside the edited routine was dropped');
+  });
+
+  test('writing a routine leaves the file body unchanged', () => {
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', written);
+    assert.strictEqual(splitFile(updated).body, splitFile(FIXTURE).body);
+  });
+});
+
+describe('routine representation', () => {
+  const routine = (fields) => normalizeRoutine({ name: 'r', ...fields });
+
+  test('runOn accepts local, and defaults to it when absent or unrecognised', () => {
+    assert.strictEqual(routine({ runOn: 'local' }).runOn, 'local');
+    assert.strictEqual(routine({}).runOn, 'local');
+    assert.strictEqual(routine({ runOn: 'lcoal' }).runOn, 'local');
+  });
+
+  test('agent-computer is recognised and kept, and is not a working value in this release', () => {
+    // Kept rather than coerced: an author who wrote it should still find it
+    // there. Excluded from the supported set: nothing may treat it as runnable.
+    assert.strictEqual(routine({ runOn: 'agent-computer' }).runOn, 'agent-computer');
+    assert.strictEqual(isRunOnSupported('agent-computer'), false);
+    assert.strictEqual(isRunOnSupported('local'), true);
+  });
+
+  test('the skill a routine runs is parsed', () => {
+    assert.strictEqual(routine({ skill: 'content-linter' }).skill, 'content-linter');
+    assert.strictEqual(routine({}).skill, null);
+  });
+
+  test('an explicit owner is parsed and beats the declaring agent', () => {
+    assert.strictEqual(normalizeRoutine({ name: 'r', owner: 'lea' }, { owner: 'penn' }).owner, 'lea');
+  });
+
+  test('enabled and paused are booleans, not the strings the old parser produced', () => {
+    const off = routine({ enabled: 'false', paused: 'true' });
+    assert.strictEqual(off.enabled, false);
+    assert.strictEqual(off.paused, true);
+    assert.strictEqual(typeof off.enabled, 'boolean');
+    assert.strictEqual(typeof off.paused, 'boolean');
+    // Quoted, because authors quote things.
+    assert.strictEqual(routine({ enabled: '"false"' }).enabled, false);
+    // Absent, and unreadable, both fall back to the meaning files have today.
+    assert.strictEqual(routine({}).enabled, true);
+    assert.strictEqual(routine({}).paused, false);
+    assert.strictEqual(routine({ enabled: 'maybe' }).enabled, true);
+  });
+
+  test('planApprovedAt and the plan hash are parsed', () => {
+    const r = routine({ planApprovedAt: '2026-08-21T09:00:00.000Z', planHash: 'deadbeef' });
+    assert.strictEqual(r.planApprovedAt, '2026-08-21T09:00:00.000Z');
+    assert.strictEqual(r.planHash, 'deadbeef');
+    assert.strictEqual(routine({}).planApprovedAt, null);
+    assert.strictEqual(routine({}).planHash, null);
+  });
+});
+
+describe('ownership', () => {
+  after(cleanup);
+
+  // Ownership used to be positional and unwritten: a routine belonged to the
+  // agent file that declared it, and nothing recorded that anywhere. An
+  // explicit owner has to leave those files meaning exactly what they mean
+  // today, which is what this asserts through the real discovery path rather
+  // than through the parser in isolation.
+  test('a routine that declares no owner is owned by the agent whose file declares it', () => {
+    const dir = makeWorkspace({
+      agents: {
+        'content-lead': agentFile({
+          name: 'content-lead', displayName: 'Penn', role: 'Content Lead',
+          type: 'specialist', order: 2,
+          routines: [
+            { name: 'morning-digest', schedule: 'every day at 08:00', prompt: 'Run the digest' },
+            { name: 'handover', schedule: 'every friday at 16:00', prompt: 'Hand over', owner: 'executive-assistant' },
+          ],
+        }),
+      },
+    });
+    srv.setWorkspace(dir);
+    const penn = srv.discoverAgents().find(a => a.id === 'content-lead');
+    assert.strictEqual(penn.routines[0].owner, 'content-lead');
+    assert.strictEqual(penn.routines[1].owner, 'executive-assistant');
+  });
+});

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -367,3 +367,36 @@ describe('migration of existing routines', () => {
     assert.ok(errors.some(e => /routine/i.test(e)), `nothing was logged, saw: ${JSON.stringify(errors)}`);
   });
 });
+
+describe('the writer at its edges', () => {
+  test('a key already present is replaced in place, not duplicated', () => {
+    const once = updateRoutineBlock(FIXTURE, 'morning-digest', { enabled: false, prompt: 'Run it differently' });
+    const twice = updateRoutineBlock(once, 'morning-digest', { enabled: true });
+    const lines = splitFile(twice).frontmatter.split('\n');
+    const block = lines
+      .slice(lines.indexOf('  - name: morning-digest'), lines.indexOf('  - name: weekly-review'))
+      .filter(l => /^\s+(enabled|prompt):/.test(l));
+    assert.deepStrictEqual(block, ['    prompt: Run it differently', '    enabled: true']);
+  });
+
+  test('a block with nothing but a name gets its keys at the indent the marker implies', () => {
+    const bare = ['---', 'name: penn', 'routines:', '  - name: solo', '---', '', 'body', ''].join('\n');
+    const written = updateRoutineBlock(bare, 'solo', { runOn: 'local' });
+    assert.ok(written.includes('  - name: solo\n    runOn: local\n'), written);
+  });
+
+  test('a routine named in no block leaves the file alone', () => {
+    assert.strictEqual(updateRoutineBlock(FIXTURE, 'not-a-routine', { runOn: 'local' }), FIXTURE);
+    assert.strictEqual(updateRoutineBlock('no frontmatter here', 'solo', { runOn: 'local' }), 'no frontmatter here');
+    assert.strictEqual(updateRoutineBlock('---\nname: penn\n---\nbody', 'solo', { runOn: 'local' }),
+      '---\nname: penn\n---\nbody');
+  });
+
+  test('a value carrying a line break is refused rather than written', () => {
+    // One key would silently become two and every routine below it would move
+    // into the wrong block, so this fails where it can still be seen.
+    assert.throws(
+      () => updateRoutineBlock(FIXTURE, 'morning-digest', { prompt: 'line one\nline two' }),
+      /cannot contain a line break/);
+  });
+});

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -582,3 +582,64 @@ describe('writing a whole routine back', () => {
     assert.strictEqual(computePlanHash(readBack), before, 'the plan hash moved across a round trip');
   });
 });
+
+describe('caller-supplied text is data, not pattern', () => {
+  // A prompt is free text a person wrote, and a dollar sign is ordinary in
+  // one. Splicing it in through a replacement template hands it to the regex
+  // engine: $1 becomes the captured prefix, $& the whole match, $` and $' the
+  // text around it, and $$ collapses to one dollar. Only the replace-in-place
+  // branch was exposed, which is why migration, which only ever appends,
+  // never touched it.
+  test('a value full of dollar sequences replaces an existing key byte for byte', () => {
+    const value = "Budget is $1 per run, $& of $$100, $` and $' too";
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', { prompt: value });
+    const r = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' })
+      .find(x => x.name === 'morning-digest');
+    assert.strictEqual(r.prompt, value);
+    assert.ok(updated.includes(`    prompt: ${value}`), 'the line was rewritten as something else');
+  });
+
+  test('the same sequences survive on a key that has to be appended', () => {
+    const value = '$1$&$$';
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', { skill: value });
+    const r = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' })
+      .find(x => x.name === 'morning-digest');
+    assert.strictEqual(r.skill, value);
+  });
+
+  // The routine name reaches the block locator, which is the other place a
+  // caller-supplied string could become a pattern. It does not: the locator
+  // matches every item line with one fixed regex and compares the captured
+  // name with ===. This pins that, because a name is exactly the kind of
+  // string that would grow a regex under a later refactor.
+  const NAMES = [
+    '---',
+    'name: penn',
+    'routines:',
+    '  - name: axb',
+    '    prompt: the wrong one',
+    '  - name: a.b',
+    '    prompt: the right one',
+    '---',
+    '',
+    'body',
+    '',
+  ].join('\n');
+
+  test('a routine name carrying regex metacharacters matches only itself', () => {
+    const updated = updateRoutineBlock(NAMES, 'a.b', { skill: 'content-linter' });
+    const routines = parseRoutines(extractFrontmatterText(updated), { owner: 'penn' });
+    assert.strictEqual(routines.find(r => r.name === 'a.b').skill, 'content-linter');
+    assert.strictEqual(routines.find(r => r.name === 'axb').skill, null,
+      'a dot in the name matched a different routine');
+  });
+
+  // The key is interpolated into a RegExp to find its line. The parser only
+  // ever reads back keys made of word characters, so a key it could not read
+  // is refused at the boundary rather than compiled into a pattern.
+  test('a key the parser could never read back is refused', () => {
+    assert.throws(
+      () => updateRoutineBlock(FIXTURE, 'morning-digest', { 'pro.*mpt': 'x' }),
+      /not a routine field name/);
+  });
+});

--- a/test/unit/routine-model.test.js
+++ b/test/unit/routine-model.test.js
@@ -249,7 +249,27 @@ describe('plan hash', () => {
     assert.notStrictEqual(plan({ prompt: 'Run something else' }), base);
     assert.notStrictEqual(plan({ skill: 'voice-editor' }), base);
     assert.notStrictEqual(plan({ runOn: 'agent-computer' }), base);
-    assert.notStrictEqual(plan({ owner: 'executive-assistant' }), base);
+  });
+
+  // Ownership is settled by the caller for almost every routine there is,
+  // because files declare it only rarely and it otherwise resolves from the
+  // agent file's name and its position on the roster. Hashing it would mean a
+  // rename, or an agent gaining or losing order zero, silently invalidating an
+  // approval while every byte of the routine stayed where it was. That is the
+  // same failure excluding the schedule exists to prevent, arriving by a
+  // different road, so the hash reads only what the routine itself declares.
+  test('who owns a routine does not reach the hash, declared or resolved', () => {
+    const raw = { name: 'morning-digest', prompt: 'Run the digest', skill: 'content-linter' };
+    // Resolved: the same bytes read from two different agent files.
+    assert.strictEqual(
+      computePlanHash(normalizeRoutine(raw, { owner: 'content-lead' })),
+      computePlanHash(normalizeRoutine(raw, { owner: 'default' })));
+    // Declared: the cost of the choice, pinned so it cannot drift back by
+    // accident. Owner is a field in its own right, so an approval flow can
+    // compare it directly rather than through the hash.
+    assert.strictEqual(
+      computePlanHash(normalizeRoutine({ ...raw, owner: 'executive-assistant' }, { owner: 'penn' })),
+      computePlanHash(normalizeRoutine(raw, { owner: 'penn' })));
   });
 
   test('the hash does not depend on the order the fields appear in the file', () => {


### PR DESCRIPTION
## What

Routines get a typed representation, a way to write one back into an agent file, a hash of what the routine does, and a lazy migration for the routines people have already written.

Fields: `runOn`, the skill a routine runs, an explicit owner, enabled and paused as real booleans, `planApprovedAt`, and a plan hash. The schedule grammar and everything that reads it are untouched.

## How

**A line editor, not a serialiser.** Nothing in this repository has ever written a routine back to disk, the frontmatter format is hand rolled, and there is no YAML library in the server path. So the writer locates one routine block, replaces or appends the keys it was given, and carries every other byte through untouched. Re-serialising would mean deciding how to render every key an author ever wrote, and the keys this code has never heard of are exactly the ones it must not lose. The block scan moved next to the writer, because the reader and the writer need the same idea of where a block starts and stops and two copies of that would drift.

**Typing is the work.** The old reader copied whatever `key: value` it found as a string, with no whitelist, so new fields parsed for free and arrived as the wrong type. A paused routine read back as the string `'false'`, which is truthy, is a routine that still runs. Quotes are stripped only from the fields this change types: doing it to `prompt` or `schedule` would change what the scheduler already sends to the command line.

**The hash covers what a routine does, not when it runs.** The instruction, the skill, where it runs, and which agent it runs as. Not the schedule: an approval that a ten-minute shift invalidates is an approval that gets clicked through. Not enabled or paused either, which change whether something happens rather than what happens. It reads those by name from the normalised routine, so the order an author writes fields in cannot reach it.

**The migration is lazy and best effort**, following the conversation store. No schema version anywhere: whether a file has been migrated is a question the data answers. The migrated content is computed before anything is written and returned whether or not the write lands, so a workspace nobody can write to still reads correctly. The write only happens when the file on disk is byte for byte what was read, which refuses both clobbering an edit made in the meantime and rewriting a Windows-line-ending checkout line by line to record four keys. A backup is taken once, before the first migrating write, and never overwritten.

**Ownership stays positional unless declared.** An undeclared owner resolves to the agent whose file declares the routine, which is what ownership already meant when it was implicit, and no owner is written into a file that never named one.

## Verification

- Full suite green, including the four pre-commit checks (unit tests, typecheck, style lint, reference scan) on every commit.
- Coverage: `lib/agents/discovery.js` 100%, `lib/scheduler.js` 100%, the new `lib/agents/routines.js` 100%. All 50 committed floors hold.
- The tests were proven to fail without the change, mechanically, with `red-first` against `main`.
- Nine blocks were deleted by hand one at a time to check a named test goes red. Eight did. The ninth exposed a guard nothing could reach and a weak idempotency assertion: the assertion now proves a second pass says nothing at all rather than only that the bytes match, and the unreachable guard is gone. Two further gaps surfaced the same way and are now covered: replacing a key that already exists, which everything so far only ever appended around, and the refusal to touch a file whose line endings differ from the text the editors work on.

The exact-shape assertion in the discovery tests was updated, as expected: it pins the routine shape with `deepStrictEqual`, so every new field breaks it.

## Scope

Not here: the scheduler, its grammar, and next-run computation. No run records. No interface for creating, editing, pausing or approving a routine, and no approval flow: this carries the hash and the timestamp, and nothing asks anyone anything yet. `agent-computer` is recognised and kept through a round trip so an author who writes it does not silently lose it, and is excluded from the supported set so nothing treats it as runnable in this release.
