### PR TITLE
Leave a record when a scheduled slot passes with nobody watching

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -417,6 +417,14 @@ function parseSchedule(schedule) {
 // Takes the time rather than reading it, so it adds no clock read to a tick
 // that is pinned to exactly one, and so the answer is a pure function of the
 // schedule and the instant asked about.
+//
+// THE COPY ON THE FIRST LINE IS LOAD-BEARING, and it is the only thing keeping
+// this off the double-fire guard. The tick reads the clock once and hands the
+// SAME Date to this and, two lines later, to the `now >= nextRun` comparison
+// that decides whether a routine fires. setHours mutates in place, so calling
+// it on the argument would move the tick's own instant to the routine's
+// scheduled time and every routine after it would be judged against a clock
+// this one had reset. Copy first, mutate the copy.
 function slotFor(parsed, now) {
   const target = new Date(now);
   target.setHours(parsed.hour, parsed.minute, 0, 0);

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -65,6 +65,18 @@ function loadRoutineState() {
   // The runs being dropped here belong to the workspace being left, and so do
   // the announcements. This is the workspace-switch path.
   announcedRefusals.clear();
+  // Slot records sit on THIS side of the line, with the run state rather than
+  // with the in-flight set. Two reasons, and the second is the stronger. Keys
+  // are workspace-local and collide freely, so carrying one workspace's gaps
+  // into another files them under a routine that never had them. And while
+  // the other workspace was open nobody was watching this one, which is
+  // exactly the condition a gap record describes, so its last observation
+  // belongs to the workspace and travels with it.
+  //
+  // Called from here rather than beside each of loadRoutineState's three call
+  // sites: one place to remember is one place to forget, and the two stores
+  // have the same lifetime for the same reason.
+  loadRoutineSlots();
   try {
     const file = path.join(rundockDir(), 'routine-state.json');
     const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
@@ -83,6 +95,126 @@ function saveRoutineState() {
   const dir = rundockDir();
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'routine-state.json'), JSON.stringify(routineState, null, 2));
+}
+
+// ===== SLOTS THAT PASSED UNSERVED =====
+// A record that a scheduled slot went by while nobody was watching. NOT a run
+// state: no run happened, so it does not belong in a vocabulary beside
+// 'failed', and it must not sit in routineState either.
+//
+// WHY IT CANNOT LIVE IN routineState. That object is simultaneously the
+// display record and the ONLY input to double-fire suppression, read as
+// getNextRun(schedule, routineState[key]?.lastRun). Writing a gap into it
+// stamps lastRun with the moment the gap was noticed, the daily suppression
+// fires on that instant, and the routine loses the catch-up run it was still
+// owed today. Not-silently-skipped and not-double-run are the same field
+// there, and no naming decision fixes that. So the records live here, in
+// their own object and their own file, and nothing in this block is ever
+// read by the suppression.
+//
+// WHAT MAKES DETECTION POSSIBLE. Two things this file never used to keep:
+// `due`, the instant each routine is next scheduled for, which used to be a
+// local recomputed every tick and thrown away; and `observedAt`, the last
+// instant the scheduler was awake and looking. A slot is missed when it lies
+// between the last observation and now, and its own period has closed. That
+// is a comparison of two persisted instants, not an inference from how late
+// an interval arrived: there is no monotonic clock here, the tick is unrefed
+// and measurably jittery, and lateness cannot tell a sleeping machine from a
+// starved event loop.
+//
+// THE PERIOD IS UNCHANGED. A slot still catches up within its own calendar
+// day (its own weekday, for a weekly routine), or it is recorded and never
+// run. Five closed days leave five records and zero catch-up runs.
+//
+// Exported by identity and mutated in place, like routineState, so every
+// holder sees the same live object.
+const routineSlots = { observedAt: null, routines: {} }; // { key: { due, missed: [{ slot }] } }
+
+// How far back one wake will walk. A month closed is thirty steps; this is
+// for a `due` absurdly far in the past, which a restored backup or a clock
+// set years wrong can produce and where enumerating every day since would be
+// neither quick nor useful. It is a guard, not a retention policy: what is
+// recorded is kept.
+const MAX_SLOTS_PER_WAKE = 500;
+
+let slotWriteFailed = false;
+
+function loadRoutineSlots() {
+  routineSlots.observedAt = null;
+  for (const key of Object.keys(routineSlots.routines)) delete routineSlots.routines[key];
+  try {
+    const file = path.join(rundockDir(), 'routine-slots.json');
+    const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    if (typeof saved.observedAt === 'string') routineSlots.observedAt = saved.observedAt;
+    for (const [key, entry] of Object.entries(saved.routines || {})) {
+      // A key with no due instant has nothing to walk from, so it would
+      // report every slot since the epoch. Dropped, like a run state with no
+      // lastRun.
+      if (!entry || typeof entry.due !== 'string') continue;
+      const missed = Array.isArray(entry.missed) ? entry.missed.filter(m => m && typeof m.slot === 'string') : [];
+      routineSlots.routines[key] = { due: entry.due, missed };
+    }
+  } catch (e) { /* missing or unreadable file: start empty */ }
+}
+
+function saveRoutineSlots() {
+  const dir = rundockDir();
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'routine-slots.json'), JSON.stringify(routineSlots, null, 2));
+}
+
+// Written on every tick, because a stale observed time is worse than none: it
+// would report as missed the very slots the scheduler watched and served.
+// Said once per outage rather than once a minute, since the tick meets an
+// unwritable .rundock sixty times an hour and a routine's own failures are
+// what a log line should be for.
+function persistRoutineSlots() {
+  try {
+    saveRoutineSlots();
+    slotWriteFailed = false;
+  } catch (e) {
+    if (!slotWriteFailed) {
+      slotWriteFailed = true;
+      console.error('[Scheduler] Failed to persist routine slots:', e && e.message ? e.message : e);
+    }
+  }
+}
+
+/**
+ * Record the scheduled slots that passed for `key` while nobody was watching,
+ * and leave `due` pointing at the instant it is next due.
+ *
+ * `observedBefore` is the last observation from BEFORE this tick, so a slot
+ * later than it is one no tick ever saw. A slot still inside the period `now`
+ * falls in is not recorded: it is still catchable, and the tick that follows
+ * this one is what catches it up.
+ */
+function recordPassedSlots(key, parsed, observedBefore, now) {
+  const current = slotFor(parsed, now);
+  const entry = routineSlots.routines[key];
+  if (!entry) {
+    // First sight. There is no observation to be absent from, so this routine
+    // has no history and inventing one would report every slot since whenever
+    // its schedule string was written. A routine added while the machine slept
+    // lands here, and so does one RENAMED while it slept, because a rename is
+    // a new key. Neither wakes up already late.
+    routineSlots.routines[key] = { due: current.toISOString(), missed: [] };
+    return;
+  }
+  if (observedBefore) {
+    let slot = new Date(entry.due);
+    let steps = 0;
+    while (slot <= now && slot.toDateString() !== now.toDateString()) {
+      if (++steps > MAX_SLOTS_PER_WAKE) {
+        console.warn(`[Scheduler] ${key}: due instant ${entry.due} is too far behind to enumerate; resyncing`);
+        break;
+      }
+      if (slot > observedBefore) entry.missed.push({ slot: slot.toISOString() });
+      slot = new Date(slot);
+      slot.setDate(slot.getDate() + (parsed.kind === 'weekly' ? 7 : 1));
+    }
+  }
+  entry.due = current.toISOString();
 }
 
 function recordRoutineRun(key, state) {
@@ -177,6 +309,10 @@ function startScheduler() {
     const agents = discoverAgents();
     const now = deps.now();
 
+    // The last observation, read BEFORE this tick overwrites it: a slot later
+    // than this is one no tick has ever seen.
+    const observedBefore = routineSlots.observedAt ? new Date(routineSlots.observedAt) : null;
+
     const onRoster = new Set();
 
     for (const agent of agents) {
@@ -186,6 +322,11 @@ function startScheduler() {
         onRoster.add(key);
         const refusedBy = routineRefusal(routine);
         if (!refusedBy) announcedRefusals.delete(key);
+        // Before due-ness is decided, and deliberately reading NOTHING that
+        // due-ness depends on. A slot that has already gone is not a question
+        // about whether this routine may fire now.
+        const parsed = parseSchedule(routine.schedule);
+        if (parsed) recordPassedSlots(key, parsed, observedBefore, now);
         const nextRun = getNextRun(routine.schedule, routineState[key]?.lastRun);
         if (nextRun && now >= nextRun) {
           // Refusal is checked AFTER due-ness so that a routine which is
@@ -218,6 +359,13 @@ function startScheduler() {
     for (const key of announcedRefusals.keys()) {
       if (!onRoster.has(key)) announcedRefusals.delete(key);
     }
+    // Slot records are NOT pruned the same way, and the difference is the
+    // point. An announcement is a silence, so one outliving what it described
+    // hands that silence to the next routine written under the name. A gap
+    // record is history, and the run state beside it keeps dead keys for the
+    // same reason: a routine renamed and renamed back still happened.
+    routineSlots.observedAt = now.toISOString();
+    persistRoutineSlots();
   }, checkInterval);
   tickTimer.unref(); // see heartbeat unref note: listener keeps process alive in production
 }
@@ -445,5 +593,6 @@ function broadcastRoutineUpdate() {
 module.exports = {
   wireSchedulerDeps,
   routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
+  routineSlots, loadRoutineSlots, saveRoutineSlots,
   startScheduler, stopScheduler, getNextRun, executeRoutine,
 };

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -126,9 +126,17 @@ function saveRoutineState() {
 // day (its own weekday, for a weekly routine), or it is recorded and never
 // run. Five closed days leave five records and zero catch-up runs.
 //
+// REFUSED ROUTINES ACCRUE RECORDS TOO, and that is a decision rather than an
+// oversight. A slot passed and nothing served it, which is what a record says,
+// so a paused routine is not exempted here. Whether a paused routine should
+// SHOW gaps is a different question, it belongs to the routines view, and it
+// is carded there: this file stores what happened and that card rules on what
+// it means. Pinned by a test, so ruling the other way is a visible change
+// rather than an accidental one.
+//
 // Exported by identity and mutated in place, like routineState, so every
 // holder sees the same live object.
-const routineSlots = { observedAt: null, routines: {} }; // { key: { due, missed: [{ slot }] } }
+const routineSlots = { observedAt: null, routines: {} }; // { key: { due, schedule, missed: [{ slot }] } }
 
 // How far back one wake will walk. A month closed is thirty steps; this is
 // for a `due` absurdly far in the past, which a restored backup or a clock
@@ -157,7 +165,11 @@ function loadRoutineSlots() {
       // lastRun.
       if (!entry || typeof entry.due !== 'string') continue;
       const missed = Array.isArray(entry.missed) ? entry.missed.filter(m => m && typeof m.slot === 'string') : [];
-      routineSlots.routines[key] = { due: entry.due, missed };
+      // A file written before the anchor carried its schedule has no shape to
+      // compare, and null matches none, so the first wake resyncs and records
+      // nothing rather than walking under a schedule it cannot vouch for.
+      const shape = typeof entry.schedule === 'string' ? entry.schedule : null;
+      routineSlots.routines[key] = { due: entry.due, schedule: shape, missed };
     }
   } catch (e) { /* missing or unreadable file: start empty */ }
 }
@@ -196,6 +208,7 @@ function persistRoutineSlots() {
  */
 function recordPassedSlots(key, parsed, observedBefore, now) {
   const current = slotFor(parsed, now);
+  const shape = scheduleShape(parsed);
   const entry = routineSlots.routines[key];
   if (!entry) {
     // First sight. There is no observation to be absent from, so this routine
@@ -203,20 +216,38 @@ function recordPassedSlots(key, parsed, observedBefore, now) {
     // its schedule string was written. A routine added while the machine slept
     // lands here, and so does one RENAMED while it slept, because a rename is
     // a new key. Neither wakes up already late.
-    routineSlots.routines[key] = { due: current.toISOString(), missed: [] };
+    routineSlots.routines[key] = { due: current.toISOString(), schedule: shape, missed: [] };
+    return;
+  }
+  // A routine edited while the machine was closed. The anchor was computed
+  // under the old schedule and the walk would step using the new one, so every
+  // slot it named would be an hour, or a weekday, the routine was never due
+  // at. There is no honest way to reconstruct what was owed under a schedule
+  // that no longer exists, so the anchor resyncs and this wake records
+  // nothing, which is what a routine the scheduler cannot vouch for is owed.
+  //
+  // History already written is KEPT. Those slots did pass, under the schedule
+  // in force when they did, and a later edit is not a reason to lose them.
+  if (entry.schedule !== shape) {
+    entry.schedule = shape;
+    entry.due = current.toISOString();
     return;
   }
   if (observedBefore) {
+    // WHICH END OF THE WALK THE BOUND CUTS. Walking forward from the anchor
+    // and stopping at a cap keeps the OLDEST slots, so a `due` left years
+    // behind by a restored backup or a wrong clock would fill the file with
+    // slots from years ago and none from the week before the wake, which is
+    // the only part anyone would look at. So the bound moves the START.
     let slot = new Date(entry.due);
-    let steps = 0;
+    const earliest = stepSlots(parsed, current, -MAX_SLOTS_PER_WAKE);
+    if (slot < earliest) {
+      console.warn(`[Scheduler] ${key}: due instant ${entry.due} is too far behind to enumerate; keeping the most recent`);
+      slot = earliest;
+    }
     while (slot <= now && slot.toDateString() !== now.toDateString()) {
-      if (++steps > MAX_SLOTS_PER_WAKE) {
-        console.warn(`[Scheduler] ${key}: due instant ${entry.due} is too far behind to enumerate; resyncing`);
-        break;
-      }
       if (slot > observedBefore) entry.missed.push({ slot: slot.toISOString() });
-      slot = new Date(slot);
-      slot.setDate(slot.getDate() + (parsed.kind === 'weekly' ? 7 : 1));
+      slot = stepSlots(parsed, slot, 1);
     }
   }
   entry.due = current.toISOString();
@@ -430,6 +461,25 @@ function slotFor(parsed, now) {
   target.setHours(parsed.hour, parsed.minute, 0, 0);
   if (parsed.kind === 'weekly') target.setDate(target.getDate() + ((parsed.day - now.getDay() + 7) % 7));
   return target;
+}
+
+// `periods` slots away from `slot`, forwards or backwards. Steps a CALENDAR
+// day (or week) rather than twenty-four hours, because a schedule is a
+// wall-clock time: on the day the clocks change, 23:00 is still 23:00.
+function stepSlots(parsed, slot, periods) {
+  const next = new Date(slot);
+  next.setDate(next.getDate() + periods * (parsed.kind === 'weekly' ? 7 : 1));
+  return next;
+}
+
+// The schedule fields the walk actually depends on, in a form that can be
+// stored beside the anchor and compared on the next wake. Derived from the
+// parse rather than from the raw string, so case and spacing do not read as
+// an edit.
+function scheduleShape(parsed) {
+  return parsed.kind === 'weekly'
+    ? `weekly:${parsed.day}:${parsed.hour}:${parsed.minute}`
+    : `daily:${parsed.hour}:${parsed.minute}`;
 }
 
 function getNextRun(schedule, lastRunISO) {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -231,54 +231,78 @@ function stopScheduler() {
   tickTimer = null;
 }
 
+const WEEKDAYS = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
+
+// The schedule grammar, read once and shared by the two questions asked of it.
+// getNextRun asks "may this routine fire", which needs the run guard; the slot
+// arithmetic asks "when was this routine due", which must not have it. Both
+// need the same two patterns, and a second copy of the regexes would be a
+// second copy to forget.
+//
+// Everything else returns null, which is what makes an unrecognised schedule
+// silently never fire. That is documented as a pitfall rather than fixed here.
+function parseSchedule(schedule) {
+  if (!schedule) return null;
+  const s = schedule.toLowerCase();
+  // Daily is matched FIRST, and the order carries weight: "every day at 05:00"
+  // also satisfies the weekly pattern's \w+, with "day" as the weekday.
+  const dailyMatch = s.match(/every day at (\d{2}):(\d{2})/);
+  if (dailyMatch) return { kind: 'daily', hour: parseInt(dailyMatch[1]), minute: parseInt(dailyMatch[2]) };
+  const weeklyMatch = s.match(/every (\w+) at (\d{2}):(\d{2})/);
+  if (weeklyMatch) {
+    const day = WEEKDAYS[weeklyMatch[1]];
+    if (day === undefined) return null;
+    return { kind: 'weekly', day, hour: parseInt(weeklyMatch[2]), minute: parseInt(weeklyMatch[3]) };
+  }
+  return null;
+}
+
+// The instant this routine is due in the period `now` falls in: today for a
+// daily routine, and this week's weekday for a weekly one (which is today when
+// today IS that weekday, and a date in the future otherwise).
+//
+// Takes the time rather than reading it, so it adds no clock read to a tick
+// that is pinned to exactly one, and so the answer is a pure function of the
+// schedule and the instant asked about.
+function slotFor(parsed, now) {
+  const target = new Date(now);
+  target.setHours(parsed.hour, parsed.minute, 0, 0);
+  if (parsed.kind === 'weekly') target.setDate(target.getDate() + ((parsed.day - now.getDay() + 7) % 7));
+  return target;
+}
+
 function getNextRun(schedule, lastRunISO) {
   if (!schedule) return null;
   const now = deps.now();
-  const s = schedule.toLowerCase();
+  const parsed = parseSchedule(schedule);
+  if (!parsed) return null;
 
-  // Parse "every day at HH:MM"
-  const dailyMatch = s.match(/every day at (\d{2}):(\d{2})/);
-  if (dailyMatch) {
+  if (parsed.kind === 'daily') {
     // Don't re-run if already ran today. This suppression (fed by the
     // persisted routine state) is the ONLY thing standing between a due
     // routine and a duplicate fire, which is why it is checked first.
     if (lastRunISO) {
       const lastRun = new Date(lastRunISO);
-      if (lastRun.toDateString() === now.toDateString() && lastRun.getHours() >= parseInt(dailyMatch[1])) return null;
+      if (lastRun.toDateString() === now.toDateString() && lastRun.getHours() >= parsed.hour) return null;
     }
-    const target = new Date(now);
-    target.setHours(parseInt(dailyMatch[1]), parseInt(dailyMatch[2]), 0, 0);
     // A target already past today stays TODAY: the scheduler's `now >= nextRun`
     // check fires it on the next tick (same-day catch-up). The previous code
     // rolled it to tomorrow, which meant the fire condition was only
     // satisfiable in the single millisecond HH:MM:00.000 - routines whose
     // tick did not land exactly on that instant never fired at all.
-    return target;
+    return slotFor(parsed, now);
   }
 
-  // Parse "every [weekday] at HH:MM"
-  const weeklyMatch = s.match(/every (\w+) at (\d{2}):(\d{2})/);
-  if (weeklyMatch) {
-    const days = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
-    const targetDay = days[weeklyMatch[1]];
-    if (targetDay === undefined) return null;
-    // Suppression first, same reasoning as the daily branch.
-    if (lastRunISO) {
-      const lastRun = new Date(lastRunISO);
-      const daysSinceLastRun = (now - lastRun) / (1000 * 60 * 60 * 24);
-      if (daysSinceLastRun < 1 && lastRun.getDay() === targetDay) return null;
-    }
-    const target = new Date(now);
-    target.setHours(parseInt(weeklyMatch[2]), parseInt(weeklyMatch[3]), 0, 0);
-    const daysUntil = (targetDay - now.getDay() + 7) % 7;
-    target.setDate(target.getDate() + daysUntil);
-    // On the target weekday a past-due target stays TODAY so the scheduler
-    // fires it (same-day catch-up); the suppression above prevents re-fires.
-    // See the daily branch for why the old roll-forward meant never firing.
-    return target;
+  // Suppression first, same reasoning as the daily branch.
+  if (lastRunISO) {
+    const lastRun = new Date(lastRunISO);
+    const daysSinceLastRun = (now - lastRun) / (1000 * 60 * 60 * 24);
+    if (daysSinceLastRun < 1 && lastRun.getDay() === parsed.day) return null;
   }
-
-  return null;
+  // On the target weekday a past-due target stays TODAY so the scheduler
+  // fires it (same-day catch-up); the suppression above prevents re-fires.
+  // See the daily branch for why the old roll-forward meant never firing.
+  return slotFor(parsed, now);
 }
 
 /**

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -142,6 +142,11 @@ let slotWriteFailed = false;
 function loadRoutineSlots() {
   routineSlots.observedAt = null;
   for (const key of Object.keys(routineSlots.routines)) delete routineSlots.routines[key];
+  // The write complaint is throttled per outage, and an outage belongs to the
+  // workspace it happened in. Carrying the flag across would let the first
+  // unwritable workspace silence every one after it for the life of the
+  // process, which is the opposite of saying something once.
+  slotWriteFailed = false;
   try {
     const file = path.join(rundockDir(), 'routine-slots.json');
     const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -126,13 +126,20 @@ function saveRoutineState() {
 // day (its own weekday, for a weekly routine), or it is recorded and never
 // run. Five closed days leave five records and zero catch-up runs.
 //
-// REFUSED ROUTINES ACCRUE RECORDS TOO, and that is a decision rather than an
-// oversight. A slot passed and nothing served it, which is what a record says,
-// so a paused routine is not exempted here. Whether a paused routine should
-// SHOW gaps is a different question, it belongs to the routines view, and it
-// is carded there: this file stores what happened and that card rules on what
-// it means. Pinned by a test, so ruling the other way is a visible change
-// rather than an accidental one.
+// WHAT A RECORD IS, EXACTLY, because the near-miss is the useful part. A
+// record is a slot whose whole period went by with the scheduler not watching.
+// A slot that passed while the scheduler was AWAKE and was not served leaves
+// nothing, even once its period closes: the machine was on and said so at the
+// time, in the refusal log and in the routine's own state, and the gap this
+// card exists to close is the one with no trace at all. Deciding otherwise
+// would also mean asking whether the routine ran in that period, which is the
+// suppression's question and the one thing this block must not read.
+//
+// So refused routines DO accrue records, but only for periods that passed
+// entirely unobserved: a paused routine on a machine that stays on accrues
+// nothing. That is a decision rather than an oversight, and both sides of the
+// boundary are pinned by one test. Whether a paused routine should SHOW its
+// gaps is the routines view's ruling and is carded there.
 //
 // Exported by identity and mutated in place, like routineState, so every
 // holder sees the same live object.
@@ -165,9 +172,12 @@ function loadRoutineSlots() {
       // lastRun.
       if (!entry || typeof entry.due !== 'string') continue;
       const missed = Array.isArray(entry.missed) ? entry.missed.filter(m => m && typeof m.slot === 'string') : [];
-      // A file written before the anchor carried its schedule has no shape to
-      // compare, and null matches none, so the first wake resyncs and records
-      // nothing rather than walking under a schedule it cannot vouch for.
+      // An anchor whose schedule is missing or not a string cannot be checked
+      // against anything, and null matches no shape, so the first wake resyncs
+      // and records nothing rather than walking under a schedule it cannot
+      // vouch for. Same guard as the due instant above, on the other field the
+      // walk depends on, and reachable the same way: a hand edit, a truncated
+      // write, a file from a build that stored less.
       const shape = typeof entry.schedule === 'string' ? entry.schedule : null;
       routineSlots.routines[key] = { due: entry.due, schedule: shape, missed };
     }
@@ -350,6 +360,10 @@ function startScheduler() {
     const observedBefore = routineSlots.observedAt ? new Date(routineSlots.observedAt) : null;
 
     const onRoster = new Set();
+    // Keys whose anchor this pass could vouch for. Narrower than onRoster on
+    // purpose: a routine whose schedule no longer parses is still declared and
+    // still refusable, but nothing can say when it was next due.
+    const anchored = new Set();
 
     for (const agent of agents) {
       if (!agent.routines) continue;
@@ -362,7 +376,10 @@ function startScheduler() {
         // due-ness depends on. A slot that has already gone is not a question
         // about whether this routine may fire now.
         const parsed = parseSchedule(routine.schedule);
-        if (parsed) recordPassedSlots(key, parsed, observedBefore, now);
+        if (parsed) {
+          recordPassedSlots(key, parsed, observedBefore, now);
+          anchored.add(key);
+        }
         const nextRun = getNextRun(routine.schedule, routineState[key]?.lastRun);
         if (nextRun && now >= nextRun) {
           // Refusal is checked AFTER due-ness so that a routine which is
@@ -400,6 +417,16 @@ function startScheduler() {
     // hands that silence to the next routine written under the name. A gap
     // record is history, and the run state beside it keeps dead keys for the
     // same reason: a routine renamed and renamed back still happened.
+    //
+    // The ANCHOR does not survive, though, and that is the other half. A slot
+    // cannot pass for a routine that does not exist, so the days after a
+    // routine is deleted are days on which nothing was due; walking from the
+    // old anchor when it returns would record every one of them. Marking the
+    // anchor unknown is the same answer a changed schedule gets, deliberately
+    // in the same shape: keep the history, resync on the first tick back.
+    for (const [key, entry] of Object.entries(routineSlots.routines)) {
+      if (!anchored.has(key)) entry.schedule = null;
+    }
     routineSlots.observedAt = now.toISOString();
     persistRoutineSlots();
   }, checkInterval);

--- a/server.js
+++ b/server.js
@@ -450,6 +450,7 @@ function discoverWorkspaces() {
 const schedulerLib = require('./lib/scheduler.js');
 const {
   routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
+  routineSlots, loadRoutineSlots, saveRoutineSlots,
   startScheduler, stopScheduler, getNextRun, executeRoutine,
 } = schedulerLib;
 // Hand lib/agents its root-owned dependencies (see the module headers).
@@ -3057,6 +3058,7 @@ module.exports._internal = {
   // scheduler
   getNextRun, executeRoutine, routineState, startScheduler, stopScheduler,
   loadRoutineState, saveRoutineState, recordRoutineRun,
+  routineSlots, loadRoutineSlots, saveRoutineSlots,
   // agent + skill discovery / parsing
   discoverAgents, invalidateAgentCache, discoverSkills, parseSkillFile,
   parseAgentFrontmatter, extractFrontmatterText, parseCapabilities,

--- a/test/integration/scheduler-missed-slots.test.js
+++ b/test/integration/scheduler-missed-slots.test.js
@@ -1,0 +1,194 @@
+'use strict';
+// A slot that passed while nobody was watching leaves a record.
+//
+// The whole point of the card is the SEPARATION: a record that a slot passed
+// must not land in the one field double-fire suppression reads, because that
+// field is what decides whether the routine may still run. So every test here
+// asserts both halves. "A record appeared" on its own is satisfied by code
+// that records a gap and breaks the guard; "it still ran" on its own is
+// satisfied by code that records nothing at all.
+//
+// Setup is the scheduler-clock template: stop the boot-armed tick FIRST, then
+// mock setInterval, then start, so the interval being driven is the mocked one.
+// The clock is the scheduler's own seam, so six days pass in one 60-second
+// interval and nothing here rests on how late a tick arrived.
+//
+// One agent, one routine, and each test resets the timeline and re-establishes
+// it with a REAL run rather than a hand-written state literal. What a run
+// leaves behind is production's shape, not the test's guess at it.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
+
+const scheduler = require('../../lib/scheduler.js');
+
+const AGENT = 'sleeper';
+const KEY = 'sleeper:briefing';
+const BODY = 'briefing routine body';
+
+// August 2026, local components, so the fixture is timezone-independent.
+const at = (day, hour, minute = 0) => new Date(2026, 7, day, hour, minute, 0);
+const slot = (day) => at(day, 5).toISOString();
+
+before(async () => {
+  await h.boot({
+    agents: {
+      sleeper: agentFile({
+        name: 'sleeper', type: 'specialist', order: 1,
+        routines: [{ name: 'briefing', schedule: 'every day at 05:00', prompt: BODY }],
+      }),
+    },
+  });
+  h.writeScenario([
+    { match: { agent: AGENT, promptIncludes: BODY }, turn: [{ text: 'routine ran' }] },
+  ]);
+});
+after(h.shutdown);
+
+// Everything the scheduler remembers about this routine, dropped so each test
+// starts from a machine that has never seen it. Deliberately NOT a fresh
+// module: these are the live objects production mutates.
+function resetTimeline() {
+  h.internal.stopScheduler();
+  delete h.internal.routineState[KEY];
+  h.internal.routineSlots.observedAt = null;
+  for (const k of Object.keys(h.internal.routineSlots.routines)) delete h.internal.routineSlots.routines[k];
+  h.clearPrompts();
+}
+
+function slots() { return h.internal.routineSlots.routines[KEY]; }
+function missedSlots() { return (slots() ? slots().missed : []).map(m => m.slot); }
+function runCount() { return h.promptsFor(AGENT).filter(p => p.includes(BODY)).length; }
+
+/** Tick once, and wait for any run it started to reach an outcome. */
+async function settle(t) {
+  t.mock.timers.tick(60_000);
+  await h.waitUntil(() => {
+    const s = h.internal.routineState[KEY];
+    return !s || s.status !== 'running';
+  });
+}
+
+test('five days closed leave five records naming the five slots, and start no runs', async (t) => {
+  const clock = { at: at(15, 5, 30) };
+  const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+  resetTimeline();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  try {
+    h.internal.startScheduler();
+
+    // Saturday the 15th: the routine is seen for the first time and runs. This
+    // is what makes the machine "closed for five days" rather than "never
+    // opened": there is an observation to be absent from.
+    await settle(t);
+    assert.strictEqual(runCount(), 1, 'the routine ran on the day the machine was open');
+    assert.deepStrictEqual(missedSlots(), [],
+      'a routine seen for the first time has no history, so no slot is reported missed');
+    assert.strictEqual(slots().due, slot(15), "the day's scheduled instant is persisted, not discarded");
+    const guardBefore = { ...h.internal.routineState[KEY] };
+
+    // Six days later, in ONE punctual 60-second interval. The interval was not
+    // late by a second; the clock moved. Detection that rested on how late a
+    // tick arrived would have nothing to work with here.
+    clock.at = at(21, 3, 0);
+    await settle(t);
+
+    assert.deepStrictEqual(missedSlots(), [slot(16), slot(17), slot(18), slot(19), slot(20)],
+      'five closed days left five records, each naming the instant that passed');
+    assert.deepStrictEqual(Object.keys(slots().missed[0]), ['slot'],
+      'the record carries the scheduled instant and nothing else: no duration, no status, no claim a run happened');
+    assert.strictEqual(runCount(), 1,
+      'and five closed days produced zero catch-up runs: never five runs in one day');
+    assert.deepStrictEqual(h.internal.routineState[KEY], guardBefore,
+      'recording the gaps did not touch the field double-fire suppression reads');
+    assert.strictEqual(slots().due, slot(21), 'the next due instant moved to today');
+
+    // The routine is not broken by carrying records: at its own time, it runs.
+    // Without this the assertions above are satisfied by a scheduler that
+    // would never fire this routine again.
+    clock.at = at(21, 5, 0);
+    await settle(t);
+    assert.strictEqual(runCount(), 2, 'at 05:00 on the sixth day it ran, once');
+    assert.strictEqual(missedSlots().length, 5, 'and running did not disturb the records');
+  } finally {
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+    scheduler.wireSchedulerDeps(prevDeps);
+  }
+});
+
+test('a routine carrying records still catches up within its own day, and is then suppressed', async (t) => {
+  const clock = { at: at(15, 5, 30) };
+  const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+  resetTimeline();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  try {
+    h.internal.startScheduler();
+    await settle(t);
+    assert.strictEqual(runCount(), 1, 'the routine ran on the day the machine was open');
+
+    // Woken on the sixth day AFTER 05:00. Five slots are gone for good and
+    // today's has passed but is still inside its own day, so it catches up.
+    //
+    // THIS IS THE CARD. Write the gap into routineState[KEY] and the daily
+    // suppression fires on the instant it was noticed, and the catch-up run
+    // below never happens.
+    clock.at = at(21, 9, 0);
+    await settle(t);
+
+    assert.deepStrictEqual(missedSlots(), [slot(16), slot(17), slot(18), slot(19), slot(20)],
+      'the five closed days were recorded');
+    assert.strictEqual(runCount(), 2,
+      "today's slot was caught up despite the records, so the guard was not corrupted");
+    assert.strictEqual(h.internal.routineState[KEY].lastRun, at(21, 9).toISOString(),
+      'the run stamped the field the guard reads, and the gaps did not');
+    assert.strictEqual(h.internal.routineState[KEY].status, 'completed',
+      'a real run, not a record dressed as one');
+
+    // And the guard still guards: the same day, past the same hour, no second
+    // run. A catch-up window without suppression is a double-fire.
+    clock.at = at(21, 9, 30);
+    await settle(t);
+    assert.strictEqual(runCount(), 2, 'having run today, it did not run again');
+    assert.strictEqual(missedSlots().length, 5, 'and no slot was invented for the day it ran');
+  } finally {
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+    scheduler.wireSchedulerDeps(prevDeps);
+  }
+});
+
+test('a tick eleven hours late records nothing, because no scheduled slot passed', async (t) => {
+  const clock = { at: at(15, 5, 30) };
+  const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+  resetTimeline();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  try {
+    h.internal.startScheduler();
+    await settle(t);
+    assert.strictEqual(runCount(), 1, 'the routine ran at 05:30');
+
+    // Eleven and a quarter hours pass between two ticks: a sleeping machine, a
+    // starved event loop, a suspended laptop. Nothing can tell them apart, and
+    // nothing here needs to, because no 05:00 slot lies between 05:30 and 23:45.
+    clock.at = at(15, 23, 45);
+    await settle(t);
+    assert.deepStrictEqual(missedSlots(), [],
+      'a very late tick that crossed no scheduled instant left no record');
+    assert.strictEqual(runCount(), 1, 'and started no run');
+
+    // The positive control, on the same routine through the same code: move
+    // past a slot instead of merely arriving late, and the record appears. An
+    // "it recorded nothing" assertion is otherwise satisfied by a tick that
+    // records nothing ever.
+    clock.at = at(17, 6, 0);
+    await settle(t);
+    assert.deepStrictEqual(missedSlots(), [slot(16)],
+      'crossing an unwatched 05:00 is what writes a record, not the size of the gap');
+  } finally {
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+    scheduler.wireSchedulerDeps(prevDeps);
+  }
+});

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -967,6 +967,14 @@ test('a due instant years behind is bounded rather than enumerated, and resyncs'
     assert.ok(missed.length > 0, 'the slots it did walk were recorded');
     assert.ok(missed.length < daysSince, `the walk stopped short of every day since (${missed.length})`);
     assert.ok(warnings.some(w => w.includes(LATE_KEY)), 'and said which routine it gave up on');
+    // WHICH END IT KEPT. Walking forward from the ancient anchor and stopping
+    // at a cap keeps the oldest slots and drops the recent ones, which is the
+    // wrong half: nobody opening a laptop wants 2023 and nothing about last
+    // week. The bound is applied to where the walk STARTS.
+    assert.strictEqual(missed[missed.length - 1].slot, new Date(2026, 7, 14, 23, 0, 0).toISOString(),
+      'the last record is last night, the slot immediately before today');
+    assert.ok(new Date(missed[0].slot) > new Date(2024, 0, 1),
+      `the walk did not spend its budget on 2023 (first record ${missed[0].slot})`);
     assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 15, 23, 0, 0).toISOString(),
       'the due instant resynced to today');
 
@@ -1117,4 +1125,138 @@ test('a second unwritable workspace is announced too, rather than silenced by th
     fs.rmSync(wsA, { recursive: true, force: true });
     fs.rmSync(wsB, { recursive: true, force: true });
   }
+});
+
+// THE CLOSED LAPTOP, END TO END, through the boot path rather than around it.
+//
+// Every other test here walks from state the same scheduler instance put in
+// memory a moment earlier, so the load path is exercised and the walk is
+// exercised and nothing joins them. That is the double sweep's finding one
+// level up: the record survives the file, and nothing proved the walk can
+// start from what the loader admitted. A second scheduler module IS the
+// second process: its own empty state, filled only by loadRoutineState.
+test('a second process loads the file and walks from what it read, which is the closed laptop', (t) => {
+  withTempWorkspace((ws) => {
+    const before = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, before, new Date(2026, 7, 15, 8, 0, 0));
+    assert.deepStrictEqual(before.routineSlots.routines[LATE_KEY].missed, [], 'nothing was owed when the lid closed');
+
+    const after = freshScheduler();
+    assert.strictEqual(after.routineSlots.observedAt, null,
+      'the new process starts knowing nothing, which is what makes the rest of this mean something');
+
+    after.loadRoutineState(); // the boot path, and the workspace-switch path
+    assert.strictEqual(after.routineSlots.observedAt, new Date(2026, 7, 15, 8, 0, 0).toISOString(),
+      'and takes its last observation off disk');
+
+    observeOnce(t, after, new Date(2026, 7, 17, 8, 0, 0));
+    assert.deepStrictEqual(after.routineSlots.routines[LATE_KEY].missed, [
+      { slot: new Date(2026, 7, 15, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 16, 23, 0, 0).toISOString() },
+    ], 'the walk started from the loaded instants and named exactly the nights between them and the tick');
+    assert.strictEqual(after.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 17, 23, 0, 0).toISOString(),
+      'and resynced to tonight');
+  });
+});
+
+// A routine edited while the machine was closed. The walk starts from an
+// instant computed under the OLD schedule and would step using the NEW one,
+// so every record it wrote would name an hour, or a weekday, that was never
+// scheduled. Reachable by editing a routine and closing the lid.
+test('a schedule edited while the machine was closed resyncs instead of recording the old hour', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE); // 23:00
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+
+    writeRoutineAgent(ws, [{ name: 'late', schedule: 'every day at 22:00', prompt: 'p' }]);
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [],
+      'two nights passed, and neither is recorded at an hour the routine was never due at');
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 17, 22, 0, 0).toISOString(),
+      'the anchor moved to the schedule actually in force');
+
+    // And the resync is a pause, not an off switch: under the new schedule the
+    // walk works again, at the new hour.
+    observeOnce(t, sched, new Date(2026, 7, 19, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [
+      { slot: new Date(2026, 7, 17, 22, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 18, 22, 0, 0).toISOString() },
+    ], 'every recorded slot names 22:00, which is when the routine was actually due');
+  });
+});
+
+// A paused routine still accrues records, and that is pinned rather than
+// endorsed: see the block comment in lib/scheduler.js. Whether a paused
+// routine should show gaps is the routines view's ruling to make, and this
+// test is what makes that change deliberate instead of accidental.
+test('a paused routine accrues records too, which is today behaviour and the view card owns it', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, [{ name: 'late', schedule: 'every day at 23:00', prompt: 'p', paused: true }]);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [
+      { slot: new Date(2026, 7, 15, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 16, 23, 0, 0).toISOString() },
+    ], 'being paused did not stop the slots being recorded');
+  });
+});
+
+// The other half of the resync, which the resync test cannot show because it
+// has no history yet when the edit lands. Slots recorded before an edit passed
+// under the schedule that was in force when they did. Editing the routine
+// afterwards is not a reason to lose them, and dropping them would be the
+// quiet way to make an edit erase a week of gaps.
+test('a schedule edit resyncs the anchor without discarding the history already recorded', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE); // 23:00
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+    const earned = [
+      { slot: new Date(2026, 7, 15, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 16, 23, 0, 0).toISOString() },
+    ];
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, earned, 'two nights were already recorded');
+
+    writeRoutineAgent(ws, [{ name: 'late', schedule: 'every day at 22:00', prompt: 'p' }]);
+    observeOnce(t, sched, new Date(2026, 7, 19, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, earned,
+      'the edit added nothing and took nothing away');
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 19, 22, 0, 0).toISOString(),
+      'only the anchor moved');
+  });
+});
+
+// A file written before the anchor carried its schedule, which every workspace
+// already running this scheduler has. There is nothing to compare, so the walk
+// cannot vouch for what the anchor was computed under, and treating an absent
+// shape as a match would walk the old file under whatever schedule is current.
+test('an anchor stored without its schedule resyncs on the first wake rather than being trusted', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+
+    const file = path.join(ws, '.rundock', 'routine-slots.json');
+    const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    assert.ok(saved.routines[LATE_KEY].schedule, 'the anchor normally carries its schedule');
+    delete saved.routines[LATE_KEY].schedule; // the older shape
+    fs.writeFileSync(file, JSON.stringify(saved, null, 2));
+    sched.loadRoutineSlots();
+
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [],
+      'the first wake on an older file records nothing rather than guessing');
+
+    // One wake of silence, not a permanent one.
+    observeOnce(t, sched, new Date(2026, 7, 19, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [
+      { slot: new Date(2026, 7, 17, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 18, 23, 0, 0).toISOString() },
+    ], 'and the wake after it walks normally, from an anchor it can vouch for');
+  });
 });

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -976,3 +976,30 @@ test('a due instant years behind is bounded rather than enumerated, and resyncs'
       'so the next tick walks nothing: giving up once is giving up');
   });
 });
