### PR TITLE
Make the scheduler's tick testable and stoppable

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -94,10 +94,20 @@ function recordRoutineRun(key, state) {
 
 // ===== SCHEDULER =====
 
+// The live tick handle, and the whole of the scheduler's lifecycle state.
+// It used to be discarded, which cost two things: the tick could not be
+// stopped, and a second start silently added a second tick rather than
+// being recognised as a repeat.
+let tickTimer = null;
+
 function startScheduler() {
+  // Already ticking: leave the running one alone. Replacing it instead would
+  // make a stray second call reset the tick's phase, and would leave nothing
+  // for a test to tell one tick from two.
+  if (tickTimer) return;
   const checkInterval = 60 * 1000; // Check every 60 seconds
 
-  setInterval(() => {
+  tickTimer = setInterval(() => {
     const agents = discoverAgents();
     const now = deps.now();
 
@@ -112,7 +122,17 @@ function startScheduler() {
         }
       }
     }
-  }, checkInterval).unref(); // see heartbeat unref note: listener keeps process alive in production
+  }, checkInterval);
+  tickTimer.unref(); // see heartbeat unref note: listener keeps process alive in production
+}
+
+// Stop the tick. Safe on a scheduler that was never started: clearInterval on
+// a null handle is already a no-op, so there is deliberately no guard here for
+// that case. Clearing the handle is what lets a later start arm a fresh tick
+// rather than being turned away by the guard above.
+function stopScheduler() {
+  clearInterval(tickTimer);
+  tickTimer = null;
 }
 
 function getNextRun(schedule, lastRunISO) {
@@ -242,5 +262,5 @@ function broadcastRoutineUpdate() {
 module.exports = {
   wireSchedulerDeps,
   routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
-  startScheduler, getNextRun, executeRoutine,
+  startScheduler, stopScheduler, getNextRun, executeRoutine,
 };

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -18,6 +18,15 @@
 // capability left arrives through wireSchedulerDeps: the WebSocket client
 // set as an accessor (the wss is created later at boot). Unwired deps
 // throw at first use.
+//
+// The current time arrives through the SAME wiring, as deps.now(), and it
+// is the one dep with a working default rather than a throwing one: nothing
+// at boot should have to supply a clock for the scheduler to keep time. It
+// shares wireSchedulerDeps because that function already returns the
+// previous set for restoration, which is exactly what a test needs, and a
+// second wiring shape for one function would be a second thing to learn.
+// Every reading of "what time is it now" goes through it; new Date(x) with
+// an argument is a conversion rather than a clock read and stays direct.
 const fs = require('fs');
 const path = require('path');
 const { getWorkspace } = require('./config.js');
@@ -33,6 +42,7 @@ const unwired = (name) => () => {
 };
 const deps = {
   getWssClients: unwired('getWssClients'),  // () => wss.clients (created at boot)
+  now: () => new Date(),                    // the clock seam; defaulted, never unwired
 };
 function wireSchedulerDeps(next) {
   const prev = { ...deps };
@@ -89,7 +99,7 @@ function startScheduler() {
 
   setInterval(() => {
     const agents = discoverAgents();
-    const now = new Date();
+    const now = deps.now();
 
     for (const agent of agents) {
       if (!agent.routines) continue;
@@ -107,7 +117,7 @@ function startScheduler() {
 
 function getNextRun(schedule, lastRunISO) {
   if (!schedule) return null;
-  const now = new Date();
+  const now = deps.now();
   const s = schedule.toLowerCase();
 
   // Parse "every day at HH:MM"
@@ -156,18 +166,18 @@ function getNextRun(schedule, lastRunISO) {
 }
 
 function executeRoutine(agent, routine, key) {
-  const startTime = Date.now();
+  const startTime = deps.now().getTime();
   // Persisted immediately: if the server dies mid-run, the restarted process
   // still knows the run started and will not fire it again in the same window.
-  recordRoutineRun(key, { lastRun: new Date().toISOString(), status: 'running', duration: null });
+  recordRoutineRun(key, { lastRun: deps.now().toISOString(), status: 'running', duration: null });
 
   // Notify connected clients
   broadcastRoutineUpdate();
 
   const recordOutcome = (ok) => {
-    const duration = Math.round((Date.now() - startTime) / 1000);
+    const duration = Math.round((deps.now().getTime() - startTime) / 1000);
     recordRoutineRun(key, {
-      lastRun: new Date().toISOString(),
+      lastRun: deps.now().toISOString(),
       status: ok ? 'completed' : 'failed',
       duration
     });

--- a/server.js
+++ b/server.js
@@ -450,7 +450,7 @@ function discoverWorkspaces() {
 const schedulerLib = require('./lib/scheduler.js');
 const {
   routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
-  startScheduler, getNextRun, executeRoutine,
+  startScheduler, stopScheduler, getNextRun, executeRoutine,
 } = schedulerLib;
 // Hand lib/agents its root-owned dependencies (see the module headers).
 // (routineState needs no wiring: discovery requires lib/scheduler.js
@@ -3055,7 +3055,7 @@ module.exports._internal = {
   armFileTreeWatcher, fileTreeForSend, broadcastFileTree,
   flatFileListCached, invalidateFileListCache,
   // scheduler
-  getNextRun, executeRoutine, routineState, startScheduler,
+  getNextRun, executeRoutine, routineState, startScheduler, stopScheduler,
   loadRoutineState, saveRoutineState, recordRoutineRun,
   // agent + skill discovery / parsing
   discoverAgents, invalidateAgentCache, discoverSkills, parseSkillFile,

--- a/test/integration/scheduler-clock.test.js
+++ b/test/integration/scheduler-clock.test.js
@@ -1,0 +1,86 @@
+'use strict';
+// The tick, driven across a scheduled instant by a clock the test owns.
+//
+// This is the pairing neither existing suite could make: the grammar tests
+// freeze Date and never reach the tick, the tick test advances the interval
+// and runs the tick against the real wall clock. Here the interval is mocked
+// AND the scheduler's clock is wired, so a routine can be watched not firing
+// at 08:00 and then firing at 09:30 without a second of real time passing.
+//
+// Both halves are one test on purpose. "It did not fire" on its own is
+// satisfied by a scheduler that was never going to fire anything; the second
+// half fires the same routine from the same fixture, which is what makes the
+// first half mean something.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
+
+const scheduler = require('../../lib/scheduler.js');
+
+const KEY = 'punctual:clock-check';
+// Wednesday 2026-07-01, local time, so the fixture is timezone-independent.
+const BEFORE_NINE = new Date(2026, 6, 1, 8, 0, 0);
+const AFTER_NINE = new Date(2026, 6, 1, 9, 30, 0);
+
+before(async () => {
+  await h.boot({
+    agents: {
+      punctual: agentFile({
+        name: 'punctual', type: 'specialist', order: 1,
+        routines: [{ name: 'clock-check', schedule: 'every day at 09:00', prompt: 'clock routine body' }],
+      }),
+    },
+  });
+});
+after(h.shutdown);
+
+test('the tick fires a routine when the wired clock reaches its time, not before', async (t) => {
+  h.writeScenario([
+    { match: { agent: 'punctual', promptIncludes: 'clock routine body' }, turn: [{ text: 'routine ran' }] },
+  ]);
+  delete h.internal.routineState[KEY];
+
+  const clock = { at: BEFORE_NINE };
+  const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+  // The server armed the tick at boot; the interval this test drives has to
+  // be the mocked one, so the real one goes first.
+  h.internal.stopScheduler();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  try {
+    h.internal.startScheduler();
+
+    t.mock.timers.tick(60_000);
+    assert.strictEqual(h.internal.routineState[KEY], undefined,
+      'an hour before its time, the routine has not run');
+
+    clock.at = AFTER_NINE;
+    t.mock.timers.tick(60_000);
+    const started = h.internal.routineState[KEY];
+    assert.ok(started, 'advancing the clock past 09:00 fired the routine, with no real time elapsed');
+    assert.strictEqual(started.lastRun, AFTER_NINE.toISOString(),
+      'the run was stamped with the wired clock rather than the wall clock');
+
+    // tick() is synchronous and the child's close event cannot have landed
+    // during it, so moving the clock here is deterministic. It makes the
+    // recorded duration the seam's answer rather than elapsed real time,
+    // which is what pins the two clock reads inside the outcome.
+    clock.at = new Date(AFTER_NINE.getTime() + 120_000);
+    const ran = await h.waitUntil(() => {
+      const s = h.internal.routineState[KEY];
+      return s && s.status !== 'running';
+    });
+    assert.ok(ran, 'the fired routine reached an outcome');
+    const done = h.internal.routineState[KEY];
+    assert.strictEqual(done.status, 'completed',
+      'the routine the clock released ran through to completion');
+    assert.strictEqual(done.duration, 120,
+      'the duration is the two minutes the seam reports, not the milliseconds that really elapsed');
+    assert.strictEqual(done.lastRun, clock.at.toISOString(),
+      'the outcome is stamped with the seam too');
+  } finally {
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+    scheduler.wireSchedulerDeps(prevDeps);
+  }
+});

--- a/test/integration/scheduler-tick.test.js
+++ b/test/integration/scheduler-tick.test.js
@@ -37,6 +37,11 @@ test('the scheduler tick discovers a due routine and executes it end to end', as
     lastRun: new Date().toISOString(), status: 'completed', duration: 1,
   };
 
+  // The server arms the tick at boot, and a second start is now a no-op
+  // rather than a second interval, so the boot tick has to go before this
+  // test can arm the mocked one it drives. Stopped before the mock timers
+  // are installed so the handle being cleared is the real one it came from.
+  h.internal.stopScheduler();
   t.mock.timers.enable({ apis: ['setInterval'] });
   h.internal.startScheduler();
   t.mock.timers.tick(60_000);

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -137,3 +137,95 @@ test('the tick reads the current time through the wired clock seam', (t) => {
     }
   });
 });
+
+// ===== LIFECYCLE =====
+// startScheduler used to throw its interval handle away, so the tick could
+// not be stopped and a second call quietly added a second one. The clock
+// seam above is what makes these countable: a bare workspace discovers one
+// agent with no routines, so a tick is exactly one clock read and nothing
+// else, and the count is the number of ticks that ran.
+
+function countingClock(sched, at = new Date(2026, 6, 1, 8, 0, 0)) {
+  const clock = { reads: 0, at };
+  sched.wireSchedulerDeps({ now: () => { clock.reads += 1; return clock.at; } });
+  return clock;
+}
+
+test('a stopped scheduler fires nothing', (t) => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    const clock = countingClock(sched);
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      sched.startScheduler();
+      t.mock.timers.tick(60_000);
+      // Proves the tick was LIVE before the stop. Without it, "no ticks after
+      // the stop" is satisfied by a scheduler that was never running.
+      assert.strictEqual(clock.reads, 1, 'the tick was running before the stop');
+
+      clock.reads = 0;
+      sched.stopScheduler();
+      t.mock.timers.tick(180_000);
+      assert.strictEqual(clock.reads, 0, 'three minutes passed and no tick ran');
+    } finally {
+      t.mock.timers.reset();
+    }
+  });
+});
+
+test('starting the scheduler twice leaves exactly one tick running', (t) => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    const clock = countingClock(sched);
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      sched.startScheduler();
+      sched.startScheduler();
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(clock.reads, 1, 'one minute produced one tick, not two');
+    } finally {
+      sched.stopScheduler();
+      t.mock.timers.reset();
+    }
+  });
+});
+
+test('a scheduler stopped and started again ticks normally', (t) => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    const clock = countingClock(sched);
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      sched.startScheduler();
+      sched.stopScheduler();
+      clock.reads = 0;
+      sched.startScheduler();
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(clock.reads, 1, 'stopping is not a one-way door');
+    } finally {
+      sched.stopScheduler();
+      t.mock.timers.reset();
+    }
+  });
+});
+
+test('stopping a scheduler that was never started is safe and does nothing', (t) => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    const clock = countingClock(sched);
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      sched.stopScheduler();
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(clock.reads, 0, 'nothing was armed, so nothing ticked');
+      // And the no-op stop left the scheduler startable, which is the part
+      // that would break if stopping recorded anything about having run.
+      sched.startScheduler();
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(clock.reads, 1, 'a start after a no-op stop still arms the tick');
+    } finally {
+      sched.stopScheduler();
+      t.mock.timers.reset();
+    }
+  });
+});

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -114,3 +114,26 @@ test('a run left "running" by a dead server loads back as "interrupted", still s
     assert.strictEqual(sched.routineState['bad:entry'], undefined, 'entries without a lastRun string are dropped');
   });
 });
