### PR TITLE
Hold a routine to one run at a time

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -120,6 +120,21 @@ let tickTimer = null;
 // anything.
 const announcedRefusals = new Map();
 
+// Routines whose run has started and has not yet reached an outcome.
+//
+// Keyed by the SAME `agentId:routineName` as the run state, which is what
+// decides that two routines sharing a name under one agent are held together
+// rather than separately. They already share one state slot, so a lock at a
+// finer grain than the state it protects would let one namesake run while the
+// other's hold still stood, and both would then write the same slot. There is
+// also no finer identity to key on that survives a tick: the roster is re-read
+// on every pass, so routine objects are fresh, and a routine's position in its
+// agent's list moves whenever the file is edited.
+//
+// This is in-process only. Two copies of Rundock over one workspace still tick
+// independently, which wants a lock on disk and has its own card.
+const inFlight = new Set();
+
 // Why the routine's own fields refuse it, named after the FIELD that decided,
 // or null if none of them do. "It did not run" without a field is a support
 // question rather than an answer.
@@ -167,8 +182,15 @@ function startScheduler() {
             }
             continue;
           }
-          console.log(`[Scheduler] Running routine: ${routine.name} (${agent.name})`);
-          executeRoutine(agent, routine, key);
+          if (executeRoutine(agent, routine, key)) {
+            console.log(`[Scheduler] Running routine: ${routine.name} (${agent.name})`);
+          } else {
+            // Said on every held tick rather than once, unlike a refusal. A
+            // hold lasts exactly as long as one run, so the only way to hear
+            // this twice is a run that has outlived its window, which is worth
+            // saying every time it is true. A refusal can stay true for months.
+            console.log(`[Scheduler] Not starting routine: ${routine.name} (${agent.name}): its previous run has not finished`);
+          }
         }
       }
     }
@@ -243,7 +265,22 @@ function getNextRun(schedule, lastRunISO) {
   return null;
 }
 
+/**
+ * Start a run of `routine`, unless one is already in flight for it.
+ *
+ * The guard lives HERE rather than in the tick so that a second entry point (a
+ * run-now button, say) cannot start a run the tick would have refused. The
+ * return value is what the tick reads to say why nothing happened; it is not
+ * an error, because a held routine is a normal state rather than a fault.
+ */
 function executeRoutine(agent, routine, key) {
+  if (inFlight.has(key)) return false;
+  inFlight.add(key);
+  beginRun(agent, routine, key);
+  return true;
+}
+
+function beginRun(agent, routine, key) {
   const startTime = deps.now().getTime();
   // Persisted immediately: if the server dies mid-run, the restarted process
   // still knows the run started and will not fire it again in the same window.
@@ -252,7 +289,12 @@ function executeRoutine(agent, routine, key) {
   // Notify connected clients
   broadcastRoutineUpdate();
 
+  // Both runtimes and both outcomes end here, so the release lives at this one
+  // point rather than at each of the three call sites below. It goes first, so
+  // that nothing between here and the end of the function can leave a routine
+  // held after its run has finished.
   const recordOutcome = (ok) => {
+    inFlight.delete(key);
     const duration = Math.round((deps.now().getTime() - startTime) / 1000);
     recordRoutineRun(key, {
       lastRun: deps.now().toISOString(),

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -300,10 +300,17 @@ function beginRun(agent, routine, key) {
   broadcastRoutineUpdate();
 
   // Both runtimes and both outcomes end here, so the release lives at this one
-  // point rather than at each of the three call sites below. It goes first, so
+  // point rather than at each of the four call sites below. It goes first, so
   // that nothing between here and the end of the function can leave a routine
   // held after its run has finished.
+  //
+  // A run ends once. The flag is local to this run, so it says nothing about
+  // any other, and it is what lets the claude path listen for both ends of its
+  // child without recording a failure that reports twice as two failures.
+  let recorded = false;
   const recordOutcome = (ok) => {
+    if (recorded) return;
+    recorded = true;
     inFlight.delete(key);
     const duration = Math.round((deps.now().getTime() - startTime) / 1000);
     recordRoutineRun(key, {
@@ -358,10 +365,17 @@ function beginRun(agent, routine, key) {
     stdio: ['ignore', 'pipe', 'pipe']
   });
 
-  // Every end of this run arrives here, including one that never began: a
-  // child that fails to launch emits 'error' and then 'close' with a negative
-  // code, so a missing runtime records a failure and releases the routine
-  // rather than holding it on a spawn that threw nothing.
+  // Both ends of a child are outcomes, and the routine is released by whichever
+  // arrives first.
+  //
+  // Listening to close alone would rest on close always following error. That
+  // holds for a binary that is not there, and it is not established for the
+  // failures a tick is most likely to meet: under file-descriptor exhaustion
+  // the handle is torn down early, and whether it still closes is a question
+  // about a Node version rather than about this file. A routine held on the
+  // answer being yes would be held for the life of the process, because
+  // nothing else would ever remove it. Listening to both removes the question.
+  proc.on('error', () => recordOutcome(false));
   proc.on('close', (code) => recordOutcome(code === 0));
 }
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -131,6 +131,22 @@ const announcedRefusals = new Map();
 // on every pass, so routine objects are fresh, and a routine's position in its
 // agent's list moves whenever the file is edited.
 //
+// DELIBERATELY NOT RESET BY loadRoutineState, unlike every other keyed state
+// in this file. A workspace switch drops the run state and the announcements
+// because those describe the workspace being left, but the CHILD PROCESS of a
+// run in flight is not dropped: it is still running, and it still holds the
+// only thing that will ever release its key. Clearing the set would leave a
+// release with nothing to release and a routine free to start again while its
+// first run was still going, which is the whole fault this set exists for.
+//
+// The cost, named rather than hidden: keys are workspace-local and collide
+// freely, so a routine in the NEW workspace sharing an agent id and name is
+// held until the old workspace's child exits. That is a delayed run rather
+// than a duplicated one, and it clears itself. The same collision already
+// bleeds through the run state, where the old run's outcome lands in the new
+// workspace's slot, and closing it properly is the cross-process locking card's
+// work rather than this one's.
+//
 // This is in-process only. Two copies of Rundock over one workspace still tick
 // independently, which wants a lock on disk and has its own card.
 const inFlight = new Set();

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -276,7 +276,17 @@ function getNextRun(schedule, lastRunISO) {
 function executeRoutine(agent, routine, key) {
   if (inFlight.has(key)) return false;
   inFlight.add(key);
-  beginRun(agent, routine, key);
+  try {
+    beginRun(agent, routine, key);
+  } catch (err) {
+    // A start that throws leaves no child, so no close event and no outcome,
+    // so nothing that will ever release. Held forever is how a guard turns
+    // into a routine that never runs again, and it takes no bug in the guard
+    // to get there. Rethrown once the routine is free: what the caller does
+    // about a failed start is unchanged by this file.
+    inFlight.delete(key);
+    throw err;
+  }
   return true;
 }
 
@@ -348,6 +358,10 @@ function beginRun(agent, routine, key) {
     stdio: ['ignore', 'pipe', 'pipe']
   });
 
+  // Every end of this run arrives here, including one that never began: a
+  // child that fails to launch emits 'error' and then 'close' with a negative
+  // code, so a missing runtime records a failure and releases the routine
+  // rather than holding it on a spawn that threw nothing.
   proc.on('close', (code) => recordOutcome(code === 0));
 }
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -360,7 +360,22 @@ function beginRun(agent, routine, key) {
       });
       const sub = server.startTurn(threadId, routinePrompt);
       const status = await new Promise((resolve) => {
-        sub.on('event', (ev) => { if (ev.type === 'done') resolve(ev.status); });
+        sub.on('event', (ev) => {
+          if (ev.type === 'done') return resolve(ev.status);
+          // A turn that ends any other way still ends. The client documents
+          // done as terminal and exactly once and every path in it reaches
+          // one today, but this promise is the only thing that will ever
+          // release the routine, so a hold resting on that staying true is a
+          // hold for the life of the process. Before single-flight the same
+          // hang left stale running state and the next window fired anyway;
+          // waiting on one event turned a self-healing failure into a
+          // permanent one, which is why this reads both.
+          //
+          // A RETRYABLE ERROR IS NOT AN ENDING. The turn is still going, and
+          // releasing here would let a second run start alongside the first,
+          // which is the fault this whole file exists to prevent.
+          if (ev.type === 'error' && !ev.willRetry) resolve('failed');
+        });
       });
       return status === 'completed';
     })().then(recordOutcome, (err) => {

--- a/test/integration/scheduler-single-flight.test.js
+++ b/test/integration/scheduler-single-flight.test.js
@@ -1,0 +1,276 @@
+'use strict';
+// One run of a routine at a time.
+//
+// The executor used to spawn and return, holding neither the child, the
+// promise, nor a flag. The only thing resembling a guard was the run's start
+// time being stamped before the spawn, which the next-run calculation then
+// suppressed on a same-day comparison. That is a rule about schedules, and it
+// fails at exactly the case it looks like it covers: a run that outlives its
+// window fires again at the next window, because its stored start time is
+// stale rather than open.
+//
+// Every test here drives the real tick through the wired clock, so a run can
+// be watched outliving its window with no real time passing. The run that
+// outlives it is a real child process, hung on a scenario delay, and it is
+// ended by killing it rather than by waiting for it.
+//
+// The held tests assert on the STORED STATE as well as on the absence of a
+// second spawn. "Nothing spawned" is an absence, and an absence is satisfied
+// by a tick that was never going to run anything; a routine firing beside the
+// held one on the same tick is what makes the absence mean the guard.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
+
+const scheduler = require('../../lib/scheduler.js');
+
+const SLOW = 'slow:slow-check';
+const OTHER = 'other:other-check';
+const TWIN = 'twin:twin-check';
+const BRISK = 'brisk:brisk-check';
+const ALL = [SLOW, OTHER, TWIN, BRISK];
+
+// July 2026, local time, so the fixture is timezone-independent. Each test
+// owns its own days: the run under test has to survive from one day to the
+// next, and a shared day would mean one test's stamp suppressing another's.
+function dayAt(day, hour, minute) { return new Date(2026, 6, day, hour, minute, 0); }
+
+const clock = { at: dayAt(1, 9, 30) };
+let prevDeps = null;
+
+before(async () => {
+  await h.boot({
+    agents: {
+      // Hangs on a scenario delay until the test kills it, which is what a run
+      // outliving its window looks like from the scheduler's side.
+      slow: agentFile({
+        name: 'slow', type: 'specialist', order: 1,
+        routines: [{ name: 'slow-check', schedule: 'every day at 09:00', prompt: 'slow body' }],
+      }),
+      // The control. It fires on the same tick that holds the slow routine,
+      // which is both the proof the tick was live and the proof that one
+      // routine being in flight does not hold a different one.
+      other: agentFile({
+        name: 'other', type: 'specialist', order: 2,
+        routines: [{ name: 'other-check', schedule: 'every day at 09:00', prompt: 'other body' }],
+      }),
+      // Two routines, one agent, one name. The data model allows it on
+      // purpose and the writer indexes namesakes by occurrence. They share one
+      // state slot, and therefore one identity, and single-flight holds them
+      // together for that reason. The second is due an hour earlier so it can
+      // be due on a day the first is not, which is the only way its hold is
+      // visibly the FIRST routine's run rather than its own.
+      twin: agentFile({
+        name: 'twin', type: 'specialist', order: 3,
+        routines: [
+          { name: 'twin-check', schedule: 'every day at 09:00', prompt: 'first twin body' },
+          { name: 'twin-check', schedule: 'every day at 07:00', prompt: 'second twin body' },
+        ],
+      }),
+      // Runs to completion in milliseconds, so its release is the success
+      // path rather than the failure one.
+      brisk: agentFile({
+        name: 'brisk', type: 'specialist', order: 4,
+        routines: [{ name: 'brisk-check', schedule: 'every day at 06:00', prompt: 'brisk body' }],
+      }),
+    },
+  });
+  h.writeScenario([
+    { match: { agent: 'slow', promptIncludes: 'slow body' }, delayMs: 600000, turn: [{ text: 'never arrives' }] },
+    { match: { agent: 'other', promptIncludes: 'other body' }, turn: [{ text: 'control ran' }] },
+    { match: { agent: 'twin', promptIncludes: 'first twin body' }, delayMs: 600000, turn: [{ text: 'never arrives' }] },
+    { match: { agent: 'twin', promptIncludes: 'second twin body' }, turn: [{ text: 'the twin should never run' }] },
+    { match: { agent: 'brisk', promptIncludes: 'brisk body' }, turn: [{ text: 'brisk ran' }] },
+  ]);
+  prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+});
+
+after(async () => {
+  for (const inv of h.readInvocations()) killPid(inv.pid);
+  if (prevDeps) scheduler.wireSchedulerDeps(prevDeps);
+  await h.shutdown();
+});
+
+// One tick of the real scheduler with the console captured. The server armed a
+// tick at boot and a second start is a no-op, so the real one is stopped
+// before the mocked one this drives is armed.
+function driveTick(t) {
+  const logs = [];
+  const realLog = console.log;
+  h.internal.stopScheduler();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  console.log = (...args) => logs.push(args.join(' '));
+  try {
+    h.internal.startScheduler();
+    t.mock.timers.tick(60_000);
+  } finally {
+    console.log = realLog;
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+  }
+  return logs;
+}
+
+// A tick sees every routine in the workspace, so a test that says nothing
+// about the others still fires them. A run recorded late on the test's own day
+// suppresses them through the ordinary schedule rule, which leaves each tick
+// carrying only the routines its test is about.
+function quieten(day, live) {
+  for (const key of ALL) {
+    if (live.includes(key)) continue;
+    h.internal.routineState[key] = { lastRun: dayAt(day, 23, 0).toISOString(), status: 'completed', duration: 1 };
+  }
+}
+
+// Every spawn carrying this prompt, in order. The routine spawn passes the
+// prompt as the last positional argument, and the stub logs its whole argv.
+function spawns(prompt) {
+  return h.readInvocations().filter(i => (i.argv || []).includes(prompt));
+}
+
+function killPid(pid) {
+  try { process.kill(pid, 'SIGKILL'); } catch (e) { /* already gone */ }
+}
+
+// Wait for a spawned run to reach the stub, so its pid is available to kill.
+// The invocation log is written by the child, so it lands after the tick.
+async function waitForSpawns(prompt, count) {
+  const arrived = await h.waitUntil(() => spawns(prompt).length >= count);
+  assert.ok(arrived, `expected ${count} spawn(s) of "${prompt}", saw ${spawns(prompt).length}`);
+  return spawns(prompt);
+}
+
+function settled(key) {
+  return h.waitUntil(() => {
+    const s = h.internal.routineState[key];
+    return s && s.status !== 'running';
+  });
+}
+
+test('a routine whose run outlives its window is not started a second time', async (t) => {
+  clock.at = dayAt(1, 9, 30);
+  delete h.internal.routineState[SLOW];
+  delete h.internal.routineState[OTHER];
+  quieten(1, [SLOW, OTHER]);
+
+  driveTick(t);
+  await waitForSpawns('slow body', 1);
+  const held = { ...h.internal.routineState[SLOW] };
+  assert.strictEqual(held.status, 'running', 'the slow routine started and has not finished');
+  assert.strictEqual(held.lastRun, dayAt(1, 9, 30).toISOString(), 'and its run belongs to the first day');
+  // The control ran on this tick too, and it has to be finished before the
+  // next one or the guard under test would hold IT, and the control would stop
+  // being a control. Waited for rather than assumed: on a loaded machine the
+  // child outlives the tick that spawned it.
+  assert.ok(await settled(OTHER), 'the control run from the first day has finished');
+
+  // A day later. The stored start time is now stale rather than open, which is
+  // exactly the case the schedule rule cannot see.
+  clock.at = dayAt(2, 9, 30);
+  quieten(2, [SLOW, OTHER]);
+  const logs = driveTick(t);
+
+  // The stored state and the log line first: both are written synchronously by
+  // the tick just driven. A spawn count is a lagging indicator, because the
+  // invocation log is written by the child rather than by the server, so a
+  // second run that HAD started would not be in it yet.
+  assert.deepStrictEqual(h.internal.routineState[SLOW], held,
+    'being held recorded nothing: the stored run is still the one that is in flight');
+  assert.ok(logs.some(l => l.includes('Not starting routine') && l.includes('slow-check')),
+    'and the tick said why, so a held routine is not mistaken for one that is not due');
+
+  // The control, on the very tick that did the holding.
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('other-check')),
+    'a different routine started on the same tick, so that tick was live');
+  assert.strictEqual(h.internal.routineState[OTHER].lastRun, dayAt(2, 9, 30).toISOString(),
+    'and its run belongs to this tick rather than to the day before');
+
+  // Only now, with the control's whole spawn and exit elapsed, is the absence
+  // of a second slow spawn worth reading.
+  await settled(OTHER);
+  assert.strictEqual(spawns('slow body').length, 1,
+    'the routine still in flight was not started a second time');
+});
+
+test('a run that fails releases the routine, and the next window starts a new one', async (t) => {
+  const [running] = spawns('slow body');
+  killPid(running.pid);
+  assert.ok(await settled(SLOW), 'the killed run reached an outcome');
+  assert.strictEqual(h.internal.routineState[SLOW].status, 'failed',
+    'a run whose child dies is recorded as failed');
+
+  clock.at = dayAt(3, 9, 30);
+  quieten(3, [SLOW]);
+  const logs = driveTick(t);
+
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('slow-check')),
+    'the failed run released the routine, so the next window started a new one');
+  const started = await waitForSpawns('slow body', 2);
+  assert.strictEqual(started.length, 2, 'exactly one further run, not two');
+  assert.strictEqual(h.internal.routineState[SLOW].lastRun, dayAt(3, 9, 30).toISOString(),
+    'and the new run is stamped with this tick');
+  killPid(started[1].pid);
+  await settled(SLOW);
+});
+
+test('a run that completes releases the routine', async (t) => {
+  clock.at = dayAt(4, 6, 30);
+  delete h.internal.routineState[BRISK];
+  quieten(4, [BRISK]);
+
+  driveTick(t);
+  assert.ok(await settled(BRISK), 'the first run reached an outcome');
+  assert.strictEqual(h.internal.routineState[BRISK].status, 'completed', 'and it succeeded');
+
+  clock.at = dayAt(5, 6, 30);
+  quieten(5, [BRISK]);
+  const logs = driveTick(t);
+
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('brisk-check')),
+    'the completed run released the routine, so the next window started a new one');
+  await waitForSpawns('brisk body', 2);
+  assert.ok(await settled(BRISK), 'the second run reached an outcome');
+  assert.strictEqual(h.internal.routineState[BRISK].lastRun, dayAt(5, 6, 30).toISOString(),
+    'and the second run is stamped with the second tick');
+});
+
+// The identity decision, pinned so it cannot change silently. Two routines
+// sharing a name under one agent share one state slot, and single-flight holds
+// them together for that reason: a lock finer-grained than the state it
+// protects would let one namesake run while the other's hold was still
+// standing, and both would write the same slot.
+test('two routines sharing a name under one agent are held together', async (t) => {
+  clock.at = dayAt(6, 9, 30);
+  delete h.internal.routineState[TWIN];
+  quieten(6, [TWIN]);
+
+  driveTick(t);
+  await waitForSpawns('first twin body', 1);
+  const held = { ...h.internal.routineState[TWIN] };
+  assert.strictEqual(held.status, 'running', 'the first namesake started');
+
+  // 08:30 the next day: the first namesake (09:00) is not due, the second
+  // (07:00) is, and it has never run. Anything it does now is its own.
+  clock.at = dayAt(7, 8, 30);
+  quieten(7, [TWIN, BRISK]);
+  const logs = driveTick(t);
+
+  assert.deepStrictEqual(h.internal.routineState[TWIN], held,
+    'and the shared state slot still describes the run that is in flight');
+  const heldLines = logs.filter(l => l.includes('Not starting routine') && l.includes('twin-check'));
+  assert.strictEqual(heldLines.length, 1,
+    'the tick reached the namesake, found it due, and held it');
+
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('brisk-check')),
+    'a routine of another name started on the same tick, so that tick was live');
+
+  // Read after the control's run has been and gone, for the same reason as
+  // above: the invocation log lags the tick by a whole child process.
+  await settled(BRISK);
+  assert.strictEqual(spawns('second twin body').length, 0,
+    'the namesake did not start: the two share one identity, so one run holds both');
+
+  killPid(spawns('first twin body')[0].pid);
+  await settled(TWIN);
+});

