### PR TITLE
A schedule stores the timezone it was set in, as location words

### DIFF
--- a/.review/schedule-timezone-evidence.md
+++ b/.review/schedule-timezone-evidence.md
@@ -1,0 +1,281 @@
+# Evidence: a schedule stores its timezone as location words
+
+Recorded here because a reviewer sees the change and these criteria and nothing
+else. Every measurement below is reproducible from a clone with the command
+shown next to it.
+
+The acceptance criteria this was judged against live outside this repository,
+so each one is quoted in full rather than cited by number. A reader with only
+this checkout can still follow what was asked and check whether it was done.
+
+## What this card is
+
+The storage half only. A schedule carries when it runs and never carried where
+"when" is measured from. Rendering belongs to the views, the per-platform
+caveat copy belongs to the editor and has shipped there, and nothing here
+changes how a schedule is parsed or when it fires.
+
+## The trap, and how the proof is built around it
+
+`Intl.DateTimeFormat().resolvedOptions().timeZone` returns location words and
+looks exactly like the value this field wants. It answers a different question:
+what this computer is set to, rather than what the person chose when they built
+the schedule. On the machine a routine was made on those are the same string,
+which is why a test that inherits the runner's zone cannot tell them apart, and
+why a value defaulted from the machine passes such a test everywhere.
+
+`test/unit/routine-timezone.test.js` sets `process.env.TZ = 'UTC'` before its
+first require, in its own file so no other suite is affected, on the same
+grounds as `test/unit/scheduler-slots-dst.test.js`. The host's zone is then a
+constant the file controls rather than a reading it inherits, and every zone
+the tests store is a different one, chosen in the test:
+
+    const HOST_ZONE = 'UTC';
+    const SET_ZONE = 'Pacific/Kiritimati';   // +14
+    const OTHER_ZONE = 'Pacific/Niue';       // -11
+
+`the host zone is pinned, so a zone differing from it is a real difference`
+asserts the pinning itself, because if it failed every assertion below would be
+comparing against whatever the runner happened to be set to, which is the
+defect rather than the check.
+
+Nothing else in the suite reads a clock, a zone or a home directory. The
+migration tests write throwaway files under the system temp directory and call
+the migration directly, so no workspace, cache or agent roster is involved.
+
+## The hole
+
+> **AC-1:** A schedule stores its timezone as location words.
+
+`normalizeRoutine` reads a `timezone` key through `readTimezone`, and
+`appendRoutineBlock` writes one, refusing anything that is not an area and a
+place. `a timezone is read off the file as the location words it carries` and
+`a value that is not location words is refused rather than stored`, which walks
+`+01:00`, `-05:00`, `GMT+1`, `UTC+2`, `BST`, `PST`, `UTC`, the empty string,
+`Europe`, `Europe//London` and `../../etc/passwd` through the write path and
+requires each to be refused, then stores `Europe/London`,
+`America/Argentina/Buenos_Aires`, `Australia/Lord_Howe`,
+`America/Port-au-Prince` and `Etc/GMT+10` and reads each back.
+
+**The shape is checked rather than the zone database.** `Intl` knows which
+zones exist, and asking it would make what a file may contain depend on the ICU
+data of whichever machine did the writing: the same zone accepted on one
+computer and refused on another, and refused everywhere on a Node built without
+full ICU. That is the machine reaching a stored value by a second road. Which
+zones exist is not this module's question; whether this is location words
+rather than an offset is.
+
+**The cost, named rather than hidden:** `UTC` is refused. It is a real zone
+identifier and it names no place, and it is what a machine in a container
+reports, so accepting it would mean accepting the one value that cannot be
+distinguished from a default. A caller that means it can say `Etc/UTC`.
+
+> **AC-2:** The value round-trips byte-for-byte, on the same terms as every
+> other field the data model already carries.
+
+`a timezone survives a write-then-read cycle on a file carrying fields this
+card never touches`. The fixture carries a frontmatter key nobody declared, a
+key inside the routine block the writer has never heard of, a second routine, a
+top-level key after the section and a body. The test asserts the write landed,
+then compares every line above the edited block, every line from the next
+routine onward, the unknown key inside the edited block and the whole body,
+byte for byte. A second write of the same value returns identical content.
+
+**Its last assertion is the one that says the field is typed rather than
+carried.** The block parser copies every `key: value` it finds with no
+whitelist, so an unrecognised `timezone` already arrived on the routine as the
+raw text of its line. Most of the round-trip assertions therefore hold against
+the reader this card started from as well. A quoted value discriminates: the
+raw text carries the quotes and the typed read does not, on the same terms as
+every other field this module types.
+
+> **AC-3:** No machine timezone reaches a stored value.
+
+Two assertions, both on values constructed in the test.
+
+`the stored timezone is the one that was set, never the one this machine is in`
+creates a routine with `SET_ZONE`, reads it back, asserts it is `SET_ZONE`,
+asserts it is not `HOST_ZONE`, and asserts the string `UTC` appears nowhere in
+the written file. A second routine set in `OTHER_ZONE` keeps its own, so the
+value travels with the schedule rather than with the process.
+
+`a routine created without a timezone is left without one rather than filled in
+from the machine` is the other half and the more important one: it creates a
+routine naming no zone and requires the file to carry no `timezone` key at all,
+on a machine that has a perfectly good zone available to default from.
+
+`the migration invents no timezone, least of all the machine's` says the same
+of the migration path.
+
+**The mutation is what makes these more than assertions.** The harness rewrites
+the absent branch to `Intl.DateTimeFormat().resolvedOptions().timeZone`, which
+is the defect in its exact form, and a test goes red. See the table below.
+
+> **AC-4:** A routine whose timezone is absent is distinguishable from one
+> whose timezone is empty.
+
+`a routine with no timezone is distinguishable from one whose timezone is
+blank`. Absent reads as `null`, `timezone:` with nothing after it reads as the
+empty string, both from a raw block and from a real file, and a blank one
+round-trips as a blank rather than as an absence or as the four letters n-u-l-l.
+
+This is why `readTimezone` exists instead of a call to `readString`, which
+folds both to `null`. Every routine written before this field existed is in the
+absent state, and whatever later decides what to do about a routine with no
+zone has to tell a gap to fill from an answer already given.
+
+> **AC-5:** Migration of existing routines is idempotent, on the same terms as
+> the existing migration.
+>
+> **AC-6:** A routine already carrying the field is left byte-identical by a
+> migration pass.
+>
+> **AC-7:** The backup behaviour the existing migration has is unchanged.
+
+**The migration is not changed by this card, and that is the decision rather
+than an omission.** `MIGRATED_KEYS` does not gain `timezone`. Every key already
+in that list has a true value the migration can work out from the file: the run
+target defaults, the two switches have the meaning files already had, and the
+plan hash is computed from the routine itself. A routine written before this
+field existed was set in a zone nobody recorded, and no value in the file says
+which. The only value this process could supply is the machine it happens to be
+running on, which is not the person's choice and is wrong for every routine
+another computer wrote. Absent is the honest record. The reason is in the
+source, beside the list.
+
+Proven rather than argued, in `migrating a routine that predates the field`:
+
+- `running the migration twice over a routine that carries a timezone changes
+  nothing and says nothing` (AC-5, and the two-pass comparison AC-13 asks for).
+- `a routine already carrying the field is left byte-identical by a migration
+  pass` (AC-6), on a file made by migrating one and then adding the timezone to
+  the result, so the only thing the pass could react to is this field.
+- `the pre-migration backup still holds the file as it was before anything
+  touched it` (AC-7), including the second migrating write that must not
+  overwrite it.
+
+> **AC-8:** Whether the timezone participates in the plan hash is decided in
+> the source with its reason.
+
+**It does not participate.** The reason is in `lib/agents/routines.js`, in the
+comment block above `PLAN_FIELDS`, where the exclusions of the schedule, of
+enabled and paused, and of the owner already live. It states the argument for
+inclusion first, because it is a real one: changing a zone changes when a
+routine runs by up to a day, which is a bigger move than the ten minutes the
+schedule exclusion is written around.
+
+It is excluded for the reason the schedule is. The line this hash draws is what
+a routine DOES against WHEN it happens, not big changes against small ones. A
+zone is the second half of a schedule: `08:00` is not a time until something
+says where, and moving a routine from one zone to another is the same edit as
+moving it by an hour, said differently. An approval that survived a schedule
+edit and broke on a zone edit would draw the line somewhere nobody could
+explain, and the person re-approving would be confirming a plan that had not
+changed.
+
+The cost is named there too: a routine moved across the world runs at a
+genuinely different moment and nobody is asked again. That is the cost the
+schedule exclusion already accepts. What approval covers is what a run will do
+and which files it touches, and neither moves when the zone does.
+
+**Plan approval is a later card and inherits this**, which is why it is decided
+here rather than settled by leaving the field out of a list.
+
+> **AC-9:** If it does participate, an existing routine's plan hash is not
+> invalidated by the migration alone.
+
+It does not participate, so the condition is not met. Pinned anyway, both ways
+round: `a timezone does not reach the plan hash, so changing one does not
+invalidate an approval` (two different zones, one hash, and the hash still
+notices a changed skill so the equalities are not two hashes of nothing), and
+`the hash a migration stamps is the same whether or not the routine names a
+zone`, which is the criterion read the only way it can be given the decision
+above.
+
+> **AC-10:** Nothing in this card renders a time.
+
+No file under `public/` is touched, and no file outside `lib/agents/` other
+than tests and the mutation harness. `git show --stat` on the two commits is
+the whole of it. The editor's own reading of the browser zone, which it uses
+for a caption, is untouched and reaches no stored value.
+
+> **AC-11:** Nothing in this card reaches the value double-fire suppression
+> reads.
+
+`lib/scheduler.js` is not touched. `routineState.lastRun` is the only input to
+double-fire suppression, and nothing added here is threaded into it.
+
+Pinned as well as argued, in `nothing this card stores reaches double-fire
+suppression`: with the scheduler's clock wired to a fixed instant and the
+process zone pinned, a routine that declares `Pacific/Kiritimati` is judged due
+at exactly the same moment as one that declares nothing, is suppressed by the
+same recorded run, and `getNextRun` still takes two arguments, a schedule and
+the last run. A later change that threads a stored zone into the next-run
+calculation puts a second input beside `lastRun` and turns this red.
+
+> **AC-12:** A test proves the round trip on a file that also carries fields
+> this card does not touch.
+
+The AC-2 fixture, described above. Nothing in the file except the routine's own
+`timezone` line is written by any of these tests.
+
+> **AC-13:** A test proves the migration idempotent by running it twice and
+> comparing bytes.
+
+`running the migration twice over a routine that carries a timezone changes
+nothing and says nothing`. Both the returned content and the file on disk are
+compared with `strictEqual` against the first pass's bytes, and `console.log`
+is captured for the run: identical bytes alone would not be enough, because a
+second pass that rewrites the same content and announces it has still done
+something. The existing migration returns the content it was given and touches
+no disk when nothing is pending, and that is what is asserted.
+
+> **AC-14:** Each proof fails when its own guard is removed.
+
+`node test/tools/mutate-routine-editor-guards.js --markdown`, wired into
+`npm run mutate:guards`, which is a step in `npm run precommit` and runs on
+every pull request. It exits non-zero if any mutation turns nothing red, so
+this is a check rather than a report and the table below is machine-verified
+rather than transcribed.
+
+The eight rows this card adds, run on the tree this file is committed with:
+
+| Guard broken | Tests red | Which |
+|---|---|---|
+| an absent timezone is left absent rather than filled in from the machine | 1 | `a routine created without a timezone is left without one rather than filled in from the machine` |
+| absent and blank are read as different answers | 1 | `a routine with no timezone is distinguishable from one whose timezone is blank` |
+| the timezone is a field the model reads, not a string carried through | 5 | `a timezone is read off the file as the location words it carries`<br>`a timezone survives a write-then-read cycle on a file carrying fields this card never touches`<br>`a routine with no timezone is distinguishable from one whose timezone is blank`<br>`a routine created without a timezone is left without one rather than filled in from the machine`<br>`the migration invents no timezone, least of all the machine's` |
+| a written timezone is checked before it becomes bytes in a file | 1 | `a value that is not location words is refused rather than stored` |
+| a timezone is location words rather than any text at all | 1 | `a value that is not location words is refused rather than stored` |
+| a created routine carries its timezone into the file | 2 | `the stored timezone is the one that was set, never the one this machine is in`<br>`a value that is not location words is refused rather than stored` |
+| the timezone stays out of the plan hash | 2 | `a timezone does not reach the plan hash, so changing one does not invalidate an approval`<br>`the hash a migration stamps is the same whether or not the routine names a zone` |
+| the migration does not invent a timezone for a routine that never recorded one | 1 | `the migration invents no timezone, least of all the machine's` |
+
+**The first row is the one these exist for.** It rewrites the absent branch of
+the write path to read the machine's zone: it type-checks, it returns location
+words, and on the computer a routine was made on it returns the right answer.
+No test that inherited the runner's zone could see it. The suite pins the
+process zone and stores a different one, so it has nowhere to hide.
+
+**The last two are the decision made breakable.** Adding `timezone` to
+`PLAN_FIELDS` or to `MIGRATED_KEYS` reverses a decision this card was required
+to make, silently, which is exactly how it would happen. Both turn a test red.
+
+## Red first
+
+`node scripts/red-first.js --base origin/main --tests "npm test"`. The result
+is folded into `.precommit-gate.json` and travels with the tree it was measured
+on.
+
+Its limitation travels with it: reverting proves the tests notice this change,
+not that they assert the right thing. The mutation table above is the other
+half, and the pinned process zone is what stops the AC-3 assertions measuring a
+proxy.
+
+## What the suite could not have caught on its own
+
+Before the round-trip test's last assertion was added, every assertion in it
+passed against the reader as it was, because the block parser already carried
+an unrecognised `timezone` through as raw text. That is recorded here rather
+than quietly fixed: a round-trip test for a new field on this module starts out
+unable to fail, and the quoted value is what gives it teeth.