+
+// A routine RENAMED while the machine slept, which is the case that makes
+// both halves of this necessary. The new name is a key the scheduler has
+// never seen, so it has no history and must not be handed one: a rename would
+// otherwise report the whole sleep as gaps the moment the machine woke. And
+// the old name keeps what it earned, because a gap record is history and a
+// rename is not a reason to lose it. The announcement map answers the same
+// question the other way, on purpose: a silence outliving what it described
+// is handed to whatever is written under the name next.
+test('a routine renamed while the machine slept wakes with no history, and the old name keeps its own', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    assert.ok(sched.routineSlots.routines[LATE_KEY], 'the original name was being watched');
+
+    writeRoutineAgent(ws, [{ name: 'renamed', schedule: 'every day at 23:00', prompt: 'p' }]);
+    observeOnce(t, sched, new Date(2026, 7, 21, 8, 0, 0));
+
+    assert.deepStrictEqual(sched.routineSlots.routines['nightly:renamed'].missed, [],
+      'six days of sleep were not billed to a name the scheduler had never seen');
+    assert.strictEqual(sched.routineSlots.routines['nightly:renamed'].due, new Date(2026, 7, 21, 23, 0, 0).toISOString(),
+      'it starts from the slot it is next due, which is what the next wake compares against');
+    assert.ok(sched.routineSlots.routines[LATE_KEY],
+      'and the old name was not swept off with the roster, unlike its announcement');
+  });
+});

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -1187,11 +1187,12 @@ test('a schedule edited while the machine was closed resyncs instead of recordin
   });
 });
 
