### PR TITLE
Choose a workspace and routines actually run

### DIFF
--- a/.review/scheduler-lifecycle-evidence.md
+++ b/.review/scheduler-lifecycle-evidence.md
@@ -1,0 +1,290 @@
+# Evidence: the scheduler starts when a workspace does
+
+Recorded here because a reviewer sees the change and nothing else. Every
+measurement below is reproducible from a clone with the command shown beside
+it, and nothing here asks for a number on trust.
+
+The acceptance criteria this was judged against live outside this repository,
+so each is quoted in full rather than cited by number.
+
+## The defect, verified before the change
+
+Verified by reading the source rather than by taking the report on trust:
+
+```
+git grep -n 'startScheduler\|stopScheduler' -- ':!test' ':!node_modules'
+```
+
+At `b602f5a` that answered:
+
+- `startScheduler()`: one call in the product, `server.js`, inside
+  `startServer`'s `if (WORKSPACE)` block. Every other hit is the declaration in
+  `lib/scheduler.js`, the destructuring import, the `_internal` re-export, or a
+  comment.
+- `stopScheduler()`: no call in the product at all. Declaration, import and
+  re-export only.
+
+Choosing a workspace at runtime goes through
+`lib/protocol/handlers/workspace.js`. Both paths that land on a workspace,
+`openWorkspace` and `handleCreateWorkspace`, call `loadRoutineState()` and
+neither starts the scheduler. So the sequence install, open, choose a folder
+leaves nothing watching the clock until a restart, which is the ordinary first
+run rather than an edge.
+
+The eight suites that already tested this scheduler all arm the tick by calling
+`startScheduler` themselves, which is why none of them noticed:
+
+```
+grep -rl 'startScheduler(' test/ | wc -l
+```
+
+## The change
+
+The lifecycle belongs to `setWorkspaceRoot` in `server.js`, the one function
+that writes the workspace root. Every way of arriving at a workspace already
+reaches it, and `test/unit/config.test.js` has pinned that since before this
+card. So no path has to remember to start a scheduler, and the next path added
+gets one without being told.
+
+Not the roster and not the file watcher, deliberately: both fire often and for
+reasons unrelated to a workspace being chosen, and a scheduler armed from a
+path like that is how two tickers happen.
+
+`schedulerRunning()` in `lib/scheduler.js` reports whether a tick is armed,
+read from the interval handle the tick depends on rather than from a flag kept
+beside it. It exists because the only previous way to ask was to call the
+starter and see what happened.
+
+## The record
+
+> **AC-1:** Choosing a workspace at runtime starts the scheduler.
+>
+> **AC-2:** AC-1 is proven through the real workspace-set path rather than by
+> calling the starter.
+
+`test/integration/scheduler-workspace-lifecycle.test.js`, test *choosing a
+folder arms the tick, and the routine runs when its time comes*.
+
+The server boots with no workspace (`h.boot({ workspace: false })`), which is
+the state a first run starts in. The test then sends
+`{type:'set_workspace', path}` over a real WebSocket: the exact message
+`public/app.js` sends when someone picks a folder. Nothing in that file calls
+`startScheduler` or `stopScheduler`, and a check enforces it (below).
+
+The result is read through the tick's own behaviour: an hour before its time
+the routine has not run, and after the wired clock passes 09:00 it fires, is
+stamped with the wired clock, and completes.
+
+> **AC-3:** Starting when a scheduler is already running does not leave two
+> tickers.
+
+Same file, test *choosing a workspace twice leaves one ticker, not two*. Clock
+reads per tick are counted and calibrated against a single choose, so the
+number does not depend on how many reads one pass happens to make. The second
+choose costs exactly one pass, not two.
+
+> **AC-4:** Switching away from a workspace stops the scheduler that was
+> running for it.
+
+Two tests, because there are two shapes of switching away.
+
+*switching away re-arms the tick rather than leaving the old one running*: the
+old ticker is thirty seconds from firing when the switch happens. If it
+survived, the next thirty seconds would fire it. It does not, and thirty
+seconds after that the new one does, which is what proves a ticker exists at
+all.
+
+*a workspace that disappears takes its ticker with it*: the case with nowhere
+to land, where the stop is the only thing doing the work. The pointer is
+cleared by the real `get_workspaces` handler over the real socket, and after it
+`schedulerRunning()` is false.
+
+The pointer is put there by the product's own workspace setter rather than by
+choosing over the wire, and that is forced rather than chosen: opening a folder
+writes to its `.rundock`, and those writes recreate the directory faster than a
+test can delete it, so a workspace opened over the wire never reads as
+vanished. `test/integration/workspace-picker.test.js` sets the pointer the same
+way for the same reason. The clearing, which is what the test is about, still
+goes through the real handler.
+
+> **AC-5:** After a switch, the previous workspace's routines do not fire.
+>
+> **AC-6:** AC-5 is proven by advancing the clock past a due slot of the old
+> workspace and asserting nothing started.
+
+Same file, test *the previous workspace routine does not fire when its slot
+passes*. A workspace with a routine due at 09:00 is chosen at 08:00 and
+switched away from. The wired clock then moves to 09:30 and a tick runs. Three
+assertions, none of them about the scheduler's internals: the routine has no
+run state, the stub was never spawned in that workspace (its own prompt log,
+read from that directory), and no `routine-state.json` was written there.
+
+Both workspaces are built by the test.
+
+> **AC-7:** Every caller of the starter and the stopper is enumerated in a
+> check that reads the source.
+>
+> **AC-8:** A path that sets a workspace without starting the scheduler fails
+> that check by name.
+>
+> **AC-9:** The enumeration names any deliberate exclusion with its reason.
+
+`test/unit/scheduler-lifecycle-doors.test.js`. It extends the instrument
+already in `test/unit/routine-editor-doors.test.js` and
+`test/unit/routines-view-doors.test.js` rather than inventing a third: an
+enumeration, a check that reads the source and fails when the two disagree, and
+a reverse check so a row cannot name a test nobody wrote.
+
+What it covers:
+
+- **`CALLERS`**: every call to `startScheduler` or `stopScheduler` in the
+  product, keyed by file and enclosing function, each row naming its surface
+  and the test that drives it. Three rows: the stop and the start in
+  `setWorkspaceRoot`, and the start in `startServer` for a workspace preset in
+  the environment, which never passes through the setter. The scan walks every
+  `.js` file outside `test/`, `node_modules` and build output, strips comments
+  so prose cannot read as a call, and tells a declaration from a call.
+- **`WORKSPACE_SETTERS`**: every product path that sets the workspace root, six
+  rows across `server.js` and `lib/protocol/handlers/workspace.js`.
+- Two checks make listing enough rather than a matter of memory: nothing may
+  write the workspace root except `setWorkspaceRoot` (so no path can set a
+  workspace and bypass the lifecycle), and `setWorkspaceRoot` must contain both
+  lifecycle calls with the stop before the start.
+- A check that the lifecycle proofs never arm the tick themselves, since
+  calling the starter is the habit that let this ship.
+
+`NOT_ENUMERATED` carries the exclusions with reasons: the declarations in
+`lib/scheduler.js`, the whole of `test/` including the eight suites that arm
+the tick themselves, and the import and re-export lines that name the functions
+without calling them.
+
+> **AC-10:** Nothing this card adds writes to the value double-fire suppression
+> reads.
+
+Test *choosing a workspace does not write the value suppression reads*. A
+workspace is prepared with a `routine-state.json` recording a run at 09:05, and
+opened with the clock at 09:30. `lastRun` is unchanged after the open, the tick
+it armed does not re-fire the routine, nothing is spawned, and the file is
+byte-identical to what was written.
+
+> **AC-11:** A routine that was mid-run when a workspace is switched is not
+> re-fired by the new start.
+
+Test *a routine mid-run when the workspace is switched is not re-fired by the
+new start*. The routine fires, the stub holds it open, the routine is asserted
+`running`, the workspace is switched away and back, and a further tick starts
+nothing: the prompt log still holds one entry after real elapsed time in which
+a second spawn would have appeared.
+
+> **AC-12:** Each proof fails when its own guard is removed.
+
+Below, in full.
+
+## Mutation results
+
+Each mutation applied alone, `npm test` run in full (2361 tests), source
+restored, next mutation applied. Failing counts are out of the whole suite, so
+the blast radius is visible rather than asserted.
+
+| # | Mutation | Failing | Tests that turned red |
+|---|---|---|---|
+| M1 | remove `stopScheduler()` from the workspace setter | 6 | *choosing a workspace twice leaves one ticker, not two*; *switching away re-arms the tick rather than leaving the old one running*; *a workspace that disappears takes its ticker with it*; *a routine mid-run when the workspace is switched is not re-fired by the new start*; *no product code arms or disarms the scheduler without being listed here*; *the function every workspace-setting path reaches runs the lifecycle* |
+| M2 | remove `startScheduler()` from the workspace setter | 6 | *choosing a folder arms the tick, and the routine runs when its time comes*, plus the five above other than the vanished-workspace one |
+| M3 | start before stop instead of after | 5 | *choosing a folder arms the tick...*; *choosing a workspace twice...*; *switching away re-arms...*; *a routine mid-run...*; *the function every workspace-setting path reaches runs the lifecycle* |
+| M4 | start even when there is no workspace (`if (dir)` dropped) | 1 | *a workspace that disappears takes its ticker with it* |
+| M5 | `schedulerRunning()` always returns true | 1 | *a first run has no workspace and nothing watching the clock* |
+| M6 | remove the pre-existing `if (tickTimer) return` double-arm guard | 1 | *starting the scheduler twice leaves exactly one tick running* (`test/unit/scheduler-lib.test.js`, pre-existing) |
+| M7 | let a workspace switch clear the in-flight hold | 1 | *the workspace switch does not release a run that is still going* (pre-existing) |
+| M8 | drop the boot caller from `CALLERS` | 1 | *no product code arms or disarms the scheduler without being listed here* |
+| M9 | point a `CALLERS` row at a test nobody wrote | 1 | *every caller names a test, and every named test exists* |
+| M10 | the no-workspace boot seam ignores its option | 1 | *a first run has no workspace and nothing watching the clock* |
+| M11 | a new handler sets the workspace root directly, bypassing the setter | 1 | *the workspace root cannot be written except through the function that runs the lifecycle* |
+| M12 | a new handler reaches the setter and is not listed | 1 | *no product code sets a workspace without being listed here* |
+
+M11 and M12 are AC-8 read literally: a path that sets a workspace and starts
+nothing, added on purpose to check that it fails by name. Both do, and the
+failure names the file and the function.
+
+No mutation turned nothing red, and none turned the suite red: the largest
+blast radius is six tests out of 2361, and every one of those six is about this
+lifecycle.
+
+### What the mutations exposed, reported rather than tidied away
+
+**M1 initially missed the test written for it.** *a workspace that disappears
+takes its ticker with it* passed with the stop removed. Each test in that file
+has to arm the scheduler on real timers before enabling mock timers (see
+below), and with the stop gone the start met that live handle, declined, and no
+mocked interval was ever created, so counting zero tick bodies proved nothing.
+The test was strengthened to assert `schedulerRunning()` is false after the
+clear, and M1 was re-run: it now fails, and that is the M1 row above. The
+weaker version is not in the diff.
+
+**M6 does not turn the AC-3 test red, and that is correct.** With stop before
+start, a second choose stops the ticker first, so `if (tickTimer) return` never
+fires on that path. AC-3 is guarded here by the stop, which M1 turns red; the
+pre-existing guard keeps its own pre-existing test.
+
+**M7 does not turn the AC-11 test red.** With the hold cleared on switch, the
+routine is still not re-fired, because `lastRun` was stamped when the run began
+and suppression holds. The hold itself has its own pre-existing test, which M7
+does turn red. The AC-11 test proves the criterion as written, that the new
+start does not re-fire the run, and it is turned red by M1, M2 and M3.
+
+## A node behaviour that shapes the test file
+
+A `node:test` mock-timer handle created in one test and cleared inside a LATER
+test's mock instance leaves that instance unable to fire anything at all. This
+is node, not Rundock, and reproduces in a plain `node --test` file with no
+Rundock in it:
+
+```js
+let stale = null;
+for (const n of [1, 2, 3]) {
+  test('mock ' + n, (t) => {
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    let fired = 0;
+    if (stale) clearInterval(stale);
+    const h = setInterval(() => { fired++; }, 60000);
+    t.mock.timers.tick(60000);
+    console.log(n, 'fired:', fired);   // 1, then 0, then 0
+    stale = h;
+    t.mock.timers.reset();
+  });
+}
+```
+
+The scheduler holds exactly such a handle at the end of every test in the
+lifecycle file, and the next workspace change clears it. Each test therefore
+arms the scheduler on real timers first, through the same workspace-set path,
+so the clear that happens under the mock is a clear of a real handle. Without
+that, every test after the first would drive a tick that could never fire and
+read the silence as the defect.
+
+## Nothing here depends on the machine it runs on
+
+The clock is wired through the scheduler's `deps.now` seam and never read from
+the wall. The home directory is a temp dir the harness makes. Every workspace is
+built by the test that uses it. The interval is driven by mock timers rather
+than by elapsed time. The two instants are local-time constructions
+(`new Date(2026, 6, 1, 8, 0, 0)`), so a schedule written in local time and a
+clock read in local time agree in any zone. The one place real elapsed time is
+used is where something must be shown NOT to happen, which cannot be done any
+other way.
+
+## Gate
+
+```
+git add -A && npm run precommit
+```
+
+PASS, six steps: `test:coverage`, `typecheck`, `lint:styles`, `check:refs`,
+`mutate:guards`, `check:fixture`.
+
+```
+node scripts/red-first.js --base origin/main --tests "npm test"
+```
+
+PROVEN: the tests fail without the change and pass with it. That check carries
+its own limit, which travels with this record: reverting proves the tests
+notice the change, not that they assert the right thing.