--- a/.review/schedule-timezone-evidence.md
+++ b/.review/schedule-timezone-evidence.md
@@ -47,9 +47,9 @@ the migration directly, so no workspace, cache or agent roster is involved.
 
 > **AC-1:** A schedule stores its timezone as location words.
 
-`normalizeRoutine` reads a `timezone` key through `readTimezone`, and
-`appendRoutineBlock` writes one, refusing anything that is not an area and a
-place. `a timezone is read off the file as the location words it carries` and
+`normalizeRoutine` reads a `timezone` key through `readTimezone`, and the
+writer refuses anything that is not an area and a place. `a timezone is read
+off the file as the location words it carries` and
 `a value that is not location words is refused rather than stored`, which walks
 `+01:00`, `-05:00`, `GMT+1`, `UTC+2`, `BST`, `PST`, `UTC`, the empty string,
 `Europe`, `Europe//London` and `../../etc/passwd` through the write path and
@@ -69,6 +69,44 @@ rather than an offset is.
 identifier and it names no place, and it is what a machine in a container
 reports, so accepting it would mean accepting the one value that cannot be
 distinguished from a default. A caller that means it can say `Etc/UTC`.
+
+**THE CHECK SITS ON THE WRITER RATHER THAN ON THE PATH THAT CREATES A
+ROUTINE**, and that placement is the point. `appendRoutineBlock` makes a
+routine that is not in the file yet; `updateRoutineBlock` changes one that is,
+and it is the only path that writes a key at all, so creating goes through it
+too. A rule enforced on the creating road alone holds for exactly as long as
+nothing edits a routine, and an edit flow is the next thing to be built: by
+then the gap would read as a decision somebody made rather than a road nobody
+had built yet. `a value that is not location words is refused on the road every
+edit takes` drives the writer directly, including a write that carries a good
+prompt beside a bad zone and must land neither.
+
+Two things follow from putting it there, both deliberate.
+
+**Quotes come off before the question is asked.** Authors quote things and this
+module writes a value literally, so `"Europe/London"` is a zone written with
+quotation marks around it rather than a zone with quotation marks in it. The
+question the rule asks is what the value will read back as, which is what the
+reader will report, so a quoted zone is accepted on both roads.
+
+**Clearing stays available on the edit road and is refused on the create
+road**, which is the one place the two roads differ and it is a difference
+between the acts rather than an oversight. Empty is how this module clears a
+field. For this field it reads back as blank rather than absent, which is the
+honest record of an edit that removed a zone: the key was declared and then
+emptied. A routine being made has no way to have reached that state, so
+`appendRoutineBlock` refuses an empty zone, in either the bare or the quoted
+form. `a zone somebody recorded can still be cleared, which is what an edit
+that removes one did` holds the first half; the refusal list in the create test
+holds the second.
+
+**One thing the rule table is not.** It is a `Map` rather than an object
+because the key is caller-supplied and `\w+` admits every name on Object's
+prototype. Nothing on that prototype does damage when called as a rule, so that
+is hygiene rather than a guard, and it carries no mutation row for that reason:
+a mutation that swaps the container breaks `.get` and reddens the whole suite,
+which would prove that the code stopped running rather than that anything is
+guarded.
 
 > **AC-2:** The value round-trips byte-for-byte, on the same terms as every
 > other field the data model already carries.
@@ -259,15 +297,16 @@ every pull request. It exits non-zero if any mutation turns nothing red, so
 this is a check rather than a report and the table below is machine-verified
 rather than transcribed.
 
-The eight rows this card adds, run on the tree this file is committed with:
+The nine rows this card adds, run on the tree this file is committed with:
 
 | Guard broken | Tests red | Which |
 |---|---|---|
 | an absent timezone is left absent rather than filled in from the machine | 1 | `a routine created without a timezone is left without one rather than filled in from the machine` |
-| absent and blank are read as different answers | 1 | `a routine with no timezone is distinguishable from one whose timezone is blank` |
-| the timezone is a field the model reads, not a string carried through | 5 | `a timezone is read off the file as the location words it carries`<br>`a timezone survives a write-then-read cycle on a file carrying fields this card never touches`<br>`a routine with no timezone is distinguishable from one whose timezone is blank`<br>`a routine created without a timezone is left without one rather than filled in from the machine`<br>`the migration invents no timezone, least of all the machine's` |
-| a written timezone is checked before it becomes bytes in a file | 1 | `a value that is not location words is refused rather than stored` |
-| a timezone is location words rather than any text at all | 1 | `a value that is not location words is refused rather than stored` |
+| absent and blank are read as different answers | 2 | `a routine with no timezone is distinguishable from one whose timezone is blank`<br>`a zone somebody recorded can still be cleared, which is what an edit that removes one did` |
+| the timezone is a field the model reads, not a string carried through | 6 | `a timezone is read off the file as the location words it carries`<br>`a timezone survives a write-then-read cycle on a file carrying fields this card never touches`<br>`a routine with no timezone is distinguishable from one whose timezone is blank`<br>`a routine created without a timezone is left without one rather than filled in from the machine`<br>`a value that is not location words is refused on the road every edit takes`<br>`the migration invents no timezone, least of all the machine's` |
+| a written timezone is checked on the road every write takes | 2 | `a value that is not location words is refused rather than stored`<br>`a value that is not location words is refused on the road every edit takes` |
+| a routine is not created carrying an empty timezone | 1 | `a value that is not location words is refused rather than stored` |
+| a timezone is location words rather than any text at all | 2 | `a value that is not location words is refused rather than stored`<br>`a value that is not location words is refused on the road every edit takes` |
 | a created routine carries its timezone into the file | 2 | `the stored timezone is the one that was set, never the one this machine is in`<br>`a value that is not location words is refused rather than stored` |
 | the timezone stays out of the plan hash | 2 | `a timezone does not reach the plan hash, so changing one does not invalidate an approval`<br>`the hash a migration stamps is the same whether or not the routine names a zone` |
 | the migration does not invent a timezone for a routine that never recorded one | 1 | `running the migration twice over a routine that predates the field changes nothing and says nothing` |