-// A paused routine still accrues records, and that is pinned rather than
-// endorsed: see the block comment in lib/scheduler.js. Whether a paused
-// routine should show gaps is the routines view's ruling to make, and this
-// test is what makes that change deliberate instead of accidental.
-test('a paused routine accrues records too, which is today behaviour and the view card owns it', (t) => {
+// Being paused does not exempt a routine from records for periods that passed
+// entirely unobserved, which is pinned rather than endorsed: see the block
+// comment in lib/scheduler.js, and the boundary test below for the other side
+// of the line. Whether a paused routine should SHOW gaps is the routines
+// view's ruling, and this is what makes changing it deliberate.
+test('a paused routine accrues records for the days nobody was watching at all', (t) => {
   withTempWorkspace((ws) => {
     const sched = freshScheduler();
     writeRoutineAgent(ws, [{ name: 'late', schedule: 'every day at 23:00', prompt: 'p', paused: true }]);
@@ -1258,5 +1259,87 @@ test('an anchor stored without its schedule resyncs on the first wake rather tha
       { slot: new Date(2026, 7, 17, 23, 0, 0).toISOString() },
       { slot: new Date(2026, 7, 18, 23, 0, 0).toISOString() },
     ], 'and the wake after it walks normally, from an anchor it can vouch for');
+  });
+});
+
+// THE BOUNDARY OF WHAT A RECORD IS, at the exact edge, in one test.
+//
+// A record is a slot whose whole period went by with the scheduler not
+// watching. A slot that passed while the scheduler was AWAKE and was not
+// served leaves nothing, even once its period closes: the machine was on and
+// said so at the time, in the refusal log and in the routine's own state. The
+// gap this card exists to close is the one with no trace at all.
+//
+// Both halves are one test on purpose. Either alone is satisfied by a walk
+// that records everything or nothing.
+test('a slot the scheduler was awake for leaves no record; a day it was closed for leaves one', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, [{ name: 'late', schedule: 'every day at 05:00', prompt: 'p', paused: true }]);
+
+    observeOnce(t, sched, new Date(2026, 7, 15, 4, 0, 0));  // awake before the slot
+    observeOnce(t, sched, new Date(2026, 7, 15, 9, 0, 0));  // reopened after it, paused, nothing served it
+    observeOnce(t, sched, new Date(2026, 7, 15, 23, 0, 0)); // still awake as its day closes
+    observeOnce(t, sched, new Date(2026, 7, 16, 9, 0, 0));  // and into the next
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [],
+      'the 05:00 slot passed unserved while the scheduler watched it happen, so it is not a gap');
+
+    observeOnce(t, sched, new Date(2026, 7, 18, 9, 0, 0));  // closed for all of the 17th
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [
+      { slot: new Date(2026, 7, 17, 5, 0, 0).toISOString() },
+    ], 'a day nobody was watching at all leaves exactly one, and being paused did not exempt it');
+  });
+});
+
+// A routine deleted and re-added under the same name. The days in between are
+// days on which no slot existed to pass, so walking from the old anchor would
+// record gaps for a routine that did not exist. Same answer as a changed
+// schedule, deliberately in the same shape: history stays, anchor unknown, the
+// first tick after it returns resyncs without walking.
+test('a routine removed and re-added later wakes with no records for the days it did not exist', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+    const earned = [
+      { slot: new Date(2026, 7, 15, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 16, 23, 0, 0).toISOString() },
+    ];
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, earned, 'two real nights were recorded');
+
+    writeRoutineAgent(ws, undefined); // the routine is deleted from the agent
+    observeOnce(t, sched, new Date(2026, 7, 19, 8, 0, 0));
+
+    writeRoutineAgent(ws, LATE_ROUTINE); // and written back, days later
+    observeOnce(t, sched, new Date(2026, 7, 21, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, earned,
+      'nothing was recorded for the days the routine did not exist, and nothing it had earned was lost');
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 21, 23, 0, 0).toISOString(),
+      'the anchor resynced to the schedule that is back in force');
+  });
+});
+
+// The narrower half of the same rule: a routine can be declared, and refusable,
+// and still have no anchor anyone can vouch for, because its schedule stopped
+// parsing. An unparseable schedule never fires, so the days it spans are days
+// on which nothing was due, exactly like the days after a deletion.
+test('a schedule that stopped parsing loses its anchor too, not just a routine that vanished', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+
+    // A documented pitfall: the hour must be zero-padded, so this parses as a
+    // routine and never matches as a schedule.
+    writeRoutineAgent(ws, [{ name: 'late', schedule: 'every day at 9:00', prompt: 'p' }]);
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 19, 8, 0, 0));
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, [],
+      'no slot passed on the days the schedule named no time at all');
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 19, 23, 0, 0).toISOString(),
+      'and the anchor resynced once the schedule parsed again');
   });
 });

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -791,3 +791,188 @@ test('stopping a scheduler that was never started is safe and does nothing', (t)
     }
   });
 });