--- a/.review/scheduler-lifecycle-evidence.md
+++ b/.review/scheduler-lifecycle-evidence.md
@@ -114,10 +114,38 @@ goes through the real handler.
 
 Same file, test *the previous workspace routine does not fire when its slot
 passes*. A workspace with a routine due at 09:00 is chosen at 08:00 and
-switched away from. The wired clock then moves to 09:30 and a tick runs. Three
-assertions, none of them about the scheduler's internals: the routine has no
-run state, the stub was never spawned in that workspace (its own prompt log,
-read from that directory), and no `routine-state.json` was written there.
+switched away from. The wired clock then moves to 09:30 and ticks run.
+
+**The three absences this criterion asks for do not, on their own, prove
+anything about the stop, and the first version of this test asserted only
+them.** The tick reads the workspace root at use time, through
+`discoverAgents`, so a ticker that survived the switch would discover the
+roster of the workspace just ENTERED. It could never fire a routine belonging
+to the one that was left, whether it was stopped, left running, or never armed
+at all. An absence guaranteed by the scheduler's use-time read is not evidence
+about the lifecycle. Round 1 of review rejected it on exactly that, and it was
+right to.
+
+So the absences stay, because they are what the criterion asks for in so many
+words, and the observation that DOES differ is made beside them: whether the
+ticker armed for the workspace that was left is still there afterwards, read
+through the tick's phase rather than through anything it spawned.
+
+- The premise is asserted rather than assumed: after choosing the workspace, a
+  tick pass runs, so the ticker under test exists and is the mocked one.
+- It is then left thirty seconds from its next minute, and the switch happens.
+- Those thirty seconds run no pass, which is what a stopped ticker looks like
+  and a surviving one does not.
+- The thirty after them run one, which is what proves a ticker exists to have
+  been counted at all.
+- Then the three absences: no run state for the routine, nothing spawned in the
+  left workspace (its own prompt log, read from that directory), no
+  `routine-state.json` written there.
+
+M17 is the mutation that fires the surviving-ticker assertion specifically: the
+stop forgets the handle without clearing the interval, so the pre-switch ticker
+lives on. It fails with `1 !== 0` on the line that says *it is gone, not merely
+looking elsewhere*.
 
 Both workspaces are built by the test.
 
@@ -180,6 +208,28 @@ a second spawn would have appeared.
 
 Below, in full.
 
+## The boot proof, and why it is booted the way it is
+
+`test/integration/scheduler-boot-lifecycle.test.js` is the test the `CALLERS`
+row for the boot caller names. It has to reach `startServer` with nothing
+already armed, which the obvious harness boot does not do: pointing the server
+at the fixture through `internal.setWorkspace` goes through `setWorkspaceRoot`,
+which now arms the tick, so `startServer` would meet a live handle, decline,
+and the test would stay green with the boot call deleted. Round 1 of review
+caught that; the first version of this test proved nothing.
+
+The harness gained a `presetWorkspace` option, documented beside the `workspace`
+one. It puts the fixture path in `process.env.WORKSPACE` after the fixture
+exists and before `server.js` is required, which is the only window in which
+that variable does anything: `lib/config` reads it once, at require time. The
+setter is never called. `boot()` also records `schedulerRunning()` between the
+require and the listen, a window no test can otherwise reach because `boot()`
+owns both halves.
+
+The test then asserts all three: the root came from the environment, nothing had
+armed a tick before the server listened, and a tick is armed after. M14 removes
+`startScheduler()` from `startServer` and turns it red.
+
 ## Mutation results
 
 Each mutation applied alone, `npm test` run in full (2361 tests), source
@@ -188,48 +238,111 @@ the blast radius is visible rather than asserted.
 
 | # | Mutation | Failing | Tests that turned red |
 |---|---|---|---|
-| M1 | remove `stopScheduler()` from the workspace setter | 6 | *choosing a workspace twice leaves one ticker, not two*; *switching away re-arms the tick rather than leaving the old one running*; *a workspace that disappears takes its ticker with it*; *a routine mid-run when the workspace is switched is not re-fired by the new start*; *no product code arms or disarms the scheduler without being listed here*; *the function every workspace-setting path reaches runs the lifecycle* |
-| M2 | remove `startScheduler()` from the workspace setter | 6 | *choosing a folder arms the tick, and the routine runs when its time comes*, plus the five above other than the vanished-workspace one |
-| M3 | start before stop instead of after | 5 | *choosing a folder arms the tick...*; *choosing a workspace twice...*; *switching away re-arms...*; *a routine mid-run...*; *the function every workspace-setting path reaches runs the lifecycle* |
+| M1 | remove `stopScheduler()` from the workspace setter | 7 | *choosing a workspace twice leaves one ticker, not two*; *switching away re-arms the tick rather than leaving the old one running*; *the previous workspace routine does not fire when its slot passes*; *a workspace that disappears takes its ticker with it*; *a routine mid-run when the workspace is switched is not re-fired by the new start*; *no product code arms or disarms the scheduler without being listed here*; *the function every workspace-setting path reaches runs the lifecycle* |
+| M2 | remove `startScheduler()` from the workspace setter | 8 | the seven above, plus *choosing a folder arms the tick, and the routine runs when its time comes* |
+| M3 | start before stop instead of after | 7 | as M2, without *no product code arms or disarms...* (both calls are still present, so only the order check fails) |
 | M4 | start even when there is no workspace (`if (dir)` dropped) | 1 | *a workspace that disappears takes its ticker with it* |
-| M5 | `schedulerRunning()` always returns true | 1 | *a first run has no workspace and nothing watching the clock* |
-| M6 | remove the pre-existing `if (tickTimer) return` double-arm guard | 1 | *starting the scheduler twice leaves exactly one tick running* (`test/unit/scheduler-lib.test.js`, pre-existing) |
+| M5 | `schedulerRunning()` always returns true | 3 | *a first run has no workspace and nothing watching the clock*; *a workspace that disappears takes its ticker with it*; *booting with a workspace already set arms the tick...* |
+| M6 | remove the pre-existing `if (tickTimer) return` double-arm guard | 1 | *starting the scheduler twice leaves exactly one tick running* (pre-existing) |
 | M7 | let a workspace switch clear the in-flight hold | 1 | *the workspace switch does not release a run that is still going* (pre-existing) |
 | M8 | drop the boot caller from `CALLERS` | 1 | *no product code arms or disarms the scheduler without being listed here* |
 | M9 | point a `CALLERS` row at a test nobody wrote | 1 | *every caller names a test, and every named test exists* |
-| M10 | the no-workspace boot seam ignores its option | 1 | *a first run has no workspace and nothing watching the clock* |
+| M10 | the no-workspace boot seam ignores its option | 2 | *a first run has no workspace and nothing watching the clock*; *booting with a workspace already set arms the tick...* |
 | M11 | a new handler sets the workspace root directly, bypassing the setter | 1 | *the workspace root cannot be written except through the function that runs the lifecycle* |
 | M12 | a new handler reaches the setter and is not listed | 1 | *no product code sets a workspace without being listed here* |
+| M13 | the open re-stamps the value suppression reads | 6 | *choosing a workspace does not write the value suppression reads*, plus five pre-existing suppression tests |
+| M14 | remove `startScheduler()` from the boot path | 2 | *booting with a workspace already set arms the tick...*; *no product code arms or disarms the scheduler without being listed here* |
+| M15 | an exclusion in the enumeration loses its reason | 2 | *a call left out of the enumeration says why* (plus one unrelated flake, below) |
+| M16 | a lifecycle proof arms the tick itself | 1 | *the lifecycle proofs never arm the tick themselves* |
+| M17 | the stop forgets the handle without clearing the interval | 6 | *choosing a workspace twice...*; *switching away re-arms...*; *the previous workspace routine does not fire when its slot passes*; *a workspace that disappears...*; plus two pre-existing scheduler tests |
 
 M11 and M12 are AC-8 read literally: a path that sets a workspace and starts
 nothing, added on purpose to check that it fails by name. Both do, and the
 failure names the file and the function.
 
-No mutation turned nothing red, and none turned the suite red: the largest
-blast radius is six tests out of 2361, and every one of those six is about this
-lifecycle.
+No mutation turned nothing red, and none turned the suite red. The largest
+blast radius is eight tests out of 2361.
 
-### What the mutations exposed, reported rather than tidied away
+## Every proof, and the mutation that names it
 
