### PR TITLE
Let a routine's own fields decide whether it runs

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -35,6 +35,7 @@ const { recordEvent } = require('./signals.js');
 const { buildSystemPrompt } = require('./agents/prompt.js');
 const { getCodexAppServer, waitForCodexReady, readAgentInstructions } = require('./runtime/codex-glue.js');
 const { discoverAgents } = require('./agents/discovery.js');
+const { isRunOnSupported } = require('./agents/routines.js');
 const { spawnClaude, getBareArgs, modelArgs, getSpawnEnv } = require('./runtime/claude.js');
 
 const unwired = (name) => () => {
@@ -100,6 +101,29 @@ function recordRoutineRun(key, state) {
 // being recognised as a repeat.
 let tickTimer = null;
 
+// Which refusal each routine was last announced under, so a routine that is
+// refused says so once rather than once a minute. A refusal deliberately does
+// not record a run (that is what stops it being counted as one), so a refused
+// routine stays due for the rest of its window and the tick meets it again on
+// every pass. Forgotten as soon as a routine stops being refused, so pausing
+// something a second time is announced a second time.
+const announcedRefusals = new Map();
+
+// Why the routine's own fields refuse it, named after the FIELD that decided,
+// or null if none of them do. "It did not run" without a field is a support
+// question rather than an answer.
+//
+// The supported set is not repeated here: which run targets exist is the data
+// model's to know, and a second list in the scheduler is a second list to
+// forget to update. Nothing is normalised either, because normalizeRoutine has
+// already defaulted and lowercased everything by the time a routine gets here.
+function routineRefusal(routine) {
+  if (routine.paused) return 'paused';
+  if (!routine.enabled) return 'enabled';
+  if (!isRunOnSupported(routine.runOn)) return 'runOn';
+  return null;
+}
+
 function startScheduler() {
   // Already ticking: leave the running one alone. Replacing it instead would
   // make a stray second call reset the tick's phase, and would leave nothing
@@ -115,8 +139,20 @@ function startScheduler() {
       if (!agent.routines) continue;
       for (const routine of agent.routines) {
         const key = `${agent.id}:${routine.name}`;
+        const refusedBy = routineRefusal(routine);
+        if (!refusedBy) announcedRefusals.delete(key);
         const nextRun = getNextRun(routine.schedule, routineState[key]?.lastRun);
         if (nextRun && now >= nextRun) {
+          // Refusal is checked AFTER due-ness so that a routine which is
+          // simply not due stays silent, and so that what makes a routine due
+          // is decided by exactly the code it was decided by before.
+          if (refusedBy) {
+            if (announcedRefusals.get(key) !== refusedBy) {
+              announcedRefusals.set(key, refusedBy);
+              console.log(`[Scheduler] Not running routine: ${routine.name} (${agent.name}): ${refusedBy} is ${String(routine[refusedBy])}`);
+            }
+            continue;
+          }
           console.log(`[Scheduler] Running routine: ${routine.name} (${agent.name})`);
           executeRoutine(agent, routine, key);
         }

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -62,6 +62,9 @@ const routineState = {}; // { routineKey: { lastRun, status, duration } }
 
 function loadRoutineState() {
   for (const key of Object.keys(routineState)) delete routineState[key];
+  // The runs being dropped here belong to the workspace being left, and so do
+  // the announcements. This is the workspace-switch path.
+  announcedRefusals.clear();
   try {
     const file = path.join(rundockDir(), 'routine-state.json');
     const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
@@ -107,6 +110,14 @@ let tickTimer = null;
 // routine stays due for the rest of its window and the tick meets it again on
 // every pass. Forgotten as soon as a routine stops being refused, so pausing
 // something a second time is announced a second time.
+//
+// Scoped to the life of the routine rather than the life of the process, which
+// takes both of the resets below. Keys are `agentId:routineName`, which are
+// workspace-local and collide freely between workspaces, so a key that outlived
+// what it described would hand its silence to a different routine that happened
+// to be named the same. A refusal silent on its first tick cannot be told apart
+// from a routine that is simply not due, which is the whole point of saying
+// anything.
 const announcedRefusals = new Map();
 
 // Why the routine's own fields refuse it, named after the FIELD that decided,
@@ -135,10 +146,13 @@ function startScheduler() {
     const agents = discoverAgents();
     const now = deps.now();
 
+    const onRoster = new Set();
+
     for (const agent of agents) {
       if (!agent.routines) continue;
       for (const routine of agent.routines) {
         const key = `${agent.id}:${routine.name}`;
+        onRoster.add(key);
         const refusedBy = routineRefusal(routine);
         if (!refusedBy) announcedRefusals.delete(key);
         const nextRun = getNextRun(routine.schedule, routineState[key]?.lastRun);
@@ -157,6 +171,14 @@ function startScheduler() {
           executeRoutine(agent, routine, key);
         }
       }
+    }
+
+    // A routine that is no longer declared cannot be refused, so its
+    // announcement describes nothing. Keeping it means the next routine written
+    // under that name inherits a silence it never earned, and a rename is
+    // enough to produce one.
+    for (const key of announcedRefusals.keys()) {
+      if (!onRoster.has(key)) announcedRefusals.delete(key);
     }
   }, checkInterval);
   tickTimer.unref(); // see heartbeat unref note: listener keeps process alive in production

--- a/test/integration/scheduler-gating.test.js
+++ b/test/integration/scheduler-gating.test.js
@@ -21,7 +21,11 @@ const assert = require('node:assert');
 const h = require('../helpers/harness.js');
 const { agentFile } = require('../helpers/workspace.js');
 
+const fs = require('node:fs');
+const path = require('node:path');
+
 const scheduler = require('../../lib/scheduler.js');
+const { invalidateAgentCache } = require('../../lib/agents/discovery.js');
 
 // Wednesday 2026-07-01 local time, so the fixture is timezone-independent.
 // Each refused routine comes due at its own hour, and each test sets the clock
@@ -33,6 +37,11 @@ const PAST_TEN = new Date(2026, 6, 1, 10, 30, 0);
 const PAST_ELEVEN = new Date(2026, 6, 1, 11, 30, 0);
 const PAST_NOON = new Date(2026, 6, 1, 12, 30, 0);
 const LATE = new Date(2026, 6, 1, 23, 30, 0);
+// The next two Thursdays. The flip test needs a routine that is not due on
+// the Wednesday every other test runs on, or its announcement would be spent
+// before it starts, and it needs two separate due windows.
+const THURSDAY = new Date(2026, 6, 2, 6, 30, 0);
+const NEXT_THURSDAY = new Date(2026, 6, 9, 6, 30, 0);
 // Yesterday, so it cannot suppress today's run: the refused routines have to
 // be genuinely due, or they prove nothing.
 const YESTERDAY = { lastRun: new Date(2026, 5, 30, 9, 5, 0).toISOString(), status: 'completed', duration: 7 };
@@ -42,6 +51,15 @@ const DISABLED = 'retiree:disabled-check';
 const ELSEWHERE = 'traveller:elsewhere-check';
 const ORDINARY = 'worker:ordinary-check';
 const QUIET = 'mute:quiet-check';
+
+const FLIP = 'flipper:flip-check';
+
+function flipperFile(paused) {
+  return agentFile({
+    name: 'flipper', type: 'specialist', order: 6,
+    routines: [{ name: 'flip-check', schedule: 'every thursday at 06:00', prompt: 'flip body', paused }],
+  });
+}
 
 const clock = { at: PAST_NINE };
 let prevDeps = null;
@@ -70,6 +88,9 @@ before(async () => {
       }),
       // Due only late in the day, so nothing else in this file wakes it and
       // the announcement test can count from zero.
+      // Weekly, on a day no other test in this file visits, so its
+      // announcements are all its own.
+      flipper: flipperFile(true),
       mute: agentFile({
         name: 'mute', type: 'specialist', order: 5,
         routines: [{ name: 'quiet-check', schedule: 'every day at 23:00', prompt: 'quiet body', paused: true }],
@@ -113,6 +134,17 @@ function armControl() {
   delete h.internal.routineState[ORDINARY];
 }
 
+// Stamped with the wired clock, so this says the control fired on the tick
+// just driven. A bare truthiness check on its state would also be satisfied
+// by the run it did in the previous test, which would make every refusal
+// test's proof-of-life assertion pass without the tick doing anything at all.
+function assertControlFiredOnThisTick() {
+  const state = h.internal.routineState[ORDINARY];
+  assert.ok(state, 'the ordinary routine ran');
+  assert.strictEqual(state.lastRun, clock.at.toISOString(),
+    'the ordinary routine fired on the tick just driven, so that tick was live');
+}
+
 function seed(key) {
   h.internal.routineState[key] = { ...YESTERDAY };
 }
@@ -126,8 +158,7 @@ test('a paused routine does not fire', (t) => {
 
   assert.deepStrictEqual(h.internal.routineState[PAUSED], YESTERDAY,
     'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
-  assert.ok(h.internal.routineState[ORDINARY],
-    'the ordinary routine fired on the same tick, so the tick itself was live');
+  assertControlFiredOnThisTick();
   assert.ok(logs.some(l => l.includes('paused-check') && l.includes('paused is true')),
     'the refusal is announced and names the field that caused it');
 });
@@ -141,8 +172,7 @@ test('a disabled routine does not fire', (t) => {
 
   assert.deepStrictEqual(h.internal.routineState[DISABLED], YESTERDAY,
     'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
-  assert.ok(h.internal.routineState[ORDINARY],
-    'the ordinary routine fired on the same tick, so the tick itself was live');
+  assertControlFiredOnThisTick();
   assert.ok(logs.some(l => l.includes('disabled-check') && l.includes('enabled is false')),
     'the refusal is announced and names the field that caused it');
 });
@@ -156,8 +186,7 @@ test('a routine whose runOn is not supported does not fire', (t) => {
 
   assert.deepStrictEqual(h.internal.routineState[ELSEWHERE], YESTERDAY,
     'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
-  assert.ok(h.internal.routineState[ORDINARY],
-    'the ordinary routine fired on the same tick, so the tick itself was live');
+  assertControlFiredOnThisTick();
   assert.ok(logs.some(l => l.includes('elsewhere-check') && l.includes('runOn is agent-computer')),
     'the refusal is announced and names the field that caused it');
 });
@@ -192,4 +221,41 @@ test('a refusal is announced once, not on every tick for as long as it stays due
     'a routine refused for the same reason says so once; a refusal never records a run, so it stays due all day');
   assert.strictEqual(h.internal.routineState[QUIET], undefined,
     'and three ticks later it still has not run');
+});
+
+// The line that forgets an announcement is a WRITE, and a write is proved by
+// removing it rather than by breaking a read. Nothing else in this file can
+// see it: every other routine keeps one setting for the whole run, and for
+// those a scheduler that never forgot anything behaves identically. This is
+// the case where it does not: refused, released, refused again for the same
+// reason, which has to be announced twice or the second refusal is invisible
+// to whoever is reading the log to find out why nothing ran.
+test('a routine refused, released and refused again says so both times', async (t) => {
+  const file = path.join(h.workspaceDir, '.claude', 'agents', 'flipper.md');
+  h.writeScenario([
+    { match: { agent: 'flipper', promptIncludes: 'flip body' }, turn: [{ text: 'routine ran' }] },
+  ]);
+
+  clock.at = THURSDAY;
+  const first = driveTick(t);
+  assert.strictEqual(h.internal.routineState[FLIP], undefined, 'refused, so nothing ran');
+
+  fs.writeFileSync(file, flipperFile(false));
+  invalidateAgentCache();
+  driveTick(t);
+  await h.waitUntil(() => {
+    const s = h.internal.routineState[FLIP];
+    return s && s.status !== 'running';
+  });
+  assert.strictEqual(h.internal.routineState[FLIP].status, 'completed',
+    'released, so it ran: the release is real and not just a quieter refusal');
+
+  fs.writeFileSync(file, flipperFile(true));
+  invalidateAgentCache();
+  clock.at = NEXT_THURSDAY;
+  const third = driveTick(t);
+
+  const announced = (logs) => logs.filter(l => l.includes('Not running routine') && l.includes('flip-check'));
+  assert.strictEqual(announced(first).length, 1, 'the first refusal was announced');
+  assert.strictEqual(announced(third).length, 1, 'and so was the refusal a week later, after the release in between');
 });

--- a/test/integration/scheduler-gating.test.js
+++ b/test/integration/scheduler-gating.test.js
@@ -1,0 +1,195 @@
+'use strict';
+// A routine's own fields decide whether the tick runs it.
+//
+// The data model shipped runOn, enabled and paused and the scheduler read
+// none of them, so a paused routine fired, a disabled routine fired, and a
+// routine reserved for hardware that does not exist yet ran locally.
+//
+// Every test here drives the SAME tick through the same fixture at the same
+// instant, and every refusal test asserts the ordinary routine fired on that
+// very tick. "It did not fire" is the absence of something, and absence is
+// satisfied by a scheduler that was never going to run anything; the control
+// firing beside it is what makes the absence mean the gate rather than the
+// path being broken.
+//
+// The refused routines are seeded with a run from the PREVIOUS day, so the
+// assertion is that their stored state is untouched rather than merely
+// missing. A refusal that quietly stamped a run would still leave nothing
+// spawned, and would still be a routine that never fires again.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
+
+const scheduler = require('../../lib/scheduler.js');
+
+// Wednesday 2026-07-01 local time, so the fixture is timezone-independent.
+// Each refused routine comes due at its own hour, and each test sets the clock
+// just past that hour. A single instant that made all three due at once would
+// mean the first test's tick announced all three refusals, and the other two
+// would then be asserting against an announcement already spent.
+const PAST_NINE = new Date(2026, 6, 1, 9, 30, 0);
+const PAST_TEN = new Date(2026, 6, 1, 10, 30, 0);
+const PAST_ELEVEN = new Date(2026, 6, 1, 11, 30, 0);
+const PAST_NOON = new Date(2026, 6, 1, 12, 30, 0);
+const LATE = new Date(2026, 6, 1, 23, 30, 0);
+// Yesterday, so it cannot suppress today's run: the refused routines have to
+// be genuinely due, or they prove nothing.
+const YESTERDAY = { lastRun: new Date(2026, 5, 30, 9, 5, 0).toISOString(), status: 'completed', duration: 7 };
+
+const PAUSED = 'sleeper:paused-check';
+const DISABLED = 'retiree:disabled-check';
+const ELSEWHERE = 'traveller:elsewhere-check';
+const ORDINARY = 'worker:ordinary-check';
+const QUIET = 'mute:quiet-check';
+
+const clock = { at: PAST_NINE };
+let prevDeps = null;
+
+before(async () => {
+  await h.boot({
+    agents: {
+      sleeper: agentFile({
+        name: 'sleeper', type: 'specialist', order: 1,
+        routines: [{ name: 'paused-check', schedule: 'every day at 09:00', prompt: 'paused body', paused: true }],
+      }),
+      retiree: agentFile({
+        name: 'retiree', type: 'specialist', order: 2,
+        routines: [{ name: 'disabled-check', schedule: 'every day at 10:00', prompt: 'disabled body', enabled: false }],
+      }),
+      traveller: agentFile({
+        name: 'traveller', type: 'specialist', order: 3,
+        routines: [{ name: 'elsewhere-check', schedule: 'every day at 11:00', prompt: 'elsewhere body', runOn: 'agent-computer' }],
+      }),
+      // Declares none of the three fields, so it is also the proof that a
+      // routine written before they existed still fires on the model's
+      // defaults rather than being refused by an absent value.
+      worker: agentFile({
+        name: 'worker', type: 'specialist', order: 4,
+        routines: [{ name: 'ordinary-check', schedule: 'every day at 08:00', prompt: 'ordinary body' }],
+      }),
+      // Due only late in the day, so nothing else in this file wakes it and
+      // the announcement test can count from zero.
+      mute: agentFile({
+        name: 'mute', type: 'specialist', order: 5,
+        routines: [{ name: 'quiet-check', schedule: 'every day at 23:00', prompt: 'quiet body', paused: true }],
+      }),
+    },
+  });
+  prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+});
+
+after(async () => {
+  if (prevDeps) scheduler.wireSchedulerDeps(prevDeps);
+  await h.shutdown();
+});
+
+// One tick of the real scheduler, with the console captured. The server armed
+// a tick at boot and a second start is a no-op, so the real one goes before
+// the mocked one this drives is armed.
+function driveTick(t, ticks = 1) {
+  const logs = [];
+  const realLog = console.log;
+  h.internal.stopScheduler();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  console.log = (...args) => logs.push(args.join(' '));
+  try {
+    h.internal.startScheduler();
+    for (let i = 0; i < ticks; i++) t.mock.timers.tick(60_000);
+  } finally {
+    console.log = realLog;
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+  }
+  return logs;
+}
+
+// The control has to be able to fire again on the next test's tick, and a run
+// recorded at 09:30 suppresses every later one that day.
+function armControl() {
+  h.writeScenario([
+    { match: { agent: 'worker', promptIncludes: 'ordinary body' }, turn: [{ text: 'routine ran' }] },
+  ]);
+  delete h.internal.routineState[ORDINARY];
+}
+
+function seed(key) {
+  h.internal.routineState[key] = { ...YESTERDAY };
+}
+
+test('a paused routine does not fire', (t) => {
+  clock.at = PAST_NINE;
+  armControl();
+  seed(PAUSED);
+
+  const logs = driveTick(t);
+
+  assert.deepStrictEqual(h.internal.routineState[PAUSED], YESTERDAY,
+    'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
+  assert.ok(h.internal.routineState[ORDINARY],
+    'the ordinary routine fired on the same tick, so the tick itself was live');
+  assert.ok(logs.some(l => l.includes('paused-check') && l.includes('paused is true')),
+    'the refusal is announced and names the field that caused it');
+});
+
+test('a disabled routine does not fire', (t) => {
+  clock.at = PAST_TEN;
+  armControl();
+  seed(DISABLED);
+
+  const logs = driveTick(t);
+
+  assert.deepStrictEqual(h.internal.routineState[DISABLED], YESTERDAY,
+    'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
+  assert.ok(h.internal.routineState[ORDINARY],
+    'the ordinary routine fired on the same tick, so the tick itself was live');
+  assert.ok(logs.some(l => l.includes('disabled-check') && l.includes('enabled is false')),
+    'the refusal is announced and names the field that caused it');
+});
+
+test('a routine whose runOn is not supported does not fire', (t) => {
+  clock.at = PAST_ELEVEN;
+  armControl();
+  seed(ELSEWHERE);
+
+  const logs = driveTick(t);
+
+  assert.deepStrictEqual(h.internal.routineState[ELSEWHERE], YESTERDAY,
+    'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
+  assert.ok(h.internal.routineState[ORDINARY],
+    'the ordinary routine fired on the same tick, so the tick itself was live');
+  assert.ok(logs.some(l => l.includes('elsewhere-check') && l.includes('runOn is agent-computer')),
+    'the refusal is announced and names the field that caused it');
+});
+
+test('a routine declaring none of the three fields still fires, and runs through', async (t) => {
+  clock.at = PAST_NOON;
+  armControl();
+
+  const logs = driveTick(t);
+
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('ordinary-check')),
+    'the ordinary routine was announced as running, not refused');
+  await h.waitUntil(() => {
+    const s = h.internal.routineState[ORDINARY];
+    return s && s.status !== 'running';
+  });
+  assert.strictEqual(h.internal.routineState[ORDINARY].status, 'completed',
+    'the routine the gate let through ran to completion exactly as before');
+});
+
+test('a refusal is announced once, not on every tick for as long as it stays due', (t) => {
+  clock.at = LATE;
+
+  const logs = driveTick(t, 3);
+
+  // Filtered on the refusal line rather than on the routine name. Any line
+  // mentioning the routine is also satisfied by the tick RUNNING it, which is
+  // the fault this whole file exists to fix, and a count of one would then be
+  // green for the opposite of the reason claimed.
+  const announcements = logs.filter(l => l.includes('Not running routine') && l.includes('quiet-check'));
+  assert.strictEqual(announcements.length, 1,
+    'a routine refused for the same reason says so once; a refusal never records a run, so it stays due all day');
+  assert.strictEqual(h.internal.routineState[QUIET], undefined,
+    'and three ticks later it still has not run');
+});

--- a/test/integration/scheduler-gating.test.js
+++ b/test/integration/scheduler-gating.test.js
@@ -40,6 +40,8 @@ const LATE = new Date(2026, 6, 1, 23, 30, 0);
 // before it starts, and it needs two separate due windows.
 const THURSDAY = new Date(2026, 6, 2, 6, 30, 0);
 const NEXT_THURSDAY = new Date(2026, 6, 9, 6, 30, 0);
+const FRIDAY = new Date(2026, 6, 3, 6, 30, 0);
+const SATURDAY = new Date(2026, 6, 4, 6, 30, 0);
 // Yesterday, so it cannot suppress today's run: the refused routines have to
 // be genuinely due, or they prove nothing.
 const YESTERDAY = { lastRun: new Date(2026, 5, 30, 9, 5, 0).toISOString(), status: 'completed', duration: 7 };
@@ -51,6 +53,19 @@ const ORDINARY = 'worker:ordinary-check';
 const QUIET = 'mute:quiet-check';
 
 const FLIP = 'flipper:flip-check';
+const VANISH = 'vanisher:vanish-check';
+const SWITCH = 'switcher:switch-check';
+
+// The routine can be taken out of the file entirely, which is what a rename or
+// a deletion looks like to the tick: a key that was on the roster and is not.
+function vanisherFile(withRoutine) {
+  return agentFile({
+    name: 'vanisher', type: 'specialist', order: 7,
+    routines: withRoutine
+      ? [{ name: 'vanish-check', schedule: 'every friday at 06:00', prompt: 'vanish body', paused: true }]
+      : undefined,
+  });
+}
 
 function flipperFile(paused) {
   return agentFile({
@@ -89,6 +104,11 @@ before(async () => {
       // Weekly, on a day no other test in this file visits, so its
       // announcements are all its own.
       flipper: flipperFile(true),
+      vanisher: vanisherFile(true),
+      switcher: agentFile({
+        name: 'switcher', type: 'specialist', order: 8,
+        routines: [{ name: 'switch-check', schedule: 'every saturday at 06:00', prompt: 'switch body', paused: true }],
+      }),
       mute: agentFile({
         name: 'mute', type: 'specialist', order: 5,
         routines: [{ name: 'quiet-check', schedule: 'every day at 23:00', prompt: 'quiet body', paused: true }],
@@ -281,4 +301,54 @@ test('a routine refused, released and refused again says so both times', async (
   const announced = (logs) => logs.filter(l => l.includes('Not running routine') && l.includes('flip-check'));
   assert.strictEqual(announced(first).length, 1, 'the first refusal was announced');
   assert.strictEqual(announced(third).length, 1, 'and so was the refusal a week later, after the release in between');
+});
+
+// The once-only announcement has to be scoped to the life of the routine, not
+// to the life of the process. Both tests below are the other half of that
+// decision: without them, a key announced once is silent forever, and a
+// refusal that says nothing on its first tick is indistinguishable from a
+// routine that is simply not due, which is the distinction the announcement
+// exists to draw.
+test('a routine that leaves the roster loses its announcement', (t) => {
+  const file = path.join(h.workspaceDir, '.claude', 'agents', 'vanisher.md');
+  clock.at = FRIDAY;
+
+  const first = driveTick(t);
+  assert.strictEqual(h.internal.routineState[VANISH], undefined, 'refused, so nothing ran');
+
+  // Gone from the file: a rename or a deletion looks exactly like this.
+  fs.writeFileSync(file, vanisherFile(false));
+  invalidateAgentCache();
+  driveTick(t);
+
+  // Back again, which is a routine of that name being written afresh. It has
+  // never been announced in its own lifetime and has to say why it will not
+  // run, exactly as it did the first time.
+  fs.writeFileSync(file, vanisherFile(true));
+  invalidateAgentCache();
+  const third = driveTick(t);
+
+  const announced = (logs) => logs.filter(l => l.includes('Not running routine') && l.includes('vanish-check'));
+  assert.strictEqual(announced(first).length, 1, 'the first refusal was announced');
+  assert.strictEqual(announced(third).length, 1, 'and so was the refusal after the routine left the roster and came back');
+});
+
+// loadRoutineState is what a workspace switch calls, and it empties the run
+// state because the runs belong to the workspace being left. The announcements
+// belong to it just as much: agent ids and routine names are workspace-local
+// and collide freely between one workspace and the next, so a routine in the
+// new workspace can inherit the silence earned by a different routine in the
+// old one.
+test('resetting the routine state resets what has been announced with it', (t) => {
+  clock.at = SATURDAY;
+
+  const first = driveTick(t);
+  assert.strictEqual(h.internal.routineState[SWITCH], undefined, 'refused, so nothing ran');
+
+  scheduler.loadRoutineState();
+  const second = driveTick(t);
+
+  const announced = (logs) => logs.filter(l => l.includes('Not running routine') && l.includes('switch-check'));
+  assert.strictEqual(announced(first).length, 1, 'the first refusal was announced');
+  assert.strictEqual(announced(second).length, 1, 'and the reset put the refusal back on speaking terms');
 });

--- a/test/integration/scheduler-gating.test.js
+++ b/test/integration/scheduler-gating.test.js
@@ -132,22 +132,41 @@ function armControl() {
   delete h.internal.routineState[ORDINARY];
 }
 
-// Stamped with the wired clock, so this says the control fired on the tick
-// just driven. A bare truthiness check on its state would also be satisfied
-// by the run it did in the previous test, which would make every refusal
-// test's proof-of-life assertion pass without the tick doing anything at all.
-function assertControlFiredOnThisTick() {
+// The proof that the tick just driven was live. It leads with the line that
+// tick wrote, because that line is the one thing here no earlier test can
+// produce: the console is captured only for the duration of one drive, and
+// only the tick writes it, synchronously, while the drive is in progress.
+//
+// The state check is second and no longer stands alone. A run stamped with
+// this test's clock instant looks like proof, and is not: a control spawned by
+// an EARLIER test records its outcome whenever the child happens to exit, and
+// it reads the clock at that moment, so a late arrival stamps whatever instant
+// this test has since wired. That is the same fault as asserting a default,
+// wearing a timestamp.
+function assertControlFiredOnThisTick(logs) {
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('ordinary-check')),
+    'the tick just driven announced the control as running, so that tick was live');
   const state = h.internal.routineState[ORDINARY];
   assert.ok(state, 'the ordinary routine ran');
   assert.strictEqual(state.lastRun, clock.at.toISOString(),
-    'the ordinary routine fired on the tick just driven, so that tick was live');
+    'and its run belongs to this drive rather than to an earlier one');
+}
+
+// Waited for at the end of every refusal test, so no control run is still in
+// flight when the next test wires a new instant. This closes the bleed at
+// source rather than only asserting around it.
+function settleControl() {
+  return h.waitUntil(() => {
+    const s = h.internal.routineState[ORDINARY];
+    return s && s.status !== 'running';
+  });
 }
 
 function seed(key) {
   h.internal.routineState[key] = { ...YESTERDAY };
 }
 
-test('a paused routine does not fire', (t) => {
+test('a paused routine does not fire', async (t) => {
   clock.at = PAST_NINE;
   armControl();
   seed(PAUSED);
@@ -156,12 +175,14 @@ test('a paused routine does not fire', (t) => {
 
   assert.deepStrictEqual(h.internal.routineState[PAUSED], YESTERDAY,
     'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
-  assertControlFiredOnThisTick();
+  assertControlFiredOnThisTick(logs);
   assert.ok(logs.some(l => l.includes('paused-check') && l.includes('paused is true')),
     'the refusal is announced and names the field that caused it');
+
+  await settleControl();
 });
 
-test('a disabled routine does not fire', (t) => {
+test('a disabled routine does not fire', async (t) => {
   clock.at = PAST_TEN;
   armControl();
   seed(DISABLED);
@@ -170,12 +191,14 @@ test('a disabled routine does not fire', (t) => {
 
   assert.deepStrictEqual(h.internal.routineState[DISABLED], YESTERDAY,
     'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
-  assertControlFiredOnThisTick();
+  assertControlFiredOnThisTick(logs);
   assert.ok(logs.some(l => l.includes('disabled-check') && l.includes('enabled is false')),
     'the refusal is announced and names the field that caused it');
+
+  await settleControl();
 });
 
-test('a routine whose runOn is not supported does not fire', (t) => {
+test('a routine whose runOn is not supported does not fire', async (t) => {
   clock.at = PAST_ELEVEN;
   armControl();
   seed(ELSEWHERE);
@@ -184,9 +207,11 @@ test('a routine whose runOn is not supported does not fire', (t) => {
 
   assert.deepStrictEqual(h.internal.routineState[ELSEWHERE], YESTERDAY,
     'the refused routine kept yesterday\'s run: refusing is not recorded as a run');
-  assertControlFiredOnThisTick();
+  assertControlFiredOnThisTick(logs);
   assert.ok(logs.some(l => l.includes('elsewhere-check') && l.includes('runOn is agent-computer')),
     'the refusal is announced and names the field that caused it');
+
+  await settleControl();
 });
 
 test('a routine declaring none of the three fields still fires, and runs through', async (t) => {

--- a/test/integration/scheduler-gating.test.js
+++ b/test/integration/scheduler-gating.test.js
@@ -5,12 +5,11 @@
 // none of them, so a paused routine fired, a disabled routine fired, and a
 // routine reserved for hardware that does not exist yet ran locally.
 //
-// Every test here drives the SAME tick through the same fixture at the same
-// instant, and every refusal test asserts the ordinary routine fired on that
-// very tick. "It did not fire" is the absence of something, and absence is
-// satisfied by a scheduler that was never going to run anything; the control
-// firing beside it is what makes the absence mean the gate rather than the
-// path being broken.
+// Every test here drives the real tick, and every refusal test asserts the
+// ordinary routine fired on that very tick. "It did not fire" is the absence
+// of something, and absence is satisfied by a scheduler that was never going
+// to run anything; the control firing beside it is what makes the absence
+// mean the gate rather than the path being broken.
 //
 // The refused routines are seeded with a run from the PREVIOUS day, so the
 // assertion is that their stored state is untouched rather than merely
@@ -18,11 +17,10 @@
 // spawned, and would still be a routine that never fires again.
 const { test, before, after } = require('node:test');
 const assert = require('node:assert');
-const h = require('../helpers/harness.js');
-const { agentFile } = require('../helpers/workspace.js');
-
 const fs = require('node:fs');
 const path = require('node:path');
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
 
 const scheduler = require('../../lib/scheduler.js');
 const { invalidateAgentCache } = require('../../lib/agents/discovery.js');


### PR DESCRIPTION
## What

The routine data model shipped `runOn`, `enabled` and `paused`, and the scheduler read none of them. So a paused routine fired, a disabled routine fired, and a routine whose `runOn` names hardware that does not exist yet ran on this machine instead, which is the single outcome reserving that value exists to prevent. `isRunOnSupported()` was written for this and has had no caller since it shipped; it has one now.

## How

The tick asks three questions before it runs anything, and the answer to each is the name of the field that decided. Which run targets exist is asked of the data model rather than answered from a list kept in the scheduler: a second list is a second thing to forget when a third target lands. Nothing is normalised on the way in, because everything reaching the tick has already been through `normalizeRoutine`.

Refusal is checked after due-ness rather than before, for two reasons. What makes a routine due is decided by exactly the code that decided it yesterday, which is visible in the diff as a line that did not move. And a routine that is simply not due stays silent, so the only thing that ever says anything is a routine that would otherwise have run.

A refusal deliberately does not record a run. That is what stops it being counted as one, and it is also why a refused routine stays due for the rest of its window and the tick meets it again every sixty seconds. So the announcement is made once per reason rather than once a minute, and forgotten as soon as the routine stops being refused, so pausing something a second time is announced a second time.

## Verification

Six tests, one new file, every guard checked by hand.

Every refusal test asserts an ordinary routine fired on the same tick, because "it did not fire" is the absence of something and an absence is satisfied by a scheduler that was never going to run anything. Each refused routine is seeded with a run from the previous day, so the assertion is that its stored state is untouched rather than merely missing: a refusal that quietly stamped a run would still spawn nothing, and would still be a routine that never runs again.

`red-first --base main` with the full suite: PROVEN, 1782 passing with the change, 5 failing without.

Eleven block-level mutations on the source, each deleted by hand, each turning a named test red:

| Mutation | Named test that went red |
| --- | --- |
| delete the paused guard | a paused routine does not fire |
| delete the enabled guard | a disabled routine does not fire |
| delete the runOn guard | a routine whose runOn is not supported does not fire |
| ask the scheduler instead of the data model | a routine whose runOn is not supported does not fire |
| delete the whole refusal block from the tick | all four refusal tests |
| refuse but do not announce | all four refusal tests |
| remove the write that remembers the announcement | a refusal is announced once |
| announce on every tick | a refusal is announced once |
| never forget an announcement | refused, released and refused again |
| announce without naming the field | the three refusal tests |
| refuse before due-ness instead of after | three tests |

Two of those started green and are the reason for the second commit. The line that forgets an announcement had nothing on it, because every routine in the file kept one setting for the whole run. And the proof-of-life assertion checked that the control routine had state, when it had state from the previous test, so removing the reset that lets it fire again left every refusal test green while nothing ran at all. Both are the same failure as the refusals themselves, one level up, and both were found by the same lens: remove the write, not the read.

Two more mutations on the tests' own writes, both now load-bearing: removing the control reset reddens three tests, removing the seed on the refused routine reddens three.

`lib/scheduler.js` holds its 100% floor at 302/302 lines. Every existing scheduler test passes unmodified: 82 across the two integration files and the two unit files.

## Scope

Executing `skill` rather than `prompt` is not done here. It changes what a run does rather than whether it happens, and it belongs with the change that owns execution. No missed-run detection, no single-flight, no drift, no interface for pausing or disabling.

## Notes for review

Two failures seen locally, neither from this change and neither fixed here. `test/unit/pid-file.test.js` fails under the command sandbox, which blocks the `ps` the recycled-pid guard reads, and passes outside it. And the coverage floor on `lib/protocol/handlers/files.js` failed one run at 95.3% and held at 97.6% on the next two, with all 50 floors passing; that file is untouched here and the flake is already carded.