### PR TITLE
Give every run a record of its own

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -405,6 +405,16 @@ function beginRunRecord(agent, routine, startedAt) {
  * Close a run's record. Rewrites the file the opening wrote, so a run has one
  * record whatever happened to it.
  *
+ * THE SHAPE IS STATED IN FULL HERE AND IN THE OPENING, rather than shared
+ * between them or spread from one into the other. Two reasons, and both are
+ * about this file rather than about taste. It is the convention the run state
+ * already follows, for the reason recorded at recordFailedStart: a record that
+ * names every field it has is a record a reader can check against the writer
+ * without following an indirection. And the risk duplication creates, the two
+ * shapes drifting apart, is the thing the open record's own test pins: deleting
+ * the owner from the opening alone turns it red, because the opening is
+ * asserted in full and not only for the fields a closed record lacks.
+ *
  * `err` is the reason a failure gave, when the failure gave one. Three endings
  * do: a start that threw, a child that never launched, and a codex turn that
  * could not start. Each is handed an object with a message, and that message is
@@ -698,7 +708,7 @@ function startScheduler() {
           // own bookkeeping behind one guard, which is how the next failure
           // gets to be silent again.
           try {
-            if (executeRoutine(agent, routine, key)) {
+            if (executeRoutine(agent, routine, key, now)) {
               console.log(`[Scheduler] Running routine: ${routine.name} (${agent.name})`);
             } else {
               // Said on every held tick rather than once, unlike a refusal. A
@@ -860,7 +870,20 @@ function getNextRun(schedule, lastRunISO) {
  * return value is what the tick reads to say why nothing happened; it is not
  * an error, because a held routine is a normal state rather than a fault.
  */
-function executeRoutine(agent, routine, key) {
+/**
+ * ...and `now` is the instant the caller judged this routine due.
+ *
+ * The tick reads the clock ONCE per pass and judges every routine against that
+ * one reading, so it hands the same Date on rather than letting this function
+ * take another. Three readings of a live clock describing one start is three
+ * different answers to when the run began, and the failed-start path already
+ * stamps with the tick's instant for exactly this reason: the two now agree.
+ *
+ * Optional, because a direct caller (a run-now button, a test) has no tick
+ * instant to give. That caller's reading is taken below, inside the guard,
+ * because reading the clock can throw.
+ */
+function executeRoutine(agent, routine, key, now) {
   if (inFlight.has(key)) return false;
   inFlight.add(key);
   // The run's record is opened HERE rather than inside beginRun so that its
@@ -884,8 +907,9 @@ function executeRoutine(agent, routine, key) {
   // attempt per period.
   let run = null;
   try {
-    run = beginRunRecord(agent, routine, deps.now());
-    beginRun(agent, routine, key, run);
+    const startedAt = now || deps.now();
+    run = beginRunRecord(agent, routine, startedAt);
+    beginRun(agent, routine, key, run, startedAt);
   } catch (err) {
     // A start that throws leaves no child, so no close event and no outcome,
     // so nothing that will ever release. Held forever is how a guard turns
@@ -900,10 +924,18 @@ function executeRoutine(agent, routine, key) {
   return true;
 }
 
-function beginRun(agent, routine, key, run) {
-  const startTime = deps.now().getTime();
+function beginRun(agent, routine, key, run, startedAt) {
+  const startTime = startedAt.getTime();
   // Persisted immediately: if the server dies mid-run, the restarted process
   // still knows the run started and will not fire it again in the same window.
+  //
+  // THIS READING IS DELIBERATELY ITS OWN, and it is the only one left that is.
+  // The field is the sole input to double-fire suppression, and moving it to
+  // the tick's instant would change what suppresses a routine, which is a
+  // behaviour change rather than a tidy-up. It is also the read that
+  // test/integration/scheduler-tick-isolation.test.js drives a throw at, to
+  // prove the failed-start path stamps a floor when a start dies before
+  // writing anything.
   recordRoutineRun(key, { lastRun: deps.now().toISOString(), status: 'running', duration: null });
 
   // Notify connected clients

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -13,6 +13,12 @@
 // for routine cwd), so a workspace switch immediately redirects where
 // state persists and where routines run.
 //
+// Beside it sit two stores that are NOT it and must never be read by the
+// suppression: the slot records (routineSlots, a slot that passed while nobody
+// was watching) and the run records (.rundock/runs/, one file per run, the only
+// history this file keeps). Each block says why it is separate where it is
+// defined.
+//
 // The spawn plumbing (spawnClaude/getBareArgs/modelArgs/getSpawnEnv) is a
 // direct lib require since its own extraction. The one root-owned
 // capability left arrives through wireSchedulerDeps: the WebSocket client
@@ -29,6 +35,7 @@
 // an argument is a conversion rather than a clock read and stays direct.
 const fs = require('fs');
 const path = require('path');
+const { randomUUID } = require('crypto');
 const { getWorkspace } = require('./config.js');
 const { rundockDir } = require('./store/persistence.js');
 const { recordEvent } = require('./signals.js');
@@ -276,6 +283,190 @@ function recordRoutineRun(key, state) {
     // the in-memory state. An unwritable .rundock must not kill the scheduler.
     console.error('[Scheduler] Failed to persist routine state:', e && e.message ? e.message : e);
   }
+}
+
+// ===== RUN RECORDS =====
+// One file per run under .rundock/runs/, opened when a run starts and closed
+// once when it ends. A HISTORY, which nothing in this file had: routineState
+// holds one slot per routine and every run overwrites its predecessor, so
+// nothing could say what happened yesterday, how often a routine has failed,
+// or how long it usually takes.
+//
+// WHY A SEPARATE STORE RATHER THAN MORE FIELDS ON routineState. The same
+// reason the slot records are separate, and here it is sharper still.
+// routineState is the ONLY input to double-fire suppression, read as
+// getNextRun(schedule, routineState[key]?.lastRun). Nothing in this block is
+// ever read by that, and nothing in this block writes to routineState: the two
+// stores meet only in beginRun, where each is told the same thing separately.
+//
+// ITS OWN VOCABULARY, deliberately. A record is 'running', 'succeeded' or
+// 'failed'. The routine state's 'completed' and 'interrupted' stay exactly as
+// they are, because renaming them would rewrite a file on every user's disk
+// with no migration path, and these are separate stores by design. 'queued'
+// and 'cancelled' are specified for the run-detail screen and are not written
+// here, because nothing in the product can produce either: a routine is started
+// the moment it is found due, and the child handle is never kept, so nothing
+// can reach a run to cancel it.
+//
+// WHAT A RECORD DOES NOT CARRY, and it is not an omission. The files a run
+// changed, the events it emitted, and cancellation all have their own card:
+// nothing tracks changed files, a routine's output is piped and never read
+// (which the shipped documentation states as a deliberate promise), and there
+// is no handle to cancel through. A record says only what this file can vouch
+// for at the moment it writes.
+//
+// THE IDENTITY IS THE RUN'S OWN, not the routine key. `agentId:routineName` is
+// neither unique nor stable: two routines may share a name under one agent,
+// which the data model allows and a test pins, and a rename produces a
+// different key. A record named by the key would collide between namesakes and
+// be orphaned by a rename, so each run takes a uuid at the moment it starts and
+// the file is named for it. The agent and the routine are recorded as what the
+// run BELONGED to rather than as its identity.
+
+// WHICH SIDE OF THE WORKSPACE-SWITCH RESET THIS STORE SITS ON, decided here
+// rather than left to be inferred.
+//
+// The run state and the slot records are dropped by loadRoutineState because
+// they describe the workspace being left. The in-flight set deliberately is
+// NOT, because the child process of a run in flight is not dropped by a
+// switch: it is still running, and it still holds the only thing that will
+// ever release it.
+//
+// Run records follow the in-flight set, for that same reason rather than by
+// analogy. A record is opened by a run that is still going and closed by that
+// run, so this block keeps no map for a switch to clear: an open record travels
+// in the closure that will end it. The only question a switch actually poses is
+// where the ENDING lands, and it lands beside its own beginning. The directory
+// is resolved once, when the run starts, and held. Resolving it again at the
+// end would send the ending to whichever workspace happened to be open by then,
+// leaving the workspace that did the work with a record stuck at 'running'
+// forever and the other one holding an ending for a run it never saw.
+//
+// So this is the one place in this file where the workspace root is not read at
+// use time. The reader below IS read at use time, because reading is a question
+// about the workspace open now.
+function runsDir() { return path.join(rundockDir(), 'runs'); }
+
+// Whole-file and synchronous, like every other store here, but many small
+// files written once each rather than one file rewritten on the tick. The
+// opening and the closing write the SAME path, so a run leaves one record
+// rather than two.
+//
+// CANNOT THROW, which is a requirement rather than a courtesy, and the closing
+// is where it matters most: that one runs inside executeRoutine's catch, whose
+// whole job is to release the routine and rethrow the start's own error
+// unchanged. A throw raised there would replace the reason a start failed with
+// the reason a file could not be written, while handling a failure.
+//
+// Said every time rather than once per outage, unlike the slot writes: those
+// meet an unwritable .rundock sixty times an hour, and a run is a rare event
+// whose failure is worth a line.
+function writeRunRecord(dir, record) {
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${record.id}.json`), JSON.stringify(record, null, 2));
+  } catch (e) {
+    console.error('[Scheduler] Failed to write run record:', e && e.message ? e.message : e);
+  }
+}
+
+/**
+ * Open a record for a run that is starting, and return the handle that closes
+ * it. The handle is the only thing that knows the run's identity and where its
+ * record lives, which is what keeps both out of any module-level map.
+ *
+ * Resolving the directory is the one fallible step, because there may be no
+ * workspace root to resolve against. The caller runs this inside the guard
+ * that releases the routine, for the reason recorded there.
+ */
+function beginRunRecord(agent, routine, startedAt) {
+  const run = {
+    id: randomUUID(),
+    dir: runsDir(),
+    agent: agent.id,
+    routine: routine.name,
+    startedAt: startedAt.toISOString(),
+    startedMs: startedAt.getTime(),
+  };
+  writeRunRecord(run.dir, {
+    id: run.id,
+    agent: run.agent,
+    routine: run.routine,
+    status: 'running',
+    startedAt: run.startedAt,
+    endedAt: null,
+    durationMs: null,
+    error: null,
+  });
+  return run;
+}
+
+/**
+ * Close a run's record. Rewrites the file the opening wrote, so a run has one
+ * record whatever happened to it.
+ *
+ * `err` is the reason a failure gave, and it is null for most failures rather
+ * than by oversight: a child that exits non-zero says nothing, and reading what
+ * it wrote is another card. The failure that does hand a reason over is a start
+ * that threw, which is the one a maintainer can act on.
+ *
+ * Milliseconds, and the field says so. The routine state's `duration` is whole
+ * seconds and cannot be widened without changing a file on every user's disk;
+ * this record is new, and a run that takes under a second is worth being able
+ * to tell from one that took no time at all.
+ */
+function endRunRecord(run, ok, endedAt, err) {
+  writeRunRecord(run.dir, {
+    id: run.id,
+    agent: run.agent,
+    routine: run.routine,
+    status: ok ? 'succeeded' : 'failed',
+    startedAt: run.startedAt,
+    endedAt: endedAt.toISOString(),
+    durationMs: endedAt.getTime() - run.startedMs,
+    error: err ? (err.message ? err.message : String(err)) : null,
+  });
+}
+
+/**
+ * Every run record in the workspace open now, in no promised order.
+ *
+ * Order is the caller's business, deliberately. A directory listing has an
+ * order that belongs to the filesystem, so sorting here would be a promise
+ * whose absence no test could reliably notice: whether an unsorted reader
+ * happened to hand back the right sequence would depend on how a particular
+ * filesystem lays out a particular set of random names. Every record carries
+ * the instant its run started, which is what a caller that cares about order
+ * should sort on.
+ *
+ * Keeps whatever it finds rather than whitelisting fields, exactly as the
+ * routine-state reader does and for the same reason: a reader that names the
+ * fields it expects silently discards anything a later writer adds, and the
+ * only scenario these records exist for is the one where the write and the
+ * read happen in different processes.
+ *
+ * Nothing in the server reads this yet. The run-detail screen is what it is
+ * for, and it is exported now because a store whose write cannot be read back
+ * is a store nothing can check.
+ */
+function readRunRecords() {
+  const dir = runsDir();
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch (e) {
+    return []; // no runs yet, or a workspace that cannot be read
+  }
+  const records = [];
+  for (const name of names) {
+    try {
+      const record = JSON.parse(fs.readFileSync(path.join(dir, name), 'utf-8'));
+      // A half-written file, or one somebody hand-edited into something else.
+      // Skipped rather than fatal: one bad file must not hide the history.
+      if (record && typeof record.id === 'string') records.push(record);
+    } catch (e) { /* unreadable or unparseable: skip it */ }
+  }
+  return records;
 }
 
 // ===== SCHEDULER =====
@@ -666,8 +857,29 @@ function getNextRun(schedule, lastRunISO) {
 function executeRoutine(agent, routine, key) {
   if (inFlight.has(key)) return false;
   inFlight.add(key);
+  // The run's record is opened HERE rather than inside beginRun so that its
+  // handle is in scope of the catch below. A start that throws is still a run
+  // that began and did not finish, and a record left saying 'running' forever
+  // would be the same silence in the new store that recordFailedStart removed
+  // from the old one.
+  //
+  // It is also what keeps the tick's failure path out of this. recordFailedStart
+  // runs inside the catch that keeps the whole pass alive, so a new fallible
+  // call there is a new way for one routine to end everybody's tick; the record
+  // is closed one frame below it instead, where the handle already is.
+  //
+  // INSIDE the same guard as the start, not ahead of it. Writing the record
+  // cannot throw, but reaching for the workspace root to decide where it goes
+  // can: there may not be one. Opened outside the try, that throw would leave
+  // the routine added to the in-flight set with nothing left to release it,
+  // which is held-for-the-life-of-the-process, the one fault this guard exists
+  // to prevent. The failure path below has a floor of its own for the stamp, so
+  // a start that dies before beginRun writes anything is still held to one
+  // attempt per period.
+  let run = null;
   try {
-    beginRun(agent, routine, key);
+    run = beginRunRecord(agent, routine, deps.now());
+    beginRun(agent, routine, key, run);
   } catch (err) {
     // A start that throws leaves no child, so no close event and no outcome,
     // so nothing that will ever release. Held forever is how a guard turns
@@ -675,12 +887,14 @@ function executeRoutine(agent, routine, key) {
     // to get there. Rethrown once the routine is free: what the caller does
     // about a failed start is unchanged by this file.
     inFlight.delete(key);
+    // A start that died before its record was opened has nothing to close.
+    if (run) endRunRecord(run, false, deps.now(), err);
     throw err;
   }
   return true;
 }
 
-function beginRun(agent, routine, key) {
+function beginRun(agent, routine, key, run) {
   const startTime = deps.now().getTime();
   // Persisted immediately: if the server dies mid-run, the restarted process
   // still knows the run started and will not fire it again in the same window.
@@ -709,6 +923,11 @@ function beginRun(agent, routine, key) {
       duration
     });
     console.log(`[Scheduler] Routine "${routine.name}" ${ok ? 'completed' : 'failed'} (${duration}s)`);
+    // Closed before the event and the broadcast, both of which can throw: a
+    // record left open by something that happened after the run ended would be
+    // read as a run still going, forever. The two calls below are otherwise
+    // untouched by this card.
+    endRunRecord(run, ok, deps.now(), null);
     recordEvent('routine_run', { agent: agent.id, runtime: agent.runtime || 'claude', d: { routine: routine.name, status: ok ? 'completed' : 'failed', duration } });
     broadcastRoutineUpdate();
   };
@@ -796,5 +1015,6 @@ module.exports = {
   wireSchedulerDeps,
   routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
   routineSlots, loadRoutineSlots, saveRoutineSlots,
+  readRunRecords,
   startScheduler, stopScheduler, getNextRun, executeRoutine,
 };

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -405,10 +405,16 @@ function beginRunRecord(agent, routine, startedAt) {
  * Close a run's record. Rewrites the file the opening wrote, so a run has one
  * record whatever happened to it.
  *
- * `err` is the reason a failure gave, and it is null for most failures rather
- * than by oversight: a child that exits non-zero says nothing, and reading what
- * it wrote is another card. The failure that does hand a reason over is a start
- * that threw, which is the one a maintainer can act on.
+ * `err` is the reason a failure gave, when the failure gave one. Three endings
+ * do: a start that threw, a child that never launched, and a codex turn that
+ * could not start. Each is handed an object with a message, and that message is
+ * the whole of what a maintainer has to go on, because in none of the three did
+ * a child ever run.
+ *
+ * The ending that has no reason to give is a child that ran and exited
+ * non-zero. An exit code is not a message, and whatever the child said it said
+ * on a stream nothing reads, which is another card. `null` there is the honest
+ * record rather than a gap.
  *
  * Milliseconds, and the field says so. The routine state's `duration` is whole
  * seconds and cannot be widened without changing a file on every user's disk;
@@ -911,8 +917,15 @@ function beginRun(agent, routine, key, run) {
   // A run ends once. The flag is local to this run, so it says nothing about
   // any other, and it is what lets the claude path listen for both ends of its
   // child without recording a failure that reports twice as two failures.
+  //
+  // The optional `err` is the reason a failure gave, for the two endings that
+  // are handed one: a child that never launched, and a codex turn that could
+  // not start. It reaches the run record and nothing else. The routine state,
+  // the signals event and the broadcast below are unchanged by it, and the
+  // endings that have no reason to give pass nothing, so a child that ran and
+  // exited non-zero still records none.
   let recorded = false;
-  const recordOutcome = (ok) => {
+  const recordOutcome = (ok, err) => {
     if (recorded) return;
     recorded = true;
     inFlight.delete(key);
@@ -927,7 +940,7 @@ function beginRun(agent, routine, key, run) {
     // record left open by something that happened after the run ended would be
     // read as a run still going, forever. The two calls below are otherwise
     // untouched by this card.
-    endRunRecord(run, ok, deps.now(), null);
+    endRunRecord(run, ok, deps.now(), err);
     recordEvent('routine_run', { agent: agent.id, runtime: agent.runtime || 'claude', d: { routine: routine.name, status: ok ? 'completed' : 'failed', duration } });
     broadcastRoutineUpdate();
   };
@@ -973,7 +986,10 @@ function beginRun(agent, routine, key, run) {
       return status === 'completed';
     })().then(recordOutcome, (err) => {
       console.error(`[Scheduler] Codex routine "${routine.name}" failed to run: ${err.message}`);
-      recordOutcome(false);
+      // The same reason the line above prints. Printing it and then dropping it
+      // left the record saying only that something failed, next to a log line
+      // saying exactly what, which is the half a maintainer needs.
+      recordOutcome(false, err);
     });
     return;
   }
@@ -999,7 +1015,12 @@ function beginRun(agent, routine, key, run) {
   // about a Node version rather than about this file. A routine held on the
   // answer being yes would be held for the life of the process, because
   // nothing else would ever remove it. Listening to both removes the question.
-  proc.on('error', () => recordOutcome(false));
+  // The error event carries an Error and the close event carries a number, and
+  // that difference is why only one of them passes a reason on. A child that
+  // never launched is described entirely by the message it came with; a child
+  // that ran and exited non-zero said whatever it said on a stream nothing
+  // reads, and an exit code is not a message.
+  proc.on('error', (err) => recordOutcome(false, err));
   proc.on('close', (code) => recordOutcome(code === 0));
 }
 

--- a/test/helpers/stack.js
+++ b/test/helpers/stack.js
@@ -1,0 +1,30 @@
+'use strict';
+// Which function a call came from, matched as a FRAME rather than as a
+// substring of the stack.
+//
+// WHY THIS EXISTS, because the obvious version is one character shorter and
+// wrong. A test that makes a wired dependency throw has to say WHICH call site
+// it means, and the natural way to say it is
+// `new Error().stack.includes('beginRun')`. That is a substring test, so it
+// also matches every function whose name merely STARTS with the one asked for:
+// `beginRun` matches `beginRunRecord`.
+//
+// When the technique was first written there was no such pair in this file, so
+// the ambiguity did not exist. The pair arrived later, in a change that had no
+// reason to look at these tests, which is the shape of the problem: the code
+// that breaks the selection is not the code the selection is about.
+//
+// The failure is silent in both directions. The fake fires at a call site the
+// test did not mean, or it stops firing at all and the test passes having
+// proved nothing, which is why every caller here asserts that its throw
+// actually happened before concluding anything from the result.
+//
+// A V8 frame renders the name as `    at name (file:line:col)`, or with a
+// receiver as `at Object.name (...)`. Requiring the space and the opening
+// bracket after the name is what makes one name unable to be a prefix of
+// another. `fn` is a plain identifier by contract, not a pattern.
+function calledFrom(fn) {
+  return new RegExp(`(?:^|[\\s.])${fn} \\(`, 'm').test(new Error().stack);
+}
+
+module.exports = { calledFrom };

--- a/test/integration/scheduler-run-records.test.js
+++ b/test/integration/scheduler-run-records.test.js
@@ -276,10 +276,11 @@ test('a run leaves one record, open while it runs and closed when it ends', asyn
   assert.strictEqual(rec.error, null, 'a run that succeeded gave no reason, so none is recorded');
 });
 
-// AC-6 and AC-22. The only failure that hands this file a reason today is a
-// start that threw: a child's exit code carries no message, and reading what
-// the child said is explicitly another card. So this is the test that a reason
-// reaches the record at all.
+// AC-6 and AC-22, on the first of the three failures that hand over a reason.
+// The other two are a child that never launched and a codex turn that could not
+// start, each covered by its own test. The failure with no reason to give is a
+// child that ran and exited non-zero: an exit code is not a message, and
+// reading what the child said is explicitly another card.
 //
 // It is also where a record could most easily be abandoned. The start throws
 // out of executeRoutine, so nothing on the ordinary outcome path runs, and a
@@ -401,6 +402,45 @@ test('the record names the agent by the id everything else keys on, not its disp
   assert.notStrictEqual(rec.agent, agent.name, 'and not the name a person reads on screen');
   assert.ok(h.internal.routineState[`${rec.agent}:${rec.routine}`],
     'so the record joins back to the run state, which is the point of carrying it');
+});
+
+// AC-6 on the OTHER kind of failure, and the distinction is the whole point.
+// A child that exits non-zero says nothing a record could carry, so `error` is
+// null there and that is honest. A codex turn that cannot start its thread is
+// handed an object with a message, and the scheduler already prints that
+// message to the console one line before the outcome is recorded. A record
+// saying `failed` with no reason, beside a log line saying exactly why, is a
+// reason discarded rather than a reason absent.
+//
+// The console line is what the assertion is anchored to, rather than a literal
+// string of the client's. What must hold is that the record carries the same
+// reason the failure gave, not that the reason reads any particular way.
+test('a codex run that cannot start its thread records the reason it was given', async (t) => {
+  begin(18, [CODEX]);
+  // Exhaust the client's retries so thread/start ultimately rejects. This is
+  // the rejection path, not a turn that ran and failed.
+  h.writeCodexScenario([], { overload: { method: 'thread/start', times: 10 } });
+
+  const errors = [];
+  const realError = console.error;
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    driveTicks(t);
+    assert.ok(await settled(CODEX, { timeout: 25000 }), 'the codex run reached an outcome');
+  } finally {
+    console.error = realError;
+    h.writeCodexScenario([]);
+  }
+
+  const [rec] = records();
+  assert.strictEqual(rec.status, 'failed', 'a thread that never started is a failed run');
+  assert.ok(typeof rec.error === 'string' && rec.error.length > 0,
+    'and the record carries a reason rather than nothing');
+
+  const logged = errors.find(e => e.includes('codex-check') && e.includes('failed to run'));
+  assert.ok(logged, 'the scheduler printed why, which is what proves a reason existed to be kept');
+  assert.ok(logged.includes(rec.error),
+    'and the record carries that same reason, rather than dropping it one line after it was printed');
 });
 
 // ---------------------------------------------------------------------------

--- a/test/integration/scheduler-run-records.test.js
+++ b/test/integration/scheduler-run-records.test.js
@@ -40,12 +40,17 @@ const NUL = String.fromCharCode(0);
 const KEEPER = 'keeper:briefing';
 const TWINS = 'twins:check';
 const FAULTY = 'faulty:faulty-check';
+const CRASHER = 'crasher:crash-check';
+const CODEX = 'codex-keeper:codex-check';
+const MISMATCH = 'mismatched:whoami';
 const RENAMED = 'keeper:briefing-renamed';
-const ALL = [KEEPER, TWINS, FAULTY, RENAMED];
+const ALL = [KEEPER, TWINS, FAULTY, CRASHER, CODEX, MISMATCH, RENAMED];
 
 const KEEPER_BODY = 'keeper routine body';
 const TWIN_EARLY = 'twin early body';
 const TWIN_LATE = 'twin late body';
+const CRASH_BODY = 'crasher routine body';
+const MISMATCH_BODY = 'mismatched routine body';
 
 // September 2026, local components, so the fixture is timezone-independent.
 function dayAt(day, hour, minute) { return new Date(2026, 8, day, hour, minute, 0); }
@@ -81,6 +86,31 @@ before(async () => {
         name: 'faulty', type: 'specialist', order: 3,
         routines: [{ name: 'faulty-check', schedule: 'every day at 05:00', prompt: `bad${NUL}body` }],
       }),
+      // A run whose CHILD fails, which is the only way a routine fails in the
+      // field: the CLI crashing, running out of memory, an expired login, the
+      // process killed at quit. Every one of those arrives as a non-zero close
+      // code on a child that really started, which is a different path from the
+      // start that never reached one.
+      crasher: agentFile({
+        name: 'crasher', type: 'specialist', order: 4,
+        routines: [{ name: 'crash-check', schedule: 'every day at 05:00', prompt: CRASH_BODY }],
+      }),
+      // The second runtime. Routines on it reach the same outcome closure by a
+      // completely different route, so a record written on the claude path says
+      // nothing about this one.
+      'codex-keeper': agentFile({
+        name: 'codex-keeper', type: 'specialist', order: 5, runtime: 'codex',
+        routines: [{ name: 'codex-check', schedule: 'every day at 05:00', prompt: 'codex routine body' }],
+      }),
+      // THE ONLY AGENT IN THIS FILE WHOSE ID AND NAME DIFFER, and it exists for
+      // exactly that. The id comes from the filename and the name from the
+      // frontmatter, and every other fixture here sets them to the same string,
+      // so a record carrying either one would look identical. A hand-written or
+      // marketplace agent normally has them apart.
+      mismatched: agentFile({
+        name: 'Mismatched Display Name', type: 'specialist', order: 6,
+        routines: [{ name: 'whoami', schedule: 'every day at 05:00', prompt: MISMATCH_BODY }],
+      }),
     },
   });
   keeperAgentFile = path.join(h.workspaceDir, '.claude', 'agents', 'keeper.md');
@@ -90,7 +120,15 @@ before(async () => {
     // the record while it is still open.
     { match: { agent: 'keeper' }, delayMs: 200, turn: [{ text: 'keeper ran' }] },
     { match: { agent: 'twins' }, turn: [{ text: 'twin ran' }] },
+    // Exits non-zero WITHOUT a result envelope: an abnormal mid-run death, not
+    // a routine that reported a failure. The delay holds it open past the
+    // synchronous tick, the same as the keeper rule above.
+    { match: { agent: 'crasher' }, delayMs: 200, crash: 1 },
+    { match: { agent: 'mismatched' }, turn: [{ text: 'mismatched ran' }] },
   ]);
+  // No rules: the codex stub answers an unmatched prompt with an ordinary turn
+  // that completes, which is the successful path on that runtime.
+  h.writeCodexScenario([]);
   prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
 });
 
@@ -168,11 +206,11 @@ function driveTicks(t, count = 1) {
   return { logs, errors };
 }
 
-function settled(key) {
+function settled(key, opts) {
   return h.waitUntil(() => {
     const s = h.internal.routineState[key];
     return s && s.status !== 'running';
-  });
+  }, opts);
 }
 
 // ---------------------------------------------------------------------------
@@ -200,6 +238,23 @@ test('a run leaves one record, open while it runs and closed when it ends', asyn
   assert.strictEqual(open[0].status, 'running', 'and it says the run is running');
   assert.strictEqual(open[0].endedAt, null, 'with no ending yet');
   assert.strictEqual(open[0].durationMs, null, 'and no duration yet');
+
+  // THE OPEN RECORD IS ASSERTED IN FULL, not just for the two fields that
+  // differ from a closed one. An open record is not a transient: it is what a
+  // sleeping machine, a quit, or a killed process leaves behind, because the
+  // closing write only ever runs from a live handler. So the run that never
+  // finished is exactly the run a history most needs to show, and one carrying
+  // an id and a start time and nothing else is dropped by any reader that
+  // filters by agent. Asserting only the closed record hides this completely,
+  // because the closing write rewrites the whole file from the handle and
+  // repairs any omission before anything looks.
+  assert.deepStrictEqual(Object.keys(open[0]).sort(),
+    ['agent', 'durationMs', 'endedAt', 'error', 'id', 'routine', 'startedAt', 'status'],
+    'an open record carries every field a closed one does');
+  assert.strictEqual(open[0].agent, 'keeper', 'including the agent it belongs to');
+  assert.strictEqual(open[0].routine, 'briefing', 'and the routine it belongs to');
+  assert.strictEqual(open[0].startedAt, dayAt(1, 5, 30).toISOString(), 'and when it started');
+  assert.strictEqual(open[0].error, null, 'and nothing has gone wrong yet');
 
   // Five minutes of the run's life, chosen rather than waited for.
   clock.at = dayAt(1, 5, 35);
@@ -251,6 +306,101 @@ test('a start that throws closes its record as failed, with the reason it gave',
   // vocabulary. Neither was renamed to match the other.
   assert.strictEqual(h.internal.routineState[FAULTY].status, 'failed',
     'and the routine state recorded the same failure, unchanged by this card');
+});
+
+// AC-4, AC-6 and AC-14 on the path that actually produces failures. Every
+// other failed record in this file comes from a start that threw before there
+// was a child, which is the rare case and is documented as the rare case. What
+// happens in the field is a child that started and died: the CLI crashing,
+// running out of memory, a login that expired overnight, the process killed
+// when the app quit. All of them arrive as a non-zero close code, and this
+// store exists to answer how often a routine has failed, so a history that
+// called them all successes would answer it wrongly and confidently.
+//
+// The routine state records a failure here too, so without this test the two
+// stores would disagree with only one of them tested.
+test('a run whose child dies is recorded as failed, and gives no reason it does not have', async (t) => {
+  begin(15, [CRASHER]);
+
+  driveTicks(t);
+  clock.at = dayAt(15, 5, 32);
+  assert.ok(await settled(CRASHER), 'the run reached an outcome');
+
+  const recs = records();
+  assert.strictEqual(recs.length, 1, 'the run left one record');
+  const rec = recs[0];
+  assert.strictEqual(rec.status, 'failed', 'a child that exited non-zero is a failed run, not a succeeded one');
+  assert.strictEqual(rec.agent, 'crasher', 'naming the agent');
+  assert.strictEqual(rec.routine, 'crash-check', 'and the routine');
+  assert.strictEqual(rec.startedAt, dayAt(15, 5, 30).toISOString(), 'started when the tick started it');
+  assert.strictEqual(rec.endedAt, dayAt(15, 5, 32).toISOString(), 'and ended when its child did');
+  assert.strictEqual(rec.durationMs, 2 * 60 * 1000, 'so it has a real duration, which a start that never ran does not');
+  // NOT an omission. The child said nothing a record could carry: an exit code
+  // is not a message, and reading what a routine wrote on its way out is
+  // explicitly another card. A reason invented here would be this file's guess
+  // rather than the failure's own words.
+  assert.strictEqual(rec.error, null,
+    'and no reason, because a non-zero exit gives none and the output is not read');
+
+  assert.strictEqual(h.internal.routineState[CRASHER].status, 'failed',
+    'the routine state agrees, in its own vocabulary');
+});
+
+// The second runtime. A routine on a codex agent reaches the same outcome
+// closure by a completely different route: an app-server thread, a turn, and a
+// promise, with no child process and no close event anywhere in it. A record
+// written on the claude path proves nothing about this one, and until this test
+// no codex agent existed in this file at all.
+test('a routine on the codex runtime leaves a record too', async (t) => {
+  begin(16, [CODEX]);
+
+  driveTicks(t);
+  // The codex path is asynchronous through a real app-server handshake, so it
+  // gets room the claude path does not need.
+  assert.ok(await settled(CODEX, { timeout: 20000 }), 'the codex run reached an outcome');
+
+  // The branch is asserted, not assumed. Discovery is what decides a routine
+  // takes the codex path, and a fixture whose runtime field stopped being
+  // honoured would run this through the claude stub and produce an identical
+  // record, leaving the test green and the path uncovered.
+  assert.ok(h.codexTurnPrompts().some(prompt => prompt.includes('codex routine body')),
+    'the routine really went through the codex app-server rather than a spawned child');
+
+  const recs = records();
+  assert.strictEqual(recs.length, 1, 'the codex run left one record');
+  assert.strictEqual(recs[0].agent, 'codex-keeper', 'naming the agent whose runtime it ran on');
+  assert.strictEqual(recs[0].routine, 'codex-check', 'and the routine');
+  assert.strictEqual(recs[0].status, 'succeeded', 'in the same vocabulary the other runtime uses');
+  assert.strictEqual(recs[0].startedAt, dayAt(16, 5, 30).toISOString(), 'and the instant the tick started it');
+  assert.ok(recs[0].endedAt, 'and it was closed rather than left open');
+});
+
+// AC-7, pinned to the id rather than to a coincidence. Everything else keys on
+// the agent id: the routine key the scheduler builds, the run state, the
+// single-flight hold, and the signals event written beside this record. A
+// record carrying the display name could not be joined back to any of them.
+//
+// The consequence is deferred, because nothing reads these records yet, and
+// that is what makes it worth pinning now: the wrong string would be written to
+// users' disks permanently and could not be re-derived afterwards.
+test('the record names the agent by the id everything else keys on, not its display name', async (t) => {
+  const agent = h.internal.discoverAgents().find(a => a.id === 'mismatched');
+  // The fixture defends itself. Every other agent in this file has an id equal
+  // to its name, so if this one ever collapsed to the same shape the assertion
+  // below would pass while proving nothing.
+  assert.ok(agent, 'the agent is on the roster');
+  assert.strictEqual(agent.name, 'Mismatched Display Name', 'whose frontmatter name is not its id');
+  assert.notStrictEqual(agent.name, agent.id, 'so the two really do diverge here');
+
+  begin(17, [MISMATCH]);
+  driveTicks(t);
+  assert.ok(await settled(MISMATCH), 'the run finished');
+
+  const [rec] = records();
+  assert.strictEqual(rec.agent, 'mismatched', 'the record carries the id');
+  assert.notStrictEqual(rec.agent, agent.name, 'and not the name a person reads on screen');
+  assert.ok(h.internal.routineState[`${rec.agent}:${rec.routine}`],
+    'so the record joins back to the run state, which is the point of carrying it');
 });
 
 // ---------------------------------------------------------------------------
@@ -407,13 +557,24 @@ test('nothing a record writes reaches the value double-fire suppression reads', 
   begin(9, [KEEPER]);
 
   driveTicks(t);
+  // TWO CHOSEN INSTANTS, and the whole criterion rests on them. Frozen, the
+  // instant the run started and the instant it ended are the same string, so a
+  // record field fed into the suppression stamp would be indistinguishable from
+  // the stamp the run wrote itself, and this test would defend its criterion
+  // nowhere while appearing to defend it here.
+  clock.at = dayAt(9, 5, 45);
   assert.ok(await settled(KEEPER), 'the run finished');
+  const [rec] = records();
   assert.strictEqual(records().length, 1, 'a record really was written on this pass');
 
   assert.deepStrictEqual(Object.keys(h.internal.routineState[KEEPER]).sort(), ['duration', 'lastRun', 'status'],
     'the routine state kept its shape: no run id, no record fields, nothing new');
-  assert.strictEqual(h.internal.routineState[KEEPER].lastRun, dayAt(9, 5, 30).toISOString(),
-    'and its stamp is the one the run wrote, not one a record moved');
+  assert.strictEqual(h.internal.routineState[KEEPER].lastRun, dayAt(9, 5, 45).toISOString(),
+    'and its stamp is the one the RUN wrote when it ended');
+  assert.strictEqual(rec.startedAt, dayAt(9, 5, 30).toISOString(),
+    'while the record carries a different instant entirely');
+  assert.notStrictEqual(h.internal.routineState[KEEPER].lastRun, rec.startedAt,
+    'so a record field reaching the suppression stamp would move it, visibly');
   assert.deepStrictEqual(Object.keys(h.internal.routineSlots.routines[KEEPER]).sort(), ['due', 'missed', 'schedule'],
     'and the slot store kept its shape too');
 

--- a/test/integration/scheduler-run-records.test.js
+++ b/test/integration/scheduler-run-records.test.js
@@ -776,6 +776,69 @@ test('a start that fails before its record is opened does not hold the routine',
   assert.ok(await settled(KEEPER), 'the run that did start finished');
 });
 
+// AC-22 IN THE COMBINATION IT NAMES, which nothing above exercises. The test
+// beside this one forces the write to fail against a routine whose start
+// SUCCEEDS, and the throwing routine is only ever driven against a writable
+// store. The criterion is about neither on its own: it is about a record write
+// failing on the path that runs INSIDE the catch that keeps the whole pass
+// alive.
+//
+// That is the worst place for a swallowed failure to stop being swallowed. A
+// throw raised there escapes exactly as the original one did, one routine ends
+// the pass for every agent in the workspace, and it happens again sixty seconds
+// later with nothing recorded and nothing shown. The write helper wraps both of
+// its filesystem calls, so this holds by construction today; a criterion whose
+// named combination is left to construction is the kind of claim this project
+// has had wrong four times, every one a comment asserting what the code did not
+// do.
+//
+// The routine that follows the thrower is the isolation half, and the empty
+// store is what proves the write really was failing rather than the setup
+// quietly not taking.
+test('a start that throws while the record store is unwritable still fails safely', async (t) => {
+  begin(20, [FAULTY, MISMATCH]);
+  fs.mkdirSync(path.dirname(runsDir()), { recursive: true });
+  fs.writeFileSync(runsDir(), 'not a directory');
+  h.clearPrompts();
+
+  try {
+    const { errors } = driveTicks(t);
+
+    // The store really could not be written, on this pass, for these runs.
+    // Without this the whole test is satisfied by a writable store.
+    assert.deepStrictEqual(records(), [], 'no record could be written at all');
+    assert.ok(errors.some(e => e.includes('run record')),
+      'and the write failure was reported rather than passing silently');
+
+    // THE REASON IS THE START'S OWN. A throw escaping the record write would
+    // replace it, and the routine state would explain a filesystem problem to
+    // someone whose routine is malformed.
+    const failed = h.internal.routineState[FAULTY];
+    assert.strictEqual(failed.status, 'failed', 'the throwing start was recorded as a failed run');
+    assert.match(failed.error, /null byte/i, 'carrying the reason its own start gave');
+    assert.doesNotMatch(failed.error, /EEXIST|ENOTDIR|not a directory/i,
+      'and not the reason the record store gave, which is a different problem entirely');
+    assert.ok(errors.some(e => e.includes('faulty-check') && e.includes('failed to start')),
+      'and the log names the routine that failed to start, beside the write failure');
+
+    // The isolation half: a routine declared after the thrower, on the same
+    // pass, with the write still failing under both of them.
+    const after = h.internal.routineState[MISMATCH];
+    assert.ok(after, 'the routine declared after the thrower was reached');
+    assert.strictEqual(after.lastRun, dayAt(20, 5, 30).toISOString(), 'and started on that same pass');
+
+    // And everything below the routine loop, which the original escape skipped.
+    assert.strictEqual(h.internal.routineSlots.observedAt, dayAt(20, 5, 30).toISOString(),
+      'the end-of-tick bookkeeping still ran, so the pass did not end at the thrower');
+
+    assert.ok(await settled(MISMATCH), 'the run that did start finished');
+    assert.ok(h.promptsFor('mismatched').includes(MISMATCH_BODY),
+      'and it really did the work, rather than only being recorded as having started');
+  } finally {
+    fs.rmSync(runsDir(), { force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // The reader
 // ---------------------------------------------------------------------------

--- a/test/integration/scheduler-run-records.test.js
+++ b/test/integration/scheduler-run-records.test.js
@@ -1,0 +1,594 @@
+'use strict';
+// A run leaves a record of its own.
+//
+// Before this card there was no history. routineState holds ONE slot per
+// routine and every run overwrites its predecessor, so nothing could say what
+// happened yesterday, how often a routine has failed, or how long it usually
+// takes. These tests are about the store that can.
+//
+// WHAT EVERY TEST HERE HAS TO BE CAREFUL OF, and it is the reason several of
+// them look heavier than their assertion. A test that sees two records is
+// indistinguishable from a test that would see two whatever the writer did,
+// unless one record per run is proved by making the writer produce a different
+// number. So the accumulation tests assert the COUNT and the IDS and the
+// STATUSES together: removing the opening write leaves none, giving every run
+// the same identity leaves one, and removing the closing write leaves records
+// that never stop saying 'running'. Each of those is a different failure.
+//
+// Setup is the scheduler-tick-isolation template: stop the boot-armed tick
+// first, mock setInterval, then start, so the interval being driven is the
+// mocked one. The clock is the scheduler's own seam, so every instant in this
+// file is chosen rather than measured, and nothing rests on real elapsed time.
+//
+// A tick sees every routine in the workspace, so each test names the routines
+// it wants live and the rest are quietened with a stamp late on its own day.
+// Each test also owns a day, because a run stamped on a shared day suppresses
+// another test's routine through the ordinary schedule rule.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const h = require('../helpers/harness.js');
+const { agentFile, makeWorkspace } = require('../helpers/workspace.js');
+
+const scheduler = require('../../lib/scheduler.js');
+
+// Built rather than written, so the byte that makes the faulty fixture throw
+// is visible in the source instead of being an invisible character in it.
+const NUL = String.fromCharCode(0);
+
+const KEEPER = 'keeper:briefing';
+const TWINS = 'twins:check';
+const FAULTY = 'faulty:faulty-check';
+const RENAMED = 'keeper:briefing-renamed';
+const ALL = [KEEPER, TWINS, FAULTY, RENAMED];
+
+const KEEPER_BODY = 'keeper routine body';
+const TWIN_EARLY = 'twin early body';
+const TWIN_LATE = 'twin late body';
+
+// September 2026, local components, so the fixture is timezone-independent.
+function dayAt(day, hour, minute) { return new Date(2026, 8, day, hour, minute, 0); }
+
+const clock = { at: dayAt(1, 5, 30) };
+let prevDeps = null;
+let keeperAgentFile = null;
+
+before(async () => {
+  await h.boot({
+    agents: {
+      keeper: agentFile({
+        name: 'keeper', type: 'specialist', order: 1,
+        routines: [{ name: 'briefing', schedule: 'every day at 05:00', prompt: KEEPER_BODY }],
+      }),
+      // TWO ROUTINES SHARING A NAME UNDER ONE AGENT, which the data model
+      // deliberately allows and test/unit/routine-model.test.js pins. They
+      // share the key `twins:check`, so the key can never tell their runs
+      // apart. Different times, because sharing a key also means sharing the
+      // single-flight hold and the double-fire suppression: at 05:00 only the
+      // first is due, and at 09:00 only the second is.
+      twins: agentFile({
+        name: 'twins', type: 'specialist', order: 2,
+        routines: [
+          { name: 'check', schedule: 'every day at 05:00', prompt: TWIN_EARLY },
+          { name: 'check', schedule: 'every day at 09:00', prompt: TWIN_LATE },
+        ],
+      }),
+      // The thrower. Its prompt reaches spawn as an argument Node refuses, so
+      // the start throws synchronously through the whole production path with
+      // nothing stood in for.
+      faulty: agentFile({
+        name: 'faulty', type: 'specialist', order: 3,
+        routines: [{ name: 'faulty-check', schedule: 'every day at 05:00', prompt: `bad${NUL}body` }],
+      }),
+    },
+  });
+  keeperAgentFile = path.join(h.workspaceDir, '.claude', 'agents', 'keeper.md');
+  h.writeScenario([
+    // The delay holds the child open past the synchronous tick, which is what
+    // lets a test move the clock between a run's start and its end and read
+    // the record while it is still open.
+    { match: { agent: 'keeper' }, delayMs: 200, turn: [{ text: 'keeper ran' }] },
+    { match: { agent: 'twins' }, turn: [{ text: 'twin ran' }] },
+  ]);
+  prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+});
+
+after(async () => {
+  if (prevDeps) scheduler.wireSchedulerDeps(prevDeps);
+  await h.shutdown();
+});
+
+function runsDir() { return path.join(h.workspaceDir, '.rundock', 'runs'); }
+
+// Everything the store holds for this workspace, dropped so a test's counts
+// are its own. Accumulation is proved WITHIN a test, by running twice, which
+// is what the criterion is about; leaving the previous test's records in place
+// would only make every count a running total nobody could reason about.
+function wipeRuns() { fs.rmSync(runsDir(), { recursive: true, force: true }); }
+
+function records() { return scheduler.readRunRecords(); }
+function recordsFor(agentId) { return records().filter(r => r.agent === agentId); }
+
+// The reader promises no order, because a directory listing has none to give,
+// so a test that cares about which runs happened sorts by the instant each
+// record carries. Asserting the reader's own sequence would be asserting the
+// filesystem's.
+function startedAts(recs) { return recs.map(r => r.startedAt).sort(); }
+
+// A run recorded late on the test's own day suppresses a routine through the
+// ordinary schedule rule, so a pass only ever starts the routines it names.
+function quieten(day, live) {
+  for (const key of ALL) {
+    if (live.includes(key)) continue;
+    h.internal.routineState[key] = { lastRun: dayAt(day, 23, 0).toISOString(), status: 'completed', duration: 1 };
+  }
+}
+
+/** Move to a fresh day with `live` due and everything else quiet. */
+function advance(day, live, hour = 5, minute = 30) {
+  clock.at = dayAt(day, hour, minute);
+  for (const key of live) delete h.internal.routineState[key];
+  quieten(day, live);
+}
+
+/** As `advance`, and start from an empty store. */
+function begin(day, live, hour = 5, minute = 30) {
+  wipeRuns();
+  advance(day, live, hour, minute);
+}
+
+// Ticks the real scheduler with the console captured. The server armed a tick
+// at boot and a second start is a no-op, so the real one is stopped before the
+// mocked one this drives is armed.
+//
+// The tick is driven INSIDE the capture and not wrapped in a try, so a pass
+// that ends by throwing fails its test where it happened.
+//
+// Returns synchronously without yielding to the event loop, which several
+// tests depend on: a child spawned by the pass cannot have closed yet, so the
+// clock can still be moved before the run reaches its outcome.
+function driveTicks(t, count = 1) {
+  const logs = [];
+  const errors = [];
+  const real = { log: console.log, error: console.error };
+  h.internal.stopScheduler();
+  t.mock.timers.enable({ apis: ['setInterval'] });
+  console.log = (...args) => logs.push(args.join(' '));
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    h.internal.startScheduler();
+    for (let i = 0; i < count; i++) t.mock.timers.tick(60_000);
+  } finally {
+    console.log = real.log;
+    console.error = real.error;
+    h.internal.stopScheduler();
+    t.mock.timers.reset();
+  }
+  return { logs, errors };
+}
+
+function settled(key) {
+  return h.waitUntil(() => {
+    const s = h.internal.routineState[key];
+    return s && s.status !== 'running';
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The record
+// ---------------------------------------------------------------------------
+
+// AC-1 to AC-5, AC-7, AC-8, AC-12 and AC-14, in the one place where all of
+// them are visible at once: a run watched from the moment it starts to the
+// moment it ends.
+//
+// The two instants are DIFFERENT chosen values rather than one frozen one, and
+// the duration is asserted against the gap between them. A frozen clock would
+// make startedAt, endedAt and a duration of zero all agree with a writer that
+// stamped a constant, or with no writer at all.
+test('a run leaves one record, open while it runs and closed when it ends', async (t) => {
+  begin(1, [KEEPER]);
+
+  driveTicks(t);
+
+  // The child is still alive: the record exists and says so. This is also the
+  // proof that the ending REPLACES this record rather than adding a second,
+  // since the count below never changes.
+  const open = records();
+  assert.strictEqual(open.length, 1, 'the run that started opened exactly one record');
+  assert.strictEqual(open[0].status, 'running', 'and it says the run is running');
+  assert.strictEqual(open[0].endedAt, null, 'with no ending yet');
+  assert.strictEqual(open[0].durationMs, null, 'and no duration yet');
+
+  // Five minutes of the run's life, chosen rather than waited for.
+  clock.at = dayAt(1, 5, 35);
+  assert.ok(await settled(KEEPER), 'the run finished');
+
+  const closed = records();
+  assert.strictEqual(closed.length, 1, 'the run that ended left one record, not a second one');
+  const rec = closed[0];
+  assert.strictEqual(rec.id, open[0].id, 'and it is the same record the start opened');
+  assert.strictEqual(typeof rec.id, 'string', 'a run carries an identity of its own');
+  assert.ok(rec.id.length > 0, 'and it is not empty');
+  assert.strictEqual(rec.agent, 'keeper', 'the record names the agent it belongs to');
+  assert.strictEqual(rec.routine, 'briefing', 'and the routine it belongs to');
+  assert.strictEqual(rec.status, 'succeeded', 'the outcome, in the record vocabulary');
+  assert.strictEqual(rec.startedAt, dayAt(1, 5, 30).toISOString(), 'when the run started');
+  assert.strictEqual(rec.endedAt, dayAt(1, 5, 35).toISOString(), 'when it ended');
+  assert.strictEqual(rec.durationMs, 5 * 60 * 1000,
+    'and how long it took, which is the gap between those two instants and not a constant');
+  assert.strictEqual(rec.error, null, 'a run that succeeded gave no reason, so none is recorded');
+});
+
+// AC-6 and AC-22. The only failure that hands this file a reason today is a
+// start that threw: a child's exit code carries no message, and reading what
+// the child said is explicitly another card. So this is the test that a reason
+// reaches the record at all.
+//
+// It is also where a record could most easily be abandoned. The start throws
+// out of executeRoutine, so nothing on the ordinary outcome path runs, and a
+// record opened and never closed would sit at 'running' forever: the exact
+// silence recordFailedStart removed from the routine state.
+test('a start that throws closes its record as failed, with the reason it gave', async (t) => {
+  begin(2, [FAULTY]);
+
+  driveTicks(t);
+
+  const recs = records();
+  assert.strictEqual(recs.length, 1, 'the attempt left one record');
+  const rec = recs[0];
+  assert.strictEqual(rec.status, 'failed', 'closed as failed rather than abandoned at running');
+  assert.match(rec.error, /null byte/i, 'carrying the reason the failure itself gave');
+  assert.strictEqual(rec.agent, 'faulty', 'and naming the agent');
+  assert.strictEqual(rec.routine, 'faulty-check', 'and the routine');
+  assert.strictEqual(rec.endedAt, rec.startedAt,
+    'a failure that never reached a child ends in the instant it began');
+  assert.strictEqual(rec.durationMs, 0, 'so it took no time');
+
+  // The two stores agree that this failed, in their own words. The routine
+  // state keeps the tokens it shipped with; the record uses the frozen
+  // vocabulary. Neither was renamed to match the other.
+  assert.strictEqual(h.internal.routineState[FAULTY].status, 'failed',
+    'and the routine state recorded the same failure, unchanged by this card');
+});
+
+// ---------------------------------------------------------------------------
+// Accumulation
+// ---------------------------------------------------------------------------
+
+// AC-12, AC-13, AC-27 and AC-28. Two runs of ONE routine, on two days.
+//
+// Every assertion here is chosen so that a different fault produces a
+// different failure: no opening write leaves zero records, one identity for
+// every run leaves one, and no closing write leaves two that still say
+// 'running'.
+test('two runs of one routine leave two records, one for each', async (t) => {
+  begin(3, [KEEPER]);
+  driveTicks(t);
+  assert.ok(await settled(KEEPER), 'the first run finished');
+  assert.strictEqual(records().length, 1, 'one run so far, one record');
+
+  advance(4, [KEEPER]);
+  driveTicks(t);
+  assert.ok(await settled(KEEPER), 'the second run finished');
+
+  const recs = recordsFor('keeper');
+  assert.strictEqual(recs.length, 2, 'the second run did not replace the first');
+  assert.notStrictEqual(recs[0].id, recs[1].id,
+    'the two runs have different identities, which is what stops one overwriting the other');
+  assert.deepStrictEqual(startedAts(recs), [dayAt(3, 5, 30).toISOString(), dayAt(4, 5, 30).toISOString()],
+    'and the two records are the two runs, each carrying the instant its own began');
+  assert.deepStrictEqual(recs.map(r => r.status), ['succeeded', 'succeeded'],
+    'both reached an ending, so neither was left open');
+  assert.deepStrictEqual(recs.map(r => r.routine), ['briefing', 'briefing'],
+    'and both belong to the one routine that ran twice');
+});
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+// AC-9 and AC-10. The routine key `agentId:routineName` is neither unique nor
+// stable, and this is the unique half: two routines under one agent, both
+// named `check`, sharing one key, one state slot and one single-flight hold.
+// Nothing keyed by the routine could tell their runs apart.
+//
+// The prompts are what make this two ROUTINES rather than one routine twice.
+// Without them the test is satisfied by the accumulation above.
+test('two routines sharing a name under one agent leave records that can be told apart', async (t) => {
+  begin(5, [TWINS]);
+  h.clearPrompts();
+
+  driveTicks(t);
+  assert.ok(await settled(TWINS), 'the 05:00 routine finished');
+
+  // Same day, four hours on, and the clock alone: the run state is what makes
+  // this work. The 05:00 routine is suppressed by the stamp its own run left,
+  // and the 09:00 namesake reads that same stamp as too early to suppress it.
+  // Re-quietening here would overwrite that stamp and silence both.
+  clock.at = dayAt(5, 9, 30);
+  driveTicks(t);
+  assert.ok(await settled(TWINS), 'the 09:00 routine finished');
+
+  const prompts = h.promptsFor('twins');
+  assert.ok(prompts.includes(TWIN_EARLY), 'the first namesake ran');
+  assert.ok(prompts.includes(TWIN_LATE), 'and so did the second, which is a different routine');
+
+  const recs = recordsFor('twins');
+  assert.strictEqual(recs.length, 2, 'two runs, two records');
+  assert.notStrictEqual(recs[0].id, recs[1].id,
+    'told apart by an identity of their own, which is the only thing that can: the key is the same for both');
+  assert.deepStrictEqual(startedAts(recs), [dayAt(5, 5, 30).toISOString(), dayAt(5, 9, 30).toISOString()],
+    'and each carries the instant its own run started');
+  assert.deepStrictEqual(recs.map(r => r.routine), ['check', 'check'],
+    'both name the routine they belong to, which for namesakes is the same name: the record says what it can vouch for');
+});
+
+// AC-11, the stable half. A rename produces a different key, so anything
+// identified by the key would either lose its history or hand it to the new
+// name. A record is written once and never rewritten, so what it says about
+// itself survives an edit to the routine that made it.
+test('renaming a routine leaves the records it already wrote untouched', async (t) => {
+  const original = fs.readFileSync(keeperAgentFile, 'utf-8');
+  begin(6, [KEEPER]);
+  driveTicks(t);
+  assert.ok(await settled(KEEPER), 'the run under the old name finished');
+  const before = records();
+  assert.strictEqual(before.length, 1, 'one run under the old name');
+
+  try {
+    fs.writeFileSync(keeperAgentFile, original.replace('name: briefing', 'name: briefing-renamed'));
+    h.internal.invalidateAgentCache();
+
+    advance(7, [RENAMED]);
+    driveTicks(t);
+    assert.ok(await settled(RENAMED), 'the run under the new name finished');
+
+    const after = records();
+    assert.strictEqual(after.length, 2, 'the rename added a record rather than replacing one');
+    const kept = after.find(r => r.id === before[0].id);
+    assert.deepStrictEqual(kept, before[0],
+      'the record written before the rename is byte-for-byte what it was, still naming the routine that ran');
+    assert.strictEqual(kept.routine, 'briefing', 'including the name the routine had at the time');
+    const fresh = after.find(r => r.id !== before[0].id);
+    assert.strictEqual(fresh.routine, 'briefing-renamed', 'and the new run recorded the name it ran under');
+  } finally {
+    fs.writeFileSync(keeperAgentFile, original);
+    h.internal.invalidateAgentCache();
+    delete h.internal.routineState[RENAMED];
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+// AC-14, AC-15 and AC-16 together, because they are one decision seen from
+// three sides: the record has its own words, it writes none it cannot mean,
+// and the routine state keeps the words it shipped with.
+test('records use the frozen vocabulary and the routine state keeps its own', async (t) => {
+  begin(8, [KEEPER, FAULTY]);
+
+  driveTicks(t);
+  assert.ok(await settled(KEEPER), 'the run that succeeds finished');
+
+  const statuses = records().map(r => r.status).sort();
+  assert.deepStrictEqual(statuses, ['failed', 'succeeded'],
+    'a pass with one success and one failure wrote exactly those two words');
+  for (const status of records().map(r => r.status)) {
+    assert.ok(['running', 'succeeded', 'failed'].includes(status), `"${status}" is outside the record vocabulary`);
+  }
+  // Not producible yet, and so never written: routines start the moment they
+  // are found due, and the child handle is never kept, so nothing can reach a
+  // run to cancel it.
+  const written = new Set(records().map(r => r.status));
+  assert.ok(!written.has('queued'), 'nothing queues a run, so no record claims it');
+  assert.ok(!written.has('cancelled'), 'nothing can cancel a run, so no record claims it');
+
+  assert.strictEqual(h.internal.routineState[KEEPER].status, 'completed',
+    'the routine state still says completed, which is the token on every user disk and was not renamed');
+});
+
+// ---------------------------------------------------------------------------
+// Separation, which is the crux
+// ---------------------------------------------------------------------------
+
+// AC-17, AC-18 and AC-19. routineState is simultaneously the display record
+// and the ONLY input to double-fire suppression, read as
+// getNextRun(schedule, routineState[key]?.lastRun). A run record that reached
+// it would move the instant the suppression fires on.
+//
+// This is a negative criterion, so removing the record writer cannot make it
+// fail. That is what the first assertion is for: without a record on disk the
+// test is satisfied by a build that has no run records at all. What it DOES
+// catch is the mutation it exists for, a field or a stamp leaking across.
+test('nothing a record writes reaches the value double-fire suppression reads', async (t) => {
+  begin(9, [KEEPER]);
+
+  driveTicks(t);
+  assert.ok(await settled(KEEPER), 'the run finished');
+  assert.strictEqual(records().length, 1, 'a record really was written on this pass');
+
+  assert.deepStrictEqual(Object.keys(h.internal.routineState[KEEPER]).sort(), ['duration', 'lastRun', 'status'],
+    'the routine state kept its shape: no run id, no record fields, nothing new');
+  assert.strictEqual(h.internal.routineState[KEEPER].lastRun, dayAt(9, 5, 30).toISOString(),
+    'and its stamp is the one the run wrote, not one a record moved');
+  assert.deepStrictEqual(Object.keys(h.internal.routineSlots.routines[KEEPER]).sort(), ['due', 'missed', 'schedule'],
+    'and the slot store kept its shape too');
+
+  // The consequence, which is what the criterion is really about: the routine
+  // is still held for the rest of its period. A stamp moved by a record would
+  // show up here as a second run.
+  driveTicks(t);
+  assert.strictEqual(records().length, 1, 'the same day started no second run, so no second record');
+});
+
+// ---------------------------------------------------------------------------
+// Failing safely
+// ---------------------------------------------------------------------------
+
+// AC-20, AC-21 and AC-30. A regular file where the store must create a folder,
+// so mkdir throws for a real reason rather than through a stub. The routine
+// still runs, the pass still finishes its bookkeeping, and the reader survives
+// the same directory.
+test('a workspace that cannot be written to does not stop the run or the pass', async (t) => {
+  begin(10, [KEEPER]);
+  fs.mkdirSync(path.dirname(runsDir()), { recursive: true });
+  fs.writeFileSync(runsDir(), 'not a directory');
+  h.clearPrompts();
+
+  try {
+    const { errors } = driveTicks(t);
+
+    assert.ok(await settled(KEEPER), 'the run reached an outcome');
+    assert.strictEqual(h.internal.routineState[KEEPER].status, 'completed',
+      'the routine ran and completed, so an unwritable store did not stop it');
+    assert.ok(h.promptsFor('keeper').includes(KEEPER_BODY), 'and the agent really was asked to do the work');
+    assert.strictEqual(h.internal.routineSlots.observedAt, dayAt(10, 5, 30).toISOString(),
+      'and the bookkeeping below the routine loop still ran, so the pass did not end either');
+    assert.ok(errors.some(e => e.includes('run record')),
+      'the failure was said once rather than swallowed silently');
+    assert.deepStrictEqual(records(), [],
+      'and the reader answers for an unreadable store rather than throwing out of its caller');
+  } finally {
+    fs.rmSync(runsDir(), { force: true });
+  }
+});
+
+// AC-22 from the other side. Writing a record cannot throw, but getting as far
+// as opening one can: it needs the clock, and it needs a workspace root to
+// resolve a directory against. Opened outside the guard that releases the
+// routine, that throw arrives after the routine has been added to the in-flight
+// set and before anything exists to take it out again, and the routine is held
+// for the life of the process: no spawn, no child, no close, nothing that will
+// ever release it.
+//
+// The clock is the seam, because it is the one this file can make fail without
+// making anything else pretend. Single-shot, and selected on the call site
+// rather than on a count of readings: the tick reads once and then once per
+// routine to ask whether each is due, and that total moves whenever the fixture
+// grows. beginRun is excluded because its readings are deeper in the same stack
+// and are a different case, already pinned elsewhere.
+//
+// What is asserted is that the SECOND start gets going. A routine still held
+// would be turned away by the single-flight guard and would return false
+// without throwing, which is the failure that looks like success.
+//
+// The message is asserted too, and that is the other half. A record handle that
+// was never opened has nothing to close; closing it anyway raises a throw of its
+// own from inside the catch, and the reason the start failed is replaced by the
+// reason the cleanup failed.
+test('a start that fails before its record is opened does not hold the routine', async () => {
+  begin(14, [KEEPER]);
+  const agent = { id: 'keeper', name: 'keeper' };
+  const routine = { name: 'briefing', prompt: KEEPER_BODY };
+
+  let thrown = false;
+  const prev = scheduler.wireSchedulerDeps({
+    now: () => {
+      const stack = new Error().stack;
+      if (!thrown && stack.includes('executeRoutine') && !stack.includes('beginRun')) {
+        thrown = true;
+        throw new Error('clock unavailable');
+      }
+      return clock.at;
+    },
+  });
+  try {
+    const start = () => h.internal.executeRoutine(agent, routine, KEEPER);
+    assert.throws(start, /clock unavailable/,
+      'the start threw where the record is opened, and the reason that reached the caller is the start\'s own');
+    // Proves the setup did what it claims before anything is concluded from it.
+    assert.ok(thrown, 'the clock really did throw, so the record was never opened');
+    assert.strictEqual(start(), true,
+      'and the second start was allowed, so the first one released the routine on its way out');
+  } finally {
+    scheduler.wireSchedulerDeps(prev);
+  }
+
+  assert.ok(await settled(KEEPER), 'the run that did start finished');
+});
+
+// ---------------------------------------------------------------------------
+// The reader
+// ---------------------------------------------------------------------------
+
+// AC-29. The scenario these records exist for is the one where the write and
+// the read happen in different processes, so a reader that quietly disagrees
+// with the writer about the shape would discard every record on every load
+// with nothing red. This reads the file itself and holds the reader to it.
+test('the reader returns what the writer wrote, from disk, keeping every field', async (t) => {
+  begin(11, [KEEPER]);
+  driveTicks(t);
+  clock.at = dayAt(11, 5, 33);
+  assert.ok(await settled(KEEPER), 'the run finished');
+
+  const [rec] = records();
+  const file = path.join(runsDir(), `${rec.id}.json`);
+  assert.ok(fs.existsSync(file), 'the record is a file of its own, named for the run');
+  const onDisk = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  assert.deepStrictEqual(rec, onDisk,
+    'and the reader hands back exactly what is on disk, dropping no field the writer wrote');
+  assert.deepStrictEqual(Object.keys(onDisk).sort(),
+    ['agent', 'durationMs', 'endedAt', 'error', 'id', 'routine', 'startedAt', 'status'],
+    'which is the whole record: identity, ownership, both instants, the outcome, how long, and any reason');
+});
+
+test('the reader keeps going past a file it cannot use', async (t) => {
+  begin(12, [KEEPER]);
+  driveTicks(t);
+  assert.ok(await settled(KEEPER), 'the run finished');
+
+  // A truncated write, and a file that parses to something that is not a
+  // record. Both are reachable by hand-editing a directory the product invites
+  // people to look in.
+  fs.writeFileSync(path.join(runsDir(), 'half-written.json'), '{"id": "abc",');
+  fs.writeFileSync(path.join(runsDir(), 'empty.json'), 'null');
+
+  const recs = records();
+  assert.strictEqual(recs.length, 1, 'the record that is a record is still returned');
+  assert.strictEqual(recs[0].routine, 'briefing', 'and it is the real one');
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+// AC-23, as behaviour rather than as prose. The run state and the slot records
+// are dropped when the workspace changes because they describe the workspace
+// being left. The in-flight set deliberately is not, because the child process
+// of a run in flight is still running.
+//
+// A run's record follows the in-flight set: the run is what closes it, and the
+// run outlives the switch. So the directory is fixed when the run starts. If
+// it were resolved again at the end, the workspace that did the work would
+// keep a record stuck at 'running' forever and the workspace the user happened
+// to switch to would receive an ending for a run it never saw.
+//
+// Read through the filesystem rather than through the module's reader, because
+// the reader answers for the workspace open NOW, which is the other one.
+test('a run that outlives a workspace switch closes its record where it began', async (t) => {
+  begin(13, [KEEPER]);
+  const home = runsDir();
+  const elsewhere = makeWorkspace({ agents: {}, claudeMd: '# Elsewhere\n' });
+
+  driveTicks(t);
+  // Synchronous with the pass: the child cannot have closed yet.
+  h.internal.setWorkspace(elsewhere);
+  clock.at = dayAt(13, 5, 40);
+
+  try {
+    assert.ok(await settled(KEEPER), 'the run finished, in a process now pointed somewhere else');
+
+    const files = fs.readdirSync(home);
+    assert.strictEqual(files.length, 1, 'the run left one record, where it started');
+    const rec = JSON.parse(fs.readFileSync(path.join(home, files[0]), 'utf-8'));
+    assert.strictEqual(rec.status, 'succeeded', 'closed rather than abandoned at running');
+    assert.strictEqual(rec.endedAt, dayAt(13, 5, 40).toISOString(), 'with the instant it actually ended');
+    assert.ok(!fs.existsSync(path.join(elsewhere, '.rundock', 'runs')),
+      'and the workspace switched to received nothing: it never ran anything');
+  } finally {
+    h.internal.setWorkspace(h.workspaceDir);
+  }
+});

--- a/test/integration/scheduler-run-records.test.js
+++ b/test/integration/scheduler-run-records.test.js
@@ -30,6 +30,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const h = require('../helpers/harness.js');
 const { agentFile, makeWorkspace } = require('../helpers/workspace.js');
+const { calledFrom } = require('../helpers/stack.js');
 
 const scheduler = require('../../lib/scheduler.js');
 
@@ -475,6 +476,63 @@ test('two runs of one routine leave two records, one for each', async (t) => {
     'and both belong to the one routine that ran twice');
 });
 
+// AC-2, on the question of WHICH instant a start is. The tick reads the clock
+// once and judges every routine against that one reading. A record that read
+// the clock again would describe the same start at a different moment, and the
+// run's own elapsed time would be measured from a third. Under a frozen clock
+// all of them are the same string and nothing can tell them apart.
+//
+// THE CLOCK HERE JUMPS ONCE, on its second reading, and then holds. That is
+// what makes every reading nameable without counting any: the tick's is the
+// only one before the jump, and everything the run does afterwards sees one
+// other value. Counting readings was tried on this project twice and was wrong
+// both times, because the total moves whenever a fixture grows.
+//
+// Five minutes, so the jump stays inside the routine's own day and the pass
+// still judges it due.
+test('a run is timed from the one instant the tick judged it due', async (t) => {
+  begin(19, [KEEPER]);
+  const base = dayAt(19, 5, 30);
+  const JUMP = 5 * 60 * 1000;
+  let reads = 0;
+  const prev = scheduler.wireSchedulerDeps({
+    now: () => new Date(base.getTime() + (reads++ === 0 ? 0 : JUMP)),
+  });
+  try {
+    driveTicks(t);
+    assert.ok(await settled(KEEPER), 'the run finished');
+  } finally {
+    scheduler.wireSchedulerDeps(prev);
+  }
+
+  // Proves the clock did what the test claims before anything is concluded
+  // from it. A fake that never moved would make every assertion below pass
+  // against code that reads the clock as often as it likes.
+  assert.ok(reads > 1, 'the clock was read more than once, so its readings really do differ');
+
+  const [rec] = records();
+  assert.strictEqual(rec.startedAt, base.toISOString(),
+    "the record's start is the tick's own reading, not a later one taken on the way to it");
+  assert.strictEqual(rec.endedAt, new Date(base.getTime() + JUMP).toISOString(),
+    'and its ending is a reading from after the jump, so the two are not the same value by accident');
+  assert.strictEqual(rec.durationMs, JUMP, 'so the record spans the whole run');
+
+  // The run's own elapsed time is measured from the same instant. Read from a
+  // later reading it would be zero, because every reading after the first is
+  // the same one.
+  assert.strictEqual(h.internal.routineState[KEEPER].duration, JUMP / 1000,
+    'and the routine state measured the run from that instant too, not from a reading of its own');
+
+  // THE ONE READING DELIBERATELY LEFT ALONE, said here as well as at the code.
+  // The routine state's stamp is the sole input to double-fire suppression and
+  // is written by beginRun from its own reading. It stays there because moving
+  // the suppression's input is a behaviour change this card has no business
+  // making, and because an existing test drives a throw at exactly that read to
+  // prove the failed-start floor.
+  assert.strictEqual(h.internal.routineState[KEEPER].lastRun, new Date(base.getTime() + JUMP).toISOString(),
+    'while the suppression stamp keeps its own later reading, which is deliberate');
+});
+
 // ---------------------------------------------------------------------------
 // Identity
 // ---------------------------------------------------------------------------
@@ -566,15 +624,18 @@ test('records use the frozen vocabulary and the routine state keeps its own', as
   const statuses = records().map(r => r.status).sort();
   assert.deepStrictEqual(statuses, ['failed', 'succeeded'],
     'a pass with one success and one failure wrote exactly those two words');
-  for (const status of records().map(r => r.status)) {
-    assert.ok(['running', 'succeeded', 'failed'].includes(status), `"${status}" is outside the record vocabulary`);
-  }
-  // Not producible yet, and so never written: routines start the moment they
-  // are found due, and the child handle is never kept, so nothing can reach a
-  // run to cancel it.
-  const written = new Set(records().map(r => r.status));
-  assert.ok(!written.has('queued'), 'nothing queues a run, so no record claims it');
-  assert.ok(!written.has('cancelled'), 'nothing can cancel a run, so no record claims it');
+
+  // AC-15, that no record carries a state the product cannot produce, is NOT
+  // asserted here, and saying so is more honest than the assertion that used to
+  // be. `queued` and `cancelled` cannot be driven: nothing queues a run, since
+  // a routine starts the moment it is found due, and the child handle is never
+  // kept, so nothing can reach a run to cancel it. An assertion that an
+  // unreachable value is absent is an assertion that cannot fail, and this file
+  // has already removed one promise nothing could hold. The criterion is a
+  // property of the writer, which states its three statuses as literals and is
+  // read in the diff. The set assertion above is what catches a fourth word
+  // arriving, because it names the whole set rather than forbidding two members
+  // of it.
 
   assert.strictEqual(h.internal.routineState[KEEPER].status, 'completed',
     'the routine state still says completed, which is the token on every user disk and was not renamed');
@@ -669,8 +730,13 @@ test('a workspace that cannot be written to does not stop the run or the pass', 
 // making anything else pretend. Single-shot, and selected on the call site
 // rather than on a count of readings: the tick reads once and then once per
 // routine to ask whether each is due, and that total moves whenever the fixture
-// grows. beginRun is excluded because its readings are deeper in the same stack
-// and are a different case, already pinned elsewhere.
+// grows. beginRun is excluded because a throw from inside it happens AFTER the
+// record has been opened, which is a different case with a test of its own.
+//
+// The selection matches FRAMES, not substrings. `beginRun` is a prefix of
+// `beginRunRecord`, so a substring exclusion would stop this fake firing the
+// moment the clock reading moved inside the record opener, which is an ordinary
+// refactor that leaves the case under test exactly as it is.
 //
 // What is asserted is that the SECOND start gets going. A routine still held
 // would be turned away by the single-flight guard and would return false
@@ -688,8 +754,7 @@ test('a start that fails before its record is opened does not hold the routine',
   let thrown = false;
   const prev = scheduler.wireSchedulerDeps({
     now: () => {
-      const stack = new Error().stack;
-      if (!thrown && stack.includes('executeRoutine') && !stack.includes('beginRun')) {
+      if (!thrown && calledFrom('executeRoutine') && !calledFrom('beginRun')) {
         thrown = true;
         throw new Error('clock unavailable');
       }

--- a/test/integration/scheduler-tick-isolation.test.js
+++ b/test/integration/scheduler-tick-isolation.test.js
@@ -40,6 +40,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const h = require('../helpers/harness.js');
 const { agentFile } = require('../helpers/workspace.js');
+const { calledFrom } = require('../helpers/stack.js');
 
 const scheduler = require('../../lib/scheduler.js');
 
@@ -451,6 +452,13 @@ test('a failed start is held for THIS period even when it inherits an older stam
   // start dies ahead of its own stamp while the tick's earlier reading still
   // reaches the failure path.
   //
+  // It matches a FRAME rather than a substring of the stack, and that is not
+  // cosmetic. `beginRun` is a prefix of `beginRunRecord`, which arrived with
+  // the run-records change; a substring test would have selected whichever of
+  // the two appeared first and said nothing about it. When this was written no
+  // such pair existed, which is exactly why the guard belongs here rather than
+  // in the memory of whoever adds the next function.
+  //
   // It selects on the call site rather than on a count. Counting was tried and
   // was wrong twice: the tick reads once, then once per routine to ask whether
   // each is due, and that total moves whenever the fixture or the iteration
@@ -464,7 +472,7 @@ test('a failed start is held for THIS period even when it inherits an older stam
   let thrown = false;
   const prev = scheduler.wireSchedulerDeps({
     now: () => {
-      if (!thrown && new Error().stack.includes('beginRun')) {
+      if (!thrown && calledFrom('beginRun')) {
         thrown = true;
         throw new Error('clock unavailable');
       }

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -77,7 +77,23 @@ function enterTempWorkspace() {
     config,
     leave() {
       config.setWorkspace(original);
-      fs.rmSync(ws, { recursive: true, force: true });
+      // TOLERANT ON PURPOSE, and the reason is a property of the scheduler
+      // rather than a flake. A run in flight writes its record to the
+      // directory it STARTED in, deliberately, so that a workspace switch
+      // cannot orphan a record from its own beginning. A test that leaves a
+      // run going therefore has a writer that can recreate this directory in
+      // between the walk and the unlink, and the removal fails with ENOTEMPTY.
+      //
+      // Retried, then left to the operating system. A stray temp directory
+      // costs nothing, while a throw here reports as a failure of whichever
+      // test happened to run last, which is the least informative place a
+      // failure can appear.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          fs.rmSync(ws, { recursive: true, force: true });
+          return;
+        } catch (e) { /* a late record recreated it; try again */ }
+      }
     },
   };
 }

--- a/test/unit/scheduler-lib.test.js
+++ b/test/unit/scheduler-lib.test.js
@@ -393,6 +393,49 @@ test('a child that reports an error and never closes does not hold the routine',
   });
 });
 
+// The run record's AC-6, on the path that only a fake spawn can reach.
+//
+// A child that never launched reports an Error with a message: the binary is
+// missing, the descriptors are exhausted, the executable is not executable.
+// That reason is the whole of what a maintainer has to go on, because no child
+// existed to write anything. The outcome handler used to close the record with
+// no reason at all on every path, so this failure and a routine that ran and
+// exited non-zero were indistinguishable in the history, and only one of them
+// genuinely has nothing to say.
+//
+// This test lives here rather than beside the rest of the run-record suite
+// because the event cannot be produced against a real spawn: the integration
+// harness resolves a stub that does launch. The fake spawn is the only place
+// this path exists.
+test('a child that never launched puts the reason it gave in the run record', async () => {
+  await withTempWorkspaceAsync(async () => {
+    const child = new EventEmitter();
+    await withFakeSpawn(() => child, async (sched) => {
+      assert.strictEqual(sched.executeRoutine(AGENT, ROUTINE, KEY), true, 'the run started');
+
+      // Opened before anything went wrong, so the assertion below is about the
+      // ending rather than about whether a record exists at all.
+      const [opened] = sched.readRunRecords();
+      assert.strictEqual(opened.status, 'running', 'the run opened a record');
+
+      child.emit('error', Object.assign(new Error('spawn claude ENOENT'), { code: 'ENOENT' }));
+
+      const [rec] = sched.readRunRecords();
+      assert.strictEqual(rec.id, opened.id, 'the same record was closed rather than a second one written');
+      assert.strictEqual(rec.status, 'failed', 'a child that never launched is a failed run');
+      assert.strictEqual(rec.error, 'spawn claude ENOENT',
+        'carrying the reason the failure gave, which is all anyone has when there was no child');
+      assert.strictEqual(sched.routineState[KEY].status, 'failed',
+        'and the routine state agrees, in its own vocabulary');
+
+      // No close is driven afterwards. The run already reached an outcome, so
+      // the routine is released and a close would be swallowed by the
+      // record-once guard; the test beside this one is what covers that.
+      child.emit('close', 0);
+    });
+  });
+});
+
 // The cost of listening to both: a failure that reports twice must not be
 // recorded twice. Counted through the broadcast, which happens once when a run
 // starts and once per outcome, so a second outcome is a third broadcast.


### PR DESCRIPTION
## What

A run now leaves a file of its own under `.rundock/runs/`, opened when it starts and closed once when it ends, carrying when it started and ended, its outcome, its duration, whatever reason a failure gave, and which agent and routine it belongs to.

Before this there was no history. The routine state holds one slot per routine and every run overwrites its predecessor, so nothing could say what happened yesterday, how often a routine has failed, or how long it usually takes.

67 lines of production code in `lib/scheduler.js`; everything else is tests and reasoning.

## The decisions worth reading

**A separate store, not more fields on the routine state.** That object is the only input to double-fire suppression. Nothing in the new block writes to it and nothing in it is read by the suppression. A test asserts the shape of both older stores after a run and then proves the routine is still held for the rest of its period.

**The identity is the run's own, not the routine key.** `agentId:routineName` is neither unique nor stable. Each run takes a uuid when it starts and the file is named for it. Two same-named routines under one agent are driven end to end, and their prompts are asserted, because two records from one routine twice would look identical otherwise.

**Its own vocabulary:** `running`, `succeeded`, `failed`. The routine state keeps `completed` and `interrupted`, which are on every user's disk. Nothing writes `queued` or `cancelled`, because nothing in the product can produce either.

**A run in flight outlives a workspace switch, so its record does too.** The directory is fixed when the run starts and held, so an ending lands beside its own beginning. This is the one place in the file where the workspace root is not read at use time; the reader is, because reading is a question about the workspace open now. Driven as behaviour: a run is started, the workspace is switched under it, and the record is asserted on disk in the workspace that did the work.

**A start that throws closes its record**, one frame below the tick. The tick's failure path runs inside the catch that keeps the whole pass alive and gains no new fallible call.

**The reader promises no order.** A sort was written and removed: deleting it left the order assertions green, because whether an unsorted reader returns the right sequence depends on how a filesystem lays out a set of random names. A promise no test can hold is worse than no promise.

## Out of scope, with reasons

The files a run changed, the events it emitted, and cancellation. None has a source in the product; all three are on their own card. Retention is also open and carded, deliberately once for these records and gap records together.

## Coverage the double sweep asked for (second commit, tests only)

Four gaps, each a test that could not fail on the case it named, each measured before the fix:

- **Failures that actually happen.** Every `failed` record came from a start that threw, which is the rare case. A child that started and died (crash, OOM, expired login, killed at quit) arrives as a non-zero close code and was never driven: closing every record as a success left the whole file green. A crashing routine now drives that path.
- **The codex runtime**, a second producer with no agent in the fixture at all. Now driven, with the branch asserted from the app-server prompt log rather than assumed from the fixture.
- **The open record's ownership.** Deleting the owner from the opening write left everything green, because the closing write repairs the omission before anything looks. An open record is what a sleeping machine or a killed process leaves behind, so it is now asserted in full.
- **The agent field pinned to the id.** Every fixture had id equal to name, so the field was pinned to neither. One agent now has them apart, and the test asserts the divergence before concluding anything.
- Plus: the separation test now runs on two chosen instants rather than a frozen clock, so it defends its own criterion where the criterion is claimed.

## Review round one (third commit)

**Rejected on correctness, AC-6, and fixed.** Two of the failures reaching the outcome handler are handed an object with a message: a child that never launched, and a codex turn whose thread could not start. The codex path printed that message to the console one line before dropping it. Both were recorded as `failed` with `error: null`.

The previous commit got the crash path right and over-generalised from it. A child that ran and exited non-zero genuinely has no message to give, so `null` there is honest; that reasoning was applied to two endings that arrive holding the answer.

The outcome handler now takes an optional reason and passes it to the record only. The routine-state write, the signals event and the broadcast are untouched, and the close handler and codex success path pass nothing, so a non-zero exit still records `null` — pinned by a mutation that makes it invent one. Each site is pinned separately: dropping either reddens only its own test. The docblock claiming a start that threw is the only failure with a reason is corrected in the same commit.

## Review round two (fourth commit)

**PASS with four advisories; two fixed as asked, two judged.**

- **One instant per start.** The tick reads the clock once and now hands that reading to `executeRoutine`, which uses it for the record's start and the run's start time. The routine state's stamp keeps its own later reading, deliberately: it is the suppression's input, and an existing test drives a throw at exactly that read. Said at the code and asserted in the test. The test makes the clock jump once and hold, so every reading is nameable without counting any.
- **Stack frames, not substrings.** `beginRun` is a prefix of `beginRunRecord`, which this branch introduced, so the existing selection technique in `scheduler-tick-isolation.test.js` became ambiguous — a change of mine degrading a test that works on `main`. Both files now match a frame through one shared helper. Measured both ways: with the frame matcher, moving the clock reading into the record opener keeps all 29 tests green; with the substring test restored, the same refactor turns the guard test red for a reason nobody would connect to it.
- **Duplicated record shape: kept**, with the reason at the code. It is the convention the run state already follows, and the drift it risks is exactly what the open record's test pins — deleting the owner from the opening write alone turns it red.
- **Unfalsifiable assertions: removed.** Nothing can drive a `queued` or `cancelled` record, so asserting their absence could not fail. What catches a fourth status word is the assertion naming the whole set, which is kept, and the criterion is now stated as a property of the writer read in the diff.
- Also: the unit suite's temp-workspace teardown is tolerant of a directory recreated during removal, because a run in flight writes its record to the directory it started in and can race the cleanup. A real race this branch introduced, found by the gate.

## Review round three (fifth commit)

**Rejected on verification, AC-22, and fixed.** The criterion is about a record write failing on the *failed-start* path. The forced-write-failure test drove a routine whose start succeeds, and the throwing routine was only ever driven against a writable store, so the named combination was exercised by nothing. It held by construction — every write funnels through one guarded helper — which is why this is a test and not a fix.

A routine whose start throws now runs with a regular file where the record store needs a directory. The test asserts the combination, not either half: the routine state carries the reason the **start** gave and not the reason the **write** gave, both failures reach the log, the routine declared after the thrower still started on the same pass, and the end-of-tick bookkeeping still ran. The store is asserted empty first, so the test cannot pass against a writable one.

Two mutations, and the second shows why the gap existed:

| Mutation | Result |
|---|---|
| Write helper stops swallowing | new test **and** the existing unwritable-store test red |
| Only the **closing** write escapes (the one on the failed-start path) | existing test stays **green**; new test red on exactly the reason assertion, with the routine state reporting `ENOTDIR` instead of the malformed prompt |

## Evidence

- Suite 1851, all green. `lib/scheduler.js` at 100% across 1020 lines; both floors hold, all 50 hold.
- `red-first --base main`: PROVEN.
- 33 by-hand block mutations, every one turning a named test red, plus one paired experiment showing the frame matcher survives a refactor the substring test did not. The write-removal lens was applied to every accumulation assertion: removing the opening write leaves no records, one identity for every run leaves one, removing the closing write leaves records that never stop saying `running`.
- One mutation found a real defect during the work: opening the record outside the guard that releases the routine left a routine held for the life of the process when resolving its directory threw. Fixed, and pinned by its own test.
- No paragraph of `docs/ROUTINES.md` becomes false. Its list of what Rundock records is now incomplete rather than wrong, which belongs to the card that surfaces these records.