--- a/test/integration/scheduler-single-flight.test.js
+++ b/test/integration/scheduler-single-flight.test.js
@@ -29,7 +29,8 @@ const SLOW = 'slow:slow-check';
 const OTHER = 'other:other-check';
 const TWIN = 'twin:twin-check';
 const BRISK = 'brisk:brisk-check';
-const ALL = [SLOW, OTHER, TWIN, BRISK];
+const FALL = 'faller:fall-check';
+const ALL = [SLOW, OTHER, TWIN, BRISK, FALL];
 
 // July 2026, local time, so the fixture is timezone-independent. Each test
 // owns its own days: the run under test has to survive from one day to the
@@ -74,6 +75,12 @@ before(async () => {
         name: 'brisk', type: 'specialist', order: 4,
         routines: [{ name: 'brisk-check', schedule: 'every day at 06:00', prompt: 'brisk body' }],
       }),
+      // Hangs like the slow routine, and belongs to the failure test alone, so
+      // that test starts the run it later kills rather than inheriting one.
+      faller: agentFile({
+        name: 'faller', type: 'specialist', order: 5,
+        routines: [{ name: 'fall-check', schedule: 'every day at 09:00', prompt: 'fall body' }],
+      }),
     },
   });
   h.writeScenario([
@@ -82,6 +89,7 @@ before(async () => {
     { match: { agent: 'twin', promptIncludes: 'first twin body' }, delayMs: 600000, turn: [{ text: 'never arrives' }] },
     { match: { agent: 'twin', promptIncludes: 'second twin body' }, turn: [{ text: 'the twin should never run' }] },
     { match: { agent: 'brisk', promptIncludes: 'brisk body' }, turn: [{ text: 'brisk ran' }] },
+    { match: { agent: 'faller', promptIncludes: 'fall body' }, delayMs: 600000, turn: [{ text: 'never arrives' }] },
   ]);
   prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
 });