-**M1 initially missed the test written for it.** *a workspace that disappears
-takes its ticker with it* passed with the stop removed. Each test in that file
-has to arm the scheduler on real timers before enabling mock timers (see
-below), and with the stop gone the start met that live handle, declined, and no
+Round 1 of review found two proofs that no mutation named. The answer to that is
+not to fix the two, it is to ask the question of all of them, so this table
+covers every test in the three files this change adds. A proof with no mutation
+naming it is a proof that cannot fail.
+
+| Test | Turned red by |
+|---|---|
+| *a first run has no workspace and nothing watching the clock* | M5, M10 |
+| *choosing a folder arms the tick, and the routine runs when its time comes* | M2, M3 |
+| *choosing a workspace twice leaves one ticker, not two* | M1, M2, M3, M17 |
+| *switching away re-arms the tick rather than leaving the old one running* | M1, M2, M3, M17 |
+| *the previous workspace routine does not fire when its slot passes* | M1, M2, M3, M17 |
+| *a workspace that disappears takes its ticker with it* | M1, M2, M3, M4, M5, M17 |
+| *choosing a workspace does not write the value suppression reads* | M13 |
+| *a routine mid-run when the workspace is switched is not re-fired by the new start* | M1, M2, M3 |
+| *booting with a workspace already set arms the tick, with nobody calling the starter* | M5, M10, M14 |
+| *no product code arms or disarms the scheduler without being listed here* | M1, M2, M8, M14 |
+| *every caller names a test, and every named test exists* | M9 |
+| *a call left out of the enumeration says why* | M15 |
+| *the lifecycle proofs never arm the tick themselves* | M16 |
+| *no product code sets a workspace without being listed here* | M12 |
+| *the workspace root cannot be written except through the function that runs the lifecycle* | M11 |
+| *the function every workspace-setting path reaches runs the lifecycle* | M1, M2, M3 |
+
+Every proof is named by at least one mutation. Four of these mutations, M13
+through M16, exist only because this table was built: the proofs they name had
+no mutation before it, and two of them, the AC-10 proof and the boot proof, were
+passing regardless of the change.
+
+## What the mutations exposed, reported rather than tidied away
+
+**Two proofs could not fail, and one of them I found and one review found.** M1
+initially turned nothing red on *a workspace that disappears takes its ticker
+with it*: with the stop gone the start met a live handle, declined, and no
 mocked interval was ever created, so counting zero tick bodies proved nothing.
-The test was strengthened to assert `schedulerRunning()` is false after the
-clear, and M1 was re-run: it now fails, and that is the M1 row above. The
-weaker version is not in the diff.
+I strengthened that test and re-ran M1. I did not then ask the same question of
+its siblings, and review found the AC-5/AC-6 proof failing in the same way for a
+different reason. The table above is the answer to the class rather than to
+either instance.
 
 **M6 does not turn the AC-3 test red, and that is correct.** With stop before
 start, a second choose stops the ticker first, so `if (tickTimer) return` never
-fires on that path. AC-3 is guarded here by the stop, which M1 turns red; the
-pre-existing guard keeps its own pre-existing test.
+fires on that path. AC-3 is guarded here by the stop, which M1 and M17 turn red;
+the pre-existing guard keeps its own pre-existing test.
 
-**M7 does not turn the AC-11 test red.** With the hold cleared on switch, the
+**M7 does not turn the AC-11 test red.** With the hold cleared on switch the
 routine is still not re-fired, because `lastRun` was stamped when the run began
-and suppression holds. The hold itself has its own pre-existing test, which M7
-does turn red. The AC-11 test proves the criterion as written, that the new
-start does not re-fire the run, and it is turned red by M1, M2 and M3.
+and suppression holds. The hold has its own pre-existing test, which M7 turns
+red. The AC-11 test proves the criterion as written, that the new start does not
+re-fire the run, and M1, M2 and M3 turn it red.
+
+**M13's blast radius is five pre-existing tests, and they are the right five.**
+It re-stamps `lastRun` on load, so everything that depends on the suppression
+value surviving a load fails with it. That is the property AC-10 is about.
+
+**Two mutation runs had to be discarded and re-run.** M16 first reported 293
+failures and M17 reported 32, all `ENOSPC`. The suite's `makeWorkspace` registers
+each temp fixture for a `cleanup()` that nothing calls, so seventeen full-suite
+runs left 20,708 fixture directories and filled the volume. The numbers in the
+table are from re-runs on a clean disk, and every run is checked for `ENOSPC`
+before its result is recorded. This is a pre-existing property of the suite
+rather than anything this change introduced, and it is not fixed here.
+
+**A gate run failed one unrelated test twice, and it is not this change.**
+*agent CRUD while an orchestrator is live flags it...* in
+`test/integration/delegation.test.js` asserts a spawn count of one and saw two,
+during two gate runs taken while the disk cleanup above was still running. Two
+things settle it. Structurally, that file boots `standardTeam()`, which declares
+no routines at all, so the tick cannot spawn anything in it: `startScheduler`'s
+loop skips an agent with no routines, and no scheduler behaviour can add an
+invocation there. Empirically, five full coverage runs on `origin/main` and five
+on this branch, taken once the machine was quiet, are all green. Recorded as a
+load-sensitive pre-existing flake rather than fixed, because fixing it is not
+this card.
+
+**M15's run also failed one unrelated test, *zombie interrupt*.** It is a
+process-timing test with no connection to an enumeration comment, it passes on
+the unmutated tree, and it is recorded here as a flake rather than as a result.
 
 ## A node behaviour that shapes the test file
 
@@ -274,17 +387,26 @@ other way.
 
 ## Gate
 
-```
-git add -A && npm run precommit
-```
-
-PASS, six steps: `test:coverage`, `typecheck`, `lint:styles`, `check:refs`,
-`mutate:guards`, `check:fixture`.
+Run in the order the gate documents, so that one record describes one tree:
 
 ```
-node scripts/red-first.js --base origin/main --tests "npm test"
+git add -A && npm run precommit    # checks, and the record for the staged tree
+git commit                         # same content, so the same tree hash
+npm run red-first                  # folds the discrimination result into that record
 ```
 
-PROVEN: the tests fail without the change and pass with it. That check carries
-its own limit, which travels with this record: reverting proves the tests
-notice the change, not that they assert the right thing.
+`npm run precommit`: PASS, six steps: `test:coverage`, `typecheck`,
+`lint:styles`, `check:refs`, `mutate:guards`, `check:fixture`.
+
+`npm run red-first --base origin/main`: PROVEN, the tests fail without the
+change and pass with it, and the result is in the below-the-line record for the
+measured tree rather than only in this file.
+
+Round 1 of review flagged that those two records disagreed, because red-first
+had been run by hand against an earlier tree and the gate was then re-run for a
+later one, which cleared the field. The order above is what stops that: the
+gate record and this file now describe the same tree.
+
+Red-first carries its own limit, which travels with this record: reverting
+proves the tests notice the change, not that they assert the right thing. That
+is the gap the mutation table and the per-proof audit above exist to close.

--- a/.review/scheduler-lifecycle-evidence.md
+++ b/.review/scheduler-lifecycle-evidence.md
@@ -204,6 +204,37 @@ new start*. The routine fires, the stub holds it open, the routine is asserted
 nothing: the prompt log still holds one entry after real elapsed time in which
 a second spawn would have appeared.
 
+### The ordering the lifecycle depends on
+
+Not one of the twelve criteria, and found in review of round 2. The root
+changes before the lifecycle runs, so a tick armed before `loadRoutineState()`
+is armed into a window where `getWorkspace()` names the workspace being entered
+while `routineState` and the slot records still describe the one being left. A
+tick landing there judges the new roster against the old workspace's `lastRun`,
+and for any key the two workspaces share, which is every key when an agent and
+a routine keep their names, it suppresses a run that was due.
+
+No caller yields between the two today, so no tick can land there today. That is
+an argument that ages badly, and it is the fourth time in this release that two
+stores have disagreed about the same question with nothing making them agree.
+So `setWorkspaceRoot` loads the state and then arms, and the window does not
+exist to be argued about. The open paths load again afterwards, deliberately:
+`healWorkspaceIfMoved` runs between, and what it repairs belongs in the state a
+tick reads. The load in the setter is the floor rather than the last word.
+
+Proven by `the state a tick will read is loaded before the tick is armed`. Two
+workspaces declare the same agent and the same routine, so they share a routine
+key; the one being left has a run recorded at 09:05 and the one being entered
+has never run it. The observation is taken at the ARMING rather than through a
+tick, because the window is inside one synchronous call: nothing yields, so no
+tick can be driven into it, and a test that advanced the clock would pass under
+either ordering and prove nothing. What differs between the orderings is the
+state that exists when the interval is created, so the test stands in front of
+`setInterval` and copies `routineState` at that instant. The scheduler's is the
+only sixty-second interval armed on that path.
+
+M18 arms before loading and turns that test red, and only that test.
+
 > **AC-12:** Each proof fails when its own guard is removed.
 
 Below, in full.
@@ -238,8 +269,8 @@ the blast radius is visible rather than asserted.
 
 | # | Mutation | Failing | Tests that turned red |
 |---|---|---|---|
-| M1 | remove `stopScheduler()` from the workspace setter | 7 | *choosing a workspace twice leaves one ticker, not two*; *switching away re-arms the tick rather than leaving the old one running*; *the previous workspace routine does not fire when its slot passes*; *a workspace that disappears takes its ticker with it*; *a routine mid-run when the workspace is switched is not re-fired by the new start*; *no product code arms or disarms the scheduler without being listed here*; *the function every workspace-setting path reaches runs the lifecycle* |
-| M2 | remove `startScheduler()` from the workspace setter | 8 | the seven above, plus *choosing a folder arms the tick, and the routine runs when its time comes* |
+| M1 | remove `stopScheduler()` from the workspace setter | 8 | *choosing a workspace twice leaves one ticker, not two*; *switching away re-arms the tick rather than leaving the old one running*; *the previous workspace routine does not fire when its slot passes*; *a workspace that disappears takes its ticker with it*; *the state a tick will read is loaded before the tick is armed*; *a routine mid-run when the workspace is switched is not re-fired by the new start*; *no product code arms or disarms the scheduler without being listed here*; *the function every workspace-setting path reaches runs the lifecycle* |
+| M2 | remove `startScheduler()` from the workspace setter | 9 | the eight above, plus *choosing a folder arms the tick, and the routine runs when its time comes* |
 | M3 | start before stop instead of after | 7 | as M2, without *no product code arms or disarms...* (both calls are still present, so only the order check fails) |
 | M4 | start even when there is no workspace (`if (dir)` dropped) | 1 | *a workspace that disappears takes its ticker with it* |
 | M5 | `schedulerRunning()` always returns true | 3 | *a first run has no workspace and nothing watching the clock*; *a workspace that disappears takes its ticker with it*; *booting with a workspace already set arms the tick...* |
@@ -255,13 +286,14 @@ the blast radius is visible rather than asserted.
 | M15 | an exclusion in the enumeration loses its reason | 2 | *a call left out of the enumeration says why* (plus one unrelated flake, below) |
 | M16 | a lifecycle proof arms the tick itself | 1 | *the lifecycle proofs never arm the tick themselves* |
 | M17 | the stop forgets the handle without clearing the interval | 6 | *choosing a workspace twice...*; *switching away re-arms...*; *the previous workspace routine does not fire when its slot passes*; *a workspace that disappears...*; plus two pre-existing scheduler tests |