+
+// ===== SLOTS THAT PASSED UNSERVED =====
+// The scheduled instant used to be a local value, recomputed every tick and
+// thrown away, so nothing anywhere knew when a routine had been DUE. These
+// pin the persistence of that instant and of the time the scheduler last
+// observed, and the side of the workspace-switch line the pair sits on.
+
+function writeRoutineAgent(ws, routines) {
+  const dir = path.join(ws, '.claude', 'agents');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'nightly.md'), agentFile({
+    name: 'nightly', type: 'specialist', order: 1, routines,
+  }));
+  invalidateAgentCache();
+}
+
+// One tick at a fixed instant, with the routine's time still ahead of it so
+// the tick observes without spawning anything.
+function observeOnce(t, sched, when) {
+  sched.wireSchedulerDeps({ now: () => when });
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  try {
+    sched.startScheduler();
+    t.mock.timers.tick(60_000);
+  } finally {
+    sched.stopScheduler();
+    t.mock.timers.reset();
+  }
+}
+
+const LATE_ROUTINE = [{ name: 'late', schedule: 'every day at 23:00', prompt: 'p' }];
+const LATE_KEY = 'nightly:late';
+
+test('the due instant and the last observed time are persisted, and survive a restart', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    const observed = new Date(2026, 7, 15, 8, 0, 0);
+    const due = new Date(2026, 7, 15, 23, 0, 0);
+    observeOnce(t, sched, observed);
+
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, due.toISOString(),
+      'the instant the routine is next due is held rather than recomputed and dropped');
+    assert.strictEqual(sched.routineSlots.observedAt, observed.toISOString(),
+      'and so is the time the scheduler last observed');
+
+    const onDisk = JSON.parse(fs.readFileSync(path.join(ws, '.rundock', 'routine-slots.json'), 'utf-8'));
+    assert.strictEqual(onDisk.routines[LATE_KEY].due, due.toISOString(), 'both reached the workspace file');
+    assert.strictEqual(onDisk.observedAt, observed.toISOString());
+
+    // The restart. Losing the in-memory copy is what a new process starts
+    // from, so clobbering it is the only honest way to show the values below
+    // were read back rather than never lost.
+    sched.routineSlots.observedAt = null;
+    delete sched.routineSlots.routines[LATE_KEY];
+    sched.loadRoutineSlots();
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, due.toISOString(),
+      'a restarted process knows when the routine was due');
+    assert.strictEqual(sched.routineSlots.observedAt, observed.toISOString(),
+      'and when it was last watching, which is what tells it what it missed');
+  });
+});
+
+// WHICH SIDE OF THE WORKSPACE-SWITCH LINE. loadRoutineState drops the run
+// state and the announcements because those describe the workspace being
+// left, while the in-flight set survives because it describes child processes
+// that are still running. Slot records describe a workspace: the keys are
+// workspace-local and collide freely, so carrying A's gaps into B would file
+// them under B's routines. The last observed time is workspace-scoped for the
+// same reason and for a second one: while B was open, nobody was watching A,
+// which is precisely the condition the record exists to describe.
+//
+// Driven through the real switch handler rather than through loadRoutineState,
+// for the reason the in-flight test above gives: a reset added to
+// openWorkspace beside the two that belong there would leave this green.
+test('a workspace switch replaces the slot records the way it replaces the run state', (t) => {
+  const sched = freshScheduler();
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const slotsRef = sched.routineSlots; // held BEFORE any call: identity must survive
+  const wsA = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-slots-a-'));
+  const wsB = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-slots-b-'));
+  const noop = () => {};
+  const switchTo = (dir) => {
+    const ctx = {
+      signals: { phaseTimer: () => ({ mark: noop, summary: () => '' }), reportStartup: noop },
+      runtime: { killAllChildren: noop, cleanOrphanedProcesses: noop },
+      workspace: {
+        setWorkspaceRoot: (d) => config.setWorkspace(d),
+        armAgentsDirWatcher: noop, armFileTreeWatcher: noop, healWorkspaceIfMoved: noop,
+        saveRecentWorkspace: noop, fileTreeForSend: () => [],
+      },
+      agents: { armAgentsDirWatcher: noop, invalidateAgentCache: noop },
+      store: { clearSearchFailure: noop, ensureSearchEngine: noop },
+    };
+    const sent = [];
+    freshWorkspaceHandlers(sched).handleSetWorkspace(ctx, { send: (raw) => sent.push(JSON.parse(raw)) },
+      { type: 'set_workspace', path: dir });
+    assert.ok(sent.some(m => m.type === 'workspace_set'),
+      'the switch ran its open path to the end rather than into the rollback');
+    invalidateAgentCache();
+  };
+  try {
+    config.setWorkspace(wsA);
+    writeRoutineAgent(wsA, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    assert.ok(slotsRef.routines[LATE_KEY], "workspace A's slot state was recorded");
+
+    switchTo(wsB);
+    assert.strictEqual(sched.routineSlots, slotsRef, 'routineSlots is never reassigned');
+    assert.deepStrictEqual(Object.keys(slotsRef.routines), [],
+      "workspace A's records did not follow the switch into B");
+    assert.strictEqual(slotsRef.observedAt, null,
+      'and neither did the time A was last observed: B has its own, or none');
+
+    switchTo(wsA);
+    assert.ok(slotsRef.routines[LATE_KEY], "and A's own records came back when A did");
+    assert.strictEqual(slotsRef.observedAt, new Date(2026, 7, 15, 8, 0, 0).toISOString());
+  } finally {
+    config.setWorkspace(original);
+    invalidateAgentCache();
+    fs.rmSync(wsA, { recursive: true, force: true });
+    fs.rmSync(wsB, { recursive: true, force: true });
+  }
+});
+
+// The sibling of the recordRoutineRun case in the characterization suite, at
+// the one call site that runs sixty times an hour rather than once a run.
+test('a tick survives an unwritable .rundock, and says so once rather than once a minute', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    fs.writeFileSync(path.join(ws, '.rundock'), 'a file, not a directory'); // mkdir will fail
+    const errors = [];
+    t.mock.method(console, 'error', (...args) => errors.push(args.join(' ')));
+
+    sched.wireSchedulerDeps({ now: () => new Date(2026, 7, 15, 8, 0, 0) });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      assert.doesNotThrow(() => {
+        sched.startScheduler();
+        t.mock.timers.tick(180_000);
+      }, 'three ticks against an unwritable workspace, none of them fatal');
+    } finally {
+      sched.stopScheduler();
+      t.mock.timers.reset();
+    }
+
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 15, 23, 0, 0).toISOString(),
+      'this process still knows when the routine is due: the file is protection for the NEXT one');
+    assert.strictEqual(errors.filter(e => e.includes('Failed to persist routine slots')).length, 1,
+      'the outage was announced once, not once per tick');
+  });
+});
+
+// A due instant absurdly far behind: a workspace restored from an old backup,
+// or a clock that was years wrong. Walking a slot at a time from there would
+// enumerate a record for every day since, which is neither quick nor useful,
+// and would do it again on every tick if the walk left `due` where it found it.
+test('a due instant years behind is bounded rather than enumerated, and resyncs', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    const warnings = [];
+    t.mock.method(console, 'warn', (...args) => warnings.push(args.join(' ')));
+
+    // The stale file is written by the scheduler itself, three years ago.
+    observeOnce(t, sched, new Date(2023, 7, 15, 8, 0, 0));
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2023, 7, 15, 23, 0, 0).toISOString());
+
+    const daysSince = 1096; // 2023-08-15 to 2026-08-15, two leap-free years and one leap
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    const missed = sched.routineSlots.routines[LATE_KEY].missed;
+    assert.ok(missed.length > 0, 'the slots it did walk were recorded');
+    assert.ok(missed.length < daysSince, `the walk stopped short of every day since (${missed.length})`);
+    assert.ok(warnings.some(w => w.includes(LATE_KEY)), 'and said which routine it gave up on');
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].due, new Date(2026, 7, 15, 23, 0, 0).toISOString(),
+      'the due instant resynced to today');
+
+    const bounded = missed.length;
+    observeOnce(t, sched, new Date(2026, 7, 15, 9, 0, 0));
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY].missed.length, bounded,
+      'so the next tick walks nothing: giving up once is giving up');
+  });
+});

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -1003,3 +1003,118 @@ test('a routine renamed while the machine slept wakes with no history, and the o
       'and the old name was not swept off with the roster, unlike its announcement');
   });
 });
