### PR TITLE
Ignore the workspace state a checkout accumulates by using the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ scripts/screenshots/.banned-tokens.json
 
 # Local pre-commit gate record: names the tree the checks passed on.
 .precommit-gate.json
+
+# Per-workspace scratch and local state Rundock writes into a workspace it has
+# opened. A checkout is itself a plausible workspace, so this directory appears
+# here during ordinary use and during development, and nothing in it belongs to
+# the project. Added after finding that contributor instructions said to put
+# scratch files here while `git add -A` would have committed them: the guidance
+# and the mechanism disagreed, and only the habit of deleting kept the two from
+# meeting.
+.rundock/


### PR DESCRIPTION
## What

Rundock writes per-workspace scratch and local state into a `.rundock` directory inside whatever workspace it has opened. A checkout is itself a plausible workspace, so that directory appears during ordinary use and during development, and nothing in it belongs to the project. It was not ignored.

## Why it mattered more than it looks

Contributor guidance says to put scratch files there. The same guidance says to stage with `git add -A` before running the pre-commit checks. Those two instructions were in conflict, and the only thing keeping the directory out of the repository was the habit of deleting it by hand. A habit is not a mechanism, and the guidance asked for exactly the command that would have swept it up.

## Verification

- Nothing under that path is tracked today, checked before adding the entry, so this hides no existing file.
- With a scratch file present, `git add -A` now stages only the ignore file itself. Confirmed by doing it.
- `git check-ignore -v` resolves the path to the new rule.
- The four below-the-line checks pass.

## Scope

One line plus its reasoning. No production code, no tests, no behaviour.

An audit of the same class turned up nothing else: guidance about avoiding temp directories holds here for an unrelated reason, the dash and vocabulary rules are independently enforced by the reference checker, and commit-message conventions were read from this repository's own history rather than carried in. This was the only case where a rule's premise had not been checked against the place it was applied.