+| M18 | arm the tick before the state it will read is loaded | 1 | *the state a tick will read is loaded before the tick is armed* |
 
 M11 and M12 are AC-8 read literally: a path that sets a workspace and starts
 nothing, added on purpose to check that it fails by name. Both do, and the
 failure names the file and the function.
 
 No mutation turned nothing red, and none turned the suite red. The largest
-blast radius is eight tests out of 2361.
+blast radius is nine tests out of 2361.
 
 ## Every proof, and the mutation that names it
 
@@ -279,6 +311,7 @@ naming it is a proof that cannot fail.
 | *the previous workspace routine does not fire when its slot passes* | M1, M2, M3, M17 |
 | *a workspace that disappears takes its ticker with it* | M1, M2, M3, M4, M5, M17 |
 | *choosing a workspace does not write the value suppression reads* | M13 |
+| *the state a tick will read is loaded before the tick is armed* | M1, M2, M18 |
 | *a routine mid-run when the workspace is switched is not re-fired by the new start* | M1, M2, M3 |
 | *booting with a workspace already set arms the tick, with nobody calling the starter* | M5, M10, M14 |
 | *no product code arms or disarms the scheduler without being listed here* | M1, M2, M8, M14 |
@@ -293,6 +326,11 @@ Every proof is named by at least one mutation. Four of these mutations, M13
 through M16, exist only because this table was built: the proofs they name had
 no mutation before it, and two of them, the AC-10 proof and the boot proof, were
 passing regardless of the change.
+
+M18 arrived the other way round, from review of round 2 rather than from the
+table: the ordering it mutates was a defect first and a proof second. The rule
+held anyway, because the proof written for it was required to have a mutation
+that names it before it counted as a proof at all.
 
 ## What the mutations exposed, reported rather than tidied away
 

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -1133,6 +1133,22 @@ function stopScheduler() {
   tickTimer = null;
 }
 
+// Is a tick armed?
+//
+// Reads the interval handle the tick itself depends on, rather than a flag
+// kept beside it: a second copy of this answer is a second copy to get wrong,
+// and the one question worth asking of a lifecycle is whether the thing is
+// actually running.
+//
+// It exists because the alternative was worse. For eight cards the only way to
+// find out whether the scheduler was running was to call startScheduler and
+// see what happened, and asking that way is what let the product ship with no
+// caller on the path a user takes: a suite that arms the tick itself never
+// notices that nobody else does. This lets a test ask without arming anything.
+function schedulerRunning() {
+  return tickTimer !== null;
+}
+
 const WEEKDAYS = { sunday: 0, monday: 1, tuesday: 2, wednesday: 3, thursday: 4, friday: 5, saturday: 6 };
 
 // The schedule grammar, read once and shared by the two questions asked of it.
@@ -1501,5 +1517,5 @@ module.exports = {
   routineSlots, loadRoutineSlots, saveRoutineSlots,
   nextRunFor, lastRunStartedAt, routineDisplayFacts,
   readRunRecords, readRunProgress,
-  startScheduler, stopScheduler, getNextRun, executeRoutine,
+  startScheduler, stopScheduler, schedulerRunning, getNextRun, executeRoutine,
 };

--- a/server.js
+++ b/server.js
@@ -117,8 +117,33 @@ function setWorkspaceRoot(dir) {
   // in place. When there is no new workspace to serve, the stop is all that
   // happens, and it is the only thing standing between a deleted workspace and
   // a tick that keeps running over nothing.
+  //
+  // AND THE STATE IS LOADED BEFORE THE TICK IS ARMED, never after.
+  //
+  // The root is already the new workspace by the time this runs, so between an
+  // arm and a load the two stores disagree about which workspace they describe:
+  // getWorkspace() names the one being entered while routineState and the slot
+  // records still hold the one being left. A tick landing in that window judges
+  // the new roster against the old workspace's lastRun, and for any key the two
+  // workspaces share, which is every key when an agent and a routine keep their
+  // names, it suppresses a run that was due or releases one that was not.
+  //
+  // Closing that window by argument rather than by order would mean arguing
+  // that no tick can land there, which is true today only because the callers
+  // happen not to yield between the two. That is the kind of guarantee that
+  // holds until someone makes an open path asynchronous, and then fails in a
+  // way nobody can reproduce. Loading first means there is no window to argue
+  // about: at the instant the tick is armed, the state it will read already
+  // describes the workspace it will read it for.
+  //
+  // The open paths load again after this, and that is deliberate rather than
+  // redundant: healWorkspaceIfMoved runs between, and what it repairs belongs
+  // in the state a tick reads. This load is the floor, not the last word.
   stopScheduler();
-  if (dir) startScheduler();
+  if (dir) {
+    loadRoutineState();
+    startScheduler();
+  }
 }
 
 // Workspace boundary check. A bare `startsWith(resolve(WORKSPACE))`

--- a/server.js
+++ b/server.js
@@ -88,6 +88,37 @@ function setWorkspaceRoot(dir) {
   // accumulate with nothing ever clearing it. Housekeeping must never be able
   // to break a switch, hence the guard.
   try { pruneScratch(); } catch (e) { /* not worth failing a switch over */ }
+  // THE SCHEDULER'S LIFECYCLE, AND IT LIVES HERE FOR A REASON.
+  //
+  // It used to live at exactly one place, the boot path, inside `if
+  // (WORKSPACE)`. So a workspace remembered at startup got a scheduler and a
+  // workspace CHOSEN got none, which is the ordinary first run: install, open,
+  // pick a folder, and nothing is watching the clock until a restart. Found by
+  // a real routine that was correctly written, correctly migrated, on the
+  // roster, and never fired.
+  //
+  // Putting it here rather than in the handler that opens a workspace is the
+  // whole fix. There is more than one way to arrive at a new workspace (open
+  // one, create one, roll back to the previous one after a failed open, clear
+  // the pointer to one that has gone), and every one of them reaches this
+  // function, because the root's mirror and lib/config must never drift and
+  // this is the only place that writes both. Anything that sets a workspace
+  // therefore gets a scheduler without having to remember to, and the next
+  // path someone adds gets one too.
+  //
+  // NOT from the roster or the file watcher, deliberately. Both fire often and
+  // for reasons that have nothing to do with a workspace being chosen, and a
+  // scheduler armed from a path like that is how two tickers happen. This
+  // function fires only when the workspace actually changes.
+  //
+  // Stop THEN start, always in that order and unconditionally. The stop is
+  // what ends the tick that was running for the workspace being left; without
+  // it the start would meet a live handle, decline, and leave the old ticker
+  // in place. When there is no new workspace to serve, the stop is all that
+  // happens, and it is the only thing standing between a deleted workspace and
+  // a tick that keeps running over nothing.
+  stopScheduler();
+  if (dir) startScheduler();
 }
 
 // Workspace boundary check. A bare `startsWith(resolve(WORKSPACE))`
@@ -471,7 +502,7 @@ const schedulerLib = require('./lib/scheduler.js');
 const {
   routineState, loadRoutineState, saveRoutineState, recordRoutineRun,
   routineSlots, loadRoutineSlots, saveRoutineSlots,
-  startScheduler, stopScheduler, getNextRun, executeRoutine,
+  startScheduler, stopScheduler, schedulerRunning, getNextRun, executeRoutine,
 } = schedulerLib;
 // Hand lib/agents its root-owned dependencies (see the module headers).
 // (routineState needs no wiring: discovery requires lib/scheduler.js