--- a/.review/schedule-timezone-evidence.md
+++ b/.review/schedule-timezone-evidence.md
@@ -145,14 +145,32 @@ source, beside the list.
 
 Proven rather than argued, in `migrating a routine that predates the field`:
 
-- `running the migration twice over a routine that carries a timezone changes
+- `running the migration twice over a routine that predates the field changes
   nothing and says nothing` (AC-5, and the two-pass comparison AC-13 asks for).
+- `running the migration twice over a routine that carries a timezone changes
+  nothing and says nothing`, the same walk over a file that has the field.
 - `a routine already carrying the field is left byte-identical by a migration
   pass` (AC-6), on a file made by migrating one and then adding the timezone to
   the result, so the only thing the pass could react to is this field.
 - `the pre-migration backup still holds the file as it was before anything
   touched it` (AC-7), including the second migrating write that must not
   overwrite it.
+
+**WHICH FIXTURE THE IDEMPOTENCE PROOF RUNS ON IS THE PROOF, not a detail of
+it.** A routine that already exists carries no `timezone` key, by definition:
+it was written before the field was. That is the only population AC-5 is about
+and the only one that can exhibit the defect. A file that already carries the
+field answers `needsMigration` with false on a second pass whether or not
+`timezone` is a migrated key, so a two-pass comparison over one of those cannot
+fail for the thing it is written to guard: it reads as a proof and is not one.
+
+Over the legacy fixture it can fail. Were `timezone` a migrated key, that file
+would never be finished: the writer skips an absent value, so the key is never
+written, `needsMigration` stays true for ever, and every read rewrites the file
+and announces it. The bytes would still match. **The silence is what notices**,
+which is why the log capture is an assertion rather than a courtesy, and why
+the first pass's single line is asserted too: without that, a suite in which
+nothing is ever migrated passes by doing nothing twice.
 
 > **AC-8:** Whether the timezone participates in the plan hash is decided in
 > the source with its reason.
@@ -222,13 +240,16 @@ The AC-2 fixture, described above. Nothing in the file except the routine's own
 > **AC-13:** A test proves the migration idempotent by running it twice and
 > comparing bytes.
 
-`running the migration twice over a routine that carries a timezone changes
-nothing and says nothing`. Both the returned content and the file on disk are
-compared with `strictEqual` against the first pass's bytes, and `console.log`
-is captured for the run: identical bytes alone would not be enough, because a
-second pass that rewrites the same content and announces it has still done
-something. The existing migration returns the content it was given and touches
-no disk when nothing is pending, and that is what is asserted.
+`running the migration twice over a routine that predates the field changes
+nothing and says nothing`, on the legacy fixture for the reason given under
+AC-5, and `running the migration twice over a routine that carries a timezone
+changes nothing and says nothing` for the file that has the field. Both the
+returned content and the file on disk are compared with `strictEqual` against
+the first pass's bytes, and `console.log` is captured for the run: identical
+bytes alone would not be enough, because a second pass that rewrites the same
+content and announces it has still done something. The existing migration
+returns the content it was given and touches no disk when nothing is pending,
+and that is what is asserted.
 
 > **AC-14:** Each proof fails when its own guard is removed.
 
@@ -249,7 +270,7 @@ The eight rows this card adds, run on the tree this file is committed with:
 | a timezone is location words rather than any text at all | 1 | `a value that is not location words is refused rather than stored` |
 | a created routine carries its timezone into the file | 2 | `the stored timezone is the one that was set, never the one this machine is in`<br>`a value that is not location words is refused rather than stored` |
 | the timezone stays out of the plan hash | 2 | `a timezone does not reach the plan hash, so changing one does not invalidate an approval`<br>`the hash a migration stamps is the same whether or not the routine names a zone` |
-| the migration does not invent a timezone for a routine that never recorded one | 1 | `the migration invents no timezone, least of all the machine's` |
+| the migration does not invent a timezone for a routine that never recorded one | 1 | `running the migration twice over a routine that predates the field changes nothing and says nothing` |
 
 **The first row is the one these exist for.** It rewrites the absent branch of
 the write path to read the machine's zone: it type-checks, it returns location
@@ -259,7 +280,9 @@ process zone and stores a different one, so it has nowhere to hide.
 
 **The last two are the decision made breakable.** Adding `timezone` to
 `PLAN_FIELDS` or to `MIGRATED_KEYS` reverses a decision this card was required
-to make, silently, which is exactly how it would happen. Both turn a test red.
+to make, silently, which is exactly how it would happen. Both turn a test red,
+and both turn it red through behaviour: no test in this suite asserts the shape
+of either constant. An earlier version did, which is recorded below.
 
 ## Red first
 
@@ -272,10 +295,28 @@ not that they assert the right thing. The mutation table above is the other
 half, and the pinned process zone is what stops the AC-3 assertions measuring a
 proxy.
 
-## What the suite could not have caught on its own
+## Two proofs that were aimed at a case which could not fail
 
-Before the round-trip test's last assertion was added, every assertion in it
-passed against the reader as it was, because the block parser already carried
-an unrecognised `timezone` through as raw text. That is recorded here rather
-than quietly fixed: a round-trip test for a new field on this module starts out
-unable to fail, and the quoted value is what gives it teeth.
+Both are recorded rather than quietly fixed, because they are the same fault
+and this suite produced it twice.
+
+**The round trip, found while writing it.** Before its last assertion was
+added, every assertion in that test passed against the reader as it was,
+because the block parser already carried an unrecognised `timezone` through as
+raw text. A round-trip test for a new field on this module starts out unable to
+fail; the quoted value is what gives it teeth.
+
+**The idempotence proof, found in review.** Both two-pass tests originally ran
+on a file that already carried the field, which is not the population AC-5 is
+about and is the one population that cannot exhibit the defect. The mutation
+that should have caught that was passing for the matching reason: it turned red
+only through an assertion on the shape of `MIGRATED_KEYS`, so the row in the
+table was a statement about a constant rather than about the migration. Deleted
+that one line and the harness would have reported nothing red while the mutated
+migration rewrote and logged every legacy file on every read.
+
+Fixed by adding the two-pass run over the legacy fixture and by removing both
+assertions on the shape of a constant, from this test and from the plan-hash
+one, so every red in the table above is behaviour. The mutation now goes red
+through `running the migration twice over a routine that predates the field
+changes nothing and says nothing`.

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -64,6 +64,67 @@ function readBoolean(raw, key, fallback) {
   return fallback;
 }
 