+
+// WRITER AND READER, MADE TO AGREE. The record's shape is stated twice in
+// production: once where a slot is pushed, once where the load path names the
+// fields it will keep. Nothing but a round trip makes those two agree, and the
+// failure is silent in the worst possible way: the filter is per record, so a
+// renamed field leaves the file parsing cleanly and coming back empty, with no
+// error and no log line.
+//
+// It also lands exactly where the feature is for. These records are written
+// just before a process dies and are only ever of use once it restarts, so
+// every in-memory assertion in this diff could stay green while a laptop
+// closed for five days reopened showing nothing.
+test('a missed record survives the file it is written to, with its content intact', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+
+    const nights = [
+      { slot: new Date(2026, 7, 15, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 16, 23, 0, 0).toISOString() },
+    ];
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, nights,
+      'two unwatched nights went by and both were recorded');
+
+    const file = path.join(ws, '.rundock', 'routine-slots.json');
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(file, 'utf-8')).routines[LATE_KEY].missed, nights,
+      'and reached the file in the shape they were written in');
+
+    // What a restart starts from: nothing in memory, everything on disk.
+    delete sched.routineSlots.routines[LATE_KEY];
+    sched.loadRoutineSlots();
+    assert.deepStrictEqual(sched.routineSlots.routines[LATE_KEY].missed, nights,
+      'and came back off it, which is the only moment they are ever read');
+  });
+});
+
+test('a slot entry with no due instant is dropped on load, without taking the file with it', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, LATE_ROUTINE);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 7, 17, 8, 0, 0));
+
+    // Production's own file with one field taken back out: a hand edit, a
+    // truncated write, an older shape. An entry with no due instant has
+    // nothing to walk from, so keeping it would walk from an invalid date.
+    const file = path.join(ws, '.rundock', 'routine-slots.json');
+    const saved = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    assert.strictEqual(saved.routines[LATE_KEY].missed.length, 2, 'the entry about to be damaged had real history');
+    delete saved.routines[LATE_KEY].due;
+    fs.writeFileSync(file, JSON.stringify(saved, null, 2));
+
+    sched.loadRoutineSlots();
+    assert.strictEqual(sched.routineSlots.routines[LATE_KEY], undefined,
+      'the entry was dropped whole rather than loaded with nothing to anchor it');
+    assert.strictEqual(sched.routineSlots.observedAt, saved.observedAt,
+      'and the rest of the file still loaded: one bad entry is not a lost workspace');
+  });
+});
+
+// Weekly is half the grammar, and the walk steps by a different amount for it.
+test('a weekly routine walks a week at a time, so a fortnight closed leaves two records', (t) => {
+  withTempWorkspace((ws) => {
+    const sched = freshScheduler();
+    writeRoutineAgent(ws, [{ name: 'weekly', schedule: 'every friday at 23:00', prompt: 'p' }]);
+    const key = 'nightly:weekly';
+
+    observeOnce(t, sched, new Date(2026, 7, 21, 8, 0, 0)); // Friday 21 August 2026
+    assert.strictEqual(sched.routineSlots.routines[key].due, new Date(2026, 7, 21, 23, 0, 0).toISOString(),
+      'on its own weekday the slot is today, still ahead at 08:00');
+
+    observeOnce(t, sched, new Date(2026, 8, 4, 8, 0, 0)); // two Fridays later
+    assert.deepStrictEqual(sched.routineSlots.routines[key].missed, [
+      { slot: new Date(2026, 7, 21, 23, 0, 0).toISOString() },
+      { slot: new Date(2026, 7, 28, 23, 0, 0).toISOString() },
+    ], 'two Fridays passed unwatched, and the thirteen days between them are not slots');
+    assert.strictEqual(sched.routineSlots.routines[key].due, new Date(2026, 8, 4, 23, 0, 0).toISOString(),
+      "and today's Friday is still to come rather than already gone");
+  });
+});
+
+// The complaint is throttled per outage, so the flag that throttles it has to
+// end with the workspace it described. Otherwise the first unwritable
+// workspace silences every one that follows it, for the life of the process.
+test('a second unwritable workspace is announced too, rather than silenced by the first', (t) => {
+  const sched = freshScheduler();
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const wsA = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-unwritable-a-'));
+  const wsB = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-unwritable-b-'));
+  const errors = [];
+  t.mock.method(console, 'error', (...args) => errors.push(args.join(' ')));
+  const complaints = () => errors.filter(e => e.includes('Failed to persist routine slots')).length;
+  try {
+    for (const ws of [wsA, wsB]) {
+      writeRoutineAgent(ws, LATE_ROUTINE);
+      fs.writeFileSync(path.join(ws, '.rundock'), 'a file, not a directory');
+    }
+    config.setWorkspace(wsA);
+    observeOnce(t, sched, new Date(2026, 7, 15, 8, 0, 0));
+    assert.strictEqual(complaints(), 1, "workspace A's outage was announced");
+
+    config.setWorkspace(wsB);
+    sched.loadRoutineState();
+    observeOnce(t, sched, new Date(2026, 7, 15, 9, 0, 0));
+    assert.strictEqual(complaints(), 2, "and so was workspace B's, which is a different workspace failing");
+  } finally {
+    config.setWorkspace(original);
+    invalidateAgentCache();
+    fs.rmSync(wsA, { recursive: true, force: true });
+    fs.rmSync(wsB, { recursive: true, force: true });
+  }
+});