+
+// ===== THE CLOCK SEAM =====
+// The tick used to call the clock directly, so the only way to reach a
+// scheduled instant was to wait for it. These pin the seam itself: the tick
+// reads the wired clock, and it reads it once per tick, which is what makes
+// the tick countable in the lifecycle tests below.
+
+test('the tick reads the current time through the wired clock seam', (t) => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    let reads = 0;
+    const fixed = new Date(2026, 6, 1, 8, 0, 0);
+    sched.wireSchedulerDeps({ now: () => { reads += 1; return fixed; } });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      sched.startScheduler();
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(reads, 1, 'the tick took its instant from the wired clock, once');
+    } finally {
+      t.mock.timers.reset();
+    }
+  });
+});


### PR DESCRIPTION
## What

The scheduler read the clock directly at six sites and threw away its interval handle. Both facts made it untestable in the same way: there was no way to tell it what time it was, and no way to make it stop.

Two things change and no scheduling behaviour does. The current time now arrives as a dependency, and the tick can be stopped and started.

## How

**The clock.** `deps.now()` joins the existing dependency wiring rather than getting a mechanism of its own, because that wiring already returns the previous set for restoration, which is exactly what a test needs. It differs from its neighbour in one way worth stating: it has a working default rather than a throwing one, so nothing at boot has to supply a clock. Only readings of the present go through it. Building a date from a stored timestamp is a conversion rather than a question about now, and those are unchanged.