+// ===== THE TIMEZONE A SCHEDULE WAS SET IN =====
+
+/**
+ * The zone a schedule was built in, as location words: `Europe/London`.
+ *
+ * WORDS RATHER THAN AN OFFSET, because an offset is true until the next clock
+ * change and then silently wrong, twice a year, in the direction nobody
+ * notices until a routine runs an hour late.
+ *
+ * ABSENT AND BLANK ARE DIFFERENT ANSWERS, which is the whole reason this does
+ * not go through readString. A file with no `timezone` key never recorded one,
+ * and every routine written before this field existed is in that state. A file
+ * carrying `timezone:` with nothing after it was written by somebody who
+ * declared the field and left it empty. readString folds both to null, and
+ * whatever later decides what to do about a routine with no zone has to be
+ * able to tell "never recorded" from "deliberately blank": the first is a gap
+ * to fill and the second is an answer already given.
+ *
+ * NOTHING HERE ASKS THE MACHINE. `Intl.DateTimeFormat().resolvedOptions()
+ * .timeZone` returns location words and looks exactly like the value this
+ * field wants. It answers a different question: what this computer is set to,
+ * rather than what the person chose when they built the schedule. The two are
+ * the same string on the machine a routine was made on and different
+ * everywhere else, including on the server that later reads the file, so a
+ * value defaulted from the machine is a value that changes when nothing about
+ * the routine did. A routine with no zone stays a routine with no zone.
+ */
+function readTimezone(raw) {
+  const value = raw.timezone;
+  if (value === undefined || value === null) return null;
+  return unquote(value);
+}
+
+// What a timezone may be when one is WRITTEN: an area and a place, e.g.
+// `Europe/London` or `America/Argentina/Buenos_Aires`.
+//
+// CHECKED BY SHAPE, NOT AGAINST A ZONE DATABASE. Intl knows which zones exist,
+// and asking it would make what a file may contain depend on the ICU data of
+// whichever machine did the writing: the same zone accepted on one computer
+// and refused on another, and refused everywhere on a Node built without full
+// ICU. Which zones exist is not this module's question, and answering it from
+// the runtime is the machine reaching a stored value by a second road.
+// Whether this is location words rather than an offset is the question, and
+// the shape answers it.
+//
+// What it refuses is the point. `+01:00` and `GMT+1` are offsets. `BST` and
+// `PST` name several places at once and change meaning with the season. `UTC`
+// names no place at all and is what a machine in a container reports, which is
+// exactly the value this field must not silently accept as somebody's choice.
+const TIMEZONE_WORDS = /^[A-Za-z][A-Za-z0-9_-]*(?:\/[A-Za-z0-9_+-]+)+$/;
+// The longest name in the zone database is about half this. The cap is here
+// because the value arrives from a message rather than from a person, and a
+// line in somebody's agent file is not the place to discover that.
+const TIMEZONE_MAX = 64;
+
+function assertTimezoneWords(value) {
+  if (value.length > TIMEZONE_MAX || !TIMEZONE_WORDS.test(value)) {
+    throw new Error(`timezone "${value.slice(0, TIMEZONE_MAX)}" is not location words, like Europe/London`);
+  }
+}
+
 function readRunOn(raw) {
   const text = readString(raw, 'runOn');
   if (!text) return RUN_ON_DEFAULT;
@@ -89,6 +150,7 @@ function normalizeRoutine(raw, opts = {}) {
     prompt: raw.prompt === undefined ? null : raw.prompt,
     skill: readString(raw, 'skill'),
     runOn: readRunOn(raw),
+    timezone: readTimezone(raw),
     owner: readString(raw, 'owner') || opts.owner || null,
     enabled: readBoolean(raw, 'enabled', true),
     paused: readBoolean(raw, 'paused', false),
@@ -348,6 +410,21 @@ function appendRoutineBlock(content, routine) {
     throw new Error(`runOn "${runOn}" is reserved and cannot be written`);
   }
 
+  // The zone, when the caller names one, checked HERE rather than on the way
+  // in. Reading keeps whatever an author wrote, because their bytes are theirs
+  // and a read that coerced them would lose the only record of what the file
+  // says. Writing is where a value becomes this module's, so it is where the
+  // shape is refused, on the same terms as the reserved run target above.
+  //
+  // ABSENT STAYS ABSENT. There is no zone this code could invent that would be
+  // true, and the one it could reach for is the machine's. A routine created
+  // without a zone gets no key, which is the same absence every routine
+  // written before this field had.
+  const timezone = routine.timezone === undefined || routine.timezone === null
+    ? null
+    : String(routine.timezone);
+  if (timezone !== null) assertTimezoneWords(timezone);
+
   // THIS REFUSES RATHER THAN RETURNING THE CONTENT IT WAS GIVEN, and the
   // difference is the whole point. Handing back the original bytes makes a
   // file this function cannot edit indistinguishable from one it edited
@@ -426,6 +503,7 @@ function appendRoutineBlock(content, routine) {
     prompt: routine.prompt,
     skill: routine.skill,
     runOn,
+    timezone,
     enabled: routine.enabled === undefined ? true : routine.enabled,
     planHash: computePlanHash(normalized),
   }, occurrence);
@@ -475,6 +553,30 @@ function appendRoutineBlock(content, routine) {
 // flow can compare it directly, and it does not need smuggling through a hash
 // to be noticed.
 //
+// AND DELIBERATELY NOT THE TIMEZONE, decided here rather than settled by
+// leaving it out.
+//
+// The argument for including it is real and worth stating: changing a zone
+// changes when a routine runs, by up to a day, which is a bigger move than the
+// ten minutes the schedule exclusion is written around. Both answers are
+// defensible, and whichever is chosen here is the one plan approval inherits,
+// because approval is exactly "this hash, approved once".
+//
+// It is excluded, for the reason the schedule is. The line this hash draws is
+// what a routine DOES against WHEN it happens, not big changes against small
+// ones. A zone is the second half of a schedule: "08:00" is not a time until
+// something says where, and moving a routine from one zone to another is the
+// same edit as moving it by an hour, said differently. An approval that
+// survived a schedule edit and broke on a zone edit would be drawing the line
+// somewhere nobody could explain, and the person re-approving would be
+// confirming a plan that had not changed.
+//
+// The cost, named rather than hidden: a routine moved across the world runs at
+// a genuinely different moment and nobody is asked again. That is the same
+// cost the schedule exclusion already accepts. What approval covers is what a
+// run will do and which files it will touch, and neither of those moves when
+// the zone does.
+//
 // Read by name from a normalised routine, so the order the fields appear in
 // the file cannot reach the hash either.
 const PLAN_FIELDS = ['prompt', 'skill', 'runOn'];
@@ -496,6 +598,18 @@ function computePlanHash(routine) {
 // writing it into every file that never named an owner would turn an implicit
 // meaning into an explicit one that is then free to drift from the file it
 // lives in.
+//
+// `timezone` is deliberately absent too, and for a sharper reason. Every other
+// key here has a true value the migration can work out from the file: the run
+// target defaults, the two switches have the meaning files already had, and
+// the plan hash is computed from the routine itself. A routine written before
+// this field existed was set in a zone nobody recorded, and there is no value
+// in the file that says which. The only value this process could supply is the
+// machine it happens to be running on, which is not the person's choice and is
+// wrong for every routine somebody else's computer wrote. So the field is left
+// absent, which is the honest record, and stays readable as "never recorded"
+// rather than becoming a plausible wrong answer nobody can tell from a right
+// one.
 const MIGRATED_KEYS = ['runOn', 'enabled', 'paused', 'planHash'];
 const BACKUP_SUFFIX = '.pre-routine-model-backup';
 

--- a/lib/agents/routines.js
+++ b/lib/agents/routines.js
@@ -125,6 +125,31 @@ function assertTimezoneWords(value) {
   }
 }
 
+/**
+ * What the WRITER accepts for a timezone: location words, or nothing.
+ *
+ * The empty value is how this module clears a field. For this field it reads
+ * back as blank rather than as absent, which is the honest record of what
+ * happened: the key was declared and then emptied, which is not the same as
+ * never having recorded a zone at all. Removing a zone somebody recorded is an
+ * ordinary edit, so it is not refused here.
+ *
+ * Creating a routine with an empty one is a different act, and is refused
+ * where routines are made.
+ *
+ * THE QUOTES COME OFF BEFORE THE QUESTION IS ASKED, because the question is
+ * what this value will read back as. Authors quote things and this module
+ * writes a value literally, so `"Europe/London"` is a zone written with
+ * quotation marks around it rather than a zone with quotation marks in it. The
+ * reader takes them off; a check that did not would refuse a value it then
+ * accepts on the way back in.
+ */
+function assertWritableTimezone(value) {
+  const text = unquote(value);
+  if (text === '') return;
+  assertTimezoneWords(text);
+}
+
 function readRunOn(raw) {
   const text = readString(raw, 'runOn');
   if (!text) return RUN_ON_DEFAULT;
@@ -230,6 +255,37 @@ function formatValue(key, value) {
   return text;
 }
 
+// Per-field value rules, applied wherever a key becomes bytes.
+//
+// THE WRITER IS OTHERWISE FIELD-AGNOSTIC BY DESIGN. It knows the shape of a
+// key and that a value cannot carry a line break, and nothing about what any
+// key means. One field needs more than that: a timezone is the answer to where
+// a schedule was set, and an offset or an abbreviation written into it is
+// wrong in a way that is only discovered twice a year, on the morning a
+// routine runs an hour late.
+//
+// IT LIVES HERE RATHER THAN BESIDE THE PATH THAT CREATES A ROUTINE, and that
+// placement is the point. This is the road every edit takes. A rule on the
+// creating road alone is a rule the first edit flow walks straight past, and by
+// then it looks like a decision somebody made rather than a road nobody had
+// built yet.
+//
+// A MAP RATHER THAN AN OBJECT, because the key comes from the caller. `\w+`
+// admits `constructor`, `toString` and every other name on Object's prototype,
+// and a plain object hands those back from it, so the lookup would find a
+// function that is not a rule and call it with somebody's value. Nothing on
+// that prototype does damage when called that way, so this is hygiene rather
+// than a guard, and it carries no mutation for that reason: a container with
+// no inherited keys is simply the right container to look up caller input in.
+const FIELD_VALUE_RULES = new Map([
+  ['timezone', assertWritableTimezone],
+]);
+
+function assertFieldValue(key, value) {
+  const rule = FIELD_VALUE_RULES.get(key);
+  if (rule) rule(value);
+}
+
 // The indent authors actually used for this block's keys, so an appended key
 // lines up with the ones already there. Falls back to the position implied by
 // the `- ` marker when the block has nothing but a name.
@@ -285,6 +341,7 @@ function updateRoutineBlock(content, name, updates, occurrence = 0) {
     if (value === undefined || value === null) continue;
     assertFieldName(key);
     const formatted = formatValue(key, value);
+    assertFieldValue(key, formatted);
     const existing = findKeyLine(lines, target, key);
     if (existing === -1) {
       appended.push(`${indent}${key}: ${formatted}`);
@@ -410,20 +467,30 @@ function appendRoutineBlock(content, routine) {
     throw new Error(`runOn "${runOn}" is reserved and cannot be written`);
   }
 
-  // The zone, when the caller names one, checked HERE rather than on the way
-  // in. Reading keeps whatever an author wrote, because their bytes are theirs
-  // and a read that coerced them would lose the only record of what the file
-  // says. Writing is where a value becomes this module's, so it is where the
-  // shape is refused, on the same terms as the reserved run target above.
+  // The zone, when the caller names one. Its SHAPE is not checked here: every
+  // field this function writes goes through the writer below, and the writer
+  // refuses a value that is not location words on whichever road it arrives
+  // by. Reading, by contrast, keeps whatever an author wrote, because their
+  // bytes are theirs and a read that coerced them would lose the only record
+  // of what the file says.
   //
   // ABSENT STAYS ABSENT. There is no zone this code could invent that would be
   // true, and the one it could reach for is the machine's. A routine created
   // without a zone gets no key, which is the same absence every routine
   // written before this field had.
+  //
+  // AN EMPTY ONE IS REFUSED, and this is the one rule that belongs to creating
+  // rather than to editing. Empty is how the writer clears a field, which
+  // leaves a key declared and blank. That is a true record of an edit that
+  // removed a zone, and it is a state a routine being made has no way to have
+  // reached: a new routine names a place or records nothing, and recording
+  // nothing is leaving the key out.
   const timezone = routine.timezone === undefined || routine.timezone === null
     ? null
     : String(routine.timezone);
-  if (timezone !== null) assertTimezoneWords(timezone);
+  if (timezone !== null && unquote(timezone) === '') {
+    throw new Error('a new routine names a timezone or leaves it out, rather than carrying an empty one');
+  }
 
   // THIS REFUSES RATHER THAN RETURNING THE CONTENT IT WAS GIVEN, and the
   // difference is the whole point. Handing back the original bytes makes a

--- a/test/tools/mutate-routine-editor-guards.js
+++ b/test/tools/mutate-routine-editor-guards.js
@@ -61,6 +61,11 @@ const PROFILE = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 
 const SIDEBAR = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/routine-editor-doors.test.js' };
 // The data model's write path, where a routine becomes bytes in a file.
 const ROUTINES = { src: path.join(ROOT, 'lib', 'agents', 'routines.js'), suite: 'test/unit/routine-write.test.js' };
+// The same file, watched by the suite that owns the timezone a schedule was
+// set in. It is a second entry rather than a second suite on the first because
+// each mutation runs exactly one suite, and these guards are watched by that
+// one. Both entries read and restore the same file, one mutation at a time.
+const ROUTINES_TZ = { src: path.join(ROOT, 'lib', 'agents', 'routines.js'), suite: 'test/unit/routine-timezone.test.js' };
 
 // [target, label, the guard as it is written, what it becomes without it]
 const MUTATIONS = [
@@ -243,6 +248,42 @@ const MUTATIONS = [
   [ROUTINES, 'whether the file already declares routines is asked of the independent counter',
     "  const declaredRoutines = (topLevelKeyCounts(content) || new Map()).get('routines') || 0;",
     '    const declaredRoutines = locateSection(content.split(\'\\n\')) ? 1 : 0;'],
+
+  // The timezone a schedule was set in.
+  //
+  // THE ONE THESE EXIST FOR is the first: fill an absent zone in from the
+  // machine. It is the defect in its exact form, it type-checks, it returns
+  // location words, and on the computer a routine was made on it returns the
+  // right answer, which is why no test that inherits the runner's zone can
+  // see it. The suite pins the process zone and stores a different one, so
+  // this mutation has nowhere to hide.
+  [ROUTINES_TZ, 'an absent timezone is left absent rather than filled in from the machine',
+    '  const timezone = routine.timezone === undefined || routine.timezone === null\n    ? null\n    : String(routine.timezone);',
+    '  const timezone = routine.timezone === undefined || routine.timezone === null\n    ? Intl.DateTimeFormat().resolvedOptions().timeZone\n    : String(routine.timezone);'],
+  [ROUTINES_TZ, 'absent and blank are read as different answers',
+    '  const value = raw.timezone;\n  if (value === undefined || value === null) return null;\n  return unquote(value);',
+    "  return readString(raw, 'timezone');"],
+  [ROUTINES_TZ, 'the timezone is a field the model reads, not a string carried through',
+    '    timezone: readTimezone(raw),\n',
+    ''],
+  [ROUTINES_TZ, 'a written timezone is checked before it becomes bytes in a file',
+    '  if (timezone !== null) assertTimezoneWords(timezone);\n',
+    ''],
+  [ROUTINES_TZ, 'a timezone is location words rather than any text at all',
+    'const TIMEZONE_WORDS = /^[A-Za-z][A-Za-z0-9_-]*(?:\\/[A-Za-z0-9_+-]+)+$/;',
+    'const TIMEZONE_WORDS = /^[^\\n]*$/;'],
+  [ROUTINES_TZ, 'a created routine carries its timezone into the file',
+    '    runOn,\n    timezone,\n',
+    '    runOn,\n'],
+  // The decision, as a thing that can be broken rather than a comment. Adding
+  // the field to either list reverses it silently, which is exactly how it
+  // would happen.
+  [ROUTINES_TZ, 'the timezone stays out of the plan hash',
+    "const PLAN_FIELDS = ['prompt', 'skill', 'runOn'];",
+    "const PLAN_FIELDS = ['prompt', 'skill', 'runOn', 'timezone'];"],
+  [ROUTINES_TZ, 'the migration does not invent a timezone for a routine that never recorded one',
+    "const MIGRATED_KEYS = ['runOn', 'enabled', 'paused', 'planHash'];",
+    "const MIGRATED_KEYS = ['runOn', 'enabled', 'paused', 'planHash', 'timezone'];"],
 ];
 
 // The reporter is named explicitly rather than left to the default, which
@@ -285,7 +326,7 @@ function run() {
   // Both files are read up front and both are restored in the same finally, so
   // a throw part way through cannot leave either one mutated.
   const originals = new Map();
-  for (const target of [MODEL, VIEW, APP, HANDLER, PROFILE, SIDEBAR, ROUTINES]) originals.set(target, fs.readFileSync(target.src, 'utf8'));
+  for (const target of [MODEL, VIEW, APP, HANDLER, PROFILE, SIDEBAR, ROUTINES, ROUTINES_TZ]) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];
   try {
     for (const [target, label, guard, without] of MUTATIONS) {

--- a/test/tools/mutate-routine-editor-guards.js
+++ b/test/tools/mutate-routine-editor-guards.js
@@ -266,9 +266,14 @@ const MUTATIONS = [
   [ROUTINES_TZ, 'the timezone is a field the model reads, not a string carried through',
     '    timezone: readTimezone(raw),\n',
     ''],
-  [ROUTINES_TZ, 'a written timezone is checked before it becomes bytes in a file',
-    '  if (timezone !== null) assertTimezoneWords(timezone);\n',
+  // The check sits on the writer, which is the road an edit takes as well as
+  // the road a creation takes. Removing it has to be noticed from both.
+  [ROUTINES_TZ, 'a written timezone is checked on the road every write takes',
+    '    assertFieldValue(key, formatted);\n',
     ''],
+  [ROUTINES_TZ, 'a routine is not created carrying an empty timezone',
+    "  if (timezone !== null && unquote(timezone) === '') {",
+    '  if (false) {'],
   [ROUTINES_TZ, 'a timezone is location words rather than any text at all',
     'const TIMEZONE_WORDS = /^[A-Za-z][A-Za-z0-9_-]*(?:\\/[A-Za-z0-9_+-]+)+$/;',
     'const TIMEZONE_WORDS = /^[^\\n]*$/;'],

--- a/test/unit/discovery.test.js
+++ b/test/unit/discovery.test.js
@@ -90,6 +90,10 @@ describe('nested frontmatter block parsers', () => {
   // declares none of them still means what it always meant: it runs locally,
   // it is enabled, it is not paused, and its owner is settled by the caller
   // that knows which agent file this frontmatter came from.
+  //
+  // `timezone` is null here rather than the machine's zone, and this is the
+  // whole-shape assertion that would notice a default arriving from anywhere:
+  // a routine that never recorded a zone still has not recorded one.
   test('parseRoutines extracts each routine with fields, typed', () => {
     const routines = srv.parseRoutines(fm);
     assert.strictEqual(routines.length, 2);
@@ -99,6 +103,7 @@ describe('nested frontmatter block parsers', () => {
       prompt: 'Run the digest',
       skill: null,
       runOn: 'local',
+      timezone: null,
       owner: null,
       enabled: true,
       paused: false,

--- a/test/unit/routine-timezone.test.js
+++ b/test/unit/routine-timezone.test.js
@@ -1,0 +1,460 @@
+'use strict';
+// The timezone a schedule was set in, stored as location words.
+//
+// THE ZONE THIS PROCESS RUNS IN IS SET HERE, before the first require, and it
+// is the whole reason these tests can say anything at all.
+//
+// The easiest wrong answer to "what timezone was this schedule set in" is
+// `Intl.DateTimeFormat().resolvedOptions().timeZone`. It returns location
+// words and looks exactly right. It answers a different question: what this
+// machine is set to, rather than what the person chose when they built the
+// schedule. A test that inherited the runner's zone could not tell the two
+// apart, because on the machine that wrote the code they are the same string.
+//
+// So the host's zone is pinned to a known value here, and every zone these
+// tests store is a different one, chosen in the test and never read from
+// anywhere. The assertions then hold identically in London, in Auckland and on
+// a continuous integration runner, and a value that arrived from the machine
+// fails them everywhere rather than passing everywhere.
+//
+// Its own file, for the same reason test/unit/scheduler-slots-dst.test.js is:
+// node --test gives every file its own process, so setting the zone here
+// changes nothing anywhere else, and it has to be set before the first require.
+process.env.TZ = 'UTC';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  normalizeRoutine, parseRoutineBlocks, updateRoutineBlock, appendRoutineBlock,
+  computePlanHash, migrateAgentRoutines, PLAN_FIELDS, MIGRATED_KEYS,
+} = require('../../lib/agents/routines.js');
+
+// The machine's zone, as a constant this file controls rather than a reading
+// it inherits. Every stored zone below differs from it, which is what makes
+// "the stored value is not the machine's" an assertion instead of a hope.
+const HOST_ZONE = 'UTC';
+// Two zones, neither of which is the host's, and neither of which any code
+// under test could have derived from anything. Kiritimati is +14 and Niue is
+// -11, so a value that leaked in from the machine is not one clock change away
+// from these, it is a different string entirely.
+const SET_ZONE = 'Pacific/Kiritimati';
+const OTHER_ZONE = 'Pacific/Niue';
+
+test('the host zone is pinned, so a zone differing from it is a real difference', () => {
+  // If this fails, every AC-3 assertion below is comparing a value against
+  // whatever the runner happened to be set to, which is the defect rather than
+  // the check. It is asserted rather than assumed for that reason.
+  assert.strictEqual(Intl.DateTimeFormat().resolvedOptions().timeZone, HOST_ZONE);
+  assert.notStrictEqual(SET_ZONE, HOST_ZONE);
+  assert.notStrictEqual(OTHER_ZONE, HOST_ZONE);
+});
+
+// A file carrying more than this card knows about: a frontmatter key nobody
+// declared, a key inside the routine block the writer has never heard of, a
+// second routine, a key after the section, and a body. Round-tripping a new
+// field on a file like this is the claim; round-tripping it on a file
+// containing only that field would not be.
+const FIXTURE = [
+  '---',
+  'name: penn',
+  'displayName: Penn',
+  'aKeyThisCardNeverHeardOf: keep me exactly',
+  'routines:',
+  '  - name: morning-digest',
+  '    schedule: every day at 08:00',
+  '    prompt: Run the digest',
+  '    aRoutineKeyTheWriterDoesNotKnow: keep me too',
+  '  - name: weekly-review',
+  '    schedule: every friday at 16:00',
+  '    prompt: Review the week',
+  'trailingKey: still here',
+  '---',
+  '',
+  '# Penn',
+  '',
+  'Body text the writer knows nothing about.',
+  '',
+].join('\n');
+
+function frontmatterOf(content) {
+  return content.match(/^---\n([\s\S]*?)\n---/)[1];
+}
+
+function readRoutine(content, name) {
+  return parseRoutineBlocks(frontmatterOf(content))
+    .map(raw => normalizeRoutine(raw, { owner: 'penn' }))
+    .find(r => r.name === name);
+}
+
+function splitFile(content) {
+  const end = content.indexOf('\n---\n', 4);
+  return { frontmatter: content.slice(4, end), body: content.slice(end + 5) };
+}
+
+describe('a schedule stores the timezone it was set in', () => {
+  test('a timezone is read off the file as the location words it carries', () => {
+    assert.strictEqual(
+      normalizeRoutine({ name: 'r', timezone: SET_ZONE }).timezone, SET_ZONE);
+    // Authors quote things, and every other typed field in this module is read
+    // through the same unquoting.
+    assert.strictEqual(
+      normalizeRoutine({ name: 'r', timezone: `"${SET_ZONE}"` }).timezone, SET_ZONE);
+    assert.strictEqual(
+      normalizeRoutine({ name: 'r', timezone: `  ${SET_ZONE}  ` }).timezone, SET_ZONE);
+  });
+
+  test('a timezone survives a write-then-read cycle on a file carrying fields this card never touches', () => {
+    const updated = updateRoutineBlock(FIXTURE, 'morning-digest', { timezone: SET_ZONE });
+
+    // The write landed. Two files that both lost the field would also compare
+    // equal, so prove it is there before claiming anything was preserved.
+    assert.strictEqual(readRoutine(updated, 'morning-digest').timezone, SET_ZONE);
+    assert.ok(updated.includes(`    timezone: ${SET_ZONE}`),
+      'the zone was not written as the words that were given');
+
+    const before = splitFile(FIXTURE).frontmatter.split('\n');
+    const after = splitFile(updated).frontmatter.split('\n');
+    // Everything above the edited block, byte for byte.
+    const head = before.indexOf('  - name: morning-digest');
+    assert.deepStrictEqual(after.slice(0, head), before.slice(0, head));
+    // Everything from the next routine onward, which covers the second routine
+    // and the top-level key that follows the section.
+    assert.deepStrictEqual(
+      after.slice(after.indexOf('  - name: weekly-review')),
+      before.slice(before.indexOf('  - name: weekly-review')));
+    // The unknown key inside the block that was edited.
+    assert.ok(after.includes('    aRoutineKeyTheWriterDoesNotKnow: keep me too'),
+      'a key inside the edited routine was dropped');
+    // And the body.
+    assert.strictEqual(splitFile(updated).body, splitFile(FIXTURE).body);
+
+    // A second cycle, so "round trip" means repeatedly rather than once.
+    const twice = updateRoutineBlock(updated, 'morning-digest', { timezone: SET_ZONE });
+    assert.strictEqual(twice, updated);
+
+    // THE ASSERTION THAT SAYS THE FIELD IS TYPED RATHER THAN CARRIED.
+    //
+    // The block parser copies every `key: value` it finds with no whitelist,
+    // so an unrecognised `timezone` already arrives on the routine as the raw
+    // text of its line. That is why the assertions above hold on the reader
+    // this card started from as well: they cannot tell a field the model
+    // knows from a string nobody typed. A quoted value can: the raw text
+    // carries the quotes and the typed read does not, on the same terms as
+    // every other field this module types.
+    const quoted = updateRoutineBlock(FIXTURE, 'morning-digest', { timezone: `"${SET_ZONE}"` });
+    assert.ok(quoted.includes(`    timezone: "${SET_ZONE}"`), 'the quotes were not written');
+    assert.strictEqual(readRoutine(quoted, 'morning-digest').timezone, SET_ZONE);
+  });
+
+  test('a routine with no timezone is distinguishable from one whose timezone is blank', () => {
+    // Never recorded. Every routine written before this field existed is here,
+    // and a later card deciding what to do about a routine with no zone has to
+    // be able to tell this from the line below.
+    assert.strictEqual(normalizeRoutine({ name: 'r' }).timezone, null);
+    // Declared and left empty, which is somebody saying something rather than
+    // saying nothing.
+    assert.strictEqual(normalizeRoutine({ name: 'r', timezone: '' }).timezone, '');
+    assert.strictEqual(normalizeRoutine({ name: 'r', timezone: '""' }).timezone, '');
+
+    // The same distinction off a real file rather than out of a raw object,
+    // because the parser is what turns a bare `timezone:` line into a value.
+    const blank = FIXTURE.replace(
+      '    prompt: Run the digest\n', '    prompt: Run the digest\n    timezone:\n');
+    assert.strictEqual(readRoutine(blank, 'morning-digest').timezone, '');
+    assert.strictEqual(readRoutine(FIXTURE, 'morning-digest').timezone, null);
+
+    // And a blank one round-trips as a blank rather than as the four letters
+    // n-u-l-l or as an absence.
+    const back = updateRoutineBlock(blank, 'morning-digest', readRoutine(blank, 'morning-digest'));
+    assert.strictEqual(readRoutine(back, 'morning-digest').timezone, '');
+    assert.ok(!back.includes('timezone: null'), 'the text "null" reached the file');
+  });
+
+  test('the stored timezone is the one that was set, never the one this machine is in', () => {
+    const created = appendRoutineBlock(FIXTURE, {
+      name: 'evening-digest', schedule: 'every day at 18:00', prompt: 'Run it',
+      timezone: SET_ZONE,
+    });
+    const routine = readRoutine(created, 'evening-digest');
+
+    assert.strictEqual(routine.timezone, SET_ZONE);
+    // The assertion this card exists for. The machine is set to HOST_ZONE and
+    // the stored value is not it, so no path from the machine's zone to the
+    // file can have been taken.
+    assert.notStrictEqual(routine.timezone, HOST_ZONE);
+    assert.ok(!created.includes(HOST_ZONE), 'the machine\'s zone reached the file');
+
+    // A second routine set in a different zone keeps its own, so the value
+    // travels with the schedule rather than with the process.
+    const both = appendRoutineBlock(created, {
+      name: 'night-digest', schedule: 'every day at 23:00', prompt: 'Run it late',
+      timezone: OTHER_ZONE,
+    });
+    assert.strictEqual(readRoutine(both, 'evening-digest').timezone, SET_ZONE);
+    assert.strictEqual(readRoutine(both, 'night-digest').timezone, OTHER_ZONE);
+  });
+
+  test('a routine created without a timezone is left without one rather than filled in from the machine', () => {
+    const created = appendRoutineBlock(FIXTURE, {
+      name: 'evening-digest', schedule: 'every day at 18:00', prompt: 'Run it',
+    });
+    assert.strictEqual(readRoutine(created, 'evening-digest').timezone, null);
+    assert.ok(!/timezone:/.test(created), 'a timezone was invented for a routine that named none');
+    assert.ok(!created.includes(HOST_ZONE), 'the machine\'s zone reached the file');
+  });
+
+  test('a value that is not location words is refused rather than stored', () => {
+    const refused = [
+      '+01:00',      // an offset is true until the next clock change
+      '-05:00',
+      'GMT+1',
+      'UTC+2',
+      'BST',         // an abbreviation names several places at once
+      'PST',
+      'UTC',         // names no place, and is what a machine in a container says
+      '',            // an empty zone is not a zone to create
+      'Europe',      // an area with no place in it
+      'Europe//London',
+      '../../etc/passwd',
+    ];
+    for (const value of refused) {
+      assert.throws(
+        () => appendRoutineBlock(FIXTURE, {
+          name: 'evening-digest', schedule: 'every day at 18:00', prompt: 'p', timezone: value,
+        }),
+        /timezone/i,
+        `"${value}" was accepted as a timezone`);
+    }
+
+    // And the shapes a real zone comes in are accepted, including the
+    // three-part names and the ones carrying digits or a sign.
+    for (const value of [
+      'Europe/London', 'America/Argentina/Buenos_Aires', 'Australia/Lord_Howe',
+      'America/Port-au-Prince', 'Etc/GMT+10',
+    ]) {
+      const created = appendRoutineBlock(FIXTURE, {
+        name: 'evening-digest', schedule: 'every day at 18:00', prompt: 'p', timezone: value,
+      });
+      assert.strictEqual(readRoutine(created, 'evening-digest').timezone, value);
+    }
+  });
+});
+
+describe('whether a timezone invalidates a plan approval', () => {
+  const plan = (fields) => computePlanHash(normalizeRoutine({
+    name: 'morning-digest', prompt: 'Run the digest', skill: 'content-linter', ...fields,
+  }, { owner: 'penn' }));
+
+  // THE DECISION THIS CARD CANNOT AVOID, pinned so it cannot be reversed by
+  // omission. A plan approval covers what a routine does. A timezone changes
+  // when it runs, which is the same class as the schedule, and the schedule is
+  // already excluded because re-approving a routine somebody moved by ten
+  // minutes makes approval worthless. Moving one across a zone is that same
+  // edit said differently.
+  test('a timezone does not reach the plan hash, so changing one does not invalidate an approval', () => {
+    const base = plan({});
+    assert.strictEqual(plan({ timezone: SET_ZONE }), base);
+    assert.strictEqual(plan({ timezone: OTHER_ZONE }), base);
+    assert.strictEqual(plan({ timezone: '' }), base);
+    // The pair that says it directly: two zones, same plan.
+    assert.strictEqual(plan({ timezone: SET_ZONE }), plan({ timezone: OTHER_ZONE }));
+    // And the hash still notices what a routine DOES, so the equalities above
+    // are not two hashes of nothing.
+    assert.notStrictEqual(plan({ skill: 'voice-editor' }), base);
+    assert.strictEqual(PLAN_FIELDS.includes('timezone'), false);
+  });
+
+  test('the hash a migration stamps is the same whether or not the routine names a zone', () => {
+    // AC-9 read the only way it can be, given the decision above: a routine
+    // that gains its plan record in the same pass that meets its timezone must
+    // land on the hash it would have had without one, or every existing
+    // approval breaks the first time the field is written next to it.
+    const withZone = normalizeRoutine(
+      { name: 'r', prompt: 'Run the digest', timezone: SET_ZONE }, { owner: 'penn' });
+    const without = normalizeRoutine(
+      { name: 'r', prompt: 'Run the digest' }, { owner: 'penn' });
+    assert.strictEqual(computePlanHash(withZone), computePlanHash(without));
+  });
+});
+
+// ===== MIGRATION =====
+
+const LEGACY = [
+  '---',
+  'name: penn',
+  'displayName: Penn',
+  'aKeyThisCardNeverHeardOf: keep me exactly',
+  'routines:',
+  '  - name: morning-digest',
+  '    schedule: every day at 08:00',
+  '    prompt: Run the digest',
+  '---',
+  '',
+  '# Penn',
+  '',
+  'Body text the migration is not allowed to touch.',
+  '',
+].join('\n');
+
+// A throwaway file per test, under the system temp directory, removed after.
+// Nothing here reads the home directory or the real workspace.
+function withFile(content, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'routine-timezone-'));
+  const file = path.join(dir, 'penn.md');
+  fs.writeFileSync(file, content);
+  try {
+    return fn(file);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// The migration announces itself on stdout when it does something, and
+// "it said nothing" is half of what idempotent means here.
+function capturingLogs(fn) {
+  const logs = [];
+  const realLog = console.log;
+  console.log = (...args) => logs.push(args.join(' '));
+  try { fn(); } finally { console.log = realLog; }
+  return logs.filter(l => l.includes('[migrate]'));
+}
+
+function migrate(file) {
+  return migrateAgentRoutines(file, fs.readFileSync(file, 'utf-8'), { owner: 'penn' });
+}
+
+describe('migrating a routine that predates the field', () => {
+  test('the migration invents no timezone, least of all the machine\'s', () => {
+    withFile(LEGACY, (file) => {
+      const migrated = migrate(file);
+      // The migration ran: it stamps a plan hash, which nothing defaults.
+      assert.match(migrated, /planHash: [0-9a-f]{64}/);
+      // And it left the field alone. There is no true value for a routine
+      // written before anybody recorded one, and the only value available to
+      // this process is the machine's.
+      assert.strictEqual(readRoutine(migrated, 'morning-digest').timezone, null);
+      assert.ok(!/timezone:/.test(migrated), 'the migration wrote a timezone');
+      assert.ok(!migrated.includes(HOST_ZONE), 'the machine\'s zone reached the file');
+      assert.strictEqual(MIGRATED_KEYS.includes('timezone'), false);
+    });
+  });
+
+  test('running the migration twice over a routine that carries a timezone changes nothing and says nothing', () => {
+    const withZone = LEGACY.replace(
+      '    prompt: Run the digest\n',
+      `    prompt: Run the digest\n    timezone: ${SET_ZONE}\n`);
+    withFile(withZone, (file) => {
+      const first = migrate(file);
+      assert.strictEqual(fs.readFileSync(file, 'utf-8'), first, 'the first pass did not persist');
+      assert.strictEqual(readRoutine(first, 'morning-digest').timezone, SET_ZONE);
+
+      let second;
+      const logs = capturingLogs(() => { second = migrate(file); });
+
+      // Byte for byte, both in what came back and in what is on disk.
+      assert.strictEqual(second, first);
+      assert.strictEqual(fs.readFileSync(file, 'utf-8'), first);
+      // Identical bytes are not enough on their own: a second pass that
+      // rewrites the same content and announces it has still done something.
+      assert.deepStrictEqual(logs, []);
+    });
+  });
+
+  test('a routine already carrying the field is left byte-identical by a migration pass', () => {
+    // A file with nothing left to migrate, made by migrating one and then
+    // adding the timezone to the result, so the only thing the pass below
+    // could react to is the field this card adds.
+    const settled = withFile(LEGACY, (file) => migrate(file))
+      .replace('    prompt: Run the digest\n',
+        `    prompt: Run the digest\n    timezone: ${SET_ZONE}\n`);
+    withFile(settled, (file) => {
+      let after;
+      const logs = capturingLogs(() => { after = migrate(file); });
+      assert.strictEqual(after, settled);
+      assert.strictEqual(fs.readFileSync(file, 'utf-8'), settled);
+      assert.deepStrictEqual(logs, []);
+      assert.strictEqual(readRoutine(after, 'morning-digest').timezone, SET_ZONE);
+    });
+  });
+
+  test('the pre-migration backup still holds the file as it was before anything touched it', () => {
+    const withZone = LEGACY.replace(
+      '    prompt: Run the digest\n',
+      `    prompt: Run the digest\n    timezone: ${SET_ZONE}\n`);
+    withFile(withZone, (file) => {
+      migrate(file);
+      const backup = `${file}.pre-routine-model-backup`;
+      assert.ok(fs.existsSync(backup), 'no backup was written');
+      assert.strictEqual(fs.readFileSync(backup, 'utf-8'), withZone);
+
+      // A second un-migrated routine forces another migrating write. The
+      // backup must still hold the ORIGINAL file.
+      fs.writeFileSync(file, fs.readFileSync(file, 'utf-8').replace(
+        '  - name: morning-digest',
+        '  - name: handover\n    schedule: every friday at 16:00\n    prompt: Hand over\n  - name: morning-digest'));
+      migrate(file);
+      assert.ok(fs.readFileSync(file, 'utf-8').includes('  - name: handover'), 'the second routine was lost');
+      assert.strictEqual(fs.readFileSync(backup, 'utf-8'), withZone, 'the backup was overwritten');
+    });
+  });
+});
+
+// ===== THE BOUNDARY WITH THE SCHEDULER =====
+
+const SCHEDULER_KEY = require.resolve('../../lib/scheduler.js');
+
+// A private copy, so wiring a clock here never leaks into the shared instance
+// the rest of the suite runs against. Same technique as
+// test/unit/scheduler-lib.test.js.
+function freshScheduler() {
+  const cached = require.cache[SCHEDULER_KEY];
+  delete require.cache[SCHEDULER_KEY];
+  const mod = require(SCHEDULER_KEY);
+  delete require.cache[SCHEDULER_KEY];
+  if (cached) require.cache[SCHEDULER_KEY] = cached;
+  return mod;
+}
+
+describe('nothing this card stores reaches double-fire suppression', () => {
+  // The scheduler keeps two stores that must never be joined, and `lastRun` is
+  // the ONLY input to double-fire suppression. A stored timezone is exactly
+  // the kind of value a later change would thread into the next-run
+  // calculation, and doing so would put a second input beside lastRun.
+  //
+  // The clock is wired and the process zone is pinned, so this decides the
+  // same way on every machine rather than depending on when it runs.
+  test('a routine that declares a timezone is judged due exactly as one that does not', () => {
+    const sched = freshScheduler();
+    const restore = sched.wireSchedulerDeps({ now: () => new Date('2026-08-24T09:30:00.000Z') });
+    try {
+      const withZone = normalizeRoutine(
+        { name: 'r', schedule: 'every day at 08:00', prompt: 'p', timezone: SET_ZONE },
+        { owner: 'penn' });
+      const without = normalizeRoutine(
+        { name: 'r', schedule: 'every day at 08:00', prompt: 'p' }, { owner: 'penn' });
+      assert.strictEqual(withZone.timezone, SET_ZONE, 'the zone did not survive to the comparison');
+
+      // Nothing to suppress: the same slot, whatever the routine declares.
+      const dueWith = sched.getNextRun(withZone.schedule, null);
+      const dueWithout = sched.getNextRun(without.schedule, null);
+      assert.ok(dueWith instanceof Date, 'the routine was not judged due at all');
+      assert.strictEqual(dueWith.getTime(), dueWithout.getTime());
+
+      // And suppressed: a run already recorded today holds both back, so the
+      // zone reaches neither the decision nor the value it is read against.
+      const lastRun = '2026-08-24T08:00:00.000Z';
+      assert.strictEqual(sched.getNextRun(withZone.schedule, lastRun), null);
+      assert.strictEqual(sched.getNextRun(without.schedule, lastRun), null);
+
+      // The suppression input list itself, pinned: a schedule and the last run,
+      // and nothing else.
+      assert.strictEqual(sched.getNextRun.length, 2);
+    } finally {
+      sched.wireSchedulerDeps(restore);
+    }
+  });
+});

--- a/test/unit/routine-timezone.test.js
+++ b/test/unit/routine-timezone.test.js
@@ -90,6 +90,12 @@ function readRoutine(content, name) {
     .find(r => r.name === name);
 }
 
+// What a quoted value reads back as, so the assertion says the zone rather
+// than repeating the writer's own unquoting.
+function unquoted(value) {
+  return value.replace(/^"(.*)"$/, '$1');
+}
+
 function splitFile(content) {
   const end = content.indexOf('\n---\n', 4);
   return { frontmatter: content.slice(4, end), body: content.slice(end + 5) };
@@ -216,7 +222,8 @@ describe('a schedule stores the timezone it was set in', () => {
       'BST',         // an abbreviation names several places at once
       'PST',
       'UTC',         // names no place, and is what a machine in a container says
-      '',            // an empty zone is not a zone to create
+      '',            // an empty zone is not a zone to CREATE: see the road below
+      '""',          // the same thing written the way an author writes things
       'Europe',      // an area with no place in it
       'Europe//London',
       '../../etc/passwd',
@@ -241,6 +248,47 @@ describe('a schedule stores the timezone it was set in', () => {
       });
       assert.strictEqual(readRoutine(created, 'evening-digest').timezone, value);
     }
+  });
+});
+
+describe('the road every edit takes', () => {
+  // THE CHECK BELONGS TO THE WRITER, NOT TO THE PATH THAT CREATES A ROUTINE.
+  //
+  // `appendRoutineBlock` makes a routine that is not in the file yet.
+  // `updateRoutineBlock` changes one that is, and it is the only path that
+  // writes a key at all: creating goes through it too. A rule enforced on the
+  // creating road alone would hold for exactly as long as nothing edits a
+  // routine, and an edit flow is the next thing to be built.
+  //
+  // So these tests go through the writer directly rather than through append.
+  test('a value that is not location words is refused on the road every edit takes', () => {
+    for (const value of ['+01:00', '-05:00', 'GMT+1', 'UTC+2', 'BST', 'PST', 'UTC', 'Europe', 'Europe//London']) {
+      assert.throws(
+        () => updateRoutineBlock(FIXTURE, 'morning-digest', { timezone: value }),
+        /timezone/i,
+        `"${value}" was written into a file by the general writer`);
+    }
+    // A refusal is a refusal on every key in the same write, so an edit that
+    // carries a good prompt and a bad zone writes neither.
+    assert.throws(
+      () => updateRoutineBlock(FIXTURE, 'morning-digest', { prompt: 'Run it differently', timezone: 'BST' }),
+      /timezone/i);
+    // Location words land, quoted or bare, on this road as on the other.
+    for (const value of ['Europe/London', `"${SET_ZONE}"`]) {
+      const updated = updateRoutineBlock(FIXTURE, 'morning-digest', { timezone: value });
+      assert.strictEqual(readRoutine(updated, 'morning-digest').timezone, unquoted(value));
+    }
+  });
+
+  test('a zone somebody recorded can still be cleared, which is what an edit that removes one did', () => {
+    // Empty is how this module clears a field, and removing a zone is an
+    // ordinary edit. It is not the same as never having recorded one: the key
+    // stays, declared and blank, which is the honest record of what happened.
+    const set = updateRoutineBlock(FIXTURE, 'morning-digest', { timezone: SET_ZONE });
+    const cleared = updateRoutineBlock(set, 'morning-digest', { timezone: '' });
+    assert.strictEqual(readRoutine(cleared, 'morning-digest').timezone, '');
+    assert.notStrictEqual(readRoutine(cleared, 'morning-digest').timezone, null);
+    assert.ok(cleared.includes('    timezone:'), 'the key was removed rather than emptied');
   });
 });
 

--- a/test/unit/routine-timezone.test.js
+++ b/test/unit/routine-timezone.test.js
@@ -30,7 +30,7 @@ const path = require('node:path');
 
 const {
   normalizeRoutine, parseRoutineBlocks, updateRoutineBlock, appendRoutineBlock,
-  computePlanHash, migrateAgentRoutines, PLAN_FIELDS, MIGRATED_KEYS,
+  computePlanHash, migrateAgentRoutines,
 } = require('../../lib/agents/routines.js');
 
 // The machine's zone, as a constant this file controls rather than a reading
@@ -265,7 +265,6 @@ describe('whether a timezone invalidates a plan approval', () => {
     // And the hash still notices what a routine DOES, so the equalities above
     // are not two hashes of nothing.
     assert.notStrictEqual(plan({ skill: 'voice-editor' }), base);
-    assert.strictEqual(PLAN_FIELDS.includes('timezone'), false);
   });
 
   test('the hash a migration stamps is the same whether or not the routine names a zone', () => {
@@ -339,7 +338,45 @@ describe('migrating a routine that predates the field', () => {
       assert.strictEqual(readRoutine(migrated, 'morning-digest').timezone, null);
       assert.ok(!/timezone:/.test(migrated), 'the migration wrote a timezone');
       assert.ok(!migrated.includes(HOST_ZONE), 'the machine\'s zone reached the file');
-      assert.strictEqual(MIGRATED_KEYS.includes('timezone'), false);
+    });
+  });
+
+  // AC-5 AND AC-13 BELONG TO THIS FIXTURE, and which fixture they run on is
+  // the whole proof rather than a detail of it.
+  //
+  // A routine that already exists carries no `timezone` key, by definition: it
+  // was written before the field was. That is the only population the
+  // idempotence question is about, and the only one that can exhibit the
+  // defect. A file that already carries the field answers `needsMigration`
+  // with false on a second pass whether or not `timezone` is a migrated key,
+  // so a two-pass comparison over one of those cannot fail for the thing it is
+  // written to guard. It reads as a proof and is not one.
+  //
+  // Here it can fail. Were `timezone` a migrated key, this file would never be
+  // finished: the writer skips an absent value, so the key is never written,
+  // `needsMigration` stays true for ever, and every read rewrites the file and
+  // announces it. Byte-identical content would still be byte-identical. The
+  // silence is what notices.
+  test('running the migration twice over a routine that predates the field changes nothing and says nothing', () => {
+    withFile(LEGACY, (file) => {
+      let first;
+      const firstLogs = capturingLogs(() => { first = migrate(file); });
+      // The first pass did something. Without this, a suite in which nothing
+      // is ever migrated passes the comparison below by doing nothing twice.
+      assert.strictEqual(firstLogs.length, 1, `the first pass said: ${JSON.stringify(firstLogs)}`);
+      assert.strictEqual(fs.readFileSync(file, 'utf-8'), first, 'the first pass did not persist');
+      assert.ok(!/timezone:/.test(first), 'the migration wrote a timezone');
+
+      let second;
+      const logs = capturingLogs(() => { second = migrate(file); });
+
+      // Byte for byte, both in what came back and in what is on disk.
+      assert.strictEqual(second, first);
+      assert.strictEqual(fs.readFileSync(file, 'utf-8'), first);
+      // And nothing happened at all: a pass that rewrites the same content and
+      // announces it has still done something, on every read, for ever.
+      assert.deepStrictEqual(logs, [],
+        'the second pass migrated a file with nothing left to migrate');
     });
   });
 


### PR DESCRIPTION
Routines carry when they run and never carried where "when" is measured from. This adds the storage half only: a `timezone` field on the routine data model, as location words. Nothing here renders a time, nothing changes how a schedule is parsed or when it fires, and no file under `public/` or `lib/scheduler.js` is touched.

## The decision this could not avoid

**The timezone stays out of the plan hash**, and the reason is recorded in the source beside the fields that are in it, because plan approval is a later card that inherits whatever is decided here.

The argument for including it is real and is stated first: changing a zone changes when a routine runs, by up to a day. It is excluded for the reason the schedule is. The line the hash draws is what a routine does against when it happens, not big changes against small ones. A zone is the second half of a schedule: `08:00` is not a time until something says where, and moving a routine between zones is the same edit as moving it by an hour. An approval that survived a schedule edit and broke on a zone edit would draw the line somewhere nobody could explain.

**The migration does not gain the field either**, for a sharper reason. Every other migrated key has a true value the file implies. A routine written before this field existed was set in a zone nobody recorded, and the only value this process could supply is the machine's. Absent is the honest record.

## The trap

`Intl.DateTimeFormat().resolvedOptions().timeZone` returns location words and looks exactly right. It answers what this computer is set to, not what the person chose. On the machine a routine was made on those are the same string, so a test that inherits the runner's zone cannot see the difference.

`test/unit/routine-timezone.test.js` pins its own process zone before its first require and stores zones that differ from it, so the assertions hold identically anywhere and a value that arrived from the machine fails them everywhere. The migration tests write throwaway files and call the migration directly: no clock, no home directory, no workspace.

## Also

- Absent and blank are read as different answers, so a routine that never recorded a zone is distinguishable from one whose zone was declared and left empty.
- A written value is refused unless it is an area and a place, checked by shape rather than against the runtime's zone database: which zones exist would otherwise depend on the ICU data of whichever machine did the writing.
- Eight mutations join the harness in `npm run mutate:guards`, which the gate and CI both run. Each turns at least one test red; the table is in `.review/schedule-timezone-evidence.md`.

Gate: six steps green. Red first proven against `origin/main`, 8 tests failing without the change.