--- a/test/unit/scheduler-slots-dst.test.js
+++ b/test/unit/scheduler-slots-dst.test.js
@@ -1,0 +1,105 @@
+'use strict';
+// The slot walk across a daylight-saving boundary.
+//
+// A routine's schedule is a LOCAL wall-clock time: "every day at 23:00" means
+// 23:00 on the clock in the room, on the day the clocks change as much as on
+// any other. So the walk steps a calendar day rather than twenty-four hours,
+// and the difference only shows up twice a year: a 24-hour step across the
+// autumn change records 22:00, and across the spring change it records 00:00
+// on the following day, which also moves which day the slot belongs to.
+//
+// ITS OWN FILE, because it needs a timezone that has daylight saving and
+// continuous integration runs in UTC, which has none. node --test gives every
+// file its own process, so setting the zone here changes nothing anywhere
+// else. It is set before the first require for the same reason.
+process.env.TZ = 'Europe/London';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { agentFile } = require('../helpers/workspace.js');
+const { invalidateAgentCache } = require('../../lib/agents/discovery.js');
+const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
+
+// A private copy per test, so wiring never leaks into the shared instance.
+// Same technique as test/unit/scheduler-lib.test.js.
+function freshScheduler() {
+  const cached = require.cache[SCHEDULER_KEY];
+  delete require.cache[SCHEDULER_KEY];
+  const mod = require(SCHEDULER_KEY);
+  delete require.cache[SCHEDULER_KEY];
+  if (cached) require.cache[SCHEDULER_KEY] = cached;
+  return mod;
+}
+
+// A workspace holding one agent with one nightly routine, torn down after.
+function withNightlyWorkspace(fn) {
+  const config = require('../../lib/config.js');
+  const original = config.getWorkspace();
+  const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'scheduler-dst-'));
+  config.setWorkspace(ws);
+  const dir = path.join(ws, '.claude', 'agents');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'nightly.md'), agentFile({
+    name: 'nightly', type: 'specialist', order: 1,
+    routines: [{ name: 'late', schedule: 'every day at 23:00', prompt: 'p' }],
+  }));
+  invalidateAgentCache();
+  try {
+    return fn(freshScheduler());
+  } finally {
+    config.setWorkspace(original);
+    invalidateAgentCache();
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+}
+
+// One tick at a fixed instant, with 23:00 still ahead of it so the tick
+// observes without spawning anything.
+function observeOnce(t, sched, when) {
+  sched.wireSchedulerDeps({ now: () => when });
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  try {
+    sched.startScheduler();
+    t.mock.timers.tick(60_000);
+  } finally {
+    sched.stopScheduler();
+    t.mock.timers.reset();
+  }
+}
+
+const KEY = 'nightly:late';
+const slotsOf = (sched) => sched.routineSlots.routines[KEY].missed.map(m => new Date(m.slot));
+
+test('the clocks going back does not move the hour a slot was due', (t) => {
+  withNightlyWorkspace((sched) => {
+    // Friday 23 October 2026, British Summer Time. The clocks go back at
+    // 02:00 on Sunday the 25th, making that day 25 hours long.
+    observeOnce(t, sched, new Date(2026, 9, 23, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 9, 27, 8, 0, 0));
+
+    const missed = slotsOf(sched);
+    assert.deepStrictEqual(missed.map(d => d.getDate()), [23, 24, 25, 26],
+      'one slot for each night the machine was closed, including the long one');
+    assert.deepStrictEqual(missed.map(d => d.getHours()), [23, 23, 23, 23],
+      'every one of them at 23:00 on the clock in the room, which is what the schedule says');
+  });
+});
+
+test('the clocks going forward does not move the day a slot belongs to', (t) => {
+  withNightlyWorkspace((sched) => {
+    // Friday 27 March 2026, Greenwich Mean Time. The clocks go forward at
+    // 01:00 on Sunday the 29th, making that day 23 hours long.
+    observeOnce(t, sched, new Date(2026, 2, 27, 8, 0, 0));
+    observeOnce(t, sched, new Date(2026, 2, 31, 8, 0, 0));
+
+    const missed = slotsOf(sched);
+    assert.deepStrictEqual(missed.map(d => d.getDate()), [27, 28, 29, 30],
+      'four nights, four slots, and the short day is still one day');
+    assert.deepStrictEqual(missed.map(d => d.getHours()), [23, 23, 23, 23],
+      'and none of them drifted into the small hours of the following morning');
+  });
+});


