### PR TITLE
Cover the create handler's error path on purpose, not by accident

### DIFF
--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -210,11 +210,46 @@ describe('handler seams (stub ctx, capture ws)', () => {
   // handler's own `fs.mkdirSync(path.dirname(full), { recursive: true })`
   // fails EEXIST on it. The path clears both guards on their own terms, so
   // the message reaches the try for the same reason a real one would.
-  // Asserting the
-  // errno reason rather than merely "a create_error was sent" is what
-  // separates this from the branch above: the guards answer with the fixed
-  // strings 'invalid path' and 'already exists', so an EEXIST reason can only
-  // have come from the catch.
+  // Asserting the errno reason rather than merely "a create_error was sent"
+  // is what separates this from the branch above: the guards answer with the
+  // fixed strings 'invalid path' and 'already exists', so an EEXIST reason
+  // can only have come from the catch.
+  //
+  // THE MEASUREMENT, since the claim is that the file now clears its floor
+  // whatever else ran, and a claim like that is worth only the runs behind
+  // it. SIX full coverage runs were made: one before this test and FIVE
+  // after. Every figure below is `npm run test:coverage` against a floor of
+  // 97.5%.
+  //
+  //   before, 1 run:  97.6%  (83/85), uncovered 81-82
+  //   after,  run 1:  97.6%  (83/85), uncovered 81-82
+  //   after,  run 2:  97.6%  (83/85), uncovered 81-82
+  //   after,  run 3:  97.6%  (83/85), uncovered 81-82
+  //   after,  run 4:  97.6%  (83/85), uncovered 81-82
+  //   after,  run 5:  97.6%  (83/85), uncovered 81-82
+  //
+  // All five met the floor and none measured below it. The spread is zero,
+  // which is the property being claimed: same figure, same two uncovered
+  // lines, every run. Those two are handleRevealInFinder's macOS-only spawn,
+  // which nothing covers on purpose either and which is carded separately.
+  //
+  // The interleaving that was failing measured 81/85 = 95.3%, with lines
+  // 71-72 AND 81-82 of lib/protocol/handlers/files.js uncovered: the catch
+  // and the reveal spawn missing together.
+  // It cannot recur, because 71-72 no longer depends on another test
+  // happening to make a create throw. The lcov confirms the mechanism rather
+  // than just the total: line 71 was hit in all five runs, with the count
+  // varying between 1 and 3, so the incidental hits still arrive, on top of
+  // one that is now guaranteed. The worst case is therefore 83/85.
+  //
+  // DISCRIMINATION was proved by hand, and had to be. `npm run red-first`
+  // returns NOT-PROVABLE for a change that is only a test, correctly: it
+  // works by reverting the source, and there is no source here to take away.
+  // So the mutation is the only evidence, and it is this one: delete the
+  // `ws.send` inside that catch, leaving the catch itself in place, and
+  // the suite reports 14 pass, 1 fail with this test the single failure.
+  // Nothing else in the suite notices the send is gone, which is the whole
+  // reason the floor was measuring luck.
   test('create_path answers create_error carrying the failure reason when the create itself throws', () => {
     const table = buildDispatch();
     const original = config.getWorkspace();

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -195,6 +195,68 @@ describe('handler seams (stub ctx, capture ws)', () => {
     }
   });
 
+  // The error path in handleCreatePath: the catch that answers create_error
+  // when the create itself throws, as opposed to the two guard branches above
+  // it that refuse a path before touching the disk.
+  //
+  // WHY THIS TEST EXISTS AT ALL. Those two lines were already counted as
+  // covered, but by accident: whichever test happened to make a create throw
+  // picked them up, and when a run interleaved so that none did, the file
+  // measured 95.3% against a 97.5% floor and the floors job went red on
+  // changes that touched neither file. A floor held up by incidental coverage
+  // protects nothing and reports a number that is not about the tests.
+  //
+  // The throw is real, not injected: `notes` is created as a FILE, so the
+  // handler's own `fs.mkdirSync(path.dirname(full), { recursive: true })`
+  // fails EEXIST on it. The path clears both guards on their own terms, so
+  // the message reaches the try for the same reason a real one would.
+  // Asserting the
+  // errno reason rather than merely "a create_error was sent" is what
+  // separates this from the branch above: the guards answer with the fixed
+  // strings 'invalid path' and 'already exists', so an EEXIST reason can only
+  // have come from the catch.
+  test('create_path answers create_error carrying the failure reason when the create itself throws', () => {
+    const table = buildDispatch();
+    const original = config.getWorkspace();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-handlers-'));
+    try {
+      config.setWorkspace(dir);
+      // The obstruction: a regular file where the handler must make a folder.
+      fs.writeFileSync(path.join(dir, 'notes'), 'not a directory', 'utf-8');
+      let broadcasts = 0;
+      const ctx = {
+        workspace: {
+          // Real containment against this workspace rather than `() => true`:
+          // server.js's own isInsideWorkspace reads a module-local WORKSPACE
+          // that config.setWorkspace does not touch, so it cannot be borrowed
+          // here, but the rule it applies can be. isSafeCreatePath is pure and
+          // is used as it ships.
+          isInsideWorkspace: (p) => path.resolve(p).startsWith(path.resolve(dir) + path.sep),
+          isSafeCreatePath: srv.isSafeCreatePath,
+          invalidateFileListCache: () => {},
+          invalidateFileTreeCache: () => {},
+          broadcastFileTree: () => { broadcasts++; },
+        },
+        store: { ensureSearchEngine: () => null },
+      };
+      const ws = captureWs();
+      table.create_path(ctx, ws, { type: 'create_path', path: 'notes/x.md', kind: 'file', content: 'hi' });
+
+      assert.strictEqual(ws.sent.length, 1, 'exactly one answer');
+      const [answer] = ws.sent;
+      assert.strictEqual(answer.type, 'create_error');
+      assert.strictEqual(answer.path, 'notes/x.md');
+      // The errno text, which no guard branch can produce.
+      assert.match(answer.reason, /^EEXIST:/, `the catch reported the real failure, got ${answer.reason}`);
+      assert.strictEqual(broadcasts, 0, 'a failed create broadcasts no tree');
+      assert.ok(!fs.existsSync(path.join(dir, 'notes', 'x.md')), 'nothing was created');
+      assert.ok(fs.statSync(path.join(dir, 'notes')).isFile(), 'the obstruction is untouched');
+    } finally {
+      config.setWorkspace(original);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('get_skills answers from ctx.agents.discoverSkills', () => {
     const table = buildDispatch();
     const ctx = { agents: { discoverSkills: () => [{ id: 'linting', name: 'Linting' }] } };


### PR DESCRIPTION
## Why

Main is red. The coverage floors job fails on trunk, and it has failed five times in one session: four on branches whose diffs touched neither the handler nor its tests, once on main after a merge.

`lib/protocol/handlers/files.js` carries a floor of 97.5% over 85 executable lines. The two lines in the create handler's catch were reached only incidentally, by whichever test happened to make a create throw. When a run interleaved so that none did, the file measured 95.3% and the job failed. Two lines are 2.3% of that file, so the floor sat one interleaving away from failing on any change at all.

Lowering the floor would make it measure even less than it already does. This covers the path instead.

## What the test does

The throw is real, not injected. The test puts a regular file where the handler must make a folder, so the handler's own `fs.mkdirSync(path.dirname(full), { recursive: true })` fails EEXIST on its own.

The assertion is on the errno reason the handler sends back, not merely that a `create_error` was sent. The two guard branches above the try answer with the fixed strings `invalid path` and `already exists`, so an EEXIST reason can only have come from the catch. It also asserts no file tree was broadcast, nothing was created, and the obstruction is untouched.

## Proof

**Stability.** Six coverage runs total, one before the test and five after. Before: files.js measured 97.6% (83/85) with lines 81 and 82 uncovered, the catch covered incidentally that time. After: 97.6% (83/85) on all five runs, with the same two lines uncovered every run, those being the macOS-only reveal in Finder spawn. Zero spread. Line 71, the catch, was hit in every run, with the hit count varying between 1 and 3, which is the incidental coverage still happening on top of a hit that is now guaranteed.

**Mutation, by hand, twice.**

1. Remove the write in the catch (the `ws.send` of `create_error`). Result: 14 pass, 1 fail, the new test being the only failure. Nothing else in the suite noticed, which is the point.
2. Write-removal lens on the test's own setup: remove the obstruction so the create succeeds. Result: red, `actual: 'path_created', expected: 'create_error'`. The test cannot pass because the create worked.

**red-first.** `npm run red-first -- --base main --tests "npm test"` returns NOT-PROVABLE: the change touches no source, so there is nothing to take away. That is the honest outcome for a test-only change, and the by-hand mutation above is what stands in for it.

**precommit.** PASS on test, typecheck, lint:styles, check:refs.

## Survey of the other floors

All 50 floors were examined, over the same five runs. Method: for each floor, the spread in covered lines across the five runs (`moves`) and how many further lines could go uncovered before the floor breaks (`slack`). A floor is held up by luck when its margin both moves and is thin.

**One live finding, not fixed here.** `lib/agents/discovery.js` lines 139 to 140, the catch that logs a failure to read an agent file. Uncovered in one of five runs, covered in the other four. Slack of 1 line on the file floor and 0 on the `Agent discovery + frontmatter parsing` area floor. This is the same defect in the same shape as the one this PR fixes, and it is the next one to go red. Left alone deliberately, per the card's scope.

**Four floors move but do not depend on it.** `OVERALL server.js` (moves 4, slack 52), `- handleDelegation` (moves 1, slack 24), `Delegation / orchestration engine` (moves 1, slack 19), `OVERALL lib/delegation/engine.js` (moves 1, slack 7). Incidental coverage exists in all four, but the floor sits far enough below the measurement that it cannot be what holds them up. Sound.

**The remaining 44 are stable.** Zero spread across five runs, so nothing incidental is propping them up. Many have slack of 0, but that is the 100% floors, which have no margin to be held up by anything by construction. Sound.

Full table, every floor named with its numbers:

```
runs analysed: 5
slack = lines that could go uncovered before the floor breaks; moves = spread in covered lines across runs

slack moves  measured  floor  total  label
    0     2     99.4%   99.4    327  Agent discovery + frontmatter parsing
    0     0      100%    100    252  OVERALL codex.js
    0     0      100%    100     46  OVERALL lib/delegation/markers.js
    0     0      100%    100     72  OVERALL lib/delegation/handback.js
    0     0      100%    100     76  OVERALL lib/delegation/state.js
    0     0      100%    100     33  OVERALL lib/config.js
    0     0      100%    100    109  OVERALL lib/store/persistence.js
    0     0      100%    100    120  OVERALL lib/store/transcripts.js
    0     0     99.5%   99.5    367  OVERALL lib/agents/prompt.js
    0     0      100%    100     53  OVERALL lib/workspace/boundary.js
    0     0      100%    100    101  OVERALL lib/signals.js
    0     0      100%    100    311  - wireProcessHandlers (stream-json + interception)
    0     0     95.3%   95.3    213  - handleScopeReturn
    0     0     99.4%   99.4    347  System prompt + roster builders
    0     0     98.6%   98.4    139  Codex probe + root caches + open-file watch (remainder)
    0     0      100%    100     33  Workspace boundary grants
    0     0      100%    100     94  Transcripts + persistence helpers
    0     0      100%    100     89  Conversation / state persistence
    0     0      100%    100     80  Signal layer (events, retention, skill usage, docs-gap)
    0     0      100%    100     75  Transcript composition (root remainder)
    0     0      100%    100    110  Runtime status + server permission bridge (root remainder)
    0     0     98.6%   98.5    276  OVERALL lib/http-router.js
    0     0     97.9%   97.9     47  HTTP server + WS bootstrap (root remainder)
    0     0      100%    100     54  OVERALL lib/protocol/handlers/index.js
    0     0      100%    100    245  OVERALL lib/protocol/handlers/workspace.js
    0     0      100%    100    157  OVERALL lib/protocol/handlers/conversations.js
    0     0       99%   98.9    194  OVERALL lib/protocol/handlers/team.js
    0     0     97.6%   97.5     85  OVERALL lib/protocol/handlers/files.js
    0     0     99.2%   99.2    133  OVERALL lib/protocol/handlers/process-control.js
    1     2     99.4%   99.4    353  OVERALL lib/agents/discovery.js
    1     0     97.7%   97.4    341  OVERALL lib/workspace/analysis.js
    1     0      100%    100    642  Scheduler (getNextRun + startScheduler + executeRoutine)
    1     0     97.6%   97.3    328  Workspace analysis (Seven Signals)
    1     0     98.4%     98    249  HTTP request router (incl. permission bridge)
    1     0      100%    100    688  OVERALL lib/scheduler.js
    1     0      100%    100    435  WS connection + chat shim (root remainder)
    1     0     99.5%   99.3    384  OVERALL lib/runtime/claude.js
    2     0     98.4%   98.4   1067  OVERALL search.js
    2     0     96.3%   96.3    966  OVERALL lib/runtime/codex-glue.js
    2     0     99.5%   98.5    195  Skill discovery
    2     0       96%     96    897  Codex glue (app-server lifecycle, turns, delegate wiring)
    3     0     97.5%   96.9    403  Workspace mode detection + scaffolding
    3     0     94.1%     93    256  OVERALL lib/protocol/handlers/history.js
    4     0     95.3%     95    762  OVERALL codex-appserver.js
    4     0     97.6%   96.9    425  OVERALL lib/workspace/scaffold.js
    5     0     99.4%   98.1    352  Spawn plumbing (spawnClaude, resolveClaudeBin, errors)
    7     1     97.6%   97.2   1273  OVERALL lib/delegation/engine.js
   19     1     97.4%     96   1178  Delegation / orchestration engine
   24     1       98%   94.3    611  - handleDelegation
   52     4       98%   96.6   3116  OVERALL server.js
```

## Nothing else moves

No production code changed. No floor changed, raised or lowered. No existing test changed. One test added.
