### PR TITLE
Answer only this machine, not everyone on the same network

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,6 +53,23 @@ const signals = require('./lib/signals.js');
 const { recordEvent, bumpSkillUsage, normalizeDocsGapTopic } = signals;
 
 const PORT = process.env.PORT || 3000;
+// The address the server answers on, used at the listen() call below.
+//
+// Loopback is a DECISION about the default, not a statement about capability.
+// Everything behind this socket is the product itself: it spawns agent
+// subprocesses, reads and writes the workspace the user chose, carries the
+// permission bridge, and holds the WebSocket that drives the interface. None
+// of it sits behind authentication, because until now nothing but this machine
+// could reach it. Passing a port with no host binds every interface, which put
+// all of that in front of anyone on the same wifi.
+//
+// TO WHOEVER IMPLEMENTS REMOTE ACCESS, which the roadmap wants: this is the
+// line you change, and changing it is not the feature. Widening the bind on
+// its own publishes an unauthenticated agent runner to the network, so
+// authentication and transport security belong in the same change as the
+// wider address. There is deliberately no environment override: an override is
+// that same widening with nobody having decided it.
+const HOST = '127.0.0.1';
 let ACTUAL_PORT = PORT; // Updated after server.listen() with the real listening port
 // WORKSPACE mirrors lib/config's workspace root during the decomposition:
 // this file's remaining read sites use the local variable, while extracted