@@ -3082,7 +3113,7 @@ module.exports._internal = {
   armFileTreeWatcher, fileTreeForSend, broadcastFileTree,
   flatFileListCached, invalidateFileListCache,
   // scheduler
-  getNextRun, executeRoutine, routineState, startScheduler, stopScheduler,
+  getNextRun, executeRoutine, routineState, startScheduler, stopScheduler, schedulerRunning,
   loadRoutineState, saveRoutineState, recordRoutineRun,
   routineSlots, loadRoutineSlots, saveRoutineSlots,
   // agent + skill discovery / parsing

--- a/test/helpers/harness.js
+++ b/test/helpers/harness.js
@@ -16,6 +16,7 @@ let srv = null;
 let internal = null;
 let port = null;
 let workspaceDir = null;
+let schedulerBeforeListen = null;
 const clients = [];
 
 /**
@@ -29,6 +30,14 @@ const clients = [];
  *   run starts in, where the folder is chosen afterwards through the interface.
  *   The fixture is still built and h.workspaceDir still names it, so a test can
  *   choose it over the wire; the server just has not been told about it.
+ * @param {boolean} [opts.presetWorkspace=false] - hand the server its workspace
+ *   the way a REMEMBERED one arrives: in process.env.WORKSPACE, before
+ *   server.js is required, so lib/config seeds the root at require time and the
+ *   workspace setter is never called. Implies opts.workspace false, because the
+ *   whole point is that nothing has touched the root before the server boots.
+ *   Use this to test the boot path itself; opts.workspace true reaches the same
+ *   end state through the setter, which arms things the boot path is supposed
+ *   to arm for itself.
  */
 async function boot(opts = {}) {
   assert.strictEqual(srv, null, 'boot() must only be called once per test file');
@@ -43,10 +52,18 @@ async function boot(opts = {}) {
   for (const [k, v] of Object.entries(opts.env || {})) process.env[k] = v;
 
   workspaceDir = makeWorkspace({ agents: opts.agents || standardTeam(), claudeMd: '# Test Workspace\n', ...(opts.workspaceOpts || {}) });
+  // Set AFTER the fixture exists and BEFORE server.js is required, which is the
+  // only window in which it does anything: lib/config reads it once, at require
+  // time, and never again.
+  if (opts.presetWorkspace) process.env.WORKSPACE = workspaceDir;
 
   srv = require('../../server.js');
   internal = srv._internal;
-  if (opts.workspace !== false) internal.setWorkspace(workspaceDir);
+  if (opts.workspace !== false && !opts.presetWorkspace) internal.setWorkspace(workspaceDir);
+  // Read between require and listen, which is a window no test can otherwise
+  // reach: boot() owns both halves. It is the only place the question "was
+  // anything armed before the server started" can be asked at all.
+  schedulerBeforeListen = internal.schedulerRunning();
 
   // Hard safety gate: never run integration scenarios against a real claude
   // or a real codex.
@@ -323,5 +340,8 @@ module.exports = {
   get internal() { return internal; },
   get port() { return port; },
   get workspaceDir() { return workspaceDir; },
+  // Whether a tick was armed after server.js was required and before it
+  // listened. See the read in boot().
+  get schedulerBeforeListen() { return schedulerBeforeListen; },
   STUB_DIR, CODEX_STUB_DIR,
 };

--- a/test/helpers/harness.js
+++ b/test/helpers/harness.js
@@ -24,6 +24,11 @@ const clients = [];
  * @param {object} [opts.agents] - agent fixture map (default standardTeam)
  * @param {object} [opts.workspaceOpts] - extra makeWorkspace options
  * @param {object} [opts.env] - extra process.env entries set BEFORE require
+ * @param {boolean} [opts.workspace=true] - point the server at the fixture
+ *   before it listens. Pass false to boot with NO workspace: the state a first
+ *   run starts in, where the folder is chosen afterwards through the interface.
+ *   The fixture is still built and h.workspaceDir still names it, so a test can
+ *   choose it over the wire; the server just has not been told about it.
  */
 async function boot(opts = {}) {
   assert.strictEqual(srv, null, 'boot() must only be called once per test file');
@@ -41,7 +46,7 @@ async function boot(opts = {}) {
 
   srv = require('../../server.js');
   internal = srv._internal;
-  internal.setWorkspace(workspaceDir);
+  if (opts.workspace !== false) internal.setWorkspace(workspaceDir);
 
   // Hard safety gate: never run integration scenarios against a real claude
   // or a real codex.

--- a/test/integration/scheduler-boot-lifecycle.test.js
+++ b/test/integration/scheduler-boot-lifecycle.test.js
@@ -1,0 +1,39 @@
+'use strict';
+// The other caller of the starter: boot, for a workspace that was already
+// remembered or preset in the environment.
+//
+// That path never goes through the workspace setter, because the root is
+// seeded from process.env.WORKSPACE at require time rather than assigned. So
+// it arms the tick itself, it is one of the rows in
+// test/unit/scheduler-lifecycle-doors.test.js, and this is the test that row
+// names.
+//
+// It has its own file because the harness boots one server per file and this
+// one has to boot WITH a workspace, which is the opposite of what
+// test/integration/scheduler-workspace-lifecycle.test.js needs.
+//
+// Nothing here calls startScheduler or stopScheduler. Booting is the surface,
+// and the question is asked of the interval handle the tick depends on.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const h = require('../helpers/harness.js');
+const { agentFile } = require('../helpers/workspace.js');
+
+before(async () => {
+  await h.boot({
+    agents: {
+      punctual: agentFile({
+        name: 'punctual', type: 'specialist', order: 1,
+        routines: [{ name: 'clock-check', schedule: 'every day at 09:00', prompt: 'clock routine body' }],
+      }),
+    },
+  });
+});
+after(h.shutdown);
+
+test('booting with a workspace already set arms the tick, with nobody calling the starter', () => {
+  assert.strictEqual(h.internal.getWorkspace(), h.workspaceDir,
+    'the server came up pointed at the fixture, the way a remembered workspace arrives');
+  assert.strictEqual(h.internal.schedulerRunning(), true,
+    'and a tick is armed for it: this is the one path that already worked, and it still does');
+});

--- a/test/integration/scheduler-boot-lifecycle.test.js
+++ b/test/integration/scheduler-boot-lifecycle.test.js
@@ -1,19 +1,25 @@
 'use strict';
 // The other caller of the starter: boot, for a workspace that was already
-// remembered or preset in the environment.
+// remembered.
 //
-// That path never goes through the workspace setter, because the root is
-// seeded from process.env.WORKSPACE at require time rather than assigned. So
-// it arms the tick itself, it is one of the rows in
-// test/unit/scheduler-lifecycle-doors.test.js, and this is the test that row
+// That path never goes through the workspace setter. The root is seeded from
+// process.env.WORKSPACE when lib/config is first required, so nothing has
+// written it and nothing has armed a tick by the time startServer runs. It has
+// to arm one itself, and this is the test the CALLERS row for that caller
 // names.
 //
-// It has its own file because the harness boots one server per file and this
-// one has to boot WITH a workspace, which is the opposite of what
-// test/integration/scheduler-workspace-lifecycle.test.js needs.
+// WHY THE HARNESS IS BOOTED THIS PARTICULAR WAY, because the obvious way makes
+// this test prove nothing. The harness normally points the server at its
+// fixture through internal.setWorkspace before it listens, and that goes
+// through setWorkspaceRoot, which now arms the tick. startServer would then
+// reach its own startScheduler(), meet a live handle, and decline, and the
+// test would stay green with the boot call deleted. presetWorkspace puts the
+// path in the environment instead, which is how a remembered workspace really
+// arrives, and leaves the setter untouched.
 //
-// Nothing here calls startScheduler or stopScheduler. Booting is the surface,
-// and the question is asked of the interval handle the tick depends on.
+// It has its own file because the harness boots one server per file.
+//
+// Nothing here calls startScheduler or stopScheduler. Booting is the surface.
 const { test, before, after } = require('node:test');
 const assert = require('node:assert');
 const h = require('../helpers/harness.js');
@@ -21,6 +27,7 @@ const { agentFile } = require('../helpers/workspace.js');
 
 before(async () => {
   await h.boot({
+    presetWorkspace: true,
     agents: {
       punctual: agentFile({
         name: 'punctual', type: 'specialist', order: 1,
@@ -33,7 +40,10 @@ after(h.shutdown);
 
 test('booting with a workspace already set arms the tick, with nobody calling the starter', () => {
   assert.strictEqual(h.internal.getWorkspace(), h.workspaceDir,
-    'the server came up pointed at the fixture, the way a remembered workspace arrives');
+    'the root was seeded from the environment, the way a remembered workspace arrives');
+  assert.strictEqual(h.schedulerBeforeListen, false,
+    'and nothing had armed a tick before the server listened: no setter ran, so if this were true '
+    + 'the assertion below would pass without the boot path doing anything');
   assert.strictEqual(h.internal.schedulerRunning(), true,
-    'and a tick is armed for it: this is the one path that already worked, and it still does');
+    'so the tick armed while the server started is the boot path arming it, and nothing else');
 });

--- a/test/integration/scheduler-workspace-lifecycle.test.js
+++ b/test/integration/scheduler-workspace-lifecycle.test.js
@@ -235,20 +235,58 @@ describe('switching away stops the scheduler that was running', () => {
 
   // AC-5 and AC-6. The clock is advanced past a slot the workspace that was
   // LEFT was due at, and nothing about that workspace moves.
+  //
+  // THE THREE ABSENCES AT THE END OF THIS TEST DO NOT, ON THEIR OWN, PROVE
+  // ANYTHING ABOUT THE STOP, and saying so is the point of this comment. The
+  // tick reads the workspace root at use time, through discoverAgents, so a
+  // ticker that survived the switch would discover the roster of the workspace
+  // just ENTERED. It could never fire a routine belonging to the one that was
+  // left, whether it was stopped, left running, or never armed. An absence
+  // guaranteed by the scheduler's use-time read is not evidence about the
+  // lifecycle, and a first version of this test asserted only that.
+  //
+  // So the absences stay, because they are what the criterion asks for in so
+  // many words, and the observation that DOES differ is made beside them:
+  // whether the ticker armed for the workspace that was left is still there
+  // afterwards. That is read through the phase of the tick rather than through
+  // anything it spawned. The pre-switch ticker is left thirty seconds from its
+  // minute; if it survived, those thirty seconds would run a pass. They run
+  // none, and the thirty after them run one, which is what proves a ticker
+  // exists to have been counted at all.
   test('the previous workspace routine does not fire when its slot passes', async (t) => {
     const left = punctualWorkspace();
     const entered = idleWorkspace();
     const client = await h.connect();
     await armOnRealTimers(client);
     const clock = { at: BEFORE_NINE };
-    const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+    let reads = 0;
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => { reads++; return clock.at; } });
     t.mock.timers.enable({ apis: ['setInterval'] });
     try {
       await choose(client, left);
+
+      // The premise, asserted rather than assumed: choosing the workspace armed
+      // a ticker, and it is the mocked one this test can drive. Everything
+      // below is about that ticker, so silence from a ticker that was never
+      // armed would otherwise read as silence from one that was stopped.
+      t.mock.timers.tick(60_000);
+      assert.ok(reads > 0, 'the workspace that is about to be left had a ticker of its own');
+
+      // Thirty seconds into its next minute, so the switch catches it mid-cycle
+      // and its survival is a question the next thirty seconds answer.
+      t.mock.timers.tick(30_000);
+
       await choose(client, entered);
 
       clock.at = AFTER_NINE;
-      t.mock.timers.tick(60_000);
+      reads = 0;
+      t.mock.timers.tick(30_000);
+      assert.strictEqual(reads, 0,
+        'past 09:00, and the ticker that was running for the workspace that was left did not '
+        + 'complete the minute it was thirty seconds from: it is gone, not merely looking elsewhere');
+
+      t.mock.timers.tick(30_000);
+      assert.ok(reads > 0, 'while the workspace switched to has a ticker on its own minute');
 
       assert.strictEqual(h.internal.routineState[KEY], undefined,
         'past 09:00 and the routine belonging to the workspace that was left has no run state');

--- a/test/integration/scheduler-workspace-lifecycle.test.js
+++ b/test/integration/scheduler-workspace-lifecycle.test.js
@@ -1,0 +1,408 @@
+'use strict';
+// The scheduler's lifecycle, driven the way a user reaches it.
+//
+// WHY THIS FILE EXISTS AND THE EIGHT BEFORE IT DID NOT CATCH THIS.
+//
+// Eight suites proved the tick: catch-up, single-flight, missed slots, run
+// records, the schedule grammar, DST. Every one of them armed the tick by
+// calling startScheduler() itself. Not one asked who calls it in the product,
+// and the answer was one boot path guarded by `if (WORKSPACE)`. Install, open,
+// choose a folder, and nothing was watching the clock until a restart.
+//
+// So nothing in this file calls startScheduler or stopScheduler. Every test
+// arms the scheduler by sending the message the client sends when someone
+// picks a folder ({type:'set_workspace'}, public/app.js), and reads the result
+// through the tick's own behaviour. Calling the starter is exactly the habit
+// that let the defect ship while the suite stayed green.
+//
+// The server boots here with NO workspace, which is the state a first run
+// starts in and the state the defect needed.
+//
+// NOTHING HERE DEPENDS ON THE MACHINE. The clock is wired through the
+// scheduler's seam, the home directory is a temp dir the harness makes, every
+// workspace is built by the test that uses it, and the interval is driven by
+// mock timers rather than elapsed time. The two instants are local-time
+// constructions, so a schedule written in local time and a clock read in local
+// time agree in any zone.
+const { test, before, after, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const h = require('../helpers/harness.js');
+const { agentFile, makeWorkspace, makeTempDir } = require('../helpers/workspace.js');
+
+const scheduler = require('../../lib/scheduler.js');
+
+const KEY = 'punctual:clock-check';
+const SCHEDULE = 'every day at 09:00';
+const ROUTINE_BODY = 'clock routine body';
+// Wednesday 2026-07-01, local time.
+const BEFORE_NINE = new Date(2026, 6, 1, 8, 0, 0);
+const AFTER_NINE = new Date(2026, 6, 1, 9, 30, 0);
+
+function punctualAgents() {
+  return {
+    punctual: agentFile({
+      name: 'punctual', type: 'specialist', order: 1,
+      routines: [{ name: 'clock-check', schedule: SCHEDULE, prompt: ROUTINE_BODY }],
+    }),
+  };
+}
+
+// A workspace with a routine due at 09:00 every day.
+function punctualWorkspace() {
+  return makeWorkspace({ claudeMd: '# Punctual fixture\n', agents: punctualAgents() });
+}
+
+// A workspace with an agent and no routines: a tick over it does exactly one
+// thing, which is what makes the clock reads below countable.
+function idleWorkspace() {
+  return makeWorkspace({
+    claudeMd: '# Idle fixture\n',
+    agents: { idle: agentFile({ name: 'idle', type: 'specialist', order: 1 }) },
+  });
+}
+
+// What the stub recorded in a given workspace. The stub writes to its cwd, and
+// a routine runs with cwd set to the workspace it belongs to, so this asks the
+// question per workspace rather than only for the harness fixture.
+function promptsIn(dir) {
+  const file = path.join(dir, 'stub-prompts.jsonl');
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf-8').split('\n').filter(Boolean).map(l => JSON.parse(l));
+}
+
+// Choose a folder, exactly as the interface does it. The reply is awaited so
+// the open has finished before anything is asserted about it.
+async function choose(client, dir) {
+  const since = client.messages.length;
+  client.send({ type: 'set_workspace', path: dir });
+  const { msg } = await client.waitFor(
+    m => m.type === 'workspace_set' || m.type === 'workspace_error',
+    { since, label: `workspace_set for ${dir}` },
+  );
+  assert.strictEqual(msg.type, 'workspace_set', `choosing ${dir} failed: ${msg.message}`);
+  return msg;
+}
+
+// Hand the scheduler a REAL interval handle before mock timers are enabled.
+//
+// Mock timers are per test, and a handle made by one test's instance poisons
+// the next: clearing it inside a LATER instance leaves that instance unable to
+// fire anything at all. That is node's behaviour rather than Rundock's, and it
+// reproduces in a plain node --test file with no Rundock in it. The scheduler
+// is holding exactly such a handle at the end of every test below, and the
+// next workspace change clears it, so without this the second test onwards
+// would drive a tick that can never fire and read that as the defect.
+//
+// Arming on real timers first means the clear that happens under the mock is a
+// clear of a real handle, which is safe. Nothing here calls the starter: this
+// is the same workspace-set path every test drives, down the same socket.
+async function armOnRealTimers(client) {
+  await choose(client, idleWorkspace());
+}
+
+before(async () => {
+  // The fixture the harness builds is a punctual workspace, because the one
+  // test that lets a routine run to completion needs the stub's scenario and
+  // its logs to sit in the workspace the harness knows the name of.
+  await h.boot({ workspace: false, agents: punctualAgents() });
+});
+after(h.shutdown);
+
+// The state the defect needed, pinned before anything below changes it: an
+// installed Rundock that has been opened and not yet pointed at a folder.
+test('a first run has no workspace and nothing watching the clock', () => {
+  assert.strictEqual(h.internal.getWorkspace(), null, 'no workspace yet');
+  assert.strictEqual(h.internal.schedulerRunning(), false,
+    'and no scheduler: there is nothing for one to watch');
+});
+
+describe('choosing a workspace starts the scheduler', () => {
+  // AC-1 and AC-2. The routine is watched NOT firing an hour before its time
+  // and then firing after it, from the same fixture, because "it did not fire"
+  // on its own is satisfied by a scheduler that was never going to fire.
+  test('choosing a folder arms the tick, and the routine runs when its time comes', async (t) => {
+    h.writeScenario([
+      { match: { agent: 'punctual', promptIncludes: ROUTINE_BODY }, turn: [{ text: 'routine ran' }] },
+    ]);
+    const client = await h.connect();
+    const clock = { at: BEFORE_NINE };
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+    // Enabled BEFORE the folder is chosen, so the interval the open arms is
+    // the one this test drives. There is no other way to get hold of it
+    // without calling the starter.
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      await choose(client, h.workspaceDir);
+
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(h.internal.routineState[KEY], undefined,
+        'an hour before its time the routine has not run');
+
+      clock.at = AFTER_NINE;
+      t.mock.timers.tick(60_000);
+      const started = h.internal.routineState[KEY];
+      assert.ok(started,
+        'choosing the folder armed a tick: past 09:00 the routine fired, with nobody calling the starter');
+      assert.strictEqual(started.lastRun, AFTER_NINE.toISOString(),
+        'and it was stamped with the wired clock rather than the wall clock');
+
+      clock.at = new Date(AFTER_NINE.getTime() + 60_000);
+      const finished = await h.waitUntil(() => {
+        const s = h.internal.routineState[KEY];
+        return s && s.status !== 'running';
+      });
+      assert.ok(finished, 'the fired routine reached an outcome');
+      assert.strictEqual(h.internal.routineState[KEY].status, 'completed',
+        'the routine the chosen workspace released ran through to completion');
+      assert.strictEqual(promptsIn(h.workspaceDir).length, 1,
+        'and it ran once');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+
+  // AC-3. The trap this criterion exists for: a scheduler armed from a path
+  // that fires often leaves two tickers, and two tickers are worse than none.
+  // Counted rather than inferred, and calibrated against a single choose so
+  // the number does not depend on how many clock reads one pass happens to
+  // make.
+  test('choosing a workspace twice leaves one ticker, not two', async (t) => {
+    const dir = idleWorkspace();
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    let reads = 0;
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => { reads++; return BEFORE_NINE; } });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      await choose(client, dir);
+      reads = 0;
+      t.mock.timers.tick(60_000);
+      const oneTicker = reads;
+      assert.ok(oneTicker > 0, 'sanity: one choose arms a tick that reads the clock');
+
+      await choose(client, dir);
+      reads = 0;
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(reads, oneTicker,
+        'the second choose did not add a second ticker: the minute cost exactly one pass');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+});
+
+describe('switching away stops the scheduler that was running', () => {
+  // AC-4. The old ticker is thirty seconds from firing when the switch
+  // happens. If it survived, the next thirty seconds would fire it. A ticker
+  // armed for the new workspace is only thirty seconds old and does not.
+  //
+  // Both halves are one test on purpose: "it did not fire" alone is satisfied
+  // by a scheduler that was never armed, so the second half fires the same
+  // ticker thirty seconds later to prove one was.
+  test('switching away re-arms the tick rather than leaving the old one running', async (t) => {
+    const first = idleWorkspace();
+    const second = idleWorkspace();
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    let reads = 0;
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => { reads++; return BEFORE_NINE; } });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      await choose(client, first);
+      t.mock.timers.tick(30_000);
+
+      await choose(client, second);
+      reads = 0;
+      t.mock.timers.tick(30_000);
+      assert.strictEqual(reads, 0,
+        'the ticker running for the old workspace was thirty seconds from its minute and is gone');
+
+      t.mock.timers.tick(30_000);
+      assert.ok(reads > 0,
+        'and the workspace switched to has a ticker of its own, on its own minute');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+
+  // AC-5 and AC-6. The clock is advanced past a slot the workspace that was
+  // LEFT was due at, and nothing about that workspace moves.
+  test('the previous workspace routine does not fire when its slot passes', async (t) => {
+    const left = punctualWorkspace();
+    const entered = idleWorkspace();
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    const clock = { at: BEFORE_NINE };
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      await choose(client, left);
+      await choose(client, entered);
+
+      clock.at = AFTER_NINE;
+      t.mock.timers.tick(60_000);
+
+      assert.strictEqual(h.internal.routineState[KEY], undefined,
+        'past 09:00 and the routine belonging to the workspace that was left has no run state');
+      assert.deepStrictEqual(promptsIn(left), [],
+        'nothing was ever spawned in the workspace that was left');
+      assert.strictEqual(fs.existsSync(path.join(left, '.rundock', 'routine-state.json')), false,
+        'and no run was recorded there');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+
+  // AC-4 again, for the switch that has nowhere to land. A workspace that
+  // disappears clears the pointer through the picker's own refresh, and the
+  // scheduler that was running for it must go with it. This is the case where
+  // the stop is the only thing doing the work: there is no new workspace whose
+  // start could cover for it.
+  //
+  // The pointer is put there by the product's own workspace setter rather than
+  // by choosing over the wire, and that is forced rather than chosen: opening a
+  // folder writes to its .rundock, and those writes recreate the directory
+  // faster than a test can delete it, so a workspace opened over the wire never
+  // reads as vanished. test/integration/workspace-picker.test.js sets the
+  // pointer the same way for the same reason. The clearing itself, which is
+  // what this test is about, still goes through the real handler over the real
+  // socket.
+  test('a workspace that disappears takes its ticker with it', async (t) => {
+    const doomed = makeTempDir('rundock-test-doomed-');
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    const clock = { at: BEFORE_NINE };
+    let reads = 0;
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => { reads++; return clock.at; } });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      h.internal.setWorkspace(doomed);
+      assert.strictEqual(h.internal.schedulerRunning(), true,
+        'the workspace it is about to lose had a ticker, so there is one to stop');
+      fs.rmSync(doomed, { recursive: true, force: true });
+
+      // The refresh the client sends whenever it asks what workspaces exist.
+      // It is what notices the directory has gone and clears the pointer.
+      const since = client.messages.length;
+      client.send({ type: 'get_workspaces' });
+      await client.waitFor(m => m.type === 'workspaces', { since, label: 'workspaces' });
+      assert.strictEqual(h.internal.getWorkspace(), null,
+        'the pointer to the vanished workspace is cleared');
+      // Asked of the interval handle the tick itself depends on. Counting tick
+      // bodies below is the behaviour, but a ticker that survives a clear can
+      // sit on a handle the mock clock never drives, and then silence proves
+      // nothing. This is the assertion that goes red when the stop is removed.
+      assert.strictEqual(h.internal.schedulerRunning(), false,
+        'and the ticker that was running for it is stopped rather than left over');
+
+      clock.at = AFTER_NINE;
+      reads = 0;
+      t.mock.timers.tick(180_000);
+      assert.strictEqual(reads, 0,
+        'three minutes past a slot the old workspace was due at, and no tick body ran at all');
+      assert.strictEqual(h.internal.routineState[KEY], undefined,
+        'so nothing started');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+});
+
+describe('what the lifecycle must not disturb', () => {
+  // AC-10. lastRun is the sole input to double-fire suppression. Opening a
+  // workspace must not write it, or every open re-arms or cancels a run that
+  // was already decided. Asserted on the file as well as the object, because
+  // the file is what survives the restart the suppression exists for.
+  test('choosing a workspace does not write the value suppression reads', async (t) => {
+    const dir = punctualWorkspace();
+    const alreadyRan = new Date(2026, 6, 1, 9, 5, 0);
+    const stateFile = path.join(dir, '.rundock', 'routine-state.json');
+    fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+    fs.writeFileSync(stateFile, JSON.stringify(
+      { [KEY]: { lastRun: alreadyRan.toISOString(), status: 'completed', duration: 3 } }, null, 2));
+    const before = fs.readFileSync(stateFile, 'utf-8');
+
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    const clock = { at: AFTER_NINE };
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      await choose(client, dir);
+      assert.strictEqual(h.internal.routineState[KEY].lastRun, alreadyRan.toISOString(),
+        'the open read the suppression value and left it alone');
+
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(h.internal.routineState[KEY].lastRun, alreadyRan.toISOString(),
+        'and the tick it armed did not re-fire a routine that had already run today');
+      assert.deepStrictEqual(promptsIn(dir), [], 'nothing was spawned');
+      assert.strictEqual(fs.readFileSync(stateFile, 'utf-8'), before,
+        'the file the suppression is read from after a restart is byte-identical');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+
+  // AC-11. A run that was in flight when the workspace changed must not be
+  // fired again by the scheduler the change arms. The hold that prevents it is
+  // deliberately not cleared by the state reload a switch performs, and this
+  // pins that: the switch goes away and comes back, and the routine that was
+  // running is not started a second time in its window.
+  test('a routine mid-run when the workspace is switched is not re-fired by the new start', async (t) => {
+    const elsewhere = idleWorkspace();
+    // Held open long enough that the switch below happens while the run is
+    // genuinely in flight rather than after it.
+    h.writeScenario([
+      { match: { agent: 'punctual', promptIncludes: ROUTINE_BODY }, delayMs: 4000, turn: [{ text: 'still going' }] },
+    ]);
+    h.clearPrompts();
+    delete h.internal.routineState[KEY];
+
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    // A day after the run the first test in this file left behind, so the
+    // routine is due again rather than suppressed by it.
+    const dueAgain = new Date(2026, 6, 2, 9, 30, 0);
+    const clock = { at: dueAgain };
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    try {
+      await choose(client, h.workspaceDir);
+      t.mock.timers.tick(60_000);
+      assert.strictEqual(h.internal.routineState[KEY].status, 'running',
+        'the routine is in flight at the moment the workspace changes');
+      // The stub writes its prompt log from the child, so the spawn is
+      // observable a moment after the tick that caused it.
+      const spawned = await h.waitUntil(() => promptsIn(h.workspaceDir).length === 1);
+      assert.ok(spawned, `it started once, not ${promptsIn(h.workspaceDir).length} times`);
+
+      await choose(client, elsewhere);
+      await choose(client, h.workspaceDir);
+
+      t.mock.timers.tick(60_000);
+      // Real elapsed time, because this asserts something did NOT happen: a
+      // second spawn would take about as long to show up as the first did.
+      await h.delay(500);
+      assert.strictEqual(promptsIn(h.workspaceDir).length, 1,
+        'the scheduler the switch armed did not start the run again');
+    } finally {
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+});

--- a/test/integration/scheduler-workspace-lifecycle.test.js
+++ b/test/integration/scheduler-workspace-lifecycle.test.js
@@ -395,6 +395,67 @@ describe('what the lifecycle must not disturb', () => {
     }
   });
 
+  // The tick reads two stores that have to describe the same workspace: the
+  // roster, through getWorkspace() at use time, and routineState. The root
+  // changes first, so anything armed before the state is loaded is armed into a
+  // window where the two disagree, and a tick landing there judges the new
+  // roster against the old workspace's lastRun.
+  //
+  // WHY THIS IS OBSERVED AT THE ARMING RATHER THAN THROUGH A TICK. The window
+  // is inside one synchronous call: nothing yields between the arm and the load
+  // today, so no tick can be driven into it, and a test that advanced the clock
+  // would pass under either ordering and prove nothing. What distinguishes the
+  // two orderings is the state that EXISTS at the moment the interval is
+  // created, so that is what this reads, by standing in front of setInterval
+  // and taking a copy. The scheduler's is the only sixty-second interval armed
+  // on this path.
+  //
+  // Both workspaces declare the same agent and the same routine name, so they
+  // share a routine key. That is the case the disagreement actually bites in,
+  // and the one a workspace copied or renamed produces by accident.
+  test('the state a tick will read is loaded before the tick is armed', async (t) => {
+    const ranAt = new Date(2026, 6, 1, 9, 5, 0);
+    const left = punctualWorkspace();
+    const leftState = path.join(left, '.rundock', 'routine-state.json');
+    fs.mkdirSync(path.dirname(leftState), { recursive: true });
+    fs.writeFileSync(leftState, JSON.stringify(
+      { [KEY]: { lastRun: ranAt.toISOString(), status: 'completed', duration: 3 } }, null, 2));
+    // Same agent, same routine, so the same key. Never run.
+    const entered = punctualWorkspace();
+
+    const client = await h.connect();
+    await armOnRealTimers(client);
+    const clock = { at: AFTER_NINE };
+    const prevDeps = scheduler.wireSchedulerDeps({ now: () => clock.at });
+    t.mock.timers.enable({ apis: ['setInterval'] });
+    const armed = [];
+    const wrapped = global.setInterval;
+    global.setInterval = (fn, ms, ...rest) => {
+      if (ms === 60_000) armed.push(JSON.parse(JSON.stringify(h.internal.routineState)));
+      return wrapped(fn, ms, ...rest);
+    };
+    try {
+      await choose(client, left);
+      assert.strictEqual(h.internal.routineState[KEY].lastRun, ranAt.toISOString(),
+        'the workspace being left has a run recorded for the shared key');
+
+      armed.length = 0;
+      await choose(client, entered);
+
+      assert.strictEqual(armed.length, 1,
+        'exactly one tick was armed while entering the workspace');
+      assert.strictEqual(armed[0][KEY], undefined,
+        'and at the moment it was armed the state already described the workspace being ENTERED, '
+        + 'which has never run this routine. Armed first, it would have held the run the workspace '
+        + 'being LEFT recorded at 09:05, and suppressed a routine that was due');
+    } finally {
+      global.setInterval = wrapped;
+      t.mock.timers.reset();
+      scheduler.wireSchedulerDeps(prevDeps);
+      client.close();
+    }
+  });
+
   // AC-11. A run that was in flight when the workspace changed must not be
   // fired again by the scheduler the change arms. The hold that prevents it is
   // deliberately not cleared by the state reload a switch performs, and this

--- a/test/unit/scheduler-lifecycle-doors.test.js
+++ b/test/unit/scheduler-lifecycle-doors.test.js
@@ -1,0 +1,309 @@
+'use strict';
+// Every caller of the scheduler's starter and stopper, enumerated and pinned
+// to the test that drives it.
+//
+// WHY THIS FILE IS A MANIFEST AND NOT A LIST OF TESTS.
+//
+// Eight cards tested this scheduler. They proved catch-up, single-flight,
+// missed slots, run records, the schedule grammar and DST, and every one of
+// them armed the tick by calling startScheduler itself. Not one asked who
+// calls it in the product. The answer was one boot path guarded by
+// `if (WORKSPACE)`: choosing a workspace at runtime started nothing, and
+// stopScheduler had no caller in the product at all. A suite that arms the
+// tick itself cannot notice that nobody else does.
+//
+// This is the same instrument that ended the same loop one layer above, in
+// test/unit/routine-editor-doors.test.js and test/unit/routines-view-doors.test.js,
+// where four reviews each found a different untested way into the editor. Same
+// three parts, applied to a server-side lifecycle rather than to client entry
+// points: an enumeration, a check that reads the SOURCE and fails when the
+// enumeration and the source disagree, and a reverse check so a row cannot
+// name a test nobody wrote.
+//
+// It carries a second enumeration the editor's did not need. The way this
+// defect happened was not a caller going missing, it was a caller never
+// existing on a path that sets a workspace. So the workspace-setting paths are
+// enumerated too, and the check that binds them is that not one of them can
+// reach the workspace root except through the single function that runs the
+// lifecycle.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf-8');
+
+// ===== THE ENUMERATION =====
+//
+// Every call to the starter or the stopper anywhere in the product, with the
+// surface it belongs to and the test that drives that surface. Adding a call
+// means adding a row here, which means naming a test.
+const CALLERS = [
+  {
+    call: 'stopScheduler',
+    file: 'server.js',
+    fn: 'setWorkspaceRoot',
+    surface: 'every workspace change, including leaving one for no workspace at all',
+    provenIn: 'test/integration/scheduler-workspace-lifecycle.test.js',
+    provenBy: 'a workspace that disappears takes its ticker with it',
+  },
+  {
+    call: 'startScheduler',
+    file: 'server.js',
+    fn: 'setWorkspaceRoot',
+    surface: 'every workspace change that lands on a workspace: chosen, created, or rolled back to',
+    provenIn: 'test/integration/scheduler-workspace-lifecycle.test.js',
+    provenBy: 'choosing a folder arms the tick, and the routine runs when its time comes',
+  },
+  {
+    call: 'startScheduler',
+    file: 'server.js',
+    fn: 'startServer',
+    surface: 'boot, for a workspace preset in the environment, which never passes through the setter',
+    provenIn: 'test/integration/scheduler-boot-lifecycle.test.js',
+    provenBy: 'booting with a workspace already set arms the tick, with nobody calling the starter',
+  },
+];
+
+// Calls left out of the enumeration above, each with the reason. A named
+// exclusion is a decision; an unnamed one is how a lifecycle ends up with one
+// caller and nobody noticing.
+const NOT_ENUMERATED = [
+  {
+    what: 'the definitions in lib/scheduler.js',
+    why: 'a function declaration is not a call. The check below reads them out of the scan by their '
+      + 'declaration line rather than by skipping the file, so a genuine call added to the scheduler '
+      + 'itself would still have to be listed.',
+  },
+  {
+    what: 'the whole of test/, including the eight suites that arm the tick themselves',
+    why: 'those calls are the habit this card exists to correct. They prove what the tick does once it '
+      + 'is running, which is shipped and worth keeping, and they say nothing about who arms it. '
+      + 'Counting them as callers would let the product have none again and still read as covered.',
+  },
+  {
+    what: 'the destructuring import and the _internal re-export in server.js',
+    why: 'both name the functions without calling them. Neither can arm or disarm anything, and the '
+      + 'scan only matches a name followed by an opening bracket, so neither appears in it.',
+  },
+];
+
+// Every product path that sets the workspace root. None of them calls the
+// starter, and none of them should have to: they all reach it through the one
+// function that owns the lifecycle, which is the property the checks below
+// exist to hold.
+const WORKSPACE_SETTERS = [
+  {
+    file: 'server.js',
+    fn: 'startServer',
+    surface: 'boot, clearing the pointer when the remembered workspace no longer exists',
+  },
+  {
+    file: 'server.js',
+    fn: 'setWorkspace',
+    surface: 'the test-only re-export used to point a booted server at a fixture',
+  },
+  {
+    file: 'lib/protocol/handlers/workspace.js',
+    fn: 'handleGetWorkspaces',
+    surface: 'the picker refreshing, clearing the pointer when the workspace has vanished',
+  },
+  {
+    file: 'lib/protocol/handlers/workspace.js',
+    fn: 'handleSetWorkspace',
+    surface: 'rolling the root back when an open throws part way through',
+  },
+  {
+    file: 'lib/protocol/handlers/workspace.js',
+    fn: 'openWorkspace',
+    surface: 'choosing a folder: the path this card was raised for',
+  },
+  {
+    file: 'lib/protocol/handlers/workspace.js',
+    fn: 'handleCreateWorkspace',
+    surface: 'creating a workspace from a name typed into the interface',
+  },
+];
+
+// ===== READING THE SOURCE =====
+
+// Product files only. The suite is excluded deliberately and the reason is in
+// NOT_ENUMERATED; node_modules and the build outputs are not source.
+const SKIP_DIRS = new Set(['node_modules', '.git', 'test', 'dist', 'coverage', 'vendor', '.rundock']);
+
+function productFiles() {
+  const out = [];
+  const walk = (rel) => {
+    for (const entry of fs.readdirSync(path.join(ROOT, rel || '.'), { withFileTypes: true })) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const next = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) walk(next);
+      else if (entry.name.endsWith('.js')) out.push(next);
+    }
+  };
+  walk('');
+  return out;
+}
+
+// Comments are not code. A name in prose followed by a bracket would otherwise
+// read as a call, and this file's own header would be a caller.
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, p) => p + ' '.repeat(m.length - p.length));
+}
+
+// The function a byte offset sits in: the nearest declaration above it, taking
+// whichever is closer of a top-level `function name(` and an indented object
+// method `name(args) {`. Both shapes hold callers in this codebase.
+const NOT_A_FUNCTION_NAME = new Set([
+  'if', 'for', 'while', 'switch', 'catch', 'return', 'function', 'else', 'do', 'try', 'with',
+]);
+function enclosingFn(src, index) {
+  const before = src.slice(0, index);
+  let best = null;
+  for (const re of [/^function ([A-Za-z0-9_$]+)\s*\(/gm, /^\s{2,}([A-Za-z0-9_$]+)\s*\([^)]*\)\s*\{/gm]) {
+    let m;
+    while ((m = re.exec(before)) !== null) {
+      if (NOT_A_FUNCTION_NAME.has(m[1])) continue;
+      if (best === null || m.index > best.index) best = { index: m.index, name: m[1] };
+    }
+  }
+  return best ? best.name : '(top level)';
+}
+
+// Is this occurrence the DECLARATION of the name rather than a call to it?
+// Both shapes this codebase declares in look the same to a bare name-then-
+// bracket scan: `function name(args) {` at the top level, and `name(args) {`
+// as an object method. Both are preceded on their line by nothing but
+// whitespace or the `function` keyword, and both are followed by `) {`. A call
+// is followed by `)` and then anything else.
+function isDeclaration(src, index, name) {
+  const lineStart = src.lastIndexOf('\n', index) + 1;
+  const before = src.slice(lineStart, index);
+  if (!/^\s*(function\s+)?$/.test(before)) return false;
+  return /^\s*\)\s*\{/.test(src.slice(index + name.length).replace(/^\([^)]*/, ''));
+}
+
+// Every call to `name` in the product, as `name in file:function`.
+function callSites(name) {
+  const found = [];
+  for (const rel of productFiles()) {
+    const src = stripComments(read(rel));
+    const re = new RegExp(`\\b${name}\\s*\\(`, 'g');
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      if (isDeclaration(src, m.index, name)) continue;
+      found.push({ call: name, file: rel, fn: enclosingFn(src, m.index) });
+    }
+  }
+  return found;
+}
+
+const asKey = (r) => `${r.call} in ${r.file}:${r.fn}`;
+const setterKey = (r) => `${r.file}:${r.fn}`;
+
+describe('every caller of the scheduler lifecycle is enumerated', () => {
+  // THE CHECK THAT ENDS THE LOOP. A new call to either function fails here, by
+  // name, until it is listed with the test that drives its surface.
+  test('no product code arms or disarms the scheduler without being listed here', () => {
+    const found = [...callSites('startScheduler'), ...callSites('stopScheduler')].map(asKey);
+    assert.deepStrictEqual(
+      found.sort(), CALLERS.map(asKey).sort(),
+      'the scheduler is started or stopped somewhere CALLERS does not name, or a listed caller has '
+      + 'gone. Add the row and the test that drives its surface, or remove the row.',
+    );
+  });
+
+  test('every caller names a test, and every named test exists', () => {
+    for (const row of CALLERS) {
+      assert.ok(row.surface && row.provenBy && row.provenIn,
+        `${asKey(row)} needs a surface and a test that drives it`);
+      const suite = read(row.provenIn);
+      assert.ok(suite.includes(`test('${row.provenBy}'`),
+        `${asKey(row)} names "${row.provenBy}" in ${row.provenIn} and no test there has that name`);
+    }
+  });
+
+  test('a call left out of the enumeration says why', () => {
+    assert.ok(NOT_ENUMERATED.length > 0, 'the exclusions are part of the enumeration, not a gap in it');
+    for (const excluded of NOT_ENUMERATED) {
+      assert.ok(excluded.what && excluded.why && excluded.why.length > 60,
+        `"${excluded.what}" is excluded without a reason, which is how the last one went unnoticed`);
+    }
+  });
+
+  // The suite is the one place allowed to arm the tick itself, and it should
+  // stay obvious how much of the coverage that is. This is the number the card
+  // was raised over: proof of the tick, none of it proof of the lifecycle.
+  test('the lifecycle proofs never arm the tick themselves', () => {
+    const selfArming = [];
+    for (const dir of ['test/integration', 'test/unit']) {
+      for (const name of fs.readdirSync(path.join(ROOT, dir))) {
+        if (!name.endsWith('.test.js')) continue;
+        const src = stripComments(read(`${dir}/${name}`));
+        if (/\b(?:start|stop)Scheduler\s*\(/.test(src)) selfArming.push(`${dir}/${name}`);
+      }
+    }
+    assert.ok(selfArming.length >= 8,
+      `sanity: the suites that arm the tick themselves are still there, found ${selfArming.length}`);
+    for (const proof of new Set(CALLERS.map(r => r.provenIn))) {
+      assert.ok(!selfArming.includes(proof),
+        `${proof} arms or disarms the tick itself. It is the proof that the PRODUCT does, and calling `
+        + 'the starter is exactly what let eight suites stay green while nothing did');
+    }
+  });
+});
+
+describe('no path can set a workspace without starting the scheduler', () => {
+  // AC-8, and the reason the lifecycle lives where it does. Every product path
+  // that sets a workspace is listed, and the two checks after this one make
+  // listing enough: they cannot reach the root except through the function
+  // that runs the lifecycle, and that function runs it.
+  test('no product code sets a workspace without being listed here', () => {
+    const found = callSites('setWorkspaceRoot')
+      // The declaration's own body is where the root is written; it is the
+      // destination of every row below rather than a row itself.
+      .filter(r => !(r.file === 'server.js' && r.fn === 'setWorkspaceRoot'))
+      .map(setterKey);
+    assert.deepStrictEqual(
+      found.sort(), WORKSPACE_SETTERS.map(setterKey).sort(),
+      'a workspace is set somewhere WORKSPACE_SETTERS does not name, or a listed one has gone. '
+      + 'Add the row, or remove it.',
+    );
+  });
+
+  test('the workspace root cannot be written except through the function that runs the lifecycle', () => {
+    const writers = [];
+    for (const rel of productFiles()) {
+      if (rel === 'lib/config.js') continue; // where setWorkspace is declared
+      const src = stripComments(read(rel));
+      const re = /\bsetWorkspace\s*\(/g;
+      let m;
+      while ((m = re.exec(src)) !== null) {
+        if (isDeclaration(src, m.index, 'setWorkspace')) continue;
+        writers.push(`${rel}:${enclosingFn(src, m.index)}`);
+      }
+    }
+    assert.deepStrictEqual(writers.sort(), [
+      'server.js:setWorkspaceRoot',  // the one write of the root
+    ], 'lib/config.setWorkspace is being called from somewhere other than setWorkspaceRoot, so that '
+      + 'path sets a workspace and never starts a scheduler. Route it through setWorkspaceRoot.');
+  });
+
+  test('the function every workspace-setting path reaches runs the lifecycle', () => {
+    const src = stripComments(read('server.js'));
+    const start = src.indexOf('function setWorkspaceRoot(');
+    assert.ok(start > 0, 'setWorkspaceRoot has been renamed; this whole file is about that function');
+    const body = src.slice(start, src.indexOf('\n}\n', start));
+    assert.match(body, /\bstopScheduler\s*\(\s*\)/,
+      'setWorkspaceRoot no longer stops the scheduler, so a workspace left keeps its ticker');
+    assert.match(body, /\bstartScheduler\s*\(\s*\)/,
+      'setWorkspaceRoot no longer starts the scheduler, so choosing a workspace arms nothing: '
+      + 'this is the defect the card was raised for, returned');
+    assert.ok(body.indexOf('stopScheduler') < body.indexOf('startScheduler'),
+      'the stop must come first, or the start meets a live handle, declines, and leaves the old '
+      + 'ticker running for a workspace nobody is in');
+  });
+});


### PR DESCRIPTION
Install Rundock, open it, choose a folder, and no routine ever ran until the app was restarted. Found by a real routine that was due at 22:00, was correctly written, correctly migrated, appeared on the roster, and had nothing watching the clock.

## The defect, verified from the source

At `b602f5a`, `startScheduler()` had exactly one caller in the product: the boot path in `server.js`, inside `if (WORKSPACE)`. `stopScheduler()` had none at all, only its declaration, its import and its re-export. Choosing a workspace at runtime goes through `lib/protocol/handlers/workspace.js`, and both paths that land on a workspace load the routine state and start nothing.

So the scheduler survived only when the workspace was already remembered at boot: invisible to anyone who has used the app before, certain for anyone who has not.

## The change

The lifecycle belongs to `setWorkspaceRoot`, the one function that writes the workspace root. Every way of arriving at a workspace already reaches it (opening one, creating one, rolling back after a failed open, clearing a pointer to one that has gone), and a pre-existing test pins that nothing else may write the root. Nothing has to remember to start a scheduler, and the next path added gets one.

Not the roster and not the file watcher, deliberately: both fire often and for unrelated reasons, and a scheduler armed from a path like that is how two tickers happen.

Stop then start, in that order and unconditionally. Without the stop the start meets a live handle, declines, and leaves the old ticker in place. With no new workspace to serve, the stop is the only thing between a workspace that has gone and a tick that keeps running over nothing.

## Why eight suites missed it, and what stops the ninth

Eight cards tested this scheduler and every one armed the tick by calling `startScheduler` itself. Not one asked who calls it. So none of the proofs here call the starter or the stopper: they send `{type:'set_workspace'}` over a real socket, the message the client sends when someone picks a folder, and read the result through the tick's own behaviour on a clock, a home directory and a workspace the test constructs. A check enforces that they never arm the tick themselves.

`test/unit/scheduler-lifecycle-doors.test.js` extends the instrument already in `routine-editor-doors` and `routines-view-doors` rather than inventing a third. It enumerates every caller of the starter and stopper against the source, enumerates every workspace-setting path, and holds two properties that make listing enough rather than a matter of memory: nothing may write the workspace root except the function that runs the lifecycle, and that function must run it, stop before start. A new path that sets a workspace and arms nothing fails by name, verified by adding one.

## Evidence

`.review/scheduler-lifecycle-evidence.md` carries the full record: the trace, each criterion with what discharges it, and twelve mutations applied one at a time against the full suite with the tests that turned red named. Largest blast radius is 6 tests out of 2361; none turned nothing red.

Three findings are reported rather than tidied away, including a test that initially passed with the stop removed and had to be strengthened before it discriminated anything.

## Gate

- `git add -A && npm run precommit`: PASS, six steps
- `node scripts/red-first.js --base origin/main --tests "npm test"`: PROVEN
- Full suite: 2361 tests, 0 failing