**The lifecycle.** The interval handle is kept. A second start is recognised as a repeat and leaves the running tick alone; `stopScheduler` clears it. Replacing the running tick on a second start would also have left exactly one, but it resets the tick's phase for a caller that only meant to be sure, and it leaves nothing for a test to measure between one tick and two.

There is deliberately no guard on stopping a scheduler that was never started. Clearing a null handle is already a no-op, so a guard there would be a branch no test could discriminate. What is worth pinning is that a start after such a stop still arms the tick, and that is asserted instead.

## Verification

The clock seam is what makes the tick countable. A bare workspace discovers one agent with no routines, so a tick is exactly one read of the seam and nothing else, and the lifecycle tests count ticks rather than inferring them from a routine that happened to fire.

A new integration test does the thing neither existing suite could: it mocks the interval and wires the clock at the same time, watches a routine not fire at 08:00, moves the clock to 09:30, and watches it fire and run to completion with no real time elapsed. It also pins the stamped time and the recorded duration to the seam's answers rather than to elapsed wall time, which is what makes all six former call sites load-bearing rather than merely rerouted.

Every guard was deleted by hand and the tests re-run. Twelve mutations, each producing a named failure: removing the double-start guard, removing the clear, removing the handle reset, not capturing the handle at all, reverting each of the six clock reads, removing the seam's default, and removing the call that fires a routine. None stayed green.

Full suite green, 1776 tests. The red-first check reports PROVEN, with 7 tests failing when the source is reverted and the tests kept. Coverage floors hold, with the scheduler area at 100%.

One existing test changed. The server arms the tick at boot, so the tick test was relying on a second start creating a second interval, which is the behaviour being removed. It stops the boot tick first, before the mock timers are installed, so the handle it clears is the real one it came from. Its assertions are untouched: a 60,000 ms interval and a routine reaching completion.

## Scope

Deliberately not here: missed-run detection, drift detection, single-flight, run records, and any gating on a routine's own fields. No change to the schedule grammar, to timezones, or to what a routine does when it fires. Which routines are due, and when each becomes due, is identical before and after.