@@ -90,7 +98,7 @@ before(async () => {
 // exits in milliseconds, and signalling a pid that exited long ago is how a
 // recycled pid gets signalled instead. Each of these is killed by the test
 // that started it; this is the net under a test that failed before it could.
-const HANGING = ['slow body', 'first twin body'];
+const HANGING = ['slow body', 'fall body', 'first twin body'];
 
 after(async () => {
   for (const prompt of HANGING) for (const inv of spawns(prompt)) killPid(inv.pid);
@@ -197,27 +205,41 @@ test('a routine whose run outlives its window is not started a second time', asy
   await settled(OTHER);
   assert.strictEqual(spawns('slow body').length, 1,
     'the routine still in flight was not started a second time');
+
+  // Ended here rather than left for the next test. A run this file starts is
+  // this test's to finish, or the next test is reading state it did not make.
+  killPid(spawns('slow body')[0].pid);
+  assert.ok(await settled(SLOW), 'the run this test started has finished');
 });
 
 test('a run that fails releases the routine, and the next window starts a new one', async (t) => {
-  const [running] = spawns('slow body');
+  clock.at = dayAt(8, 9, 30);
+  delete h.internal.routineState[FALL];
+  quieten(8, [FALL]);
+
+  driveTick(t);
+  const [running] = await waitForSpawns('fall body', 1);
+  assert.strictEqual(h.internal.routineState[FALL].status, 'running',
+    'this test started its own run rather than inheriting one');
+
   killPid(running.pid);
-  assert.ok(await settled(SLOW), 'the killed run reached an outcome');
-  assert.strictEqual(h.internal.routineState[SLOW].status, 'failed',
+  assert.ok(await settled(FALL), 'the killed run reached an outcome');
+  assert.strictEqual(h.internal.routineState[FALL].status, 'failed',
     'a run whose child dies is recorded as failed');
 
-  clock.at = dayAt(3, 9, 30);
-  quieten(3, [SLOW]);
+  clock.at = dayAt(9, 9, 30);
+  quieten(9, [FALL]);
   const logs = driveTick(t);
 
-  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('slow-check')),
+  assert.ok(logs.some(l => l.includes('Running routine') && l.includes('fall-check')),
     'the failed run released the routine, so the next window started a new one');
-  const started = await waitForSpawns('slow body', 2);
+  const started = await waitForSpawns('fall body', 2);
   assert.strictEqual(started.length, 2, 'exactly one further run, not two');
-  assert.strictEqual(h.internal.routineState[SLOW].lastRun, dayAt(3, 9, 30).toISOString(),
+  assert.strictEqual(h.internal.routineState[FALL].lastRun, dayAt(9, 9, 30).toISOString(),
     'and the new run is stamped with this tick');
+
   killPid(started[1].pid);
-  await settled(SLOW);
+  assert.ok(await settled(FALL), 'the run this test started has finished');
 });
 
 test('a run that completes releases the routine', async (t) => {
@@ -265,6 +287,8 @@ test('two routines sharing a name under one agent are held together', async (t) 
   await waitForSpawns('first twin body', 1);
   const held = { ...h.internal.routineState[TWIN] };
   assert.strictEqual(held.status, 'running', 'the first namesake started');
+  assert.strictEqual(held.lastRun, dayAt(6, 9, 30).toISOString(),
+    'and its run belongs to this drive, so the comparison below is against a run this test made');
 
   // 08:30 the next day: the first namesake (09:00) is not due, the second
   // (07:00) is, and it has never run. Anything it does now is its own.
@@ -280,6 +304,8 @@ test('two routines sharing a name under one agent are held together', async (t) 
 
   assert.ok(logs.some(l => l.includes('Running routine') && l.includes('brisk-check')),
     'a routine of another name started on the same tick, so that tick was live');
+  assert.strictEqual(h.internal.routineState[BRISK].lastRun, dayAt(7, 8, 30).toISOString(),
+    'and the control run belongs to this tick rather than to an earlier test');
 
   // Read after the control's run has been and gone, for the same reason as
   // above: the invocation log lags the tick by a whole child process.

--- a/test/integration/scheduler-single-flight.test.js
+++ b/test/integration/scheduler-single-flight.test.js
@@ -241,6 +241,16 @@ test('a run that completes releases the routine', async (t) => {
 // protects would let one namesake run while the other's hold was still
 // standing, and both would write the same slot.
 test('two routines sharing a name under one agent are held together', async (t) => {
+  // The whole test is vacuous if the roster carries one routine where the
+  // fixture wrote two: there would be no namesake to hold, and every assertion
+  // below would pass by describing a routine that does not exist. Asserted
+  // rather than assumed, because the thing being pinned is precisely that the
+  // data model still allows this.
+  const twins = h.internal.discoverAgents()
+    .find(a => a.id === 'twin').routines.filter(r => r.name === 'twin-check');
+  assert.strictEqual(twins.length, 2, 'the fixture declares two routines of one name and the roster carries both');
+  assert.notStrictEqual(twins[0].prompt, twins[1].prompt, 'and they are two different routines, not one read twice');
+
   clock.at = dayAt(6, 9, 30);
   delete h.internal.routineState[TWIN];
   quieten(6, [TWIN]);

--- a/test/integration/scheduler-single-flight.test.js
+++ b/test/integration/scheduler-single-flight.test.js
@@ -86,8 +86,14 @@ before(async () => {
   prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
 });
 
+// The two prompts whose scenario rules hang. Every other run in this file
+// exits in milliseconds, and signalling a pid that exited long ago is how a
+// recycled pid gets signalled instead. Each of these is killed by the test
+// that started it; this is the net under a test that failed before it could.
+const HANGING = ['slow body', 'first twin body'];
+
 after(async () => {
-  for (const inv of h.readInvocations()) killPid(inv.pid);
+  for (const prompt of HANGING) for (const inv of spawns(prompt)) killPid(inv.pid);
   if (prevDeps) scheduler.wireSchedulerDeps(prevDeps);
   await h.shutdown();
 });

--- a/test/integration/scheduler-single-flight.test.js
+++ b/test/integration/scheduler-single-flight.test.js
@@ -183,6 +183,7 @@ test('a routine whose run outlives its window is not started a second time', asy
   // exactly the case the schedule rule cannot see.
   clock.at = dayAt(2, 9, 30);
   quieten(2, [SLOW, OTHER]);
+  const controlSpawns = spawns('other body').length;
   const logs = driveTick(t);
 
   // The stored state and the log line first: both are written synchronously by
@@ -200,11 +201,16 @@ test('a routine whose run outlives its window is not started a second time', asy
   assert.strictEqual(h.internal.routineState[OTHER].lastRun, dayAt(2, 9, 30).toISOString(),
     'and its run belongs to this tick rather than to the day before');
 
-  // Only now, with the control's whole spawn and exit elapsed, is the absence
-  // of a second slow spawn worth reading.
-  await settled(OTHER);
+  // The absence is read against a record this tick produced, not against time
+  // having passed. The control's spawn from THIS tick appearing in the
+  // invocation log is what makes the log current for this tick, so a second
+  // slow spawn would be in it if there were one. Waiting for the control to
+  // finish would only prove that some time elapsed, which is a reading rather
+  // than a record.
+  await waitForSpawns('other body', controlSpawns + 1);
   assert.strictEqual(spawns('slow body').length, 1,
     'the routine still in flight was not started a second time');
+  assert.ok(await settled(OTHER), 'the control run from this tick has finished');
 
   // Ended here rather than left for the next test. A run this file starts is
   // this test's to finish, or the next test is reading state it did not make.
@@ -294,6 +300,7 @@ test('two routines sharing a name under one agent are held together', async (t) 
   // (07:00) is, and it has never run. Anything it does now is its own.
   clock.at = dayAt(7, 8, 30);
   quieten(7, [TWIN, BRISK]);
+  const controlSpawns = spawns('brisk body').length;
   const logs = driveTick(t);
 
   assert.deepStrictEqual(h.internal.routineState[TWIN], held,
@@ -307,11 +314,13 @@ test('two routines sharing a name under one agent are held together', async (t) 
   assert.strictEqual(h.internal.routineState[BRISK].lastRun, dayAt(7, 8, 30).toISOString(),
     'and the control run belongs to this tick rather than to an earlier test');
 
-  // Read after the control's run has been and gone, for the same reason as
-  // above: the invocation log lags the tick by a whole child process.
-  await settled(BRISK);
+  // Read against this tick's own record, as above: the control's spawn landing
+  // in the log is what makes the log current for the tick that held the
+  // namesake.
+  await waitForSpawns('brisk body', controlSpawns + 1);
   assert.strictEqual(spawns('second twin body').length, 0,
     'the namesake did not start: the two share one identity, so one run holds both');
+  assert.ok(await settled(BRISK), 'the control run from this tick has finished');
 
   killPid(spawns('first twin body')[0].pid);
   await settled(TWIN);

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -153,6 +153,31 @@ test('a failure reported as both an error and a close records one outcome', () =
   });
 });
 
+// The decision that the in-flight set is NOT reset by a workspace switch,
+// pinned so it cannot be quietly corrected into consistency with the two
+// states beside it that ARE reset. Those describe the workspace being left.
+// A run in flight is a child process that is still running, and clearing its
+// key would free the routine to start again while the first run was still
+// going, with the eventual release then having nothing to release.
+test('switching workspace does not release a run that is still going', () => {
+  withTempWorkspace(() => {
+    const child = new EventEmitter();
+    withFakeSpawn(() => child, (sched) => {
+      assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true, 'the run started');
+      sched.loadRoutineState(); // what a workspace switch calls
+      // Only loadRoutineState writes this value, so it is the proof the reset
+      // really ran rather than being skipped over.
+      assert.strictEqual(sched.routineState[KEY].status, 'interrupted',
+        'the switch rebuilt the run state from the workspace file');
+      assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), false,
+        'and the hold survived it, because the child it describes is still running');
+      child.emit('close', 0);
+      assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true,
+        'the run ending is the only thing that releases it, switch or no switch');
+    });
+  });
+});
+
 // AC-6, at the call site it is about rather than at one that stands in for it.
 test('a start whose spawn throws does not hold the routine', () => {
   withTempWorkspace(() => {

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -16,6 +16,8 @@ const { EventEmitter } = require('node:events');
 
 const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
 const CLAUDE_KEY = require.resolve('../../lib/runtime/claude.js');
+const CODEX_GLUE_KEY = require.resolve('../../lib/runtime/codex-glue.js');
+const PROMPT_KEY = require.resolve('../../lib/agents/prompt.js');
 
 const AGENT = { id: 'runner', name: 'Runner' };
 const ROUTINE = { name: 'r', prompt: 'p' };
@@ -32,20 +34,62 @@ function freshScheduler() {
   return mod;
 }
 
-function withTempWorkspace(fn) {
+function enterTempWorkspace() {
   const config = require('../../lib/config.js');
   const original = config.getWorkspace();
   const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-lib-'));
+  config.setWorkspace(ws);
+  return {
+    ws,
+    config,
+    leave() {
+      config.setWorkspace(original);
+      fs.rmSync(ws, { recursive: true, force: true });
+    },
+  };
+}
+
+function withTempWorkspace(fn) {
+  const t = enterTempWorkspace();
   try {
-    config.setWorkspace(ws);
-    return fn(ws, config);
+    return fn(t.ws, t.config);
   } finally {
-    config.setWorkspace(original);
-    fs.rmSync(ws, { recursive: true, force: true });
+    t.leave();
   }
 }
 
+// The same workspace, held for a lifetime that outlives a synchronous return.
+// The codex path is asynchronous, so a sync finally would tear the workspace
+// down while the run under test was still going. One mechanism, two lifetimes,
+// rather than two mechanisms.
+async function withTempWorkspaceAsync(fn) {
+  const t = enterTempWorkspace();
+  try {
+    return await fn(t.ws, t.config);
+  } finally {
+    t.leave();
+  }
+}
+
+// Poll until a predicate holds. The codex path settles over several
+// microtasks and then over whatever the fake does, so a fixed flush would be
+// a guess at how many.
+async function until(predicate, tries = 200) {
+  for (let i = 0; i < tries; i++) {
+    if (predicate()) return true;
+    await new Promise(r => setTimeout(r, 5));
+  }
+  return false;
+}
+
 // A scheduler whose child processes are the test's to drive.
+//
+// WHY NOT THE SEAM THAT EXISTS. wireSchedulerDeps is the file's own injection
+// point and it reaches exactly two things, the WebSocket clients and the
+// clock. Neither is a child process. A test that has to decide how a child
+// ends, or make the spawn itself fail, needs the module the scheduler imports
+// rather than a dep it is handed, and adding a spawn dep to the wiring surface
+// would put a seam in production code that only tests would ever use.
 //
 // lib/scheduler.js destructures spawnClaude at load, so a copy required after
 // the export is swapped closes over the fake, and the swap is undone before
@@ -71,6 +115,37 @@ function withFakeSpawn(fakeSpawn, fn) {
     claude.wireClaudeRuntimeDeps(prevClaudeDeps);
   }
 }
+
+// A scheduler whose codex app-server is the test's to drive.
+//
+// Same reason as withFakeSpawn, and the same answer to "why not the seam that
+// exists": wireSchedulerDeps reaches the WebSocket clients and the clock, and
+// nothing else. A test that has to hold a turn subscription and decide how the
+// turn ends needs the module the scheduler imports, not a dep it is handed.
+// The system prompt builder is stood in for as well, because it has wiring of
+// its own that has nothing to do with what is under test here.
+async function withFakeCodex(server, fn) {
+  const glue = require(CODEX_GLUE_KEY);
+  const prompt = require(PROMPT_KEY);
+  const real = {
+    getCodexAppServer: glue.getCodexAppServer,
+    waitForCodexReady: glue.waitForCodexReady,
+    buildSystemPrompt: prompt.buildSystemPrompt,
+  };
+  glue.getCodexAppServer = async () => server;
+  glue.waitForCodexReady = async () => {};
+  prompt.buildSystemPrompt = () => 'system prompt';
+  try {
+    const sched = freshScheduler();
+    sched.wireSchedulerDeps({ getWssClients: () => [] });
+    return await fn(sched);
+  } finally {
+    Object.assign(glue, { getCodexAppServer: real.getCodexAppServer, waitForCodexReady: real.waitForCodexReady });
+    prompt.buildSystemPrompt = real.buildSystemPrompt;
+  }
+}
+
+const CODEX_AGENT = { id: 'runner', name: 'Runner', runtime: 'codex' };
 
 test('unwired root deps throw the named wiring error at first use', () => {
   withTempWorkspace(() => {
@@ -101,6 +176,14 @@ test('unwired root deps throw the named wiring error at first use', () => {
 // 'close' with a negative code, so a routine whose runtime is missing entirely
 // releases through the ordinary outcome path rather than through this one. The
 // killed-child test in the integration suite pins that path.
+//
+// WHY BOTH THIS AND THE SPAWN TEST BELOW, since one guard catches both. They
+// throw from different statements, and only one of them needs a stand-in for a
+// module: this one is reachable through the file's own wiring, so it is the
+// cheaper test and it is kept for that. The one below throws from the spawn,
+// which is what AC-6 is about, and reading it against a criterion that names
+// the spawn should not require believing that a throw from the line above
+// behaves the same way.
 test('a start that throws before the spawn does not hold the routine', () => {
   withTempWorkspace(() => {
     const sched = freshScheduler();
@@ -149,6 +232,82 @@ test('a failure reported as both an error and a close records one outcome', () =
       child.emit('close', -2);
       assert.strictEqual(broadcasts, 2,
         'the start and one outcome, not the start and the same outcome twice');
+    });
+  });
+});
+
+// The codex half of AC-7, and the half this card's own change made worse. The
+// outcome promise resolved only on a `done` event. Before single-flight, a
+// turn that never reached one left stale running state and the next window
+// fired anyway; afterwards it holds the routine for the life of the process.
+// A self-healing failure turned into a permanent one, on a path the card never
+// mentioned.
+//
+// The reasoning that fixed the claude path applies unchanged: do not try to
+// establish that every turn ends with `done`. The client documents it as
+// terminal and exactly once and every path in it reaches one today, and a
+// routine held on that staying true is held forever when it stops being true.
+test('a codex turn that ends without a done event does not hold the routine', async () => {
+  await withTempWorkspaceAsync(async () => {
+    const sub = new EventEmitter();
+    const server = { startThread: async () => ({ threadId: 't1' }), startTurn: () => sub };
+    await withFakeCodex(server, async (sched) => {
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
+      assert.ok(await until(() => sub.listenerCount('event') > 0), 'the run reached the turn subscription');
+
+      sub.emit('event', { type: 'error', message: 'app-server went away', kind: 'unknown', willRetry: false });
+
+      assert.ok(await until(() => sched.routineState[KEY] && sched.routineState[KEY].status !== 'running'),
+        'the turn ending without a done event still recorded an outcome');
+      assert.strictEqual(sched.routineState[KEY].status, 'failed', 'and recorded it as a failure');
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true,
+        'and released the routine, so the next start was allowed');
+    });
+  });
+});
+
+// The other side of that, and the reason the fix reads willRetry rather than
+// treating every error as an ending. A retryable error is not an ending: the
+// turn is still going, and releasing there would let a second run start
+// alongside the first, which is the fault this whole change exists to stop.
+test('a codex error that will be retried is not an ending', async () => {
+  await withTempWorkspaceAsync(async () => {
+    const sub = new EventEmitter();
+    const server = { startThread: async () => ({ threadId: 't1' }), startTurn: () => sub };
+    await withFakeCodex(server, async (sched) => {
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
+      assert.ok(await until(() => sub.listenerCount('event') > 0), 'the run reached the turn subscription');
+
+      sub.emit('event', { type: 'error', message: 'rate limited', kind: 'quota', willRetry: true });
+      await until(() => false, 4); // give a wrong release time to happen
+
+      assert.strictEqual(sched.routineState[KEY].status, 'running', 'the turn is still going');
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), false,
+        'so the routine is still held');
+
+      sub.emit('event', { type: 'done', status: 'completed', usage: null, error: null });
+      assert.ok(await until(() => sched.routineState[KEY].status !== 'running'), 'the turn then ended');
+      assert.strictEqual(sched.routineState[KEY].status, 'completed', 'as a success, because the retry worked');
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'and released the routine');
+    });
+  });
+});
+
+// AC-5 on the codex path. The rejection handler was implemented and only ever
+// exercised for the outcome it records, never for the release it also owes.
+test('a codex run that cannot start its thread releases the routine', async () => {
+  await withTempWorkspaceAsync(async () => {
+    const server = {
+      startThread: async () => { throw new Error('thread/start refused'); },
+      startTurn: () => { throw new Error('never reached'); },
+    };
+    await withFakeCodex(server, async (sched) => {
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
+      assert.ok(await until(() => sched.routineState[KEY] && sched.routineState[KEY].status !== 'running'),
+        'the rejected start recorded an outcome');
+      assert.strictEqual(sched.routineState[KEY].status, 'failed', 'as a failure');
+      assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true,
+        'and released the routine, which the outcome test alone never checked');
     });
   });
 });

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -18,6 +18,8 @@ const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
 const CLAUDE_KEY = require.resolve('../../lib/runtime/claude.js');
 const CODEX_GLUE_KEY = require.resolve('../../lib/runtime/codex-glue.js');
 const { createCodexAppServer } = require('../../codex-appserver.js');
+const { discoverAgents, invalidateAgentCache } = require('../../lib/agents/discovery.js');
+const { agentFile } = require('../helpers/workspace.js');
 const asfx = require('../fixtures/codex-appserver-protocol.js');
 const PROMPT_KEY = require.resolve('../../lib/agents/prompt.js');
 const STUB_CODEX = path.join(__dirname, '..', 'helpers', 'stub-codex', 'codex');
@@ -299,7 +301,25 @@ function defaultedDone() {
   return done;
 }
 
-const CODEX_AGENT = { id: 'runner', name: 'Runner', runtime: 'codex' };
+// The agent that sends a routine down the codex branch, DISCOVERED rather
+// than declared. All four codex tests take that branch because of the runtime
+// field, and discovery is what really decides it: the field is case-folded,
+// anything unrecognised falls back to claude, and an orchestrator is forced to
+// claude whatever its file says. A literal here asserts none of that, and the
+// tests would keep taking the branch after discovery stopped putting anything
+// on it.
+function realCodexAgent(dir) {
+  const agentsDir = path.join(dir, '.claude', 'agents');
+  fs.mkdirSync(agentsDir, { recursive: true });
+  fs.writeFileSync(path.join(agentsDir, 'runner.md'),
+    agentFile({ name: 'Runner', type: 'specialist', order: 1, runtime: 'codex', body: 'runner instructions' }));
+  invalidateAgentCache();
+  const agent = discoverAgents().find(a => a.id === 'runner');
+  assert.ok(agent, 'the roster carries the agent this test wrote');
+  assert.strictEqual(agent.runtime, 'codex',
+    'and discovery put it on the codex runtime, which is what sends its routines down the branch under test');
+  return agent;
+}
 
 test('unwired root deps throw the named wiring error at first use', () => {
   withTempWorkspace(() => {
@@ -433,7 +453,8 @@ test('the codex fields the scheduler reads are the ones the client emits', async
 // terminal and exactly once and every path in it reaches one today, and a
 // routine held on that staying true is held forever when it stops being true.
 test('a codex turn that ends without a done event does not hold the routine', async () => {
-  await withTempWorkspaceAsync(async () => {
+  await withTempWorkspaceAsync(async (dir) => {
+    const CODEX_AGENT = realCodexAgent(dir);
     const real = await realTurnEvents();
     const sub = new EventEmitter();
     // The client's own thread result, so the scheduler destructures the real
@@ -469,7 +490,8 @@ test('a codex turn that ends without a done event does not hold the routine', as
 // turn is still going, and releasing there would let a second run start
 // alongside the first, which is the fault this whole change exists to stop.
 test('a codex error that will be retried is not an ending', async () => {
-  await withTempWorkspaceAsync(async () => {
+  await withTempWorkspaceAsync(async (dir) => {
+    const CODEX_AGENT = realCodexAgent(dir);
     const real = await realTurnEvents();
     const sub = new EventEmitter();
     // The client's own thread result, so the scheduler destructures the real
@@ -509,7 +531,8 @@ test('a codex error that will be retried is not an ending', async () => {
 // AC-5 on the codex path. The rejection handler was implemented and only ever
 // exercised for the outcome it records, never for the release it also owes.
 test('a codex run that cannot start its thread releases the routine', async () => {
-  await withTempWorkspaceAsync(async () => {
+  await withTempWorkspaceAsync(async (dir) => {
+    const CODEX_AGENT = realCodexAgent(dir);
     const server = {
       startThread: async () => { throw new Error('thread/start refused'); },
       startTurn: () => { throw new Error('never reached'); },

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -20,6 +20,7 @@ const CODEX_GLUE_KEY = require.resolve('../../lib/runtime/codex-glue.js');
 const { createCodexAppServer } = require('../../codex-appserver.js');
 const asfx = require('../fixtures/codex-appserver-protocol.js');
 const PROMPT_KEY = require.resolve('../../lib/agents/prompt.js');
+const STUB_CODEX = path.join(__dirname, '..', 'helpers', 'stub-codex', 'codex');
 
 const AGENT = { id: 'runner', name: 'Runner' };
 const ROUTINE = { name: 'r', prompt: 'p' };
@@ -197,6 +198,42 @@ async function realTurnEvents() {
   return { error, retryable, done: seen.find(e => e.type === 'done') };
 }
 
+// The thread a run is filed under, TAKEN FROM THE CLIENT for the same reason
+// the events above are.
+//
+// executeRoutine destructures what startThread resolves and hands the id it
+// finds to startTurn. Every codex test below stood a two-method literal in for
+// the client, with a key this file chose, so nothing tied that key to the
+// producer. Rename it there and the turn is filed under `undefined` while the
+// notifications carry the real id, turn/completed finds no state and bails, no
+// `done` ever reaches the promise the routine is released by, and the routine
+// is held for the life of the process: the one failure the comment on that
+// promise says the design refuses to rest on.
+//
+// A real thread takes a real request round-trip, so this drives the repo's
+// stub app-server, binPath injected, the way codex-appserver's own tests drive
+// it. Nothing here can reach an installed codex. Started once for the file and
+// shut down before the answer is returned, because the answer is a frozen
+// object rather than a live client.
+let codexRun = null;
+function realCodexRun() {
+  if (!codexRun) codexRun = startRealCodexRun();
+  return codexRun;
+}
+
+async function startRealCodexRun() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-lib-codex-'));
+  const server = createCodexAppServer({ binPath: STUB_CODEX, cwd: dir, requestTimeoutMs: 15000 });
+  try {
+    await server.start();
+    const thread = await server.startThread({ cwd: dir });
+    return { thread };
+  } finally {
+    await server.shutdown();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 const CODEX_AGENT = { id: 'runner', name: 'Runner', runtime: 'codex' };
 
 test('unwired root deps throw the named wiring error at first use', () => {
@@ -304,6 +341,12 @@ test('the codex fields the scheduler reads are the ones the client emits', async
   assert.strictEqual(done.type, 'done', 'a turn ending is typed done');
   assert.ok(Object.hasOwn(done, 'status'),
     'and the scheduler decides success by reading status on it');
+
+  // The thread the run is filed under, from the same client. The scheduler
+  // destructures this key and hands what it finds to startTurn.
+  const { thread } = await realCodexRun();
+  assert.ok(Object.hasOwn(thread, 'threadId'),
+    'startThread resolves the key the scheduler destructures: renamed, the turn is filed under undefined, turn/completed finds no state, no done arrives, and the routine is held for the life of the process');
 });
 
 // The codex half of AC-7, and the half this card's own change made worse. The
@@ -321,10 +364,16 @@ test('a codex turn that ends without a done event does not hold the routine', as
   await withTempWorkspaceAsync(async () => {
     const real = await realTurnEvents();
     const sub = new EventEmitter();
-    const server = { startThread: async () => ({ threadId: 't1' }), startTurn: () => sub };
+    // The client's own thread result, so the scheduler destructures the real
+    // key, and what it hands on is recorded rather than ignored.
+    const { thread } = await realCodexRun();
+    let filedUnder;
+    const server = { startThread: async () => thread, startTurn: (threadId) => { filedUnder = threadId; return sub; } };
     await withFakeCodex(server, async (sched) => {
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
       assert.ok(await until(() => sub.listenerCount('event') > 0), 'the run reached the turn subscription');
+      assert.ok(Object.values(thread).includes(filedUnder),
+        'and filed it under the id the client gave it, rather than under undefined');
 
       // The client's own non-retryable error, verbatim.
       sub.emit('event', real.error);
@@ -350,10 +399,16 @@ test('a codex error that will be retried is not an ending', async () => {
   await withTempWorkspaceAsync(async () => {
     const real = await realTurnEvents();
     const sub = new EventEmitter();
-    const server = { startThread: async () => ({ threadId: 't1' }), startTurn: () => sub };
+    // The client's own thread result, so the scheduler destructures the real
+    // key, and what it hands on is recorded rather than ignored.
+    const { thread } = await realCodexRun();
+    let filedUnder;
+    const server = { startThread: async () => thread, startTurn: (threadId) => { filedUnder = threadId; return sub; } };
     await withFakeCodex(server, async (sched) => {
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
       assert.ok(await until(() => sub.listenerCount('event') > 0), 'the run reached the turn subscription');
+      assert.ok(Object.values(thread).includes(filedUnder),
+        'and filed it under the id the client gave it, rather than under undefined');
 
       // The client's own retryable error, verbatim: no field of it is named
       // here, so a rename in the client arrives intact rather than being

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -52,6 +52,34 @@ test('unwired root deps throw the named wiring error at first use', () => {
   });
 });
 
+// A run is held from the moment it is started until it records an outcome, so
+// a start that throws before there is anything to record would hold its
+// routine for the life of the process: no spawn, no child, no close event,
+// and therefore nothing that will ever release it. That is the one way the
+// guard can turn from a protection into a routine that never runs again, and
+// it needs no bug in the guard itself to happen.
+//
+// The test asserts the SECOND attempt gets as far as the first did. That is
+// the assertion that can fail: a routine still held would be turned away by
+// the guard and would return quietly, throwing nothing.
+//
+// The spawn itself is the other half, and it is not a throw. Node reports a
+// child that never launched asynchronously, as an 'error' event followed by a
+// 'close' with a negative code, so a routine whose runtime is missing entirely
+// releases through the ordinary outcome path rather than through this one. The
+// killed-child test in the integration suite pins that path.
+test('a start that throws before the spawn does not hold the routine', () => {
+  withTempWorkspace(() => {
+    const sched = freshScheduler();
+    // The broadcast is the first wired-dep touch, and it happens before any
+    // child exists. An unwired dep at boot is exactly this shape.
+    const start = () => sched.executeRoutine({ id: 'runner', name: 'Runner' }, { name: 'r', prompt: 'p' }, 'runner:r');
+    assert.throws(start, /getWssClients not wired/);
+    assert.throws(start, /getWssClients not wired/,
+      'the second start reached the same throw, so the first one released the routine on its way out');
+  });
+});
+
 test('wireSchedulerDeps returns the previous set, restorable by identity', () => {
   withTempWorkspace(() => {
     const sched = freshScheduler();

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -101,7 +101,7 @@ async function until(predicate, tries = 200) {
 // unit suite has no equivalent of the integration harness's refusal to run
 // against it, so a unit test that reaches the real spawn runs whatever happens
 // to be installed on the machine.
-function withFakeSpawn(fakeSpawn, fn) {
+async function withFakeSpawn(fakeSpawn, fn) {
   const claude = require(CLAUDE_KEY);
   const realSpawn = claude.spawnClaude;
   const prevClaudeDeps = claude.wireClaudeRuntimeDeps({ getActualPort: () => 0 });
@@ -109,7 +109,7 @@ function withFakeSpawn(fakeSpawn, fn) {
   try {
     const sched = freshScheduler();
     sched.wireSchedulerDeps({ getWssClients: () => [] });
-    return fn(sched);
+    return await fn(sched);
   } finally {
     claude.spawnClaude = realSpawn;
     claude.wireClaudeRuntimeDeps(prevClaudeDeps);
@@ -143,6 +143,20 @@ async function withFakeCodex(server, fn) {
     Object.assign(glue, { getCodexAppServer: real.getCodexAppServer, waitForCodexReady: real.waitForCodexReady });
     prompt.buildSystemPrompt = real.buildSystemPrompt;
   }
+}
+
+// Starting a run is the only way to observe that a routine was released, so
+// every release test below starts one. A run left going outlives its test: it
+// records its outcome later, into whatever workspace the next test has set,
+// which is where the stray "failed to persist routine state" lines in this
+// file's output came from. So every started run is driven to an end before its
+// test returns. A start always writes 'running' first, so leaving that state
+// is the signal the run has ended, whatever it ended as.
+async function endedAfter(sched, start) {
+  assert.strictEqual(sched.routineState[KEY].status, 'running', 'the start under test is a real run');
+  await start();
+  assert.ok(await until(() => sched.routineState[KEY].status !== 'running'),
+    'and it was ended rather than left going');
 }
 
 const CODEX_AGENT = { id: 'runner', name: 'Runner', runtime: 'codex' };
@@ -204,16 +218,17 @@ test('a start that throws before the spawn does not hold the routine', () => {
 // is exactly when a spawn fails, and whether the handle still closes after the
 // error is a question about a Node version rather than about this file. So the
 // error routes to the same outcome and the question stops mattering.
-test('a child that reports an error and never closes does not hold the routine', () => {
-  withTempWorkspace(() => {
+test('a child that reports an error and never closes does not hold the routine', async () => {
+  await withTempWorkspaceAsync(async () => {
     const child = new EventEmitter();
-    withFakeSpawn(() => child, (sched) => {
+    await withFakeSpawn(() => child, async (sched) => {
       assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true, 'the first run started');
       child.emit('error', Object.assign(new Error('too many open files'), { code: 'EMFILE' }));
       assert.strictEqual(sched.routineState[KEY].status, 'failed',
         'the error was recorded as an outcome rather than waiting for a close that may never come');
       assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true,
         'and it released the routine, so the next start was allowed');
+      await endedAfter(sched, async () => { child.emit('close', 0); });
     });
   });
 });
@@ -221,11 +236,11 @@ test('a child that reports an error and never closes does not hold the routine',
 // The cost of listening to both: a failure that reports twice must not be
 // recorded twice. Counted through the broadcast, which happens once when a run
 // starts and once per outcome, so a second outcome is a third broadcast.
-test('a failure reported as both an error and a close records one outcome', () => {
-  withTempWorkspace(() => {
+test('a failure reported as both an error and a close records one outcome', async () => {
+  await withTempWorkspaceAsync(async () => {
     const child = new EventEmitter();
     let broadcasts = 0;
-    withFakeSpawn(() => child, (sched) => {
+    await withFakeSpawn(() => child, async (sched) => {
       sched.wireSchedulerDeps({ getWssClients: () => { broadcasts += 1; return []; } });
       sched.executeRoutine(AGENT, ROUTINE, KEY);
       child.emit('error', Object.assign(new Error('no such file'), { code: 'ENOENT' }));
@@ -262,6 +277,10 @@ test('a codex turn that ends without a done event does not hold the routine', as
       assert.strictEqual(sched.routineState[KEY].status, 'failed', 'and recorded it as a failure');
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true,
         'and released the routine, so the next start was allowed');
+      await endedAfter(sched, async () => {
+        await until(() => sub.listenerCount('event') > 1);
+        sub.emit('event', { type: 'done', status: 'completed', usage: null, error: null });
+      });
     });
   });
 });
@@ -289,6 +308,10 @@ test('a codex error that will be retried is not an ending', async () => {
       assert.ok(await until(() => sched.routineState[KEY].status !== 'running'), 'the turn then ended');
       assert.strictEqual(sched.routineState[KEY].status, 'completed', 'as a success, because the retry worked');
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'and released the routine');
+      await endedAfter(sched, async () => {
+        await until(() => sub.listenerCount('event') > 1);
+        sub.emit('event', { type: 'done', status: 'completed', usage: null, error: null });
+      });
     });
   });
 });
@@ -308,6 +331,9 @@ test('a codex run that cannot start its thread releases the routine', async () =
       assert.strictEqual(sched.routineState[KEY].status, 'failed', 'as a failure');
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true,
         'and released the routine, which the outcome test alone never checked');
+      // The second start rejects on its own, so ending it is only a matter of
+      // waiting for it rather than driving it.
+      await endedAfter(sched, async () => {});
     });
   });
 });
@@ -318,10 +344,10 @@ test('a codex run that cannot start its thread releases the routine', async () =
 // A run in flight is a child process that is still running, and clearing its
 // key would free the routine to start again while the first run was still
 // going, with the eventual release then having nothing to release.
-test('switching workspace does not release a run that is still going', () => {
-  withTempWorkspace(() => {
+test('switching workspace does not release a run that is still going', async () => {
+  await withTempWorkspaceAsync(async () => {
     const child = new EventEmitter();
-    withFakeSpawn(() => child, (sched) => {
+    await withFakeSpawn(() => child, async (sched) => {
       assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true, 'the run started');
       sched.loadRoutineState(); // what a workspace switch calls
       // Only loadRoutineState writes this value, so it is the proof the reset
@@ -333,14 +359,15 @@ test('switching workspace does not release a run that is still going', () => {
       child.emit('close', 0);
       assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true,
         'the run ending is the only thing that releases it, switch or no switch');
+      await endedAfter(sched, async () => { child.emit('close', 0); });
     });
   });
 });
 
 // AC-6, at the call site it is about rather than at one that stands in for it.
-test('a start whose spawn throws does not hold the routine', () => {
-  withTempWorkspace(() => {
-    withFakeSpawn(() => { throw new Error('spawn refused'); }, (sched) => {
+test('a start whose spawn throws does not hold the routine', async () => {
+  await withTempWorkspaceAsync(async () => {
+    await withFakeSpawn(() => { throw new Error('spawn refused'); }, async (sched) => {
       const start = () => sched.executeRoutine(AGENT, ROUTINE, KEY);
       assert.throws(start, /spawn refused/);
       assert.throws(start, /spawn refused/,

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -12,8 +12,14 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { EventEmitter } = require('node:events');
 
 const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
+const CLAUDE_KEY = require.resolve('../../lib/runtime/claude.js');
+
+const AGENT = { id: 'runner', name: 'Runner' };
+const ROUTINE = { name: 'r', prompt: 'p' };
+const KEY = 'runner:r';
 
 // A private copy per test: wiring one test's fakes must never leak into
 // another test (or into the shared instance other requires would see).
@@ -36,6 +42,33 @@ function withTempWorkspace(fn) {
   } finally {
     config.setWorkspace(original);
     fs.rmSync(ws, { recursive: true, force: true });
+  }
+}
+
+// A scheduler whose child processes are the test's to drive.
+//
+// lib/scheduler.js destructures spawnClaude at load, so a copy required after
+// the export is swapped closes over the fake, and the swap is undone before
+// the shared instance the rest of the suite runs against can see it. The port
+// dep is wired because the real getSpawnEnv still runs on the way to the fake.
+//
+// Nothing here reaches a real binary, which matters more than usual next to
+// this code: resolveClaudeBin memoises whatever `which claude` finds, and the
+// unit suite has no equivalent of the integration harness's refusal to run
+// against it, so a unit test that reaches the real spawn runs whatever happens
+// to be installed on the machine.
+function withFakeSpawn(fakeSpawn, fn) {
+  const claude = require(CLAUDE_KEY);
+  const realSpawn = claude.spawnClaude;
+  const prevClaudeDeps = claude.wireClaudeRuntimeDeps({ getActualPort: () => 0 });
+  claude.spawnClaude = fakeSpawn;
+  try {
+    const sched = freshScheduler();
+    sched.wireSchedulerDeps({ getWssClients: () => [] });
+    return fn(sched);
+  } finally {
+    claude.spawnClaude = realSpawn;
+    claude.wireClaudeRuntimeDeps(prevClaudeDeps);
   }
 }
 
@@ -77,6 +110,58 @@ test('a start that throws before the spawn does not hold the routine', () => {
     assert.throws(start, /getWssClients not wired/);
     assert.throws(start, /getWssClients not wired/,
       'the second start reached the same throw, so the first one released the routine on its way out');
+  });
+});
+
+// AC-7 in its sharpest form. The claude path used to release only from the
+// child's close event, on the strength of close following error. That holds
+// for a binary that is not there, which is the case easy to reach and easy to
+// test. It is not established for the failures a tick is most likely to meet,
+// which are the file-descriptor exhaustion ones: a process under that pressure
+// is exactly when a spawn fails, and whether the handle still closes after the
+// error is a question about a Node version rather than about this file. So the
+// error routes to the same outcome and the question stops mattering.
+test('a child that reports an error and never closes does not hold the routine', () => {
+  withTempWorkspace(() => {
+    const child = new EventEmitter();
+    withFakeSpawn(() => child, (sched) => {
+      assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true, 'the first run started');
+      child.emit('error', Object.assign(new Error('too many open files'), { code: 'EMFILE' }));
+      assert.strictEqual(sched.routineState[KEY].status, 'failed',
+        'the error was recorded as an outcome rather than waiting for a close that may never come');
+      assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true,
+        'and it released the routine, so the next start was allowed');
+    });
+  });
+});
+
+// The cost of listening to both: a failure that reports twice must not be
+// recorded twice. Counted through the broadcast, which happens once when a run
+// starts and once per outcome, so a second outcome is a third broadcast.
+test('a failure reported as both an error and a close records one outcome', () => {
+  withTempWorkspace(() => {
+    const child = new EventEmitter();
+    let broadcasts = 0;
+    withFakeSpawn(() => child, (sched) => {
+      sched.wireSchedulerDeps({ getWssClients: () => { broadcasts += 1; return []; } });
+      sched.executeRoutine(AGENT, ROUTINE, KEY);
+      child.emit('error', Object.assign(new Error('no such file'), { code: 'ENOENT' }));
+      child.emit('close', -2);
+      assert.strictEqual(broadcasts, 2,
+        'the start and one outcome, not the start and the same outcome twice');
+    });
+  });
+});
+
+// AC-6, at the call site it is about rather than at one that stands in for it.
+test('a start whose spawn throws does not hold the routine', () => {
+  withTempWorkspace(() => {
+    withFakeSpawn(() => { throw new Error('spawn refused'); }, (sched) => {
+      const start = () => sched.executeRoutine(AGENT, ROUTINE, KEY);
+      assert.throws(start, /spawn refused/);
+      assert.throws(start, /spawn refused/,
+        'the second start reached the same throw, so the first one released the routine on its way out');
+    });
   });
 });
 

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -21,6 +21,7 @@ const { createCodexAppServer } = require('../../codex-appserver.js');
 const asfx = require('../fixtures/codex-appserver-protocol.js');
 const PROMPT_KEY = require.resolve('../../lib/agents/prompt.js');
 const STUB_CODEX = path.join(__dirname, '..', 'helpers', 'stub-codex', 'codex');
+const WORKSPACE_HANDLERS_KEY = require.resolve('../../lib/protocol/handlers/workspace.js');
 
 const AGENT = { id: 'runner', name: 'Runner' };
 const ROUTINE = { name: 'r', prompt: 'p' };
@@ -35,6 +36,33 @@ function freshScheduler() {
   delete require.cache[SCHEDULER_KEY];
   if (cached) require.cache[SCHEDULER_KEY] = cached;
   return mod;
+}
+
+// The real workspace switch, closed over the scheduler under test.
+//
+// handleSetWorkspace IS the switch; loadRoutineState is one of the eleven
+// things its open path calls. A test that drives the call instead of the
+// switch leaves the invariant open to the one change that would break it: a
+// reset added to openWorkspace, beside the two resets that belong there, with
+// every scheduler test still green.
+//
+// The handler destructures loadRoutineState at load, so a copy required while
+// the test's own scheduler sits in the cache closes over that one rather than
+// the shared instance the rest of the suite runs against. Same technique as
+// freshScheduler, one module further out, and undone the same way.
+function freshWorkspaceHandlers(sched) {
+  const cachedSched = require.cache[SCHEDULER_KEY];
+  const cachedHandlers = require.cache[WORKSPACE_HANDLERS_KEY];
+  require.cache[SCHEDULER_KEY] = { id: SCHEDULER_KEY, filename: SCHEDULER_KEY, loaded: true, exports: sched };
+  delete require.cache[WORKSPACE_HANDLERS_KEY];
+  try {
+    return require(WORKSPACE_HANDLERS_KEY);
+  } finally {
+    delete require.cache[WORKSPACE_HANDLERS_KEY];
+    if (cachedHandlers) require.cache[WORKSPACE_HANDLERS_KEY] = cachedHandlers;
+    if (cachedSched) require.cache[SCHEDULER_KEY] = cachedSched;
+    else delete require.cache[SCHEDULER_KEY];
+  }
 }
 
 function enterTempWorkspace() {
@@ -506,14 +534,39 @@ test('a codex run that cannot start its thread releases the routine', async () =
 // A run in flight is a child process that is still running, and clearing its
 // key would free the routine to start again while the first run was still
 // going, with the eventual release then having nothing to release.
-test('switching workspace does not release a run that is still going', async () => {
-  await withTempWorkspaceAsync(async () => {
+//
+// Driven through the real switch handler, re-selecting the same workspace
+// (which the open path treats as a switch, and which keeps the state file the
+// test wrote). Killing the children is ctx's, injected, and stubbed here: the
+// child in this test is the test's to end, and what is pinned is that the
+// SWITCH does not let go of a routine whose run is still going.
+test('the workspace switch does not release a run that is still going', async () => {
+  await withTempWorkspaceAsync(async (dir, config) => {
     const child = new EventEmitter();
     await withFakeSpawn(() => child, async (sched) => {
       assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true, 'the run started');
-      sched.loadRoutineState(); // what a workspace switch calls
-      // Only loadRoutineState writes this value, so it is the proof the reset
-      // really ran rather than being skipped over.
+
+      const sent = [];
+      const ws = { send: (raw) => sent.push(JSON.parse(raw)) };
+      const noop = () => {};
+      const ctx = {
+        signals: { phaseTimer: () => ({ mark: noop, summary: () => '' }), reportStartup: noop },
+        runtime: { killAllChildren: noop, cleanOrphanedProcesses: noop },
+        workspace: {
+          setWorkspaceRoot: (d) => config.setWorkspace(d),
+          armAgentsDirWatcher: noop, armFileTreeWatcher: noop, healWorkspaceIfMoved: noop,
+          saveRecentWorkspace: noop, fileTreeForSend: () => [],
+        },
+        agents: { armAgentsDirWatcher: noop, invalidateAgentCache: noop },
+        store: { clearSearchFailure: noop, ensureSearchEngine: noop },
+      };
+      const handlers = freshWorkspaceHandlers(sched);
+      handlers.handleSetWorkspace(ctx, ws, { type: 'set_workspace', path: dir });
+      assert.ok(sent.some(m => m.type === 'workspace_set'),
+        'the switch ran its open path to the end rather than into the rollback');
+
+      // Only loadRoutineState writes this value, so it is the proof the
+      // switch's resets really ran rather than being skipped over.
       assert.strictEqual(sched.routineState[KEY].status, 'interrupted',
         'the switch rebuilt the run state from the workspace file');
       assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), false,

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -210,6 +210,19 @@ async function realTurnEvents() {
 // is held for the life of the process: the one failure the comment on that
 // promise says the design refuses to rest on.
 //
+// The success token comes back with it, and for the same reason. The
+// scheduler branches on the status of the terminal event, and every test
+// below overwrote that one field with a token of its own, so the contract
+// test could only pin that a `done` HAS a status and never what a successful
+// one says. Rename the token and every successful codex routine records as
+// failed, in the routine state and in the signal, and the interface shows a
+// permanently failing routine while the tests stay green.
+//
+// Two tokens are read, because the client owns the value on one path and
+// passes it through on the other: a turn the stub really completes, and a
+// turn/completed carrying no status at all, where the client's own default is
+// the only thing that can name it.
+//
 // A real thread takes a real request round-trip, so this drives the repo's
 // stub app-server, binPath injected, the way codex-appserver's own tests drive
 // it. Nothing here can reach an installed codex. Started once for the file and
@@ -227,11 +240,35 @@ async function startRealCodexRun() {
   try {
     await server.start();
     const thread = await server.startThread({ cwd: dir });
-    return { thread };
+    // The id read as the value the client returned rather than by a name this
+    // file chose, so a rename has to reach the SCHEDULER's destructure, which
+    // is what the tests are about, rather than stopping here in the helper.
+    const [threadId] = Object.values(thread);
+    const seen = [];
+    server.startTurn(threadId, 'contract probe').on('event', (ev) => seen.push(ev));
+    assert.ok(await until(() => seen.some(e => e.type === 'done'), 3000),
+      'the probe turn reached its terminal event');
+    return { thread, done: seen.find(e => e.type === 'done'), defaulted: defaultedDone() };
   } finally {
     await server.shutdown();
     fs.rmSync(dir, { recursive: true, force: true });
   }
+}
+
+// The terminal event for a turn that completes without saying how, which is
+// the one success token the client owns rather than relays. Same never-started
+// client as realTurnEvents, and the same fixture, with the status removed from
+// the wire so the client has to supply it.
+function defaultedDone() {
+  const server = createCodexAppServer({ binPath: '/nonexistent', cwd: os.tmpdir(), requestTimeoutMs: 200 });
+  const seen = [];
+  server.startTurn('thread-default', 'default probe').on('event', (ev) => seen.push(ev));
+  const wire = asfx.turnCompleted('thread-default', 'turn-default');
+  delete wire.params.turn.status;
+  server._onNotification(wire.method, wire.params);
+  const done = seen.find(e => e.type === 'done');
+  assert.ok(done, 'the client ended the turn on a completion carrying no status');
+  return done;
 }
 
 const CODEX_AGENT = { id: 'runner', name: 'Runner', runtime: 'codex' };
@@ -344,9 +381,16 @@ test('the codex fields the scheduler reads are the ones the client emits', async
 
   // The thread the run is filed under, from the same client. The scheduler
   // destructures this key and hands what it finds to startTurn.
-  const { thread } = await realCodexRun();
+  const { thread, done: completed, defaulted } = await realCodexRun();
   assert.ok(Object.hasOwn(thread, 'threadId'),
     'startThread resolves the key the scheduler destructures: renamed, the turn is filed under undefined, turn/completed finds no state, no done arrives, and the routine is held for the life of the process');
+
+  // What a successful one SAYS, which is the half the assertion above cannot
+  // reach: the scheduler reads this exact token as success.
+  assert.strictEqual(completed.status, 'completed',
+    'a turn that ran to the end says completed, and the scheduler records success on that token alone: rename it and every successful routine records as failed');
+  assert.strictEqual(defaulted.status, completed.status,
+    'and a completion that carries no status gets the same token from the client, so the default cannot drift away from the value it stands in for');
 });
 
 // The codex half of AC-7, and the half this card's own change made worse. The
@@ -366,7 +410,8 @@ test('a codex turn that ends without a done event does not hold the routine', as
     const sub = new EventEmitter();
     // The client's own thread result, so the scheduler destructures the real
     // key, and what it hands on is recorded rather than ignored.
-    const { thread } = await realCodexRun();
+    const run = await realCodexRun();
+    const { thread } = run;
     let filedUnder;
     const server = { startThread: async () => thread, startTurn: (threadId) => { filedUnder = threadId; return sub; } };
     await withFakeCodex(server, async (sched) => {
@@ -385,7 +430,7 @@ test('a codex turn that ends without a done event does not hold the routine', as
         'and released the routine, so the next start was allowed');
       await endedAfter(sched, async () => {
         await until(() => sub.listenerCount('event') > 1);
-        sub.emit('event', { ...real.done, status: 'completed' });
+        sub.emit('event', run.done);
       });
     });
   });
@@ -401,7 +446,8 @@ test('a codex error that will be retried is not an ending', async () => {
     const sub = new EventEmitter();
     // The client's own thread result, so the scheduler destructures the real
     // key, and what it hands on is recorded rather than ignored.
-    const { thread } = await realCodexRun();
+    const run = await realCodexRun();
+    const { thread } = run;
     let filedUnder;
     const server = { startThread: async () => thread, startTurn: (threadId) => { filedUnder = threadId; return sub; } };
     await withFakeCodex(server, async (sched) => {
@@ -420,13 +466,13 @@ test('a codex error that will be retried is not an ending', async () => {
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), false,
         'so the routine is still held');
 
-      sub.emit('event', { ...real.done, status: 'completed' });
+      sub.emit('event', run.done);
       assert.ok(await until(() => sched.routineState[KEY].status !== 'running'), 'the turn then ended');
       assert.strictEqual(sched.routineState[KEY].status, 'completed', 'as a success, because the retry worked');
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'and released the routine');
       await endedAfter(sched, async () => {
         await until(() => sub.listenerCount('event') > 1);
-        sub.emit('event', { ...real.done, status: 'completed' });
+        sub.emit('event', run.done);
       });
     });
   });

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -17,6 +17,8 @@ const { EventEmitter } = require('node:events');
 const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
 const CLAUDE_KEY = require.resolve('../../lib/runtime/claude.js');
 const CODEX_GLUE_KEY = require.resolve('../../lib/runtime/codex-glue.js');
+const { createCodexAppServer } = require('../../codex-appserver.js');
+const asfx = require('../fixtures/codex-appserver-protocol.js');
 const PROMPT_KEY = require.resolve('../../lib/agents/prompt.js');
 
 const AGENT = { id: 'runner', name: 'Runner' };
@@ -159,6 +161,42 @@ async function endedAfter(sched, start) {
     'and it was ended rather than left going');
 }
 
+// The codex turn events, TAKEN FROM THE CLIENT rather than written here.
+//
+// The scheduler decides whether a turn has ended by reading ev.type,
+// ev.willRetry and ev.status. A test that hand-builds those events asserts a
+// contract its own author invented: rename willRetry in the client and every
+// error becomes terminal, a routine is released mid-turn, a second run starts
+// alongside the first, and every test in this file stays green while saying
+// the opposite. Verified by doing it.
+//
+// A client that was never started refuses its first request, and that refusal
+// runs the same event construction the live paths run: one error event and one
+// terminal event, built by the client, with no process spawned and nothing
+// left running.
+async function realTurnEvents() {
+  const server = createCodexAppServer({ binPath: '/nonexistent', cwd: os.tmpdir(), requestTimeoutMs: 200 });
+  const seen = [];
+  const sub = server.startTurn('thread-contract', 'contract probe');
+  sub.on('event', (ev) => seen.push(ev));
+
+  // The retryable error comes from the streaming path, which is the only one
+  // that ever sets the flag true and is a different construction site from the
+  // two below. Fed as a wire notification built by the fixture the stub and
+  // the client's own tests share, so the shape is not this file's either. The
+  // turn state exists from the synchronous startTurn above until the refusal
+  // below is handled, so this ordering is microtask-deterministic.
+  const wire = asfx.errorNotification('thread-contract', 'turn-contract', { message: 'rate limited', willRetry: true });
+  server._onNotification(wire.method, wire.params);
+  const retryable = seen.find(e => e.type === 'error');
+  assert.ok(retryable && retryable.willRetry === true, 'the client built a retryable error');
+
+  assert.ok(await until(() => seen.some(e => e.type === 'done')), 'the client reached a terminal event');
+  const error = seen.filter(e => e.type === 'error').find(e => e !== retryable);
+  assert.ok(error, 'and emitted a non-retryable error alongside it');
+  return { error, retryable, done: seen.find(e => e.type === 'done') };
+}
+
 const CODEX_AGENT = { id: 'runner', name: 'Runner', runtime: 'codex' };
 
 test('unwired root deps throw the named wiring error at first use', () => {
@@ -251,6 +289,23 @@ test('a failure reported as both an error and a close records one outcome', asyn
   });
 });
 
+// The contract the two tests below rest on, asserted against the client that
+// owns it. Without this they rest on nothing: the fields are read by the
+// scheduler and supplied by the tests, so the tests agree with themselves.
+test('the codex fields the scheduler reads are the ones the client emits', async () => {
+  const { error, retryable, done } = await realTurnEvents();
+  // Both construction sites, because renaming either one alone would leave the
+  // other still answering and this test still green.
+  for (const [what, ev] of [['a failed start', error], ['a streamed turn error', retryable]]) {
+    assert.strictEqual(ev.type, 'error', `${what} is typed error`);
+    assert.ok(Object.hasOwn(ev, 'willRetry'),
+      `${what} carries willRetry, which is how the scheduler decides an error ended the turn: renamed, every error ends it and a routine is released mid-run`);
+  }
+  assert.strictEqual(done.type, 'done', 'a turn ending is typed done');
+  assert.ok(Object.hasOwn(done, 'status'),
+    'and the scheduler decides success by reading status on it');
+});
+
 // The codex half of AC-7, and the half this card's own change made worse. The
 // outcome promise resolved only on a `done` event. Before single-flight, a
 // turn that never reached one left stale running state and the next window
@@ -264,13 +319,15 @@ test('a failure reported as both an error and a close records one outcome', asyn
 // routine held on that staying true is held forever when it stops being true.
 test('a codex turn that ends without a done event does not hold the routine', async () => {
   await withTempWorkspaceAsync(async () => {
+    const real = await realTurnEvents();
     const sub = new EventEmitter();
     const server = { startThread: async () => ({ threadId: 't1' }), startTurn: () => sub };
     await withFakeCodex(server, async (sched) => {
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
       assert.ok(await until(() => sub.listenerCount('event') > 0), 'the run reached the turn subscription');
 
-      sub.emit('event', { type: 'error', message: 'app-server went away', kind: 'unknown', willRetry: false });
+      // The client's own non-retryable error, verbatim.
+      sub.emit('event', real.error);
 
       assert.ok(await until(() => sched.routineState[KEY] && sched.routineState[KEY].status !== 'running'),
         'the turn ending without a done event still recorded an outcome');
@@ -279,7 +336,7 @@ test('a codex turn that ends without a done event does not hold the routine', as
         'and released the routine, so the next start was allowed');
       await endedAfter(sched, async () => {
         await until(() => sub.listenerCount('event') > 1);
-        sub.emit('event', { type: 'done', status: 'completed', usage: null, error: null });
+        sub.emit('event', { ...real.done, status: 'completed' });
       });
     });
   });
@@ -291,26 +348,30 @@ test('a codex turn that ends without a done event does not hold the routine', as
 // alongside the first, which is the fault this whole change exists to stop.
 test('a codex error that will be retried is not an ending', async () => {
   await withTempWorkspaceAsync(async () => {
+    const real = await realTurnEvents();
     const sub = new EventEmitter();
     const server = { startThread: async () => ({ threadId: 't1' }), startTurn: () => sub };
     await withFakeCodex(server, async (sched) => {
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'the run started');
       assert.ok(await until(() => sub.listenerCount('event') > 0), 'the run reached the turn subscription');
 
-      sub.emit('event', { type: 'error', message: 'rate limited', kind: 'quota', willRetry: true });
+      // The client's own retryable error, verbatim: no field of it is named
+      // here, so a rename in the client arrives intact rather than being
+      // papered over by a literal this file wrote.
+      sub.emit('event', real.retryable);
       await until(() => false, 4); // give a wrong release time to happen
 
       assert.strictEqual(sched.routineState[KEY].status, 'running', 'the turn is still going');
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), false,
         'so the routine is still held');
 
-      sub.emit('event', { type: 'done', status: 'completed', usage: null, error: null });
+      sub.emit('event', { ...real.done, status: 'completed' });
       assert.ok(await until(() => sched.routineState[KEY].status !== 'running'), 'the turn then ended');
       assert.strictEqual(sched.routineState[KEY].status, 'completed', 'as a success, because the retry worked');
       assert.strictEqual(sched.executeRoutine(CODEX_AGENT, ROUTINE, KEY), true, 'and released the routine');
       await endedAfter(sched, async () => {
         await until(() => sub.listenerCount('event') > 1);
-        sub.emit('event', { type: 'done', status: 'completed', usage: null, error: null });
+        sub.emit('event', { ...real.done, status: 'completed' });
       });
     });
   });


### PR DESCRIPTION
## What

The routine executor spawned and returned, holding neither the child, the promise, nor a flag. The only thing resembling a guard was the run's start time being stamped before the spawn, which the next-run calculation then suppressed on a same-day comparison. That is a rule about schedules, and it fails at exactly the case it looks like it covers: a run outliving its window fires again at the next window, because its stored start time is stale rather than open. Nothing anywhere refused a second run of a routine already running.

Routines now hold a real single-flight lock for the life of one run.

## How

The guard sits in the executor rather than in the tick. The tick is the only caller today, but a run-now button would be a second entry point, and a check the tick owns is a check a second caller silently skips. The executor answers whether it started a run, and the tick reads that answer to say why nothing happened, because a held routine and a routine that is not due look identical in a log that says nothing about either. The held line is said on every held tick rather than once, unlike a refusal: a hold lasts exactly as long as one run, so hearing it twice means a run has outlived its window, which is worth saying whenever it is true.

Release lives at one point, inside the outcome recorder, because both runtimes and both outcomes end there. Putting it at each of the three call sites would mean three chances to add a fourth and forget. It is the first statement in that function, so nothing between it and the end can leave a routine held after its run has finished. A start that throws before there is anything to record is the other escape, since it leaves no child, no close event and no outcome, so the start is wrapped, the routine is freed, and the error is rethrown unchanged. A spawn that fails to launch is not a throw at all: Node reports it asynchronously as an error event followed by a close with a negative code, so a missing runtime records a failure and releases through the ordinary path. That is now said where the close is handled.

Two routines sharing a name under one agent are held together, not separately. The data model allows namesakes on purpose, and they already share one state slot, so they already share one identity: last run, status, duration and the refusal announcement are all keyed the same way. A lock finer-grained than the state it protects would let one namesake run while the other's hold still stood, and both would then write the same slot, so the hold would be protecting nothing. There is also no finer identity that survives a tick: the roster is re-read on every pass, so routine objects are fresh, and a routine's position in its agent's list moves whenever the file is edited. A test pins the decision so it cannot change silently.

## Verification

Four integration tests drive the real tick through the clock seam, so a run can be watched outliving its window with no real time passing. The run that outlives it is a real child hung on a scenario delay, ended by killing it rather than by waiting for it. Every held test asserts the stored state is untouched, not merely that nothing spawned: a hold that quietly stamped a run would leave no spawn behind either, and would suppress the next window by the schedule rule. Every held test also asserts a different routine fired on the same tick, because absence is satisfied by a tick that was never going to run anything.

Nine hand mutations, each naming a red test:

| Mutation | Red |
| --- | --- |
| Delete the in-flight guard | outlives its window; namesakes held together |
| Delete the acquire | outlives its window; namesakes held together |
| Delete the release in the outcome recorder | seven tests, across three files |
| Delete the release on the throw path | throws before the spawn |
| Make a held routine log the same line as a running one | outlives its window; namesakes held together |
| Report every start as held | eight tests, across three files |
| Swallow the failed start instead of rethrowing | three seam tests |
| Release only on a successful outcome | a run that fails releases the routine |
| Positive control: the tick starts nothing at all | eleven tests, across four files |

The last one is the check that the new assertions are not passing vacuously: "did not start a second run" is an absence, and a tick that fires nothing satisfies it trivially. Every test in the new file goes red under it. The same lens found a real hole in the namesake test, fixed in its own commit: had the roster ever carried one routine where the fixture writes two, there would have been no namesake to hold and every assertion would have passed by describing a routine that does not exist. The roster is now read and counted.

Review round two added four more, each a named red: deleting the error listener; deleting the once-flag guard; setting the once-flag without reading it; routing the error to a success outcome; and clearing the in-flight set on a workspace switch, which is the tidy-looking change the new pin exists to stop.

`npm run red-first --base main --tests "npm test"`: PROVEN, on the full suite, 1796/1796 with the change, 8 red without it. Coverage measured directly, since the gate record does not carry it: `lib/scheduler.js` 100.0% (425/425 executable lines), the scheduler area 380/380, and all 50 floors hold.

## Round two

Four advisories, all addressed.

**Release on either end of the child.** The claude path released only from `close`, resting on `close` always following `error`. That is established for a missing binary and not for file-descriptor exhaustion, where the handle is torn down early and a process under that pressure is exactly when a spawn fails. Rather than fix this file to a detail of a runtime it does not own, the `error` event now routes to the same outcome, and an outcome is recorded once per run so a failure reporting twice is one failed run. Pinned by a test that emits `error` with no `close` and asserts the next start is allowed.

**The workspace-switch decision is now written where the state is declared**, with its cost named: a routine in the new workspace sharing an agent id and name is held until the old workspace's child exits, which is a delayed run rather than a duplicated one. Pinned by a test, because a comment explaining an inconsistency is an invitation to remove it.

**AC-6 is now exercised at the call site it is about.** The spawn throws, rather than the broadcast in front of it. Both tests are kept: they are different statements and both are reachable.

**The integration file was re-swept, not patched.** The failure-release test opened by picking up a child the previous test had left hanging, which is the inert-test shape one step out: satisfied by somebody else's leftovers rather than by a default. It now starts its own run, the test before it ends the run it started, and every remaining assertion was re-read against the question of what an earlier test could have produced. Two controls were weak rather than wrong and now pin their stored run to the drive that made it.

## Round three

Five advisories, all addressed.

**The Codex path had the same AC-7 hole, and this change had made it worse.** The outcome promise resolved only on a `done` event, so a turn ending any other way never settled it and the key stayed in flight for the life of the process. Before single-flight, that hang left stale running state and the next window fired anyway, because the suppression was date-granular and a stale timestamp still expires. This change turned a self-healing failure into a permanent one, on a path the card never mentioned. Fixed with the reasoning already used and not repeated: a non-retryable error ends the turn too, and the idempotent outcome recorder makes a double ending harmless. **A retryable error is deliberately not an ending** — the turn is still going, and releasing there would let a second run start alongside the first, which is the fault the card exists to fix. Both halves are pinned, and the mutation that treats every error alike reds the second.

**The Codex failure path owed a release nothing asked it for.** There was a test that a rejected thread start records a failed run, and none that it frees the routine. Now there is.

**The absences are read against a record, not against elapsed time.** The two assertions that are absences by nature now wait for the control's spawn *from that tick* to appear in the invocation log, counted from where it stood before the tick ran. The invocation log is written by the child, so waiting for the control to finish only proved time passed.

**Both new test patterns keep their reasons in writing.** `wireSchedulerDeps` reaches the WebSocket clients and the clock, and neither is a child process or a turn subscription; adding either would put a seam in production code that only tests would use. Both throw tests stay because they throw from different statements, and the one AC-6 names should not have to be read as equivalent to the line above it. The temp-workspace helper gained an asynchronous lifetime out of the one mechanism rather than a second beside it.

**One extra, found while investigating a full-suite failure that has not reproduced.** Every release test started a run and left it going, against a fake child nothing would ever end, so it recorded its outcome later into whatever workspace the next test had set. That is a test leaving live state for its successors, in the tests written to prove nothing gets left running. Every started run is now driven to an end before its test returns. Whether it caused the failure is not established, and claiming it would be inference dressed as a diagnosis.

## Round four

**The finding.** The Codex release reads `ev.type`, `ev.willRetry` and `ev.status`, and every test of that branch supplied those fields itself, so the tests agreed with the scheduler about names neither owns. Proven before fixing: renaming the retry flag in the client left all eighteen tests green while the scheduler treated every error as terminal and released routines mid-turn.

The events now come from the client. A client that was never started refuses its first request, and that refusal runs the same construction the live paths run, yielding a real error event and a real terminal event with no process spawned. The retryable error comes from the streaming path, a third construction site and the only one that ever sets the flag true, driven through the client's own notification handler with a wire notification built by the fixture the stub and the client's own tests share. Pinning only the first two sites left the third's rename green, which is the site the retryable branch exists for.

**The class sweep**, which was the point of the round. Ten places in this diff where a test could have decided what reality looks like. Three were real and are fixed; seven were judged safe, four of them by mutation rather than by reading.

| # | Shape | Verdict |
| --- | --- | --- |
| 1 | Codex `{type:'error', willRetry}` | **Fixed** — taken from the client; rename reds |
| 2 | Codex `{type:'done', status}` | **Fixed** — same; not in the finding, found by the sweep |
| 3 | Codex retryable error | **Fixed** — third site, via the shared wire fixture |
| 4 | `startThread` returning `{threadId}` | Safe — pinned by the client's own tests; rename reds 5 there |
| 5 | Claude child `error`/`close` + exit code | Safe — the test drives production's listeners; renaming `close` to `exit` reds 2 |
| 6 | `routineState` status literals | Safe — production's own, asserted not supplied |
| 7 | Routine key format | Safe — a format change makes every state lookup miss |
| 8 | Log line substrings | Safe — proven by the held-line mutation |
| 9 | Fixture frontmatter and schedule grammar | Safe — parsed by production's parser; plus an explicit roster assertion |
| 10 | Stub scenario rules and the `argv` log field | Safe — the stub's shared contract, used suite-wide |

Nine production mutations re-run against the changed tests, every one a named red. `red-first`: PROVEN, 1797/1797 with the change, 8 red without. Coverage: `lib/scheduler.js` 100.0% (425/425), scheduler area 380/380, all 50 floors hold.

## Scope

Cross-process locking is deliberately not here. Two copies of Rundock over one workspace tick independently over one state file, which needs a lock on disk with its own failure modes, including a stale lock outliving a crash. Missed-run detection, drift and a persistent next run are the next change, which this one unblocks. Cancelling a run in flight belongs with the change that owns run states.