### PR DESCRIPTION
Close Rundock on Monday and never open it, and Monday's briefing does not happen and nothing anywhere says so. This makes the gap sayable.

`missed` is **a record that a slot passed unserved, not a sixth run state.** No run happened, so it is not a run state and it does not sit in a vocabulary beside `failed`. No status token is added, renamed or moved.

## The two findings this closes

**The scheduled instant was never persisted.** `lastRun` is the fire time; next-run was a local value recomputed each tick and thrown away. Nothing stored when a routine was DUE, which is why "the 05:00 slot was missed" could not be said at all. `due` is now persisted per routine, alongside `observedAt`, the last instant the scheduler was awake and looking. Both live in `.rundock/routine-slots.json`, workspace-scoped like the run state.

**There was nowhere to put a gap without corrupting the guard.** `routineState[key]` is at once the display record and the only input to double-fire suppression, read as `getNextRun(schedule, routineState[key]?.lastRun)`. Writing a gap into it stamps `lastRun` with the moment the gap was noticed, the daily suppression fires on that instant, and the routine loses the catch-up run it was still owed today. The records therefore live in their own object and their own file, and nothing in that block is ever read by the suppression. A test proves it by catching up a routine that is carrying five records; writing the record where suppression reads turns that test red.

## What detection rests on, and what it does not