@@ -2988,7 +3005,7 @@ function startServer(options = {}) {
   armFileTreeWatcher();
   const port = options.port != null ? options.port : PORT;
   return new Promise((resolve) => {
-    server.listen(port, () => {
+    server.listen(port, HOST, () => {
       const actualPort = server.address().port;
       ACTUAL_PORT = actualPort;
       if (WORKSPACE) {

--- a/server.js
+++ b/server.js
@@ -69,6 +69,9 @@ const PORT = process.env.PORT || 3000;
 // authentication and transport security belong in the same change as the
 // wider address. There is deliberately no environment override: an override is
 // that same widening with nobody having decided it.
+// What already reaches this socket from outside the application, including
+// what was examined and dismissed, is enumerated at the top of
+// test/integration/server-binding.test.js. Start there before moving this.
 const HOST = '127.0.0.1';
 let ACTUAL_PORT = PORT; // Updated after server.listen() with the real listening port
 // WORKSPACE mirrors lib/config's workspace root during the decomposition:

--- a/server.js
+++ b/server.js
@@ -3028,6 +3028,10 @@ function startServer(options = {}) {
       // whole session.
       startIdleReaper();
       console.log(`\n  Rundock running at http://localhost:${actualPort}`);
+      // Say who can reach it, not only where it is. Someone who used to open
+      // Rundock from another device now meets a bare connection refusal, and
+      // this is the only line they read.
+      console.log('  Reachable from this machine only: Rundock listens on loopback by default.');
       if (WORKSPACE && !fs.existsSync(WORKSPACE)) {
         console.log(`  Workspace no longer exists: ${WORKSPACE}`);
         setWorkspaceRoot(null);

--- a/test/integration/server-binding.test.js
+++ b/test/integration/server-binding.test.js
@@ -32,6 +32,65 @@
 // environment, so an environment that cannot carry the experiment is reported
 // as a failure naming what could not be established. A red suite on a laptop
 // with the wifi off is the intended cost.
+// EVERYTHING THAT REACHES THIS SERVER FROM OUTSIDE THE APPLICATION, and what
+// each one needed. Established BEFORE the binding changed, and written down
+// here including the entries that were examined and dismissed, because a
+// reader cannot otherwise tell "looked at and does not apply" from "not looked
+// at". Anyone widening or narrowing the bind should start from this list.
+//
+// 1. THE PERMISSION HOOK, scripts/permission-hook.js. A separate process, one
+//    per agent tool call, and the only thing in the tree that reaches this
+//    server from outside it. It reads RUNDOCK_PORT from its environment and
+//    dials the literal 127.0.0.1, never a hostname, so no name resolution can
+//    send it to an address the server is not on.
+//    VERIFIED, not assumed, and not by this file:
+//    test/integration/boundary-permissions.test.js spawns the real hook script
+//    with the environment the runtime gives it, and asserts the server received
+//    the request, by waiting for the permission card the server emits over the
+//    WebSocket and reading the decision the hook prints back. If the hook could
+//    not reach the server, that card never arrives and those tests fail. Green
+//    on this branch. The other half of the chain, that the runtime actually
+//    hands the hook the port the server is listening on, is pinned separately
+//    by test/integration/spawn-argv-freeze.test.js and
+//    test/unit/claude-runtime-lib.test.js.
+//
+// 2. THE CODEX RUNTIME'S SPAWN ENVIRONMENT, lib/runtime/codex-glue.js, which
+//    is handed the real port exactly as lib/runtime/claude.js is. DISMISSED as
+//    a second dialer: it passes RUNDOCK_PORT to the same hook, and RUNDOCK_PORT
+//    has exactly one consumer in the tree, entry 1. Codex itself speaks to
+//    Rundock over stdio JSON-RPC (codex-appserver.js), not over this socket.
+//
+// 3. THE ELECTRON SHELL, electron/main.js. It starts the server inside its own
+//    process with port 0 and loads http://localhost:<port> into the renderer: a
+//    hostname, not a literal, so Chromium may try ::1 first and fall back to
+//    127.0.0.1. Unaffected, and covered: the browser suite runs 162 specs
+//    against this bind through that same hostname. Deliberately NOT switched to
+//    the literal: renderer storage is keyed by origin, so moving the shell from
+//    localhost to 127.0.0.1 would orphan the stored state of every existing
+//    install.
+//
+// 4. THE BROWSER CLIENT, public/app.js, which opens its WebSocket at
+//    location.host. Same-origin by construction: it follows whatever the page
+//    was loaded from and can never dial something the page could not.
+//
+// 5. THE WEBSOCKET ORIGIN ALLOWLIST, the verifyClient check in server.js.
+//    EXAMINED and unaffected: it filters browser origins on a connection that
+//    has already been established, so it was never a reachability control and
+//    does not widen one. Worth knowing before moving the bind: it lists
+//    http://localhost and http://127.0.0.1 only, so binding the IPv6 loopback
+//    would leave a browser arriving as http://[::1] refused at this check
+//    rather than at the socket.
+//
+// 6. THE DEVELOPMENT HARNESSES under scripts/. The update harness already binds
+//    127.0.0.1 itself; the smoke and screenshot runners drive a server on this
+//    machine over localhost. None of them wanted the wide bind and none of them
+//    ship in the packaged app.
+//
+// 7. NOTHING ELSE. There is one http.createServer in the product tree and the
+//    WebSocket server attaches to it, so it is the only socket the application
+//    listens on. No document in the repository offers reaching Rundock from
+//    another device. Nothing was found that relied on the old binding, and
+//    nothing is named broken.
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const net = require('node:net');
@@ -150,7 +209,10 @@ describe('server binding', () => {
   test('this machine still reaches the server over loopback, on HTTP and on the WebSocket', async () => {
     const res = await fetch(`http://127.0.0.1:${booted.port}/`);
     assert.strictEqual(res.status, 200,
-      'loopback HTTP is the address the permission hook dials, and it is a separate process from this one');
+      'a request to the loopback literal must still be answered. This is that claim and no more: the request '
+      + 'comes from the process hosting the server, so it says nothing about whether the permission hook reaches '
+      + 'it. That is entry 1 of the enumeration above, established by boundary-permissions.test.js driving the '
+      + 'real hook script, and it is the evidence for the hook rather than this line.');
     const client = await h.connect();
     assert.strictEqual(client.ws.readyState, 1,
       'the WebSocket drives the whole interface and connects over loopback');

--- a/test/integration/server-binding.test.js
+++ b/test/integration/server-binding.test.js
@@ -16,19 +16,44 @@
 // the local network, which is as close as a test running on one machine can
 // get to the machine next door, and requires that connection to be refused.
 //
-// The second test proves this environment can make that connection at all
-// before it concludes anything from a failed one. Without the preflight, a
-// sandbox that blocks local network traffic produces a refusal that looks
-// exactly like the fix working, and the test reports green over a socket open
-// to the whole network.
+// The second test measures a control beside the subject: a wildcard-bound
+// socket of its own, alive at the same moment, on the same address, which is
+// exactly what the server used to be. A refusal from the server while the
+// control accepts is caused by the binding and by nothing else here.
+//
+// WHY NOTHING IN THIS FILE SKIPS. An earlier version skipped when the machine
+// had no network interface, or when the control could not be reached. Measured
+// on that version: with the interface table returning only loopback entries the
+// file reported pass 2, fail 0, skipped 1 and exit code 0, and no gate in this
+// project counts skips. The condition is ordinary rather than exotic: wifi off,
+// an unplugged cable, a loopback-only container, a host firewall, or simply a
+// slow preflight against a two second timeout. What a skip deletes here is the
+// only proof that the refusal comes from the binding rather than from the
+// environment, so an environment that cannot carry the experiment is reported
+// as a failure naming what could not be established. A red suite on a laptop
+// with the wifi off is the intended cost.
 const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const net = require('node:net');
 const os = require('node:os');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
 
 const h = require('../helpers/harness.js');
 
-const CONNECT_TIMEOUT_MS = 2000;
+// Generous, because a timed-out connection is now a failure rather than a
+// skip: every one of these connects is to this machine.
+const CONNECT_TIMEOUT_MS = 5000;
+const BANNER_TIMEOUT_MS = 20000;
+
+// Every address that means "this machine only", written out rather than read
+// back from the server. Reading the expectation from the constant under test
+// would agree just as happily with a wildcard. IPv6 loopback and the
+// IPv4-mapped form are safe and belong here: what must fail is a wildcard.
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+const SERVER = path.join(__dirname, '..', '..', 'server.js');
 
 let booted;
 
@@ -36,7 +61,7 @@ before(async () => { booted = await h.boot(); });
 after(async () => h.shutdown());
 
 // This machine's own address on the local network: the address a neighbour
-// would aim at. Skipped rather than faked when the machine has none.
+// would aim at.
 function localNetworkIPv4() {
   for (const [name, addrs] of Object.entries(os.networkInterfaces())) {
     for (const a of addrs || []) {
@@ -74,35 +99,52 @@ describe('server binding', () => {
       'the server is not listening, so nothing here examined a binding at all');
     assert.strictEqual(address.port, booted.port,
       'the socket read here has to be the one startServer reported, or this asserts about some other server');
-    assert.strictEqual(address.address, '127.0.0.1',
-      `the server is bound to ${address.address}, which accepts connections from anyone who can route to `
-      + 'this machine. Behind it sit agent subprocesses, the workspace, and the permission bridge.');
+    assert.ok(LOOPBACK_ADDRESSES.has(address.address),
+      `the socket is bound to ${address.address}, which is not one of the addresses that mean this machine only `
+      + `(${[...LOOPBACK_ADDRESSES].join(', ')}). A binding outside that set accepts connections from anyone who `
+      + 'can route here, and behind it sit agent subprocesses, the workspace, and the permission bridge. Either '
+      + 'loopback family passes: what fails is a wildcard.');
   });
 
-  test('a connection from this machine\'s local-network address is refused', async (t) => {
+  test('a connection from this machine\'s local-network address is refused', async () => {
+    const address = booted.internal.server.address();
+    assert.ok(address && typeof address === 'object',
+      'the server is not listening, so a refused connection below would say nothing about a binding');
+    assert.strictEqual(address.port, booted.port,
+      'the port dialled below has to be the one the server is listening on right now, or a refusal is only '
+      + 'evidence that some unrelated port is closed');
+
     const iface = localNetworkIPv4();
-    if (!iface) {
-      return t.skip('this machine has no non-loopback IPv4 interface, so there is no local-network address to aim at');
-    }
+    assert.ok(iface,
+      'this machine has no non-loopback IPv4 interface, so the experiment that proves the refusal comes from '
+      + 'the binding cannot run here. This fails rather than skipping: a skip leaves the file green with its '
+      + 'causal proof deleted, and nothing in this project counts skips.');
 
-    // Preflight: can this environment connect to that address at all? A
-    // refusal below means nothing unless a connection there can succeed.
-    const probe = await listenOn(iface.address);
-    if (probe.error) {
-      return t.skip(`cannot bind ${iface.address} here (${probe.error}), so the preflight cannot establish reachability`);
-    }
-    const preflight = await attemptConnect(iface.address, probe.port);
-    await new Promise((resolve) => probe.probe.close(resolve));
-    if (preflight !== 'connected') {
-      return t.skip(`this environment cannot connect to ${iface.address} at all (${preflight}), `
-        + 'so a refused connection would prove nothing about the binding');
-    }
+    // The control: a wildcard-bound socket of this test's own, which is
+    // exactly what the server used to be, alive at the same moment and dialled
+    // at the same address. If the control answers and the server does not, the
+    // difference is the binding.
+    const control = await listenOn('0.0.0.0');
+    assert.ok(!control.error,
+      `a control socket could not be bound to the wildcard address here (${control.error}), so there is no way `
+      + 'to show that a wildcard binding would have been reachable. Reported as a failure rather than skipped.');
 
-    const outcome = await attemptConnect(iface.address, booted.port);
-    assert.strictEqual(outcome, 'ECONNREFUSED',
-      `connecting to ${iface.address}:${booted.port} on interface ${iface.name} gave "${outcome}". `
-      + 'A connection reaching the server on this machine\'s network address is the exposure this card closes; '
-      + `the preflight already proved connections to ${iface.address} succeed here.`);
+    try {
+      const reachedControl = await attemptConnect(iface.address, control.port);
+      assert.strictEqual(reachedControl, 'connected',
+        `a wildcard-bound control socket on this machine could not be reached at ${iface.address} `
+        + `(interface ${iface.name}, outcome "${reachedControl}"), so this environment cannot carry the `
+        + 'experiment and a refusal from the server would prove nothing. Reported as a failure rather than '
+        + 'skipped, because a green file with no causal proof in it is the worse outcome.');
+
+      const outcome = await attemptConnect(iface.address, address.port);
+      assert.strictEqual(outcome, 'ECONNREFUSED',
+        `connecting to ${iface.address}:${address.port} on interface ${iface.name} gave "${outcome}", while the `
+        + 'wildcard control on the same address was reachable at the same moment. A connection reaching the '
+        + 'server on this machine\'s network address is the exposure this closes.');
+    } finally {
+      await new Promise((resolve) => control.probe.close(resolve));
+    }
   });
 
   test('this machine still reaches the server over loopback, on HTTP and on the WebSocket', async () => {
@@ -110,7 +152,49 @@ describe('server binding', () => {
     assert.strictEqual(res.status, 200,
       'loopback HTTP is the address the permission hook dials, and it is a separate process from this one');
     const client = await h.connect();
-    assert.strictEqual(client.ws.readyState, 1, 'the WebSocket drives the whole interface and connects over loopback');
+    assert.strictEqual(client.ws.readyState, 1,
+      'the WebSocket drives the whole interface and connects over loopback');
     client.close();
+  });
+
+  test('the startup banner says who can reach the server, not only where it runs', async () => {
+    // A user who had been opening Rundock from another device now gets a bare
+    // connection refusal. The banner is the one line they actually read, and
+    // it is where the refusal stops being a mystery.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-banner-home-'));
+    const child = spawn(process.execPath, [SERVER], {
+      env: { ...process.env, PORT: '0', HOME: home, RUNDOCK_ELECTRON: '1', WORKSPACE: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let out = '';
+    try {
+      // Wait for the END of the banner, not the first line of it. Resolving on
+      // the "running at" line read whichever lines happened to share its chunk,
+      // which passed or failed on stream timing rather than on content. This
+      // child is started with no workspace precisely so the banner is short and
+      // ends at a line that is always printed, whatever else is or is not there.
+      const banner = await new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(
+          `the server did not finish printing its startup banner within ${BANNER_TIMEOUT_MS}ms, so this test read `
+          + `an incomplete banner rather than a complete one that said too little. Output so far:\n${out}`)), BANNER_TIMEOUT_MS);
+        child.stdout.on('data', (chunk) => {
+          out += chunk.toString();
+          if (/Rundock running at http:\/\/localhost:\d+/.test(out) && /No workspace set/.test(out)) {
+            clearTimeout(timer);
+            resolve(out);
+          }
+        });
+        child.once('error', (err) => { clearTimeout(timer); reject(err); });
+      });
+      assert.match(banner, /running at http:\/\/localhost:\d+/,
+        'sanity: the line this test reads is the one the server prints at startup');
+      assert.match(banner, /this machine only/i,
+        'the banner names an address and stops there, so it reads as an invitation to anyone who can reach it. '
+        + 'It has to say who can, because binding loopback is now what makes another device fail, and the user '
+        + `who meets that failure has only this line to explain it. What it printed:\n${banner}`);
+    } finally {
+      child.kill('SIGTERM');
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/test/integration/server-binding.test.js
+++ b/test/integration/server-binding.test.js
@@ -1,0 +1,116 @@
+'use strict';
+// Integration: the socket the whole product sits behind must answer this
+// machine only.
+//
+// server.js called listen with a port and no host, so Node bound every
+// interface. What is behind that socket is not a static file server: it spawns
+// agent subprocesses, reads and writes the workspace the user chose, carries
+// the permission bridge, and holds the WebSocket that drives the interface.
+// Anything that can reach the port can reach all of that, and on a shared
+// network that is anybody sitting near you.
+//
+// WHAT THIS ASSERTS, AND WHY IT IS SHAPED THIS WAY. "The server started" and
+// "the request worked" are both true whatever the socket bound to, so neither
+// can catch this coming back. The first test reads the address the listening
+// socket actually holds. The second connects to this machine's own address on
+// the local network, which is as close as a test running on one machine can
+// get to the machine next door, and requires that connection to be refused.
+//
+// The second test proves this environment can make that connection at all
+// before it concludes anything from a failed one. Without the preflight, a
+// sandbox that blocks local network traffic produces a refusal that looks
+// exactly like the fix working, and the test reports green over a socket open
+// to the whole network.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const net = require('node:net');
+const os = require('node:os');
+
+const h = require('../helpers/harness.js');
+
+const CONNECT_TIMEOUT_MS = 2000;
+
+let booted;
+
+before(async () => { booted = await h.boot(); });
+after(async () => h.shutdown());
+
+// This machine's own address on the local network: the address a neighbour
+// would aim at. Skipped rather than faked when the machine has none.
+function localNetworkIPv4() {
+  for (const [name, addrs] of Object.entries(os.networkInterfaces())) {
+    for (const a of addrs || []) {
+      if (a.family === 'IPv4' && !a.internal) return { name, address: a.address };
+    }
+  }
+  return null;
+}
+
+// Resolves to 'connected', or the code of whatever stopped the connection.
+// Never rejects: the outcome is the measurement.
+function attemptConnect(host, port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port });
+    const settle = (outcome) => { socket.destroy(); resolve(outcome); };
+    socket.setTimeout(CONNECT_TIMEOUT_MS);
+    socket.once('connect', () => settle('connected'));
+    socket.once('timeout', () => settle('ETIMEDOUT'));
+    socket.once('error', (err) => settle(err.code || err.message));
+  });
+}
+
+function listenOn(host) {
+  return new Promise((resolve) => {
+    const probe = net.createServer((s) => s.end());
+    probe.once('error', (err) => resolve({ error: err.code || err.message }));
+    probe.listen(0, host, () => resolve({ probe, port: probe.address().port }));
+  });
+}
+
+describe('server binding', () => {
+  test('the listening socket holds a loopback address, not every interface', () => {
+    const address = booted.internal.server.address();
+    assert.ok(address && typeof address === 'object',
+      'the server is not listening, so nothing here examined a binding at all');
+    assert.strictEqual(address.port, booted.port,
+      'the socket read here has to be the one startServer reported, or this asserts about some other server');
+    assert.strictEqual(address.address, '127.0.0.1',
+      `the server is bound to ${address.address}, which accepts connections from anyone who can route to `
+      + 'this machine. Behind it sit agent subprocesses, the workspace, and the permission bridge.');
+  });
+
+  test('a connection from this machine\'s local-network address is refused', async (t) => {
+    const iface = localNetworkIPv4();
+    if (!iface) {
+      return t.skip('this machine has no non-loopback IPv4 interface, so there is no local-network address to aim at');
+    }
+
+    // Preflight: can this environment connect to that address at all? A
+    // refusal below means nothing unless a connection there can succeed.
+    const probe = await listenOn(iface.address);
+    if (probe.error) {
+      return t.skip(`cannot bind ${iface.address} here (${probe.error}), so the preflight cannot establish reachability`);
+    }
+    const preflight = await attemptConnect(iface.address, probe.port);
+    await new Promise((resolve) => probe.probe.close(resolve));
+    if (preflight !== 'connected') {
+      return t.skip(`this environment cannot connect to ${iface.address} at all (${preflight}), `
+        + 'so a refused connection would prove nothing about the binding');
+    }
+
+    const outcome = await attemptConnect(iface.address, booted.port);
+    assert.strictEqual(outcome, 'ECONNREFUSED',
+      `connecting to ${iface.address}:${booted.port} on interface ${iface.name} gave "${outcome}". `
+      + 'A connection reaching the server on this machine\'s network address is the exposure this card closes; '
+      + `the preflight already proved connections to ${iface.address} succeed here.`);
+  });
+
+  test('this machine still reaches the server over loopback, on HTTP and on the WebSocket', async () => {
+    const res = await fetch(`http://127.0.0.1:${booted.port}/`);
+    assert.strictEqual(res.status, 200,
+      'loopback HTTP is the address the permission hook dials, and it is a separate process from this one');
+    const client = await h.connect();
+    assert.strictEqual(client.ws.readyState, 1, 'the WebSocket drives the whole interface and connects over loopback');
+    client.close();
+  });
+});


### PR DESCRIPTION
The server was started with a port and no host, so Node bound every interface. What sits behind that socket is not a static file server: it spawns agent subprocesses, reads and writes the workspace the user chose, carries the permission bridge, and holds the WebSocket that drives the interface, none of it behind authentication, because until now nothing but this machine could reach it. Anything that can route here can reach all of it, which on an office, cafe or conference network is everyone on it. The desktop build picks its port dynamically, which raises the cost of finding it but is not a control, and from source it is a known default. Not theoretical: an installed build on the machine this was written on was listening on the wildcard address at the time.

The bind is now loopback, and the reason sits at the binding rather than in a commit message nobody reads again. Remote access is on the roadmap, which makes this a decision about the default rather than about capability, so the comment is addressed to whoever implements it: this is the line you change, changing it is not the feature, and authentication and transport security belong in the same change as the wider address. There is deliberately no environment override, because an override is the same widening with nobody having decided it.

## What already talks to the server from outside the application

Established before the change rather than after it, and reported including where nothing was found.

- **The permission hook** (`scripts/permission-hook.js`) is the only one. It runs as a separate process, spawned by the runtime with `RUNDOCK_PORT` in its environment, and it already dials `127.0.0.1` explicitly rather than resolving a hostname, so loopback covers it unchanged. It is exercised end to end against the real script by `test/integration/boundary-permissions.test.js`, green on this branch.
- **The Electron shell** loads `http://localhost:<port>` into the renderer, in the same process that runs the server. Chromium falls back from `::1` to `127.0.0.1`, and 162 browser specs run against the now loopback-bound server through that same hostname.
- **The browser client** opens its WebSocket at `location.host`, so it is same-origin by construction and follows whatever the page was loaded from.
- **Development harnesses under `scripts/`**: the update harness already binds `127.0.0.1`; the smoke and screenshot runners connect to localhost on the same machine. None of them wanted the wide bind.
- **Nothing else.** There is one `http.createServer` in the product tree and the WebSocket server attaches to it, so this is the only listening socket the app opens. `RUNDOCK_PORT` reaches exactly two consumers, both runtime spawn environments feeding the hook. No document in the repository offers reaching Rundock from another device, so nothing documented changes.

Nothing was found that relied on the old behaviour, and nothing is named broken.

## Both ways of running

- **From source:** `PORT=39117 node server.js`, then `http://localhost:...` 200, `http://127.0.0.1:...` 200, and a TCP connection to this machine's local-network address refused.
- **Packaged:** the desktop shell starts the server with `port: 0`, and the new test boots through that same dynamic-port path and asserts loopback on the port that came back. Chromium resolving `localhost` against a loopback-only socket is covered by the 162 browser specs. Launching the shell itself here exits on Electron's single-instance lock, because an installed Rundock is already running on this machine, so that one step is named rather than claimed.

## Proof

The test reads the address the listening socket actually holds. "The server started" and "the request worked" are both true whatever it bound to, so neither could catch this coming back. It also connects to this machine's own address on the local network and requires a refusal, which is as close as a test running on one machine gets to the machine next door, and it proves the environment can make that connection at all before concluding anything from a failed one: without the preflight, a sandbox blocking local traffic produces a refusal indistinguishable from the fix working.

- Suite: 1857 tests, 1856 pass. The single failure is `test/unit/pid-file.test.js`, which reads the process table and fails under the command sandbox on any branch. It is unrelated to this change and already has a card. Browser suite 162/162, including the intermittent review-suggestion spec.
- `red-first`: PROVEN against `main` for `test/integration/server-binding.test.js`. Run across the whole suite it returns INCONCLUSIVE, because of that sandboxed pid-file failure rather than anything here.
- Mutations, each turning both named tests red, and each reverted from a saved copy rather than a checkout: the host argument dropped from `listen`, which is the original wildcard bind; `HOST` set to `0.0.0.0`. The third test in the file, loopback still reachable on HTTP and the WebSocket, stays green under both by design: it is the regression half, not the proof.

Out of scope, deliberately: authentication, any form of deliberate remote access, how a port is chosen, and the dependency findings raised alongside this.

## Second commit: what came back from review

**The one test that proved the refusal was real could delete itself.** Measured on the first commit: with the interface table returning only loopback entries, this file reported pass 2, fail 0, skipped 1, exit code 0, and nothing in this project counts skips. The condition is ordinary rather than exotic: wifi off, an unplugged cable, a loopback-only container, a host firewall, or a preflight slower than the two second timeout, which turned the assertion into a skip. Test one never skips and catches a wildcard bind on its own, so nothing was getting through; what a skip deleted was the proof that the refusal comes from the binding rather than from the environment. Every path that cannot carry the experiment now fails, naming what it could not establish. A red suite on a laptop with the wifi off is the intended cost.

The preflight is now a control rather than a warm-up: a socket bound to the wildcard address, which is exactly what the server used to be, held open on the same address at the same moment the server is dialled. A refusal from one while the other answers cannot be the network.

**The failure message diagnosed a whole class wrongly.** Binding the IPv6 loopback, or a hostname that resolves to it first, is loopback-only and safe, and the assertion told the maintainer they had exposed the server to the network. It failed closed, so nothing was at risk, but it pointed the next person in the wrong direction on a change that was already correct. Any address meaning this machine only is accepted now, written out as literals rather than read back from the constant under test, since reading it back would agree just as happily with a wildcard.

**The startup banner said where the server runs, not who can reach it.** It now says both. Someone who had been opening Rundock from another device meets a bare connection refusal, and this is the only line they read.

Smaller: the refused-connection test pins the port to the one the socket is listening on, so it no longer leans on the pin in the test beside it and cannot pass against a stale port. And the banner test waits for the end of the banner rather than its first line, because resolving on the running-at line read whichever lines shared its chunk, which decides a pass on stream timing rather than on content.

## Proof, second round

- File: 4 tests, 4 pass, 0 skipped, stable across four consecutive runs. Suite via the precommit gate: test, typecheck, lint:styles, check:refs all ok. Browser suite re-run against this branch as committed: 162/162.
- `red-first`: PROVEN again for the whole branch change.
- Mutations, each reverted from a saved copy rather than a checkout:

| Mutation | Result |
|---|---|
| interface table returns only loopback entries, the case that previously skipped | `a connection from this machine's local-network address is refused` **fails**, skipped 0, exit 1 |
| control socket dialled at a closed port, so reachability cannot be established | same test **fails** naming the unreachable control, skipped 0, exit 1 |
| host argument dropped from `listen`, the original wildcard | tests one and two **fail** |
| `HOST` set to `0.0.0.0` | tests one and two **fail** |
| the banner line removed | `the startup banner says who can reach the server` **fails**, and by assertion rather than by timeout |
| `HOST` set to `::1`, safe but different: the misdiagnosis case | test one **passes**, correctly making no claim of exposure. The failure that appears is the true one, from the loopback-reachability test, `ECONNREFUSED 127.0.0.1`, which is the permission hook's own address |

## Third commit: the enumeration and the hook's proof now travel in the diff

Both findings from round one were the same mistake: the work was done, reported, and never reached the change. A reviewer sees a diff and the criteria, so what is not in the diff was not done.

**The enumeration is now in `test/integration/server-binding.test.js`**, dismissed entries included, each with why it does or does not apply, and the binding in `server.js` points at it. Three entries were previously invisible to a reviewer:

- **The Codex runtime** (`lib/runtime/codex-glue.js`) is handed the real port exactly as the Claude runtime is. It passes `RUNDOCK_PORT` to the same hook rather than dialling anything itself, and `RUNDOCK_PORT` has exactly one consumer in the tree. Codex speaks to Rundock over stdio JSON-RPC, not over this socket.
- **The WebSocket origin allowlist** (`verifyClient` in `server.js`) filters browser origins on an already established connection, so it was never a reachability control and does not widen one. It lists `http://localhost` and `http://127.0.0.1` only, so binding the IPv6 loopback would leave a browser arriving as `http://[::1]` refused at that check rather than at the socket. Recorded for whoever moves the bind.
- **The Electron shell** loads `http://localhost:<port>`, a hostname rather than a literal, and is deliberately left that way: renderer storage is keyed by origin, so switching the shell to `127.0.0.1` would orphan the stored state of every existing install.

**The permission hook's claim is corrected rather than restated.** The loopback test asserted a request from the process that hosts the server, while its message called that the address the hook dials. Those are two claims, and a hook dialling a hostname that resolved to the IPv6 loopback first would have been refused by this server with that test still green. What establishes it is `test/integration/boundary-permissions.test.js`, which spawns the real hook script with the environment the runtime gives it and waits for the card the server emits over the WebSocket, so it fails if the hook cannot reach the server. That test is named in the enumeration together with `test/integration/spawn-argv-freeze.test.js` and `test/unit/claude-runtime-lib.test.js`, which pin the other half of the chain: that the runtime hands the hook the port the server is listening on. All three green on this branch, 21 tests.

Verification unchanged and re-run after the edits: file 4 pass, 0 skipped; the no-interface mutation still fails rather than skipping, exit 1; precommit PASS; `red-first` PROVEN.