Two persisted instants, compared. Never how late a tick arrived: there is no monotonic clock, the tick is unrefed and jittery, and lateness cannot tell a sleeping machine from a starved event loop. So a tick eleven hours late that crossed no slot records nothing, and a punctual sixty-second tick whose clock moved six days records five.

## Catch-up is unchanged

A slot is still caught up once within its own period, or recorded and never run. Five closed days leave five records and zero catch-up runs, never five runs in one day. Both suites that pin the window pass untouched, and no paragraph of `docs/ROUTINES.md` changes.

## Decisions worth a reviewer's attention

- **Slot records sit on the same side of the workspace-switch line as the run state**, not with `inFlight`. Keys are workspace-local and collide freely, so carrying one workspace's gaps into another files them under a routine that never had them; and while the other workspace was open nobody was watching this one, which is exactly what a gap record describes. Driven through the real switch handler in the test, for the reason the in-flight test gives.
- **Off-roster keys are not swept**, unlike announcements. An announcement is a silence, so one outliving what it described gets handed to whatever is written under the name next. A gap record is history, and a rename is not a reason to lose it. A routine renamed while the machine slept is a new key with no history, so it does not wake up already late.
- **The walk is bounded**, for a `due` absurdly far behind that a restored backup or a wrong clock can produce. It is a guard, not a retention policy.
- **The file is written every tick**, because a stale observed time is worse than none: it would report as missed the very slots the scheduler watched and served. The failure is announced once per outage rather than once a minute.

## Out of scope, deliberately

Rendering, which has its own ruling and its own card. This decides what is stored so that view can say it.

## Verification

- 1805 tests green. `lib/scheduler.js` at 100.0% (598/598), all 50 coverage floors hold.
- `red-first --base main`: PROVEN.
- Nine hand mutations, all red, including removing the write entirely and writing the record where suppression reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)