### PR TITLE
Agent surfaces: the team sidebar, the agent profile, and how the guide is named

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -188,25 +188,6 @@ function formatTimeAgo(input) {
   return `${Math.floor(diff/86400)}d ago`;
 }
 
-function formatScheduleShort(schedule) {
-  if (!schedule) return '';
-  const s = schedule.toLowerCase();
-  const dailyMatch = s.match(/every day at (\d{2}):(\d{2})/);
-  if (dailyMatch) {
-    const h = parseInt(dailyMatch[1]);
-    const m = dailyMatch[2];
-    return `${h === 0 ? 12 : (h > 12 ? h - 12 : h)}:${m} ${h >= 12 ? 'PM' : 'AM'}`;
-  }
-  const weeklyMatch = s.match(/every (\w+) at (\d{2}):(\d{2})/);
-  if (weeklyMatch) {
-    const day = weeklyMatch[1].charAt(0).toUpperCase() + weeklyMatch[1].slice(1, 3);
-    const h = parseInt(weeklyMatch[2]);
-    const m = weeklyMatch[3];
-    return `${day} ${h === 0 ? 12 : (h > 12 ? h - 12 : h)}:${m} ${h >= 12 ? 'PM' : 'AM'}`;
-  }
-  return schedule;
-}
-
 function getTeamAgents() { return agents.filter(a => a.status === 'onTeam' && a.type !== 'platform'); }
 function getPlatformAgents() { return agents.filter(a => a.status === 'onTeam' && a.type === 'platform'); }
 function getGuide() { return agents.find(a => a.type === 'platform'); }
@@ -248,7 +229,7 @@ function handle(d) {
       if (currentView === 'settings') renderSettingsSection('workspace');
       break;
     case 'needs_workspace': showView('workspace'); break;
-    case 'agents': agents=d.agents; renderAgentList(); renderOrgChart(); renderRoutinesSidebar(); renderRoutines(); renderConvoList(); break;
+    case 'agents': agents=d.agents; renderAgentList(); renderOrgChart(); renderRoutines(); renderConvoList(); break;
     // renderRoutines as well as renderSkills: the routines empty state asks
     // whether the workspace has a skill, so the reply that answers that
     // question is the reply that has to redraw it. Without this the list sits
@@ -844,7 +825,7 @@ function addSystemMsgToConvo(text, convoId, isError = true) {
 // ===== 5. AGENT LIST & SIDEBAR =====
 // Moved to public/views/team.js (Foundations view module):
 // getWorkingAgentIds, renderAgentList, renderConvoEmptyAgents,
-// renderRoutinesSidebar, addToTeam. All resolve via the module's window
+// addToTeam. All resolve via the module's window
 // republication.
 
 // ===== 6. ORG CHART =====

--- a/public/app.js
+++ b/public/app.js
@@ -1019,7 +1019,7 @@ function switchNav(nav) {
   else if(nav==='skills') { showView('skills'); renderSkillsIfEmpty(); if(!skillsLoaded) { ws.send(JSON.stringify({type:'get_skills'})); } }
   else if(nav==='conversations') { if(activeConversation) { showView('chat'); if(unread.clearConvo(activeConversation.id)) { updateUnreadBadge(); renderConvoList(); } } else { const target = pickDefaultConversation(); if(target) { openConversation(target.id); } else { newConversation(); } } }
   else if(nav==='team') { showView('home'); renderOrgChart(); }
-  else if(nav==='routines') { showView('routines'); renderRoutines(); }
+  else if(nav==='routines') { showRoutinesForAgent(null); }
 }
 function showView(v) { currentView=v; ['workspace','home','profile','chat','convo-empty','editor','skills','settings','routine-editor','routines'].forEach(id=>{const e=document.getElementById(`view-${id}`);if(e){e.classList.add('hidden');e.style.display='none';e.classList.remove('main-view-transition');}}); const e=document.getElementById(`view-${v}`); if(e){e.classList.remove('hidden');e.style.display='flex';e.classList.add('main-view-transition');}  }
 function goHome() { discardIfEmpty(); activeConversation=null; switchNav('conversations'); }

--- a/public/guide-copy.js
+++ b/public/guide-copy.js
@@ -1,0 +1,77 @@
+'use strict';
+/**
+ * Every user-facing sentence that names the guide, in one object.
+ *
+ * WHY THESE ARE HERE AND NOT AT THE CALL SITES. `getGuide()` resolves the guide
+ * by `type === 'platform'` and has never resolved it by name. Four sentences a
+ * person reads named one anyway, so a workspace whose platform agent is called
+ * anything else was told to talk to somebody it does not have, with the button
+ * beside the sentence opening a conversation with a differently named agent.
+ * On the shipped default workspace the name happens to be right, which is
+ * exactly why four surfaces carried it for as long as they did.
+ *
+ * THE NAME IS A SLOT AND THE SLOT IS SUBSTITUTED, NEVER CONCATENATED, which is
+ * the rule `STEP_LEADS.pick` in routine-editor-model.js already states and the
+ * reason it gives: every word a surface ships stays readable in one object, so
+ * a copy check can read all of it. A view that built a sentence around a name
+ * would put half the copy at the call site, where nobody reviewing copy looks.
+ *
+ * AND NO SENTENCE CARRIES A PRONOUN FOR THE AGENT IT NAMES. The name is the
+ * only thing this code knows about a guide, so "he" is a guess and "they" is a
+ * different guess.
+ */
+(/** @param {any} root @param {() => object} factory */ function (root, factory) {
+  if (typeof module === 'object' && module.exports) module.exports = factory();
+  else root.RundockGuideCopy = factory();
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  const GUIDE_COPY = {
+    // The team sidebar, on a workspace with no team on it.
+    sidebar: 'No team agents yet. {agent} can explore this workspace and create a team for you.',
+    // The conversations pane, in the same state, where the question is who to
+    // talk to rather than who is on the team.
+    conversations: '{agent} can explore this workspace and set up your agent team.',
+    // The org chart on a workspace with nothing in it yet.
+    fresh: 'Fresh workspace. {agent} can help you set up your agent team from scratch.',
+    // The button on an agent that has never been set up. A label rather than a
+    // sentence, and a slot for the same reason.
+    setup: 'Setup with {agent}',
+
+    // THE TWO SURFACES THAT DRAW WITHOUT A GUIDE, and only those two.
+    //
+    // The sidebar and the conversations pane render their sentence only where
+    // a platform agent exists, so with none there is nothing to say and they
+    // say nothing. The other two draw regardless: the org chart's fresh state
+    // and the Setup button are on the page whether or not anything can answer
+    // them, so each needs a line that names no agent. Both keep their state
+    // and lose only the part that named somebody, which is the rule the empty
+    // states settled: dropping the agent drops the agent, not the next step.
+    freshNoGuide: 'Fresh workspace. Add an agent to this workspace to get started.',
+    setupNoGuide: 'Set up this agent',
+  };
+
+  /**
+   * One line, named through the slot or not naming anybody.
+   *
+   * A GUIDE WITH NO NAME IS NOT A GUIDE A SENTENCE CAN NAME. The roster always
+   * resolves a display name, falling back to the agent's id, so an empty name
+   * is a guard rather than a state anybody should meet. It resolves the way an
+   * absent guide does, because a sentence with an empty slot in it is worse
+   * than the agent-independent one.
+   *
+   * Returns null where there is no guide and no line for that case, which is
+   * the honest answer for a surface that draws nothing without one.
+   *
+   * @param {string} key
+   * @param {string|null} [guideName]
+   * @returns {string|null}
+   */
+  function guideLine(key, guideName) {
+    const name = guideName || null;
+    if (!name) return GUIDE_COPY[`${key}NoGuide`] || null;
+    const line = GUIDE_COPY[key];
+    return line ? line.replace('{agent}', name) : null;
+  }
+
+  return { GUIDE_COPY, guideLine };
+}));

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,7 @@
 <script src="/routine-editor-model.js"></script>
 <script src="/skills-model.js"></script>
 <script src="/routines-model.js"></script>
+<script src="/guide-copy.js"></script>
 <!-- Tokens first: everything below resolves var(--x) against this file. -->
 <link rel="stylesheet" href="/styles/tokens.css">
 <link rel="stylesheet" href="/styles/fonts.css">

--- a/public/index.html
+++ b/public/index.html
@@ -123,7 +123,6 @@
     <div id="sidebar-team" class="hidden">
       <div class="sidebar-header" id="sidebar-team-header"><span class="sidebar-label">Your Team</span></div>
       <div class="agent-status-list" id="agent-list"></div>
-      <div id="sidebar-routines"></div>
     </div>
     <div id="sidebar-conversations">
       <div class="sidebar-header"><span class="sidebar-label">Conversations</span></div>

--- a/public/styles/components/sidebar.css
+++ b/public/styles/components/sidebar.css
@@ -184,12 +184,6 @@
 .add-btn:hover { color: var(--accent); background: var(--accent-glow); border-color: rgba(232,122,90,0.3); }
 
 
-/* Routine sidebar items */
-.routine-item { display: flex; align-items: center; gap: 8px; padding: 8px; font-size: var(--caption); border-radius: var(--radius-lg); transition: background var(--duration-base) ease; cursor: default; }
-.routine-item:hover { background: var(--elevated); }
-.routine-name { flex: 1; color: var(--text-1); font-weight: 500; font-size: var(--body); }
-.avatar.xxs { width: 20px; height: 20px; font-size: 9px; }
-
 /* Sidebar section dividers */
 .sidebar-section-divider { border-top: 1px solid var(--border); margin: 8px 8px 0; padding: 12px 0 6px; }
 .sidebar-empty-state { padding: 16px 12px; }

--- a/public/views/profile.js
+++ b/public/views/profile.js
@@ -12,8 +12,9 @@
 // showView. The generated onclick strings (startConversation, addToTeam,
 // openConversation, selectSkill) resolve on window at click time. Load
 // order (views before app.js) is safe because nothing here touches shared
-// state until the app boots. Function bodies are byte-identical to the
-// app.js originals at column 0.
+// state until the app boots. The Routines box reaches RundockRoutinesModel
+// for a schedule's words and showRoutinesForAgent for a row's destination,
+// both off the global at call time, in the same way.
 (/** @param {any} root @param {() => object} factory */ function (root, factory) {
   if (typeof module === 'object' && module.exports) module.exports = factory();
   else {
@@ -73,42 +74,68 @@ function showProfile(agentId) {
     }
     h+=`</div></div>`;
   }
-  // Routines + Configuration card. Always rendered: the Runtime row appears
-  // for every agent, so the card always has content.
+  // Routines box. ALWAYS RENDERED, in both of its states. A box that vanished
+  // once you had used it would take the concept with it, and an agent's own
+  // schedules are what a reader came to this page to see.
+  //
+  // A ROW IS A NAME AND A SCHEDULE, AND THAT DELETES A DEFECT RATHER THAN
+  // FIXING ONE. This surface used to interpolate the run record's status word
+  // straight into the markup and print things like "Last run: 4h ago
+  // (interrupted)". The three-tone ruling decides what an outcome is called
+  // and what tone it gets, it took three rounds to settle, and it never
+  // reached here, so the one place a person met a routine while looking at an
+  // agent was the one place the vocabulary was raw. What happened last time is
+  // not restated here in better words: it is not on this page. It belongs to
+  // the routines view, where routines-model.js already owns both, and a row
+  // here goes there.
   const hasRoutines = a.routines && a.routines.length;
   const hasConnectors = a.capabilities?.connectors;
   {
-    h+=`<div class="profile-card">`;
+    // The routines model, reached the way every other module reaches a
+    // sibling: off the global at call time, with no dependency added to this
+    // view's wrapper for one string.
+    const routinesModel = typeof RundockRoutinesModel !== 'undefined' ? RundockRoutinesModel : null;
+    h+=`<div class="profile-card"><div class="profile-card-section"><div class="profile-section-label">Routines</div>`;
     if(hasRoutines) {
-      h+=`<div class="profile-card-section"><div class="profile-section-label">Routines</div>`;
       for(const r of a.routines) {
-        const stateText = r.state ? (r.state.status === 'running' ? '<span style="color:var(--working)">Running now</span>' : `Last run: ${formatTimeAgo(r.state.lastRun)} (${r.state.status})`) : '<span style="color:var(--text-2)">Not yet run</span>';
-        h+=`<div class="profile-card-item" style="display:flex;flex-direction:column;gap:3px">
+        // The schedule in the words the routines view uses, so the two places
+        // an agent's schedule is written cannot read differently. A schedule
+        // the editor never offered has no plain words, and the stored string
+        // is shown rather than nothing.
+        const when = (routinesModel && routinesModel.scheduleWords(r.schedule)) || r.schedule;
+        h+=`<div class="profile-card-item" style="display:flex;flex-direction:column;gap:3px;cursor:pointer" onclick="showRoutinesForAgent('${esc(a.id)}')">
           <span style="font-weight:600">${esc(r.name)}</span>
-          <span style="font-size:var(--caption);color:var(--text-2)">${esc(r.schedule)}</span>
-          <span style="font-size:var(--caption)">${stateText}</span>
+          <span style="font-size:var(--caption);color:var(--text-2)">${esc(when)}</span>
         </div>`;
       }
-      h+=`</div>`;
-    }
-    // Scheduling often starts from the agent: you are already looking at it
-    // and think of the schedule second. The editor opens scoped to this
-    // agent, so the picker offers only the skills it has.
-    h+=`<div class="profile-card-section"><div class="profile-section-label">Add a routine</div>
-      <div class="profile-card-text" style="padding-bottom:10px">Give one of ${esc(a.displayName)}'s skills a schedule.</div>
+    } else {
+      // FEATURE DISCOVERY, AND ONLY THAT. The offer exists to teach that
+      // routines are a thing, in the one place where an agent with no schedule
+      // is being looked at. Once this agent has one it goes, and the next is
+      // added from the routines view's own header control, which inherits the
+      // scope it is pressed in.
+      h+=`<div class="profile-card-text" style="padding-bottom:10px">Give one of ${esc(a.displayName)}'s skills a schedule and it runs without being asked.</div>
       <button class="settings-btn-primary" type="button" data-profile-action="add-routine"
-        data-agent-id="${esc(a.id)}" onclick="addRoutineForAgent('${esc(a.id)}')">Add routine</button>
-    </div>`;
-    if(hasConnectors) {
-      h+=`<div class="profile-card-section"><div class="profile-section-label">Connectors</div>${a.capabilities.connectors.split(',').map(cn=>`<div class="profile-card-item" style="display:flex;align-items:center;justify-content:space-between">${cn.trim()}<span style="color:var(--success);font-size:var(--caption)">Connected</span></div>`).join('')}</div>`;
+        data-agent-id="${esc(a.id)}" onclick="addRoutineForAgent('${esc(a.id)}')">Add routine</button>`;
     }
+    h+=`</div></div>`;
+  }
+  // Configuration box. Model and runtime by the direction; connectors sits
+  // with them because it is configuration by the same reading, and moves only
+  // if the owner says otherwise.
+  {
+    const row = (label, value) => `<div class="profile-card-item" style="display:flex;align-items:center;justify-content:space-between">${label}${value}</div>`;
     const modelLabels = {opus:'Opus (most capable)',sonnet:'Sonnet (fast, efficient)',haiku:'Haiku (lightweight)'};
-    if(a.model) h+=`<div class="profile-card-section"><div class="profile-section-label">Model</div><div class="profile-card-item">${modelLabels[a.model]||a.model}</div></div>`;
+    h+=`<div class="profile-card"><div class="profile-card-section"><div class="profile-section-label">Configuration</div>`;
+    if(hasConnectors) {
+      h+=a.capabilities.connectors.split(',').map(cn=>row(esc(cn.trim()), '<span style="color:var(--success);font-size:var(--caption)">Connected</span>')).join('');
+    }
+    if(a.model) h+=row('Model', `<span style="color:var(--text-2)">${modelLabels[a.model]||a.model}</span>`);
     // Runtime is stated for every agent, not just Codex ones, so it reads as
     // a fact about the agent rather than a special mark.
-    h+=`<div class="profile-card-section"><div class="profile-section-label">Runtime</div><div class="profile-card-item">${a.runtime === 'codex' ? 'Codex' : 'Claude Code'}</div></div>`;
-    if(a.runtime === 'codex') h+=`<div class="profile-card-section"><div class="profile-section-label">Permissions</div><div class="profile-card-text">${esc(a.displayName)} runs on Codex and uses Codex's built-in sandbox. Claude agents use Rundock's permission prompts.</div></div>`;
-    h+=`</div>`;
+    h+=row('Runtime', `<span style="color:var(--text-2)">${a.runtime === 'codex' ? 'Codex' : 'Claude Code'}</span>`);
+    if(a.runtime === 'codex') h+=`<div class="profile-card-text" style="padding-top:8px">${esc(a.displayName)} runs on Codex and uses Codex's built-in sandbox. Claude agents use Rundock's permission prompts.</div>`;
+    h+=`</div></div>`;
   }
   // Instructions card (collapsible)
   if(a.instructions) h+=`<div class="profile-card" style="cursor:pointer" onclick="document.getElementById('agent-instructions').classList.toggle('hidden')">

--- a/public/views/profile.js
+++ b/public/views/profile.js
@@ -14,7 +14,8 @@
 // order (views before app.js) is safe because nothing here touches shared
 // state until the app boots. The Routines box reaches RundockRoutinesModel
 // for a schedule's words and showRoutinesForAgent for a row's destination,
-// both off the global at call time, in the same way.
+// and the Setup button reaches RundockGuideCopy for its label, all off the
+// global at call time, in the same way.
 (/** @param {any} root @param {() => object} factory */ function (root, factory) {
   if (typeof module === 'object' && module.exports) module.exports = factory();
   else {
@@ -44,7 +45,12 @@ function showProfile(agentId) {
     </div>`;
   if(a.description) h+=`<p class="profile-desc" style="margin-bottom:24px">${esc(a.description)}</p>`;
   if(a.status === 'raw') {
-    h+=`<div class="profile-cta"><button class="profile-cta-btn" onclick="startConversation(getGuide()?.id || 'default')">Setup with Doc</button></div>`;
+    // The label names the guide the button opens, so the two cannot disagree:
+    // it used to name one agent and open a conversation with whichever agent
+    // the workspace's platform slot actually held.
+    const guideCopy = typeof RundockGuideCopy !== 'undefined' ? RundockGuideCopy : null;
+    const setupLabel = (guideCopy && guideCopy.guideLine('setup', getGuide()?.displayName)) || '';
+    h+=`<div class="profile-cta"><button class="profile-cta-btn" onclick="startConversation(getGuide()?.id || 'default')">${esc(setupLabel)}</button></div>`;
   } else if(a.status === 'available') {
     h+=`<div class="profile-cta"><button class="profile-cta-btn" onclick="addToTeam('${a.id}')">Add to team</button></div>`;
   } else {

--- a/public/views/routine-editor.js
+++ b/public/views/routine-editor.js
@@ -366,15 +366,25 @@
    * remembered.
    *
    * A destination is usable only if the shell has BOTH halves of it: a rail
-   * button carrying the name, and the sidebar panel the router reveals by that
+   * button carrying the name, and the view panel the router shows by that
    * name. Checking the pair is what makes this a resolution rather than a
-   * guess, and it is why this returns the section that lists routines today
-   * and the routines surface itself the day that one is built, with nothing
-   * here edited.
+   * guess.
+   *
+   * THE SECOND HALF USED TO BE `sidebar-${nav}` AND THAT WAS AN ACCIDENT
+   * PASSING AS A CHECK. The routines section has no sidebar panel of its own:
+   * it reveals the team one, through the router's own map. It resolved anyway
+   * because an empty element under that exact name happened to exist, nested
+   * inside the team panel, holding the listing the team sidebar used to carry.
+   * Revealing that element by name succeeded and left the reader looking at a
+   * hidden parent, which the routines doors file already records as a trap.
+   * With the listing gone the element goes with it, and this asks for the
+   * thing the router actually shows: the view panel. A rename of either half
+   * still lands a save on the team chart, so the check is unchanged in what it
+   * catches and no longer depends on a sentinel nobody meant to leave.
    */
   function navigable(nav) {
     if (typeof document === 'undefined') return false;
-    return !!(document.querySelector(`[data-nav="${nav}"]`) && document.getElementById(`sidebar-${nav}`));
+    return !!(document.querySelector(`[data-nav="${nav}"]`) && document.getElementById(`view-${nav}`));
   }
 
   function routinesListNav() {

--- a/public/views/routines.js
+++ b/public/views/routines.js
@@ -296,7 +296,18 @@ function listHtml(list) {
  * for, which is the empty state below.
  */
 function renderRoutines() {
-  const list = allRoutines();
+  let list = allRoutines();
+  // A FILTER WITH NOTHING LEFT TO SHOW IS DROPPED RATHER THAN DRAWN EMPTY.
+  // The empty state speaks for the whole team: it says nothing is scheduled and
+  // offers a picker spanning every agent's skills. Under a scope that is a lie,
+  // because the emptiness is the filter's doing and other agents still have
+  // routines, and nothing on this page names the scope, so a reader has no way
+  // to tell. Deleting an agent's last routine from a scoped list is the way in.
+  // The scope goes and the whole list is shown, which is true.
+  if (scopeAgentId && list.length === 0) {
+    scopeAgentId = null;
+    list = allRoutines();
+  }
   const content = document.getElementById('routines-content');
   if (!content) return;
   if (pendingDelete !== null && !list[pendingDelete]) pendingDelete = null;
@@ -321,6 +332,19 @@ function renderRoutines() {
  * @param {string|null} agentId
  */
 function showRoutinesForAgent(agentId) {
+  // ARRIVING CLEARS THE PENDING CONFIRMATION, AND THAT IS NOT TIDINESS.
+  // `pendingDelete` is a POSITION in the list, and the scope decides what the
+  // list contains, so a confirmation opened under one scope addresses a
+  // different routine under the next. The guard in the render only drops the
+  // index when it falls off the end, so whenever the new list is long enough
+  // the reader is shown a confirmation they never asked for, naming one
+  // routine, and confirming it deletes that one. A destructive action must not
+  // be re-aimed by navigating.
+  //
+  // The refusal goes with it, for the reason it is held at all: it answers a
+  // control pressed on a list the reader has now left.
+  pendingDelete = null;
+  pendingProblem = null;
   scopeAgentId = agentId || null;
   if (typeof setNavState === 'function') setNavState('routines');
   if (typeof showView === 'function') showView('routines');

--- a/public/views/routines.js
+++ b/public/views/routines.js
@@ -47,6 +47,15 @@ let pendingDelete = null;
 // the surface the question was asked on.
 let pendingProblem = null;
 
+// Which agent the list is scoped to, or null for the whole team.
+//
+// IT BELONGS TO THE WAY IN RATHER THAN TO THE VIEW. A row in an agent's
+// profile asks for that agent's routines; the rail asks for everybody's. Both
+// arrive through the one destination function below, which is what makes the
+// scope impossible to leave behind: a route that does not name an agent clears
+// it, because it passes null rather than because somebody remembered to.
+let scopeAgentId = null;
+
 // The clock, taken from the global so a test can supply one. Undeclared
 // identifiers are safe under typeof, so this works when the module is
 // required in node with no global at all.
@@ -85,6 +94,7 @@ function allRoutines() {
   const out = [];
   const roster = typeof agents !== 'undefined' && agents ? agents : [];
   for (const agent of roster) {
+    if (scopeAgentId && agent.id !== scopeAgentId) continue;
     if (!agent.routines) continue;
     const seen = {};
     for (const routine of agent.routines) {
@@ -296,6 +306,28 @@ function renderRoutines() {
 }
 
 /**
+ * Land the reader on this list, scoped to one agent or to the whole team.
+ *
+ * THE ONE DESTINATION, USED BY BOTH ROUTES. The rail's own arm calls this with
+ * no agent and a routine row on an agent's profile calls it with that agent,
+ * so there is one place that decides what arriving here means and one place
+ * that can get the rail wrong. A second copy of these three calls is exactly
+ * how `openRoutineEditor` ended up lighting Team on a routines surface.
+ *
+ * It sets the nav state itself, for the same reason `showProfile` does: every
+ * function that lands the user on a section says which section, or the rail
+ * lies about where the user is on every route whose author did not remember.
+ *
+ * @param {string|null} agentId
+ */
+function showRoutinesForAgent(agentId) {
+  scopeAgentId = agentId || null;
+  if (typeof setNavState === 'function') setNavState('routines');
+  if (typeof showView === 'function') showView('routines');
+  renderRoutines();
+}
+
+/**
  * The server refused the last pause or delete.
  *
  * Rendered where the control was pressed. The words are the server's whenever
@@ -352,7 +384,8 @@ function routinesSetPaused(index, paused) {
 }
 
 return {
-  renderRoutines, routinesAskDelete, routinesCancelDelete, routinesConfirmDelete, routinesSetPaused,
+  renderRoutines, showRoutinesForAgent,
+  routinesAskDelete, routinesCancelDelete, routinesConfirmDelete, routinesSetPaused,
   routinesActionFailed, routinesActionCleared,
 };
 }));

--- a/public/views/team.js
+++ b/public/views/team.js
@@ -17,7 +17,9 @@
 // wiring). ORG_PRESETS moved here as view-local state: no external
 // touchpoints. d3 is the CDN-loaded d3-hierarchy global, resolved on window
 // at call time. Helpers reached the same way: getTeamAgents,
-// getPlatformAgents, formatTimeAgo, esc, getGuide.
+// getPlatformAgents, formatTimeAgo, esc, getGuide. Every sentence that names
+// the guide comes from RundockGuideCopy, reached the same way, so no view
+// carries a guide's name and no copy check has to read four files.
 // Load order (views before app.js) is safe because nothing here touches
 // shared state until the app boots. Function bodies are byte-identical to
 // the app.js originals at column 0.
@@ -28,6 +30,13 @@
     Object.assign(root, root.RundockTeamView);
   }
 }(typeof self !== 'undefined' ? self : this, function () {
+
+// The guide copy, reached off the global at call time, the same way this file
+// reaches every other helper it does not own.
+function guideLine(key, guideName) {
+  const copy = typeof RundockGuideCopy !== 'undefined' ? RundockGuideCopy : null;
+  return (copy && copy.guideLine(key, guideName)) || '';
+}
 
 function getWorkingAgentIds() {
   const working = new Set();
@@ -62,7 +71,7 @@ function renderAgentList() {
   } else if (platform.length) {
     const guide = platform[0];
     h += `<div class="sidebar-empty-state">
-      <div class="sidebar-empty-text">No team agents yet. Doc can explore this workspace and create a team for you.</div>
+      <div class="sidebar-empty-text">${esc(guideLine('sidebar', guide.displayName))}</div>
       <button class="empty-cta" style="width:100%" onclick="startSetupConversation()">Set up your team</button>
     </div>`;
   }
@@ -141,7 +150,7 @@ function renderConvoEmptyAgents() {
     const guide = platformAgents[0];
     contentEl.className = '';
     contentEl.innerHTML = guide
-      ? `<div class="sidebar-empty-text" style="text-align:center;max-width:280px;margin:0 auto 8px">Doc can explore this workspace and set up your agent team.</div><button class="empty-cta" style="margin-top:4px" onclick="startSetupConversation()">Set up your team</button>`
+      ? `<div class="sidebar-empty-text" style="text-align:center;max-width:280px;margin:0 auto 8px">${esc(guideLine('conversations', guide.displayName))}</div><button class="empty-cta" style="margin-top:4px" onclick="startSetupConversation()">Set up your team</button>`
       : '';
   }
 }
@@ -364,7 +373,10 @@ function renderOrgChart() {
     } else {
       h += '<div class="org-empty-state">';
       h += '<div class="empty-title">Welcome to Rundock</div>';
-      h += '<div class="sidebar-empty-text" style="text-align:center;max-width:320px">Fresh workspace. Doc can help you set up your agent team from scratch.</div>';
+      // The one sentence of the four that draws whether or not a guide exists,
+      // so it is the one that needs a line for a workspace with none. It kept
+      // promising a guide either way, which is the defect in its loudest form.
+      h += `<div class="sidebar-empty-text" style="text-align:center;max-width:320px">${esc(guideLine('fresh', guide && guide.displayName))}</div>`;
       if (guide) {
         h += `<button class="empty-cta" style="margin-top:4px" onclick="startSetupConversation()">Set up your team</button>`;
       }

--- a/public/views/team.js
+++ b/public/views/team.js
@@ -4,7 +4,7 @@
 // markers.js (node-requireable, window-attached); additionally republishes
 // each view function on the root object, because classic-script function
 // declarations were window properties and the callers rely on that: the WS
-// dispatch (renderAgentList, renderOrgChart, renderRoutinesSidebar), routing
+// dispatch (renderAgentList, renderOrgChart), routing
 // (renderOrgChart on the team nav), message handling (getWorkingAgentIds),
 // and the generated onclick handlers (showProfile, addToTeam, orgZoom,
 // startConversation, startSetupConversation).
@@ -17,7 +17,7 @@
 // wiring). ORG_PRESETS moved here as view-local state: no external
 // touchpoints. d3 is the CDN-loaded d3-hierarchy global, resolved on window
 // at call time. Helpers reached the same way: getTeamAgents,
-// getPlatformAgents, formatTimeAgo, formatScheduleShort, esc, getGuide.
+// getPlatformAgents, formatTimeAgo, esc, getGuide.
 // Load order (views before app.js) is safe because nothing here touches
 // shared state until the app boots. Function bodies are byte-identical to
 // the app.js originals at column 0.
@@ -144,41 +144,6 @@ function renderConvoEmptyAgents() {
       ? `<div class="sidebar-empty-text" style="text-align:center;max-width:280px;margin:0 auto 8px">Doc can explore this workspace and set up your agent team.</div><button class="empty-cta" style="margin-top:4px" onclick="startSetupConversation()">Set up your team</button>`
       : '';
   }
-}
-
-function renderRoutinesSidebar() {
-  const container = document.getElementById('sidebar-routines');
-  if (!container) return;
-  const allRoutines = [];
-  for (const a of agents) {
-    if (a.routines) {
-      for (const r of a.routines) {
-        allRoutines.push({ ...r, agentName: a.displayName, agentColour: a.colour, agentIcon: a.icon });
-      }
-    }
-  }
-  if (allRoutines.length === 0) { container.innerHTML = ''; return; }
-
-  // The agent-agnostic way in: no agent chosen yet, so the picker spans every
-  // agent's skills and each row names which agent runs it.
-  let h = '<div class="sidebar-section-divider" style="margin:12px 16px 0;padding-top:16px">'
-    + '<span class="sidebar-label">Routines</span>'
-    + '<button class="re-link" type="button" style="float:right"'
-    + ' data-sidebar-action="add-routine" onclick="addRoutine()">Add</button>'
-    + '</div>';
-  h += '<div style="padding:8px 8px 16px">';
-  for (const r of allRoutines) {
-    const statusText = r.state?.status === 'running'
-      ? '<span style="color:var(--working)">Running...</span>'
-      : `<span style="color:var(--text-2)">${formatScheduleShort(r.schedule)}</span>`;
-    h += `<div class="routine-item">
-      <div class="avatar xxs" style="background:${r.agentColour}">${r.agentIcon}</div>
-      <span class="routine-name">${esc(r.name)}</span>
-      ${statusText}
-    </div>`;
-  }
-  h += '</div>';
-  container.innerHTML = h;
 }
 
 function addToTeam(agentId) {
@@ -442,5 +407,5 @@ function orgZoom(dir) {
   renderOrgChart();
 }
 
-return { getWorkingAgentIds, renderAgentList, renderConvoEmptyAgents, renderRoutinesSidebar, addToTeam, orgCardHtml, renderOrgChart, orgZoom };
+return { getWorkingAgentIds, renderAgentList, renderConvoEmptyAgents, addToTeam, orgCardHtml, renderOrgChart, orgZoom };
 }));

--- a/test/tools/mutate-routine-editor-guards.js
+++ b/test/tools/mutate-routine-editor-guards.js
@@ -228,8 +228,8 @@ const MUTATIONS = [
   // directly, which says nothing about whether anything calls it.
   [PROFILE, 'an agent profile offers a way to schedule its skills',
     '      <button class="settings-btn-primary" type="button" data-profile-action="add-routine"\n'
-    + '        data-agent-id="${esc(a.id)}" onclick="addRoutineForAgent(\'${esc(a.id)}\')">Add routine</button>\n',
-    ''],
+    + '        data-agent-id="${esc(a.id)}" onclick="addRoutineForAgent(\'${esc(a.id)}\')">Add routine</button>`;',
+    '`;'],
   [PROFILE, 'the way in carries the agent whose profile it is on',
     'onclick="addRoutineForAgent(\'${esc(a.id)}\')"',
     'onclick="addRoutineForAgent(\'\')"'],

--- a/test/tools/mutate-routine-editor-guards.js
+++ b/test/tools/mutate-routine-editor-guards.js
@@ -58,9 +58,6 @@ const APP = { src: path.join(ROOT, 'public', 'app.js'), suite: 'test/unit/routin
 const HANDLER = { src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'), suite: 'test/unit/routine-write.test.js' };
 // The agent profile, which renders the only way into the scoped editor.
 const PROFILE = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/routine-editor-view.test.js' };
-// The team sidebar, which renders the way into the unscoped editor. Watched by
-// the doors suite, which enumerates every way in and presses each one.
-const SIDEBAR = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/routine-editor-doors.test.js' };
 // The data model's write path, where a routine becomes bytes in a file.
 const ROUTINES = { src: path.join(ROOT, 'lib', 'agents', 'routines.js'), suite: 'test/unit/routine-write.test.js' };
 // The same file, watched by the suite that owns the timezone a schedule was
@@ -176,8 +173,8 @@ const MUTATIONS = [
   [VIEW, 'a save in flight is not sent twice',
     '    if (!state || state.saving) return;',
     '    if (!state) return;'],
-  [VIEW, 'the destination is checked for a sidebar panel, not just a rail entry',
-    '    return !!(document.querySelector(`[data-nav="${nav}"]`) && document.getElementById(`sidebar-${nav}`));',
+  [VIEW, 'the destination is checked for a view panel, not just a rail entry',
+    '    return !!(document.querySelector(`[data-nav="${nav}"]`) && document.getElementById(`view-${nav}`));',
     '    return !!document.querySelector(`[data-nav="${nav}"]`);'],
   [VIEW, 'an unreachable destination falls back to one the shell has',
     "    return navigable(destination) ? destination : 'team';",
@@ -236,11 +233,6 @@ const MUTATIONS = [
   [PROFILE, 'the way in carries the agent whose profile it is on',
     'onclick="addRoutineForAgent(\'${esc(a.id)}\')"',
     'onclick="addRoutineForAgent(\'\')"'],
-
-  // The other door, and the one four rounds of review reached last.
-  [SIDEBAR, 'the sidebar offers a way in that belongs to no agent',
-    "    + ' data-sidebar-action=\"add-routine\" onclick=\"addRoutine()\">Add</button>'\n",
-    "    + '>Add</button>'\n"],
 
   // Writing a second routines key produces invalid YAML in somebody's file.
   // Two guards stand between it and them, and each is broken on its own here.
@@ -333,7 +325,7 @@ function run() {
   // Both files are read up front and both are restored in the same finally, so
   // a throw part way through cannot leave either one mutated.
   const originals = new Map();
-  for (const target of [MODEL, VIEW, APP, HANDLER, PROFILE, SIDEBAR, ROUTINES, ROUTINES_TZ]) originals.set(target, fs.readFileSync(target.src, 'utf8'));
+  for (const target of [MODEL, VIEW, APP, HANDLER, PROFILE, ROUTINES, ROUTINES_TZ]) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];
   try {
     for (const [target, label, guard, without] of MUTATIONS) {

--- a/test/tools/mutate-routines-guards.js
+++ b/test/tools/mutate-routines-guards.js
@@ -102,6 +102,15 @@ const APP_OPENER = { src: path.join(ROOT, 'public', 'app.js'), suite: 'test/unit
 // guard away: an absence nobody can break is an absence nobody is checking.
 const TEAM_PANEL = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/team-sidebar.test.js' };
 const INDEX_SWEEP = { src: path.join(ROOT, 'public', 'index.html'), suite: 'test/unit/team-sidebar.test.js' };
+// The sentences that name the guide, and the two views that show them. They
+// sit beside the skills empty-state guards above rather than in an instrument
+// of their own, because they are the same class of rule and fail the same way:
+// copy that names an agent through a slot, on surfaces whose default workspace
+// happens to make a hard-coded name correct, which is precisely the fault a
+// green suite cannot see.
+const GUIDE_COPY_MOD = { src: path.join(ROOT, 'public', 'guide-copy.js'), suite: 'test/unit/guide-name.test.js' };
+const TEAM_COPY = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/guide-name.test.js' };
+const PROFILE_COPY = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/guide-name.test.js' };
 // The agent profile's three boxes. Two targets on one file, because a guard is
 // only proved by the suite that presses it: what the box SAYS is pressed by the
 // profile's own file, and where a row GOES is pressed by the routes
@@ -231,6 +240,31 @@ const MUTATIONS = [
   [MODEL, 'the server\'s own words are the ones shown',
     "    const message = input && typeof input.message === 'string' ? input.message.trim() : '';\n    return message || ACTION_PROBLEM;",
     '    return ACTION_PROBLEM;'],
+
+  // ===== THE SENTENCES THAT NAME THE GUIDE =====
+  //
+  // Each of the four view mutations writes the DEFAULT NAME back in, which is
+  // the defect in its exact form: it type-checks, it reads correctly, and on
+  // the shipped workspace it is even true. Only a workspace whose guide is
+  // called something else can tell, which is why the suite these point at
+  // builds one.
+  [GUIDE_COPY_MOD, 'the slot is substituted rather than left in the sentence',
+    "    return line ? line.replace('{agent}', name) : null;",
+    '    return line || null;'],
+  [GUIDE_COPY_MOD, 'a workspace with no guide gets the line that names none',
+    '    if (!name) return GUIDE_COPY[`${key}NoGuide`] || null;',
+    '    if (!name) return GUIDE_COPY[key] || null;'],
+  [GUIDE_COPY_MOD, 'no sentence carries a pronoun for the agent it names',
+    "    fresh: 'Fresh workspace. {agent} can help you set up your agent team from scratch.',",
+    "    fresh: 'Fresh workspace. {agent} can set up your agent team, and he starts from scratch.',"],
+  [TEAM_COPY, 'the sidebar names the guide the workspace actually has',
+    "guideLine('sidebar', guide.displayName)", "guideLine('sidebar', 'Doc')"],
+  [TEAM_COPY, 'the conversations pane names the guide the workspace actually has',
+    "guideLine('conversations', guide.displayName)", "guideLine('conversations', 'Doc')"],
+  [TEAM_COPY, 'the fresh-workspace state names the guide the workspace actually has',
+    "guideLine('fresh', guide && guide.displayName)", "guideLine('fresh', 'Doc')"],
+  [PROFILE_COPY, 'the Setup button names the guide it opens a conversation with',
+    "guideCopy.guideLine('setup', getGuide()?.displayName)", "guideCopy.guideLine('setup', 'Doc')"],
 
   // ===== THE AGENT PROFILE'S ROUTINES BOX =====
   //
@@ -607,7 +641,8 @@ function redTests(suite) {
 function run() {
   const targets = [MODEL, VIEW, VIEW_E2E, VIEW_REPLY, VIEW_RAIL, STYLES, SCHEDULER, END_TO_END,
     DISCOVERY, HANDLER, ROUTINES, APP, APP_SKILLS, APP_OPENER, INDEX, INDEX_RAIL, SKILLS_MODEL, SKILLS_VIEW,
-    SKILLS_VIEW_RAIL, TEAM_PANEL, INDEX_SWEEP, PROFILE_BOXES, PROFILE_ROUTE, VIEW_SCOPE];
+    SKILLS_VIEW_RAIL, TEAM_PANEL, INDEX_SWEEP, PROFILE_BOXES, PROFILE_ROUTE, VIEW_SCOPE,
+    GUIDE_COPY_MOD, TEAM_COPY, PROFILE_COPY];
   const originals = new Map();
   for (const target of targets) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];

--- a/test/tools/mutate-routines-guards.js
+++ b/test/tools/mutate-routines-guards.js
@@ -300,6 +300,16 @@ const MUTATIONS = [
   [VIEW_SCOPE, 'a route that names no agent clears the scope rather than keeping the last one',
     '  scopeAgentId = agentId || null;',
     '  if (agentId) scopeAgentId = agentId;'],
+  // A DESTRUCTIVE ACTION ADDRESSED BY POSITION, IN A LIST THE SCOPE REMAPS.
+  // Removing this line leaves a confirmation the reader never opened on the
+  // page, aimed at whichever routine now sits at that index, and confirming it
+  // deletes that one.
+  [VIEW_SCOPE, 'arriving on the list clears a confirmation opened under another scope',
+    '  pendingDelete = null;\n  pendingProblem = null;\n  scopeAgentId = agentId || null;',
+    '  scopeAgentId = agentId || null;'],
+  [VIEW_SCOPE, 'a filter with nothing left to show is dropped rather than drawn empty',
+    '  if (scopeAgentId && list.length === 0) {\n    scopeAgentId = null;\n    list = allRoutines();\n  }\n',
+    ''],
 
   // ===== WHAT THE TEAM PANEL NO LONGER CARRIES =====
   //
@@ -575,8 +585,8 @@ const MUTATIONS = [
     '<button class="nav-item" data-nav="routines" onclick="switchNav(\'routines\')" data-tooltip="Routines"'
     + ' style="display:none">'],
   [VIEW_RAIL, 'the routines render leaves the rail alone',
-    '  const list = allRoutines();\n',
-    '  const list = allRoutines();\n'
+    '  let list = allRoutines();\n',
+    '  let list = allRoutines();\n'
     + '  document.querySelector(\'.nav-item[data-nav="routines"]\').style.display = list.length ? \'\' : \'none\';\n'],
   [SKILLS_VIEW_RAIL, 'the skills render leaves the rail alone',
     '  renderSkillsSidebar(skills);\n',

--- a/test/tools/mutate-routines-guards.js
+++ b/test/tools/mutate-routines-guards.js
@@ -96,6 +96,12 @@ const APP_SKILLS = { src: path.join(ROOT, 'public', 'app.js'), suite: 'test/unit
 // The two openers, watched by the file that presses them rather than by the
 // file that calls what they draw.
 const APP_OPENER = { src: path.join(ROOT, 'public', 'app.js'), suite: 'test/unit/routines-view.test.js' };
+// The team panel, watched by the file that presses it. The rule this card
+// leaves behind is "the panel carries the roster and nothing else", which is a
+// rule about absence, so these mutations PUT SOMETHING BACK rather than take a
+// guard away: an absence nobody can break is an absence nobody is checking.
+const TEAM_PANEL = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/team-sidebar.test.js' };
+const INDEX_SWEEP = { src: path.join(ROOT, 'public', 'index.html'), suite: 'test/unit/team-sidebar.test.js' };
 // The handlers behind the row's two controls, and the data model they write
 // through.
 const HANDLER = { src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'), suite: 'test/unit/routine-actions.test.js' };
@@ -216,10 +222,33 @@ const MUTATIONS = [
     "    const message = input && typeof input.message === 'string' ? input.message.trim() : '';\n    return message || ACTION_PROBLEM;",
     '    return ACTION_PROBLEM;'],
 
+  // ===== WHAT THE TEAM PANEL NO LONGER CARRIES =====
+  //
+  // The listing is gone and the rule left behind is an absence. Each of these
+  // writes the absent thing back, in the shape it had, and requires the panel's
+  // own file to notice.
+  [TEAM_PANEL, 'the team panel carries the roster and nothing beside it',
+    "  document.getElementById('agent-list').innerHTML = h;",
+    "  document.getElementById('agent-list').innerHTML = h;\n"
+    + "  document.getElementById('sidebar-team').insertAdjacentHTML('beforeend',"
+    + " '<div class=\"routine-item\">Compile the ops summary, 7:00 AM</div>');"],
+  [TEAM_PANEL, 'an agent row says how the agent is, never how many routines it has',
+    "  if (onTeam.length) {\n    for (const a of onTeam) {\n"
+    + "      const isWorking = workingIds.has(a.id);\n"
+    + "      const last = agentLastActivity[a.id];\n"
+    + "      const statusText = isWorking ? 'working' : (last ? formatTimeAgo(last.time) : 'idle');",
+    "  if (onTeam.length) {\n    for (const a of onTeam) {\n"
+    + "      const isWorking = workingIds.has(a.id);\n"
+    + "      const last = agentLastActivity[a.id];\n"
+    + "      const statusText = `${(a.routines || []).length} routines`;"],
+  [INDEX_SWEEP, 'the element the listing rendered into went with the listing',
+    '      <div class="agent-status-list" id="agent-list"></div>\n',
+    '      <div class="agent-status-list" id="agent-list"></div>\n      <div id="sidebar-routines"></div>\n'],
+
   // ===== WHO DRAWS THIS LIST, AND HOW A READER ARRIVES AT IT =====
   [APP, 'the arriving roster redraws the list',
-    'renderRoutinesSidebar(); renderRoutines(); renderConvoList();',
-    'renderRoutinesSidebar(); renderConvoList();'],
+    'renderOrgChart(); renderRoutines(); renderConvoList();',
+    'renderOrgChart(); renderConvoList();'],
   [APP, 'the rail entry draws something into the view it shows',
     "  else if(nav==='routines') { showView('routines'); renderRoutines(); }",
     "  else if(nav==='routines') { showView('routines'); }"],
@@ -533,7 +562,7 @@ function redTests(suite) {
 function run() {
   const targets = [MODEL, VIEW, VIEW_E2E, VIEW_REPLY, VIEW_RAIL, STYLES, SCHEDULER, END_TO_END,
     DISCOVERY, HANDLER, ROUTINES, APP, APP_SKILLS, APP_OPENER, INDEX, INDEX_RAIL, SKILLS_MODEL, SKILLS_VIEW,
-    SKILLS_VIEW_RAIL];
+    SKILLS_VIEW_RAIL, TEAM_PANEL, INDEX_SWEEP];
   const originals = new Map();
   for (const target of targets) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];

--- a/test/tools/mutate-routines-guards.js
+++ b/test/tools/mutate-routines-guards.js
@@ -102,6 +102,16 @@ const APP_OPENER = { src: path.join(ROOT, 'public', 'app.js'), suite: 'test/unit
 // guard away: an absence nobody can break is an absence nobody is checking.
 const TEAM_PANEL = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/team-sidebar.test.js' };
 const INDEX_SWEEP = { src: path.join(ROOT, 'public', 'index.html'), suite: 'test/unit/team-sidebar.test.js' };
+// The agent profile's three boxes. Two targets on one file, because a guard is
+// only proved by the suite that presses it: what the box SAYS is pressed by the
+// profile's own file, and where a row GOES is pressed by the routes
+// enumeration. Pointing either at the other's suite would be a mutation that
+// cannot turn red wearing the shape of one that can.
+const PROFILE_BOXES = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/profile-boxes.test.js' };
+const PROFILE_ROUTE = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/routines-view-doors.test.js' };
+// The scope, on both sides of it: the filter that applies one and the arm that
+// clears it. Both are watched by the file that presses the two routes.
+const VIEW_SCOPE = { src: path.join(ROOT, 'public', 'views', 'routines.js'), suite: 'test/unit/routines-view-doors.test.js' };
 // The handlers behind the row's two controls, and the data model they write
 // through.
 const HANDLER = { src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'), suite: 'test/unit/routine-actions.test.js' };
@@ -222,6 +232,41 @@ const MUTATIONS = [
     "    const message = input && typeof input.message === 'string' ? input.message.trim() : '';\n    return message || ACTION_PROBLEM;",
     '    return ACTION_PROBLEM;'],
 
+  // ===== THE AGENT PROFILE'S ROUTINES BOX =====
+  //
+  // THE FIRST OF THESE IS THE DEFECT IN ITS EXACT FORM. It is the line that
+  // shipped, it reads as a helpful detail, and it routes around the three-tone
+  // ruling entirely. It is written back here so that the ruling's absence from
+  // this surface cannot return quietly.
+  [PROFILE_BOXES, 'no run outcome reaches the agent profile',
+    "          <span style=\"font-size:var(--caption);color:var(--text-2)\">${esc(when)}</span>",
+    "          <span style=\"font-size:var(--caption);color:var(--text-2)\">${esc(when)}</span>\n"
+    + "          <span style=\"font-size:var(--caption)\">${r.state ? `Last run: ${formatTimeAgo(r.state.lastRun)} (${r.state.status})` : ''}</span>"],
+  [PROFILE_BOXES, 'a schedule reads in the words the routines view uses',
+    '        const when = (routinesModel && routinesModel.scheduleWords(r.schedule)) || r.schedule;',
+    '        const when = r.schedule;'],
+  [PROFILE_BOXES, 'the Routines box is there whether or not the agent has any',
+    '    h+=`<div class="profile-card"><div class="profile-card-section"><div class="profile-section-label">Routines</div>`;\n    if(hasRoutines) {',
+    '    if (!hasRoutines) { h+=\'\'; } else {\n    h+=`<div class="profile-card"><div class="profile-card-section"><div class="profile-section-label">Routines</div>`;\n    if(hasRoutines) {'],
+  [PROFILE_BOXES, 'Add routine goes once the agent has a routine',
+    '    if(hasRoutines) {\n      for(const r of a.routines) {',
+    '    if(false) {\n      for(const r of a.routines) {'],
+  [PROFILE_BOXES, 'no pause or delete is offered on the profile',
+    '          <span style="font-weight:600">${esc(r.name)}</span>',
+    '          <span style="font-weight:600">${esc(r.name)}</span>\n'
+    + '          <button type="button" data-routines-action="pause">Pause</button>'],
+
+  // Where a row goes, watched by the file that presses the route.
+  [PROFILE_ROUTE, 'a routine row carries the agent whose profile it is on',
+    'onclick="showRoutinesForAgent(\'${esc(a.id)}\')"',
+    'onclick="showRoutinesForAgent(null)"'],
+  [VIEW_SCOPE, 'the list is filtered to the agent it was opened for',
+    '    if (scopeAgentId && agent.id !== scopeAgentId) continue;\n',
+    ''],
+  [VIEW_SCOPE, 'a route that names no agent clears the scope rather than keeping the last one',
+    '  scopeAgentId = agentId || null;',
+    '  if (agentId) scopeAgentId = agentId;'],
+
   // ===== WHAT THE TEAM PANEL NO LONGER CARRIES =====
   //
   // The listing is gone and the rule left behind is an absence. Each of these
@@ -250,8 +295,8 @@ const MUTATIONS = [
     'renderOrgChart(); renderRoutines(); renderConvoList();',
     'renderOrgChart(); renderConvoList();'],
   [APP, 'the rail entry draws something into the view it shows',
-    "  else if(nav==='routines') { showView('routines'); renderRoutines(); }",
-    "  else if(nav==='routines') { showView('routines'); }"],
+    "  else if(nav==='routines') { showRoutinesForAgent(null); }",
+    "  else if(nav==='routines') { }"],
   [APP, 'the routines section reveals a sidebar the reader can see',
     "const SIDEBAR_FOR = { routines: 'team' };",
     'const SIDEBAR_FOR = {};'],
@@ -452,8 +497,8 @@ const MUTATIONS = [
     '  if (detail && detail.firstElementChild) return false;\n',
     ''],
   [APP_OPENER, 'pressing the Routines entry draws into the pane it reveals',
-    "  else if(nav==='routines') { showView('routines'); renderRoutines(); }",
-    "  else if(nav==='routines') { showView('routines'); }"],
+    "  else if(nav==='routines') { showRoutinesForAgent(null); }",
+    "  else if(nav==='routines') { }"],
 
   // ===== THE SKILLS PANE =====
   // It had none of this until now: renderSkills returned before rendering, so
@@ -562,7 +607,7 @@ function redTests(suite) {
 function run() {
   const targets = [MODEL, VIEW, VIEW_E2E, VIEW_REPLY, VIEW_RAIL, STYLES, SCHEDULER, END_TO_END,
     DISCOVERY, HANDLER, ROUTINES, APP, APP_SKILLS, APP_OPENER, INDEX, INDEX_RAIL, SKILLS_MODEL, SKILLS_VIEW,
-    SKILLS_VIEW_RAIL, TEAM_PANEL, INDEX_SWEEP];
+    SKILLS_VIEW_RAIL, TEAM_PANEL, INDEX_SWEEP, PROFILE_BOXES, PROFILE_ROUTE, VIEW_SCOPE];
   const originals = new Map();
   for (const target of targets) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];

--- a/test/tools/mutate-routines-guards.js
+++ b/test/tools/mutate-routines-guards.js
@@ -118,6 +118,9 @@ const PROFILE_COPY = { src: path.join(ROOT, 'public', 'views', 'profile.js'), su
 // cannot turn red wearing the shape of one that can.
 const PROFILE_BOXES = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/profile-boxes.test.js' };
 const PROFILE_ROUTE = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/routines-view-doors.test.js' };
+// The team sidebar as a DOOR rather than as a panel, watched by the file that
+// enumerates every way into the editor.
+const TEAM_DOOR = { src: path.join(ROOT, 'public', 'views', 'team.js'), suite: 'test/unit/routine-editor-doors.test.js' };
 // The scope, on both sides of it: the filter that applies one and the arm that
 // clears it. Both are watched by the file that presses the two routes.
 const VIEW_SCOPE = { src: path.join(ROOT, 'public', 'views', 'routines.js'), suite: 'test/unit/routines-view-doors.test.js' };
@@ -279,6 +282,12 @@ const MUTATIONS = [
   [PROFILE_BOXES, 'a schedule reads in the words the routines view uses',
     '        const when = (routinesModel && routinesModel.scheduleWords(r.schedule)) || r.schedule;',
     '        const when = r.schedule;'],
+  // The other direction. The model has plain words only for the schedules the
+  // editor offers, so a routine written by hand has none, and without the
+  // fallback its row shows an empty line where its schedule should be.
+  [PROFILE_BOXES, 'a schedule the model cannot translate falls back to the stored string',
+    '        const when = (routinesModel && routinesModel.scheduleWords(r.schedule)) || r.schedule;',
+    '        const when = routinesModel && routinesModel.scheduleWords(r.schedule);'],
   [PROFILE_BOXES, 'the Routines box is there whether or not the agent has any',
     '    h+=`<div class="profile-card"><div class="profile-card-section"><div class="profile-section-label">Routines</div>`;\n    if(hasRoutines) {',
     '    if (!hasRoutines) { h+=\'\'; } else {\n    h+=`<div class="profile-card"><div class="profile-card-section"><div class="profile-section-label">Routines</div>`;\n    if(hasRoutines) {'],
@@ -330,6 +339,10 @@ const MUTATIONS = [
     + "      const isWorking = workingIds.has(a.id);\n"
     + "      const last = agentLastActivity[a.id];\n"
     + "      const statusText = `${(a.routines || []).length} routines`;"],
+  [TEAM_DOOR, 'the team sidebar renders no way into the editor',
+    "  document.getElementById('agent-list').innerHTML = h;",
+    "  h += '<button data-sidebar-action=\"add-routine\" onclick=\"addRoutine()\">Add</button>';\n"
+    + "  document.getElementById('agent-list').innerHTML = h;"],
   [INDEX_SWEEP, 'the element the listing rendered into went with the listing',
     '      <div class="agent-status-list" id="agent-list"></div>\n',
     '      <div class="agent-status-list" id="agent-list"></div>\n      <div id="sidebar-routines"></div>\n'],
@@ -652,7 +665,7 @@ function run() {
   const targets = [MODEL, VIEW, VIEW_E2E, VIEW_REPLY, VIEW_RAIL, STYLES, SCHEDULER, END_TO_END,
     DISCOVERY, HANDLER, ROUTINES, APP, APP_SKILLS, APP_OPENER, INDEX, INDEX_RAIL, SKILLS_MODEL, SKILLS_VIEW,
     SKILLS_VIEW_RAIL, TEAM_PANEL, INDEX_SWEEP, PROFILE_BOXES, PROFILE_ROUTE, VIEW_SCOPE,
-    GUIDE_COPY_MOD, TEAM_COPY, PROFILE_COPY];
+    GUIDE_COPY_MOD, TEAM_COPY, PROFILE_COPY, TEAM_DOOR];
   const originals = new Map();
   for (const target of targets) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];

--- a/test/unit/client-namespace.test.js
+++ b/test/unit/client-namespace.test.js
@@ -214,6 +214,7 @@ const MANIFEST = {
     "routinesCancelDelete",
     "routinesConfirmDelete",
     "routinesSetPaused",
+    "showRoutinesForAgent",
   ],
   "settings.js": [
     "changeWorkspace",

--- a/test/unit/client-namespace.test.js
+++ b/test/unit/client-namespace.test.js
@@ -239,7 +239,6 @@ const MANIFEST = {
     "renderAgentList",
     "renderConvoEmptyAgents",
     "renderOrgChart",
-    "renderRoutinesSidebar",
   ],};
 
 function viewModules() {

--- a/test/unit/guide-name.test.js
+++ b/test/unit/guide-name.test.js
@@ -1,0 +1,240 @@
+'use strict';
+// The guide is found by type and never by name, so nothing may name it.
+//
+// THE DEFECT, AND WHY IT READS AS FINE UNTIL IT DOES NOT. `getGuide()` matches
+// on `type === 'platform'`. It has never matched on a name. Four strings a
+// person reads named one anyway, so a workspace whose platform agent is called
+// anything else was told to talk to somebody it does not have, with the button
+// beside the sentence opening a conversation with a differently named agent.
+// On the shipped default workspace the name happens to be right, which is why
+// four surfaces carried it for as long as they did.
+//
+// SO THE WORKSPACE HERE IS NOT THE DEFAULT ONE. Its platform agent is Wren,
+// the same name the empty-states card used for the same reason: with the
+// default name in the fixture, a hard-coded literal passes every assertion
+// below on the strength of a coincidence.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const ROOT = path.join(__dirname, '..', '..');
+const read = (...parts) => fs.readFileSync(path.join(ROOT, ...parts), 'utf-8');
+// THE COPY MODULE IS LOADED IF IT IS THERE, AND THAT IS ABOUT WHAT THIS FILE
+// FAILS ON. Against the code before this change there is no such module and
+// the views carry the four sentences themselves, so the walks below have to go
+// red for what the page says rather than for a file that could not be read.
+// The claims about the module itself, further down, are the ones entitled to
+// fail because it is missing.
+const COPY_PATH = path.join(ROOT, 'public', 'guide-copy.js');
+const COPY_SRC = fs.existsSync(COPY_PATH) ? fs.readFileSync(COPY_PATH, 'utf-8') : '';
+const TEAM_SRC = read('public', 'views', 'team.js');
+const PROFILE_SRC = read('public', 'views', 'profile.js');
+
+// The name the shipped workspace's guide happens to have, and the one no
+// string may carry. Matched as a word so "Docs" and "document" are not hits.
+const DEFAULT_GUIDE = /\bDoc\b/;
+
+// A guide named anything cannot be assumed to be a "he", or a "they". Matched
+// as words, and deliberately not including "it": a schedule that runs is an
+// "it", and that is a pronoun for a routine rather than for an agent.
+const PRONOUNS = /\b(he|him|his|she|her|hers|they|them|their|theirs)\b/i;
+
+// The four surfaces, each named with the function that draws it and the
+// question a reader is answering when they meet it. A fifth one naming the
+// guide is a fifth row here.
+const SURFACES = [
+  { key: 'sidebar', draws: 'renderAgentList', where: 'the team sidebar with no team on it' },
+  { key: 'conversations', draws: 'renderConvoEmptyAgents', where: 'the conversations pane with no team on it' },
+  { key: 'fresh', draws: 'renderOrgChart', where: 'the org chart on a fresh workspace' },
+  { key: 'setup', draws: 'showProfile', where: 'the Setup button on an agent that has not been set up' },
+];
+
+function shellMarkup() {
+  return '<!doctype html><html><body>'
+    + '<div id="agent-list"></div><div id="sidebar-team-header"></div>'
+    + '<div id="convo-empty-label"></div><div id="convo-empty-content"></div>'
+    + '<div id="org-chart"></div>'
+    + '<div id="profile-content"></div>'
+    + '</body></html>';
+}
+
+function shell({ guideName = 'Wren', guide = true } = {}) {
+  const dom = new JSDOM(shellMarkup(), { runScripts: 'dangerously' });
+  const w = dom.window;
+  if (COPY_SRC) w.eval(COPY_SRC);
+  w.eval(TEAM_SRC);
+  w.eval(PROFILE_SRC);
+  const platform = guide
+    ? [{ id: 'archivist', displayName: guideName, role: 'Guide', colour: '#6BC67E', icon: 'W', status: 'onTeam', type: 'platform' }]
+    : [];
+  w.agents = [
+    ...platform,
+    // An agent that has never been set up, which is the state the Setup button
+    // belongs to.
+    { id: 'ted', displayName: 'Ted', role: 'Inventory', colour: '#E87A5A', icon: 'T', status: 'raw', runtime: 'claude' },
+  ];
+  w.conversations = [];
+  w.skills = [];
+  w.convoState = {};
+  w.agentLastActivity = {};
+  w.workspaceAnalysis = null;
+  w.currentWorkspacePath = null;
+  w.orgZoomOffset = 0;
+  w.esc = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  w.formatTimeAgo = () => 'a while ago';
+  w.getTeamAgents = () => w.agents.filter(a => a.status === 'onTeam' && a.type !== 'platform');
+  w.getPlatformAgents = () => w.agents.filter(a => a.status === 'onTeam' && a.type === 'platform');
+  w.getGuide = () => w.agents.filter(a => a.type === 'platform')[0] || null;
+  w.setNavState = () => {};
+  w.showView = () => {};
+  w.switchNav = () => {};
+  w.startConversation = () => {};
+  w.startSetupConversation = () => {};
+  w.addToTeam = () => {};
+  w.openConversation = () => {};
+  w.selectSkill = () => {};
+  w.showRoutinesForAgent = () => {};
+  w.addRoutineForAgent = () => {};
+  return { w, doc: w.document, dom };
+}
+
+// Every surface, drawn, one entry each. Kept apart rather than joined into one
+// blob, because "the name is somewhere on the page" is a claim two of these
+// surfaces satisfy for free: both draw the roster, and the guide is a row in
+// it. What is asked below is that the SENTENCE names the guide, surface by
+// surface.
+function drawAll(w, doc) {
+  w.renderAgentList();
+  w.renderConvoEmptyAgents();
+  w.renderOrgChart();
+  w.showProfile('ted');
+  return SURFACES.map((surface, i) => ({
+    ...surface,
+    text: [
+      doc.getElementById('agent-list'),
+      doc.getElementById('convo-empty-content'),
+      doc.getElementById('org-chart'),
+      doc.getElementById('profile-content'),
+    ][i].textContent.replace(/\s+/g, ' ').trim(),
+  }));
+}
+
+function allText(surfaces) {
+  return surfaces.map(s => s.text).join(' · ');
+}
+
+/**
+ * The surfaces whose OWN LINE names the guide.
+ *
+ * The line is taken from the copy object and substituted here, so this asks
+ * whether the page shows the sentence the object holds rather than whether the
+ * name appears anywhere near it. Where the object is absent, as it is against
+ * the code before this change, nothing can be named and the count is zero,
+ * which is the answer that makes these tests fail for the right reason.
+ */
+function surfacesNamingTheGuide(surfaces, name) {
+  const copy = COPY_SRC ? require(COPY_PATH) : null;
+  if (!copy) return 0;
+  return surfaces.filter(s => s.text.includes(copy.GUIDE_COPY[s.key].replace('{agent}', name))).length;
+}
+
+describe('the guide is named through a slot or not named at all', () => {
+  // AC-C3, and the assertion the whole file exists for. The workspace's guide
+  // is Wren, so a literal fails here rather than passing on a coincidence.
+  test('a workspace whose guide is not called the default reads correctly everywhere', () => {
+    const { w, doc, dom } = shell({ guideName: 'Wren' });
+    const surfaces = drawAll(w, doc);
+    const shown = allText(surfaces);
+    assert.ok(!DEFAULT_GUIDE.test(shown),
+      `a surface names an agent this workspace does not have: ${shown}`);
+    assert.strictEqual(surfacesNamingTheGuide(surfaces, 'Wren'), SURFACES.length,
+      'a surface either says nothing about the guide or says the wrong thing about it');
+    dom.window.close();
+  });
+
+  // The slot takes whatever the workspace calls its guide, including a name
+  // nobody would choose, because the roster is the only thing that decides it.
+  test('any name the roster carries reaches every surface that names one', () => {
+    for (const name of ['Wren', 'Atlas', 'Doc Brown & Co']) {
+      const { w, doc, dom } = shell({ guideName: name });
+      const surfaces = drawAll(w, doc);
+      assert.strictEqual(surfacesNamingTheGuide(surfaces, name), SURFACES.length,
+        `the guide is called ${name} and a surface does not say so`);
+      assert.ok(!allText(surfaces).includes('{agent}'), 'a slot reached the page unsubstituted');
+      dom.window.close();
+    }
+  });
+
+  // AC-C2. Checked on what a reader sees rather than on the copy object, so a
+  // pronoun written straight into a view is a hit too.
+  test('nothing a reader sees carries a pronoun for an agent', () => {
+    const { w, doc, dom } = shell();
+    const hit = PRONOUNS.exec(allText(drawAll(w, doc)));
+    assert.strictEqual(hit, null, hit && `a surface calls an agent "${hit[0]}"`);
+    dom.window.close();
+  });
+
+  // The state the org chart used to promise a guide in regardless. It is the
+  // only one of the four that rendered its sentence with no guide at all, so
+  // it is the only one that needs a line for that case; the others do not draw
+  // at all without one, and say so by returning nothing.
+  test('a workspace with no guide is not told to talk to one', () => {
+    const { w, doc, dom } = shell({ guide: false });
+    const shown = allText(drawAll(w, doc));
+    assert.ok(!DEFAULT_GUIDE.test(shown), 'a surface names a guide this workspace does not have');
+    assert.ok(!/Wren/.test(shown), 'a surface names a guide this workspace does not have');
+    assert.ok(!shown.includes('{agent}'), 'an empty slot reached the page');
+    // And it still says what to do next, rather than stopping at what the
+    // thing is.
+    assert.match(doc.getElementById('org-chart').textContent, /Fresh workspace/,
+      'the fresh-workspace state lost its words along with the guide');
+    dom.window.close();
+  });
+});
+
+describe('the strings stay readable in one place', () => {
+  // AC-C4. The point of one object is that a copy check can read all of it, so
+  // this asserts the object holds the surfaces rather than the views holding
+  // fragments of them.
+  test('every surface takes its line from the one copy object', () => {
+    const copy = require(path.join(ROOT, 'public', 'guide-copy.js'));
+    for (const surface of SURFACES) {
+      const line = copy.GUIDE_COPY[surface.key];
+      assert.ok(typeof line === 'string' && line.length,
+        `${surface.where} has no line in the copy object`);
+      assert.ok(line.includes('{agent}'),
+        `the line for ${surface.where} names the guide some other way than through the slot`);
+      assert.ok(!DEFAULT_GUIDE.test(line), `the line for ${surface.where} carries a name`);
+      assert.ok(!PRONOUNS.test(line), `the line for ${surface.where} carries a pronoun`);
+    }
+  });
+
+  // SUBSTITUTED RATHER THAN CONCATENATED, which is the rule the editor's own
+  // step leads already state: every word shipped stays inside one object, so a
+  // copy check reads all of it. A view that built the sentence around a name
+  // would put half the copy at the call site.
+  test('no view assembles one of these sentences at the call site', () => {
+    const copy = require(path.join(ROOT, 'public', 'guide-copy.js'));
+    for (const [key, line] of Object.entries(copy.GUIDE_COPY)) {
+      const words = line.split('{agent}').map(part => part.trim()).filter(part => part.length > 12);
+      for (const src of [TEAM_SRC, PROFILE_SRC]) {
+        for (const fragment of words) {
+          assert.ok(!src.includes(fragment),
+            `a view carries the words of "${key}" itself, so the copy is in two places`);
+        }
+      }
+    }
+  });
+
+  test('a name the workspace does not have is substituted, never concatenated', () => {
+    const copy = require(path.join(ROOT, 'public', 'guide-copy.js'));
+    assert.strictEqual(copy.guideLine('sidebar', 'Wren'), copy.GUIDE_COPY.sidebar.replace('{agent}', 'Wren'));
+    assert.strictEqual(copy.guideLine('sidebar', null), null,
+      'a surface with no line for a guideless workspace claims to have one');
+    assert.ok(copy.guideLine('fresh', null),
+      'the one surface that draws without a guide has nothing to draw');
+    assert.ok(!/\{agent\}/.test(copy.guideLine('fresh', null)), 'the guideless line carries a slot');
+  });
+});

--- a/test/unit/profile-boxes.test.js
+++ b/test/unit/profile-boxes.test.js
@@ -1,0 +1,274 @@
+'use strict';
+// The agent profile: Skills, then Routines, then Configuration.
+//
+// WHAT THIS FILE IS ACTUALLY GUARDING.
+//
+// The profile used to interpolate a run's raw status word straight into the
+// markup and print things like "Last run: 4h ago (interrupted)". The three-tone
+// ruling took three design rounds and two rejections to settle, and it never
+// reached this surface, so the one place a person met a routine while looking
+// at an agent was the one place the vocabulary was raw. It also printed
+// statuses the ruling has no tone for at all.
+//
+// THE DEFECT IS DELETED RATHER THAN FIXED. The Routines box carries a name and
+// a schedule and nothing else, so there is no outcome on this page to get
+// wrong, and outcomes live on the routines view where the model already
+// decides both the words and the tone. That is cheaper than teaching a second
+// surface the ruling, and it is only cheaper while it stays true, which is what
+// the status walk below is for: EVERY status a run record can carry is driven
+// through this page, and the list is read out of the scheduler rather than
+// written here, so a fifth status arrives as a failure rather than as a
+// screenshot somebody notices later.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const ROOT = path.join(__dirname, '..', '..');
+const read = (...parts) => fs.readFileSync(path.join(ROOT, ...parts), 'utf-8');
+const APP_SRC = read('public', 'app.js');
+const PROFILE_SRC = read('public', 'views', 'profile.js');
+const EDITOR_MODEL_SRC = read('public', 'routine-editor-model.js');
+const SKILLS_MODEL_SRC = read('public', 'skills-model.js');
+const ROUTINES_MODEL_SRC = read('public', 'routines-model.js');
+const ROUTINES_SRC = read('public', 'views', 'routines.js');
+
+// The three boxes, in the order the conformance mock draws them.
+const BOXES = ['Skills', 'Routines', 'Configuration'];
+
+/**
+ * Every status a run record can carry, READ OUT OF THE SCHEDULER.
+ *
+ * Written here as a list, this test would say what its author remembered on
+ * the day. `interrupted` is the exact case that makes the point: it arrived
+ * with the restarted-run card, months after the surface that printed it was
+ * written, and nothing asked the profile about it. So the list is derived from
+ * the two places that write a status into the run state, and a sixth one
+ * appearing anywhere else in that file is a gap this cannot see and the
+ * sanity check below is what bounds it.
+ */
+function statusesARunRecordCanCarry() {
+  const src = read('lib', 'scheduler.js');
+  const found = new Set();
+  for (const call of src.matchAll(/recordRoutineRun\(key, \{[\s\S]*?\}\)/g)) {
+    for (const m of call[0].matchAll(/status:\s*(?:\w+\s*\?\s*)?'(\w+)'(?:\s*:\s*'(\w+)')?/g)) {
+      found.add(m[1]);
+      if (m[2]) found.add(m[2]);
+    }
+  }
+  // The startup sweep, which is the only writer that does not go through the
+  // recorder, and the one that produces the word the defect printed.
+  for (const m of src.matchAll(/state\.status = '(\w+)'/g)) found.add(m[1]);
+  return [...found].sort();
+}
+
+const ROUTINES = [
+  { name: 'Compile the ops summary', schedule: 'every day at 07:00', state: null },
+  { name: 'Draft the stand-up notes', schedule: 'every monday at 08:30', state: null },
+];
+
+function shellMarkup() {
+  return '<!doctype html><html><body>'
+    + '<button class="nav-item" data-nav="team"></button>'
+    + '<button class="nav-item" data-nav="routines"></button>'
+    + '<div id="view-profile"><div id="profile-content"></div></div>'
+    + '<div id="view-routines"><div id="routines-content"></div></div>'
+    + '</body></html>';
+}
+
+function appPiece(pattern, label) {
+  const m = APP_SRC.match(pattern);
+  assert.ok(m && m[1] && m[1].trim(), `app.js no longer carries ${label}`);
+  return m[1];
+}
+
+function shell({ routines = ROUTINES, tedRoutines = [] } = {}) {
+  const dom = new JSDOM(shellMarkup(), { runScripts: 'dangerously' });
+  const w = dom.window;
+  w.eval(EDITOR_MODEL_SRC);
+  w.eval(SKILLS_MODEL_SRC);
+  w.eval(ROUTINES_MODEL_SRC);
+  w.eval(ROUTINES_SRC);
+  w.eval(PROFILE_SRC);
+  w.agents = [
+    {
+      id: 'piper', displayName: 'Piper', role: 'Ops', colour: '#E87A5A', icon: 'P',
+      status: 'onTeam', runtime: 'claude', model: 'sonnet', routines,
+    },
+    {
+      id: 'ted', displayName: 'Ted', role: 'Inventory', colour: '#6BC67E', icon: 'T',
+      status: 'onTeam', runtime: 'claude', model: 'haiku', routines: tedRoutines,
+    },
+  ];
+  w.conversations = [];
+  w.skills = [
+    { id: 'ops', name: 'Compile the ops summary', description: 'The morning numbers', assignedAgents: [{ id: 'piper' }] },
+    { id: 'inv', name: 'Update the shared inventory sheet', description: 'Stock counts', assignedAgents: [{ id: 'ted' }] },
+  ];
+  w.esc = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  w.formatTimeAgo = () => 'a while ago';
+  w.getGuide = () => ({ id: 'doc', displayName: 'Wren' });
+  w.ws = { send: () => {} };
+  w.routinesNow = () => new Date(2026, 7, 24, 9, 20);
+  w.Intl = { DateTimeFormat: () => ({ resolvedOptions: () => ({ timeZone: 'Europe/London' }) }) };
+  w.setNavState = () => {};
+  w.showView = (v) => { w.shown = v; };
+  w.closeFindBar = () => {};
+  w.startConversation = () => {};
+  w.addToTeam = () => {};
+  w.openConversation = () => {};
+  w.selectSkill = () => {};
+  w.addRoutineForAgent = () => {};
+  // The rail's own routines arm, cut out of app.js and run, so the route a row
+  // takes is the route the page ships rather than one restated here.
+  w.switchNav = (nav) => {
+    w.navigatedTo = nav;
+    if (nav !== 'routines') return;
+    w.eval(`(function () {${appPiece(/else if\(nav==='routines'\)\s*\{([\s\S]*?)\}/, "switchNav's routines arm")}\n})()`);
+  };
+  return { w, doc: w.document, dom };
+}
+
+function profileText(doc) {
+  return doc.getElementById('profile-content').textContent.replace(/\s+/g, ' ').trim();
+}
+
+function boxLabels(doc) {
+  return [...doc.querySelectorAll('.profile-card .profile-section-label')].map(el => el.textContent.trim());
+}
+
+function routinesBox(doc) {
+  const label = [...doc.querySelectorAll('.profile-card .profile-section-label')]
+    .filter(el => el.textContent.trim() === 'Routines')[0];
+  assert.ok(label, 'the profile carries no Routines box');
+  return label.closest('.profile-card');
+}
+
+describe('the profile is three boxes', () => {
+  test('the boxes are Skills, then Routines, then Configuration', () => {
+    const { w, doc, dom } = shell();
+    w.showProfile('piper');
+    assert.deepStrictEqual(boxLabels(doc), BOXES,
+      'the profile no longer reads Skills, Routines, Configuration in that order');
+    dom.window.close();
+  });
+
+  // AC-B6. A box that vanished once you used it would take the concept with
+  // it, and an agent's own schedules are what a reader came to this page for.
+  test('the Routines box is on the page whether or not the agent has any', () => {
+    for (const [who, routines] of [['piper', ROUTINES], ['ted', []]]) {
+      const { w, doc, dom } = shell({ routines, tedRoutines: routines });
+      w.showProfile(who);
+      assert.ok(routinesBox(doc), `${who} has no Routines box`);
+      assert.deepStrictEqual(boxLabels(doc), BOXES, `${who}'s profile is not three boxes`);
+      dom.window.close();
+    }
+  });
+
+  // AC-B2. Not "no status word today": the row's whole text, so anything added
+  // to it later fails here rather than passing because nobody asserted it.
+  test('a routine row is its name and its schedule and nothing else', () => {
+    const { w, doc, dom } = shell();
+    w.showProfile('piper');
+    const model = w.RundockRoutinesModel;
+    const rows = [...routinesBox(doc).querySelectorAll('.profile-card-item')];
+    assert.strictEqual(rows.length, ROUTINES.length, 'the box does not list this agent\'s routines');
+    rows.forEach((row, i) => {
+      const routine = ROUTINES[i];
+      const schedule = model.scheduleWords(routine.schedule);
+      assert.ok(schedule, 'sanity: the model has words for this schedule');
+      assert.strictEqual(row.textContent.replace(/\s+/g, ' ').trim(), `${routine.name} ${schedule}`,
+        'a routine row on the profile carries something beyond a name and a schedule');
+    });
+    dom.window.close();
+  });
+
+  // AC-B7, and the defect this card deletes.
+  //
+  // Every status, driven, on both row shapes: a run that ended and a run still
+  // going. The assertion is on the WHOLE page rather than on the row, because
+  // the word reaching any part of this profile is the fault.
+  test('no status a run record can carry reaches the page', () => {
+    const statuses = statusesARunRecordCanCarry();
+    assert.ok(statuses.includes('interrupted'),
+      'sanity: the status the restarted-run card introduced is not in the list this walk drives');
+    assert.ok(statuses.length >= 4,
+      `sanity: only ${statuses.length} statuses were found, so this walk is reading the wrong thing`);
+
+    for (const status of statuses) {
+      const routines = ROUTINES.map(r => ({
+        ...r, state: { status, lastRun: new Date(2026, 7, 24, 5, 0).toISOString() },
+      }));
+      const { w, doc, dom } = shell({ routines });
+      w.showProfile('piper');
+      const shown = profileText(doc);
+      assert.ok(!shown.includes(status),
+        `the profile prints the raw status word "${status}"`);
+      // And no outcome in the routines view's own vocabulary either: the
+      // outcome is not restated in better words here, it is not on this page.
+      for (const word of ['Ran ', 'Failed', 'Missed', 'Caught up', 'Last run', 'Running now', 'Not yet run']) {
+        assert.ok(!shown.includes(word),
+          `the profile reports an outcome ("${word}"), which belongs to the routines view`);
+      }
+      dom.window.close();
+    }
+  });
+
+  // AC-B4. Pause and delete live in one place, so a reader learns one place to
+  // change a routine rather than two that might disagree.
+  test('pause and delete appear nowhere on the profile', () => {
+    const { w, doc, dom } = shell();
+    w.showProfile('piper');
+    const card = doc.getElementById('profile-content');
+    assert.strictEqual(card.querySelector('[data-routines-action]'), null,
+      'a routines control is rendered on the profile');
+    assert.ok(!/Pause|Delete|Resume/i.test(profileText(doc)),
+      'the profile offers to pause or delete a routine');
+    assert.ok(!/routinesSetPaused|routinesAskDelete/.test(PROFILE_SRC),
+      'views/profile.js names a pause or delete handler');
+    dom.window.close();
+  });
+});
+
+describe('Add routine teaches that routines exist, and then stops', () => {
+  // AC-B5. The button is feature discovery rather than repeat use: it exists
+  // to say the concept is there, in the one place where an agent with no
+  // schedule is being looked at.
+  test('Add routine is offered while the agent has none', () => {
+    const { w, doc, dom } = shell({ routines: [] });
+    w.showProfile('piper');
+    const button = doc.querySelector('[data-profile-action="add-routine"]');
+    assert.ok(button, 'an agent with no routines is not offered a way to make one');
+    assert.ok(routinesBox(doc).contains(button), 'the offer is not inside the Routines box');
+    assert.strictEqual(button.className, 'settings-btn-primary',
+      'the offer is not the small in-card primary the mock draws');
+    dom.window.close();
+  });
+
+  test('Add routine is gone once the agent has one', () => {
+    const { w, doc, dom } = shell({ routines: [ROUTINES[0]] });
+    w.showProfile('piper');
+    assert.strictEqual(doc.querySelector('[data-profile-action="add-routine"]'), null,
+      'the profile still offers Add routine to an agent that already has one');
+    dom.window.close();
+  });
+});
+
+// THE ROW'S DESTINATION IS NOT PRESSED HERE, and that is deliberate rather
+// than a gap. Where a row lands the reader is a ROUTE, and every route into the
+// routines section is enumerated and pressed in routines-view-doors.test.js,
+// against the source, so a route added later fails there until somebody lists
+// it. Pressing it here as well would be a second proof of one thing in the file
+// that does not own it, and the one that does not own it is the one that goes
+// stale. What this file owns is the row: that it exists, and what it says.
+describe('a routine row carries the destination the routes file presses', () => {
+  test('a row is a control that opens the routines view for this agent', () => {
+    const { w, doc, dom } = shell();
+    w.showProfile('piper');
+    const row = routinesBox(doc).querySelector('.profile-card-item');
+    assert.match(row.getAttribute('onclick') || '', /^showRoutinesForAgent\('piper'\)$/,
+      'a routine row on the profile does not open the routines view for this agent');
+    dom.window.close();
+  });
+});

--- a/test/unit/profile-boxes.test.js
+++ b/test/unit/profile-boxes.test.js
@@ -229,6 +229,25 @@ describe('the profile is three boxes', () => {
       'views/profile.js names a pause or delete handler');
     dom.window.close();
   });
+
+  // THE FALLBACK, DRIVEN RATHER THAN PROMISED IN A COMMENT. The model has
+  // plain words only for the schedules the editor offers, and returns nothing
+  // for anything else. A routine written by hand, or by a future editor this
+  // one has not caught up with, carries such a schedule, and the row shows the
+  // stored string rather than an empty line. Every other fixture here resolves
+  // to model words, so without this the branch is unreachable from any test.
+  test('a schedule the model has no words for is shown as it was stored', () => {
+    const stored = 'every fortnight at 07:00';
+    const { w, doc, dom } = shell({ routines: [{ name: 'Reconcile the ledger', schedule: stored, state: null }] });
+    assert.strictEqual(w.RundockRoutinesModel.scheduleWords(stored), null,
+      'sanity: the model does have words for this schedule, so the fallback is not what is being driven');
+    w.showProfile('piper');
+    const rows = [...routinesBox(doc).querySelectorAll('.profile-card-item')];
+    assert.strictEqual(rows.length, 1, 'the row did not render at all');
+    assert.strictEqual(rows[0].textContent.replace(/\s+/g, ' ').trim(), `Reconcile the ledger ${stored}`,
+      'a routine whose schedule the model cannot translate shows nothing, or shows something else');
+    dom.window.close();
+  });
 });
 
 describe('Add routine teaches that routines exist, and then stops', () => {

--- a/test/unit/routine-editor-doors.test.js
+++ b/test/unit/routine-editor-doors.test.js
@@ -51,16 +51,13 @@ const DOORS = [
     scoped: true,
     pressedBy: 'the profile door opens the editor scoped to that agent',
   },
-  {
-    call: 'addRoutine',
-    file: 'views/team.js',
-    surface: 'the Add control in the sidebar Routines section',
-    scoped: false,
-    pressedBy: 'the sidebar door opens the editor across the whole team',
-  },
   // The door this file named as missing while the routines view did not exist.
   // It arrived with that view, this row arrived with it, and the enumeration
   // above went red in between, which is the whole point of the check.
+  //
+  // AND IT IS NOW THE ONLY UNSCOPED ONE. The team sidebar's Routines section
+  // carried a second, and went with the listing it sat under. A door removed
+  // is a row removed, on the same rule that a door added is a row added.
   {
     call: 'addRoutine',
     file: 'views/routines.js',
@@ -150,8 +147,7 @@ describe('every door into the editor is enumerated', () => {
 
 function shell() {
   const dom = new JSDOM('<!doctype html><html><body>'
-    + '<button class="nav-item" data-nav="team"></button><div id="sidebar-team">'
-    + '<div id="sidebar-routines"></div></div>'
+    + '<button class="nav-item" data-nav="team"></button><div id="sidebar-team"></div>'
     + '<div id="profile-content"></div>'
     + '<div id="view-routine-editor"><div id="routine-editor-content"></div></div>'
     + '<div id="view-routines"><div id="routines-content"></div></div>'
@@ -183,7 +179,6 @@ function shell() {
   w.skillsLoaded = true;
   w.esc = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   w.formatTimeAgo = () => 'a while ago';
-  w.formatScheduleShort = (s) => s;
   w.getGuide = () => ({ id: 'doc' });
   w.sent = [];
   w.ws = { send: (m) => w.sent.push(JSON.parse(m)) };
@@ -201,6 +196,26 @@ function shell() {
   w.renderAgentList = () => {};
   w.Intl = { DateTimeFormat: () => ({ resolvedOptions: () => ({ timeZone: 'Europe/London' }) }) };
   return { w, doc: w.document, dom };
+}
+
+// The unscoped door, opened the way a reader opens it: on a workspace with
+// nothing scheduled, from the routines view's own empty state. There is one
+// unscoped door now, so every walk that used to start at the sidebar starts
+// here, and none of them starts by calling the entry function.
+function pressUnscopedDoor(doc, w) {
+  w.agents = w.agents.map(a => ({ ...a, routines: [] }));
+  w.renderRoutines();
+  return press(doc, '[data-routines-action="add"]');
+}
+
+// The scoped door, opened the way a reader opens it: from the agent's own
+// profile. It is also the ONLY door into the editor's zero-skills state, since
+// the routines view answers a workspace with no skills with an offer to build
+// one rather than with an offer to schedule one.
+function pressScopedDoor(doc, dom, agentId) {
+  dom.window.showProfile = dom.window.RundockProfileView.showProfile;
+  dom.window.showProfile(agentId);
+  return press(doc, '[data-profile-action="add-routine"]');
 }
 
 // Press what is on the page. Never call the handler behind it: that is the
@@ -227,9 +242,7 @@ function editorText(doc) {
 describe('the doors, pressed', () => {
   test('the profile door opens the editor scoped to that agent', () => {
     const { doc, dom } = shell();
-    dom.window.showProfile = dom.window.RundockProfileView.showProfile;
-    dom.window.showProfile('piper');
-    press(doc, '[data-profile-action="add-routine"]');
+    pressScopedDoor(doc, dom, 'piper');
     assert.match(editorText(doc), /Pick a skill Piper already has/);
     assert.deepStrictEqual(
       [...doc.querySelectorAll('[data-skill-key]')].map(r => r.getAttribute('data-skill-key')),
@@ -239,49 +252,34 @@ describe('the doors, pressed', () => {
     dom.window.close();
   });
 
-  test('the sidebar door opens the editor across the whole team', () => {
-    const { doc, w, dom } = shell();
-    w.renderRoutinesSidebar();
-    press(doc, '[data-sidebar-action="add-routine"]');
-    assert.match(editorText(doc), /Pick a skill any of your agents already has/);
-    assert.deepStrictEqual(
-      [...doc.querySelectorAll('[data-skill-key]')].map(r => r.getAttribute('data-skill-key')),
-      ['ops-summary:piper', 'reading-digest:doc'],
-      'the unscoped door offers every agent\'s skills',
-    );
-    assert.match(editorText(doc), /Piper/);
-    assert.match(editorText(doc), /Doc/);
-    dom.window.close();
-  });
-
-  // The third door, and the one the sidebar cannot be: with no routines yet
-  // the sidebar section is not on the page at all (pinned below), so a
-  // workspace that has never scheduled anything reaches the editor through
-  // this control and no other.
+  // The unscoped door, and now the only one. A workspace that has never
+  // scheduled anything reaches the editor through this control or through an
+  // agent's own profile, and through nothing else.
   test('the empty state door opens the editor across the whole team', () => {
     const { doc, w, dom } = shell();
-    w.agents = w.agents.map(a => ({ ...a, routines: [] }));
-    w.renderRoutines();
-    press(doc, '[data-routines-action="add"]');
+    pressUnscopedDoor(doc, w);
     assert.match(editorText(doc), /Pick a skill any of your agents already has/);
     assert.deepStrictEqual(
       [...doc.querySelectorAll('[data-skill-key]')].map(r => r.getAttribute('data-skill-key')),
       ['ops-summary:piper', 'reading-digest:doc'],
       'the empty state door offers every agent\'s skills',
     );
+    assert.match(editorText(doc), /Piper/);
+    assert.match(editorText(doc), /Doc/);
     dom.window.close();
   });
 
-  // The sidebar section renders nothing until a routine exists, so the
-  // unscoped door appears with the first one. Worth pinning: it is why the
-  // routines view's own empty state is a door in its own right rather than a
-  // duplicate of this one.
-  test('the sidebar door appears with the first routine and not before', () => {
+  // The team sidebar's Routines section is gone, and with it the Add control
+  // that hung off its divider. Pinned here rather than assumed, because the
+  // walks below no longer touch that panel at all and would not notice it
+  // coming back.
+  test('the team sidebar offers no way into the editor', () => {
     const { doc, w, dom } = shell();
-    w.agents = w.agents.map(a => ({ ...a, routines: [] }));
-    w.renderRoutinesSidebar();
+    w.renderAgentList = w.RundockTeamView.renderAgentList;
     assert.strictEqual(doc.querySelector('[data-sidebar-action="add-routine"]'), null,
-      'no routines yet, so this section is not on the page at all');
+      'the team sidebar carries a way into the editor again and is not a listed door');
+    assert.ok(!/data-sidebar-action/.test(TEAM_SRC),
+      'views/team.js renders a sidebar action again and is not a listed door');
     dom.window.close();
   });
 });
@@ -291,10 +289,7 @@ describe('the whole journey, by pressing only', () => {
   // control loses its handler, or its handler is renamed, this walk stops.
   test('a routine can be made from the profile door without calling anything', () => {
     const { doc, w, dom } = shell();
-    dom.window.showProfile = dom.window.RundockProfileView.showProfile;
-    dom.window.showProfile('piper');
-
-    press(doc, '[data-profile-action="add-routine"]');
+    pressScopedDoor(doc, dom, 'piper');
     press(doc, '[data-skill-key="ops-summary:piper"]');
     press(doc, '.re-actions .settings-btn-primary');
 
@@ -320,10 +315,9 @@ describe('the whole journey, by pressing only', () => {
     dom.window.close();
   });
 
-  test('the same journey from the sidebar door reaches another agent\'s skill', () => {
+  test('the same journey from the unscoped door reaches another agent\'s skill', () => {
     const { doc, w, dom } = shell();
-    w.renderRoutinesSidebar();
-    press(doc, '[data-sidebar-action="add-routine"]');
+    pressUnscopedDoor(doc, w);
     press(doc, '[data-skill-key="reading-digest:doc"]');
     press(doc, '.re-actions .settings-btn-primary');
     choose(doc, w, 'frequency', 'day');
@@ -339,8 +333,7 @@ describe('the whole journey, by pressing only', () => {
   // The Edit link on the confirmation step is a control like any other.
   test('the confirmation step can be edited by pressing its own link', () => {
     const { doc, w, dom } = shell();
-    w.renderRoutinesSidebar();
-    press(doc, '[data-sidebar-action="add-routine"]');
+    pressUnscopedDoor(doc, w);
     press(doc, '[data-skill-key="ops-summary:piper"]');
     press(doc, '.re-actions .settings-btn-primary');
     choose(doc, w, 'frequency', 'friday');
@@ -359,8 +352,7 @@ describe('the whole journey, by pressing only', () => {
     w.skills = [];
     let talkedTo = null;
     w.startConversation = (id) => { talkedTo = id; };
-    w.renderRoutinesSidebar();
-    press(doc, '[data-sidebar-action="add-routine"]');
+    pressScopedDoor(doc, dom, 'piper');
     press(doc, '[data-routine-editor="create-skill"]');
     assert.strictEqual(talkedTo, 'doc', 'the offer reaches the agent that builds skills');
     dom.window.close();
@@ -389,8 +381,7 @@ describe('every control the editor renders resolves to something', () => {
     const { doc, w, dom } = shell();
     const states = [];
 
-    w.renderRoutinesSidebar();
-    press(doc, '[data-sidebar-action="add-routine"]');
+    pressUnscopedDoor(doc, w);
     states.push(doc.getElementById('routine-editor-content').innerHTML);
     press(doc, '[data-skill-key="ops-summary:piper"]');
     press(doc, '.re-actions .settings-btn-primary');
@@ -400,8 +391,7 @@ describe('every control the editor renders resolves to something', () => {
 
     const { doc: emptyDoc, w: emptyW, dom: emptyDom } = shell();
     emptyW.skills = [];
-    emptyW.renderRoutinesSidebar();
-    press(emptyDoc, '[data-sidebar-action="add-routine"]');
+    pressScopedDoor(emptyDoc, emptyDom, 'piper');
     states.push(emptyDoc.getElementById('routine-editor-content').innerHTML);
 
     const handlers = new Set();
@@ -421,7 +411,7 @@ describe('every control the editor renders resolves to something', () => {
   // that kept going untested.
   test('both doors name handlers the editor actually publishes', () => {
     const { w, dom } = shell();
-    for (const [src, label] of [[PROFILE_SRC, 'views/profile.js'], [TEAM_SRC, 'views/team.js']]) {
+    for (const [src, label] of [[PROFILE_SRC, 'views/profile.js'], [ROUTINES_SRC, 'views/routines.js']]) {
       for (const call of ENTRY_CALLS) {
         if (!new RegExp(`(?<![.\\w$])${call}\\(`).test(src)) continue;
         assert.strictEqual(typeof w[call], 'function',

--- a/test/unit/routine-editor-doors.test.js
+++ b/test/unit/routine-editor-doors.test.js
@@ -280,14 +280,22 @@ describe('the doors, pressed', () => {
   // that hung off its divider. Pinned here rather than assumed, because the
   // walks below no longer touch that panel at all and would not notice it
   // coming back.
+  //
+  // ASSERTED AGAINST THE SOURCE AND NOT AGAINST THIS FILE'S DOM. An earlier
+  // version of this test looked for the control in a document nothing had
+  // rendered the roster into, which is an assertion that cannot fail for the
+  // reason it states: it would have passed against a sidebar that had the
+  // control back. What the panel actually holds once it is drawn is proven in
+  // team-sidebar.test.js, which delivers a roster through the real dispatch
+  // into the real markup. What belongs HERE is the doors claim: that the view
+  // renders no way in and names no way in.
   test('the team sidebar offers no way into the editor', () => {
-    const { doc, w, dom } = shell();
-    w.renderAgentList = w.RundockTeamView.renderAgentList;
-    assert.strictEqual(doc.querySelector('[data-sidebar-action="add-routine"]'), null,
-      'the team sidebar carries a way into the editor again and is not a listed door');
     assert.ok(!/data-sidebar-action/.test(TEAM_SRC),
       'views/team.js renders a sidebar action again and is not a listed door');
-    dom.window.close();
+    for (const call of ENTRY_CALLS) {
+      assert.ok(!new RegExp(`(?<![.\\w$])${call}\\(`).test(TEAM_SRC),
+        `views/team.js reaches the editor through ${call} and is not a listed door`);
+    }
   });
 });
 

--- a/test/unit/routine-editor-doors.test.js
+++ b/test/unit/routine-editor-doors.test.js
@@ -212,9 +212,16 @@ function pressUnscopedDoor(doc, w) {
 // profile. It is also the ONLY door into the editor's zero-skills state, since
 // the routines view answers a workspace with no skills with an offer to build
 // one rather than with an offer to schedule one.
+// THE AGENT'S ROUTINES ARE CLEARED FIRST, and that is the door's condition
+// rather than a convenience. The offer is feature discovery: it teaches that
+// routines exist, in the one place where an agent with no schedule is being
+// looked at, and it goes once that agent has one. So the state this door
+// exists in is the state it is pressed in.
 function pressScopedDoor(doc, dom, agentId) {
-  dom.window.showProfile = dom.window.RundockProfileView.showProfile;
-  dom.window.showProfile(agentId);
+  const w = dom.window;
+  w.agents = w.agents.map(a => (a.id === agentId ? { ...a, routines: [] } : a));
+  w.showProfile = w.RundockProfileView.showProfile;
+  w.showProfile(agentId);
   return press(doc, '[data-profile-action="add-routine"]');
 }
 
@@ -361,9 +368,8 @@ describe('the whole journey, by pressing only', () => {
   // The breadcrumb, pressed, from the door that renders one.
   test('the breadcrumb returns to the profile the editor was opened from', () => {
     const { doc, w, dom } = shell();
-    dom.window.showProfile = (id) => { w.profileShown = id; };
-    w.RundockProfileView.showProfile('piper');
-    press(doc, '[data-profile-action="add-routine"]');
+    pressScopedDoor(doc, dom, 'piper');
+    w.showProfile = (id) => { w.profileShown = id; };
     w.profileShown = null;
     press(doc, '[data-routine-editor="back"]');
     assert.strictEqual(w.profileShown, 'piper');

--- a/test/unit/routine-editor-view.test.js
+++ b/test/unit/routine-editor-view.test.js
@@ -21,6 +21,24 @@ const { JSDOM } = require('jsdom');
 const ROOT = path.join(__dirname, '..', '..');
 const MODEL_SRC = fs.readFileSync(path.join(ROOT, 'public', 'routine-editor-model.js'), 'utf-8');
 const VIEW_SRC = fs.readFileSync(path.join(ROOT, 'public', 'views', 'routine-editor.js'), 'utf-8');
+// The shipped page and the shipped router, read rather than restated, because
+// the claim below is about what the real shell can show.
+const INDEX_SRC = fs.readFileSync(path.join(ROOT, 'public', 'index.html'), 'utf-8');
+const APP_SRC = fs.readFileSync(path.join(ROOT, 'public', 'app.js'), 'utf-8');
+
+/**
+ * The panel the router shows for a section, off the router's own arm.
+ *
+ * A SECTION IS NOT ALWAYS SHOWN BY A PANEL NAMED AFTER IT, and Team is the
+ * case that matters here: its arm shows the home panel. A test that planted a
+ * panel called after the section would answer its own question, which is the
+ * pattern the routines doors file exists to record.
+ */
+function panelShownFor(nav) {
+  const arm = new RegExp(`nav==='${nav}'\\)\\s*\\{\\s*showView\\('([\\w-]+)'\\)`).exec(APP_SRC);
+  assert.ok(arm, `app.js has no arm that shows anything for the ${nav} section`);
+  return arm[1];
+}
 
 // The promise that belongs to the always-on option alone. Named here as well
 // as in the model's tests, because this file asserts it about the DOM and the
@@ -42,11 +60,14 @@ function skillFixture() {
 // time zone is handed in.
 function mount(opts = {}) {
   const dom = new JSDOM('<!doctype html><html><body>'
-    // A rail button and a view panel for each section the router can reach.
-    // The routines surface has neither here, which is the condition the save
-    // destination has to resolve against.
-    + '<button class="nav-item" data-nav="team"></button><div id="view-team"></div>'
-    + '<button class="nav-item" data-nav="skills"></button><div id="view-skills"></div>'
+    // A rail button for each section the router can reach, and NO VIEW PANEL
+    // FOR EITHER OF THEM. The routines surface has neither, which is the
+    // condition the save destination has to resolve against, and the fallback
+    // it lands on is checked against the shipped page rather than against a
+    // panel this file could plant: `panelShownFor` asks the router which panel
+    // a section shows and index.html whether that panel exists.
+    + '<button class="nav-item" data-nav="team"></button>'
+    + '<button class="nav-item" data-nav="skills"></button>'
     + '<div id="view-routine-editor" class="hidden"><div id="routine-editor-content"></div></div>'
     + '</body></html>',
     // The modules are evaluated inside the window, the way index.html loads
@@ -479,20 +500,29 @@ describe('routine editor view: saving', () => {
     assert.strictEqual(w.navigatedTo, w.routinesListNav(), 'the reply is what leaves');
     assert.ok(w.navigatedTo, 'a destination was chosen');
     // Both halves, because the router needs both: the rail button it marks
-    // active and the view panel it shows by the same name.
+    // active and a panel it can actually show. The panel is resolved through
+    // the router's own arm and looked for in the shipped page, so this says
+    // the destination is showable THERE rather than showable here.
     assert.ok(doc.querySelector(`[data-nav="${w.navigatedTo}"]`),
       `the router has no rail entry for "${w.navigatedTo}", so it cannot go there`);
-    assert.ok(doc.getElementById(`view-${w.navigatedTo}`),
-      `the router has no view panel for "${w.navigatedTo}", so it would show nothing`);
+    const panel = panelShownFor(w.navigatedTo);
+    assert.ok(new RegExp(`id="view-${panel}"`).test(INDEX_SRC),
+      `the router shows #view-${panel} for "${w.navigatedTo}" and index.html carries no such panel`);
     dom.window.close();
   });
 
-  // The resolution itself, both ways round. Today there is no routines rail
-  // entry and it lands on the section that lists routines; the day that entry
-  // exists it lands on the routines surface, with nothing here edited.
+  // The resolution itself, both ways round: with neither half of a destination
+  // it falls back, and with both halves it lands on the routines surface, with
+  // nothing here edited.
+  //
+  // THE HALVES PLANTED HERE ARE THE HALVES THE SHIPPED PAGE HAS, checked
+  // against it first, so this constructs a condition that is real rather than
+  // one only this file can satisfy.
   test('the destination is the routines surface once the shell can reach it', () => {
     const { w, doc, dom } = atReady();
     assert.strictEqual(w.routinesListNav(), 'team', 'no routines rail entry yet');
+    assert.match(INDEX_SRC, /data-nav="routines"/, 'index.html carries no routines rail entry');
+    assert.match(INDEX_SRC, /id="view-routines"/, 'index.html carries no routines view panel');
 
     const button = doc.createElement('button');
     button.setAttribute('data-nav', 'routines');

--- a/test/unit/routine-editor-view.test.js
+++ b/test/unit/routine-editor-view.test.js
@@ -42,11 +42,11 @@ function skillFixture() {
 // time zone is handed in.
 function mount(opts = {}) {
   const dom = new JSDOM('<!doctype html><html><body>'
-    // The shell as it stands today: a rail button and a sidebar panel for each
-    // section the router can reach. The routines surface has neither yet, which
-    // is the condition the save destination has to resolve against.
-    + '<button class="nav-item" data-nav="team"></button><div id="sidebar-team"></div>'
-    + '<button class="nav-item" data-nav="skills"></button><div id="sidebar-skills"></div>'
+    // A rail button and a view panel for each section the router can reach.
+    // The routines surface has neither here, which is the condition the save
+    // destination has to resolve against.
+    + '<button class="nav-item" data-nav="team"></button><div id="view-team"></div>'
+    + '<button class="nav-item" data-nav="skills"></button><div id="view-skills"></div>'
     + '<div id="view-routine-editor" class="hidden"><div id="routine-editor-content"></div></div>'
     + '</body></html>',
     // The modules are evaluated inside the window, the way index.html loads
@@ -479,11 +479,11 @@ describe('routine editor view: saving', () => {
     assert.strictEqual(w.navigatedTo, w.routinesListNav(), 'the reply is what leaves');
     assert.ok(w.navigatedTo, 'a destination was chosen');
     // Both halves, because the router needs both: the rail button it marks
-    // active and the sidebar panel it reveals by the same name.
+    // active and the view panel it shows by the same name.
     assert.ok(doc.querySelector(`[data-nav="${w.navigatedTo}"]`),
       `the router has no rail entry for "${w.navigatedTo}", so it cannot go there`);
-    assert.ok(doc.getElementById(`sidebar-${w.navigatedTo}`),
-      `the router has no sidebar panel for "${w.navigatedTo}", so it would hide every one`);
+    assert.ok(doc.getElementById(`view-${w.navigatedTo}`),
+      `the router has no view panel for "${w.navigatedTo}", so it would show nothing`);
     dom.window.close();
   });
 
@@ -497,20 +497,20 @@ describe('routine editor view: saving', () => {
     const button = doc.createElement('button');
     button.setAttribute('data-nav', 'routines');
     const panel = doc.createElement('div');
-    panel.id = 'sidebar-routines';
+    panel.id = 'view-routines';
     doc.body.append(button, panel);
     assert.strictEqual(w.routinesListNav(), w.RundockRoutineEditorModel.SAVE_DESTINATION);
     dom.window.close();
   });
 
-  // Half a destination is not one. A rail button with no panel would make the
-  // router hide every sidebar and reveal nothing.
+  // Half a destination is not one. A rail button with no view panel would
+  // leave the router showing nothing at all.
   test('a destination the shell only half has is not used', () => {
     const { w, doc, dom } = atReady();
     const button = doc.createElement('button');
     button.setAttribute('data-nav', 'routines');
     doc.body.append(button);
-    assert.strictEqual(w.routinesListNav(), 'team', 'a rail entry with no panel is not a destination');
+    assert.strictEqual(w.routinesListNav(), 'team', 'a rail entry with no view panel is not a destination');
     dom.window.close();
   });
 

--- a/test/unit/routines-view-doors.test.js
+++ b/test/unit/routines-view-doors.test.js
@@ -44,6 +44,7 @@ const EDITOR_MODEL_SRC = read('public', 'routine-editor-model.js');
 // off it, in the order index.html loads them.
 const SKILLS_MODEL_SRC = read('public', 'skills-model.js');
 const EDITOR_VIEW_SRC = read('public', 'views', 'routine-editor.js');
+const PROFILE_VIEW_SRC = read('public', 'views', 'profile.js');
 
 // ===== THE ENUMERATION =====
 //
@@ -58,10 +59,15 @@ const RENDERERS = [
     surface: 'the roster arriving from the server',
     pressedBy: 'the roster arriving from the server draws the list',
   },
+  // THE RAIL NO LONGER DRAWS THIS LIST ITSELF and neither does the profile.
+  // Both arrive through one destination function, which is where the drawing
+  // moved to. Two routes into one section with two copies of the same three
+  // calls is how `openRoutineEditor` ended up lighting Team on a routines
+  // surface, so the rail's arm passes no agent and a profile row passes one.
   {
-    file: 'app.js',
-    line: "else if(nav==='routines')",
-    surface: 'the Routines entry on the nav rail',
+    file: 'views/routines.js',
+    line: 'function showRoutinesForAgent(agentId)',
+    surface: 'every arrival at this list, from the rail with no agent and from a profile row with one',
     pressedBy: 'the rail entry shows the view and draws the list',
   },
   {
@@ -134,6 +140,31 @@ const ROUTES = [
   {
     what: 'the section the rail entry reveals in the sidebar',
     pressedBy: 'every section the rail carries reveals a sidebar the reader can see',
+  },
+  {
+    what: "a routine row in the Routines box on an agent's profile",
+    pressedBy: 'a routine row on a profile opens this list scoped to that agent',
+  },
+];
+
+// Every call the client makes into this view TO LAND A READER ON IT. Separate
+// from REPLIES because the two fail differently: a reply that arrives on the
+// wrong screen is a message handled in the wrong place, and a route that
+// arrives with the wrong scope is a list that has silently lost rows. Both are
+// checked against the source by the same rule, so one added later fails by
+// name until somebody lists it with the test that presses its surface.
+const ENTRIES = [
+  {
+    call: 'showRoutinesForAgent',
+    from: 'public/app.js',
+    surface: "the rail's own arm, which passes no agent and so asks for the whole team",
+    pressedBy: 'the rail entry shows the view and draws the list',
+  },
+  {
+    call: 'showRoutinesForAgent',
+    from: 'public/views/profile.js',
+    surface: "a routine row in the Routines box on an agent's profile",
+    pressedBy: 'a routine row on a profile opens this list scoped to that agent',
   },
 ];
 
@@ -209,7 +240,7 @@ describe('every way this list gets drawn is enumerated', () => {
 
   test('every renderer names a test, and every named test exists', () => {
     const suite = fs.readFileSync(__filename, 'utf-8');
-    for (const entry of [...RENDERERS, ...ROUTES, ...REPLIES]) {
+    for (const entry of [...RENDERERS, ...ROUTES, ...REPLIES, ...ENTRIES]) {
       assert.ok(entry.pressedBy, `${entry.file || entry.what || entry.call} needs a test`);
       assert.ok(suite.includes(`test('${entry.pressedBy}'`),
         `this file names "${entry.pressedBy}" but no test here has that name`);
@@ -230,7 +261,11 @@ describe('every way this list gets drawn is enumerated', () => {
       const src = fs.readFileSync(path.join(ROOT, rel), 'utf-8');
       for (const m of src.matchAll(/(?:switchNav|showView|setNavState)\((['"])([\w-]+)\1\)/g)) {
         if (m[2] !== 'routines') continue;
-        assert.ok(/routine-editor\.js$/.test(rel),
+        // The editor, which leaves for this list after a save, and this view
+        // itself, which names its own section on the one destination function
+        // every route runs through. Anything else navigating here is a route
+        // with no row.
+        assert.ok(/routine-editor\.js$|views\/routines\.js$/.test(rel),
           `${rel} navigates to the routines section and is not a listed route`);
       }
     }
@@ -362,19 +397,67 @@ describe('the ways this list gets drawn, pressed', () => {
     const body = appPiece(/else if\(nav==='routines'\)\s*\{([\s\S]*?)\}/, "switchNav's routines arm");
     w.shown = null;
     w.showView = (v) => { w.shown = v; };
-    w.drawn = 0;
-    const realRender = w.renderRoutines;
-    w.renderRoutines = () => { w.drawn++; realRender(); };
+    w.navState = null;
+    w.setNavState = (v) => { w.navState = v; };
     w.closeFindBar = () => {};
-    w.setNavState = () => {};
     w.switchNav = (nav) => {
       assert.strictEqual(nav, 'routines', 'the rail entry asks for another section');
       w.eval(`(function () {${body}\n})()`);
     };
     entry.click();
     assert.strictEqual(w.shown, 'routines', 'the rail entry does not show this view');
-    assert.strictEqual(w.drawn, 1, 'the rail entry shows the view without drawing anything into it');
-    assert.strictEqual(doc.querySelectorAll('.routine-row').length, 1);
+    assert.strictEqual(w.navState, 'routines', 'the rail says one section and the pane shows another');
+    assert.strictEqual(doc.querySelectorAll('.routine-row').length, 1,
+      'the rail entry shows the view without drawing anything into it');
+    dom.window.close();
+  });
+
+  // THE OTHER ROUTE, and the one that carries a scope. Pressed as markup on a
+  // rendered profile, because what a row does is the claim: calling the
+  // destination function would say nothing about whether any row calls it.
+  //
+  // The scope is checked in BOTH directions in one walk. A list that shows the
+  // agent's routines proves nothing on a workspace with one agent, and a scope
+  // that never clears is a list that has silently lost rows the next time
+  // somebody arrives from the rail.
+  test('a routine row on a profile opens this list scoped to that agent', () => {
+    const { w, doc, dom } = shell();
+    const profilePanel = /<div id="view-profile"[\s\S]*?<\/div>\s*<\/div>/.exec(INDEX_SRC);
+    assert.ok(profilePanel, 'index.html no longer carries a profile panel');
+    doc.body.insertAdjacentHTML('beforeend', profilePanel[0]);
+    w.eval(PROFILE_VIEW_SRC);
+    w.agents = [
+      w.agents[0],
+      { id: 'ted', displayName: 'Ted', colour: '#6BC67E', icon: 'T', status: 'onTeam',
+        routines: [{ ...ROUTINE, name: 'Reconcile the delivery log' }] },
+    ];
+    w.conversations = [];
+    w.skills = [];
+    w.formatTimeAgo = () => 'a while ago';
+    w.getGuide = () => ({ id: 'doc' });
+    w.showView = () => {};
+    w.setNavState = () => {};
+    w.switchNav = () => {};
+    w.startConversation = () => {};
+    w.addToTeam = () => {};
+    w.openConversation = () => {};
+    w.selectSkill = () => {};
+    w.addRoutineForAgent = () => {};
+
+    w.showProfile('piper');
+    const row = doc.querySelector('#profile-content .profile-card-item[onclick^="showRoutinesForAgent"]');
+    assert.ok(row, 'the profile carries no routine row that opens this list');
+    row.click();
+    let listed = doc.getElementById('routines-content').textContent;
+    assert.match(listed, /Compile the ops summary/, 'the list does not carry the agent whose row was pressed');
+    assert.ok(!listed.includes('Reconcile the delivery log'),
+      'the list carries another agent, so the row opened it unscoped');
+
+    // And the rail, which asks for everybody, gets everybody.
+    w.eval(`(function () {${appPiece(/else if\(nav==='routines'\)\s*\{([\s\S]*?)\}/, "switchNav's routines arm")}\n})()`);
+    listed = doc.getElementById('routines-content').textContent;
+    assert.match(listed, /Reconcile the delivery log/,
+      'the rail entry inherited the last profile\'s scope, so the list has lost rows');
     dom.window.close();
   });
 
@@ -449,9 +532,20 @@ describe('every reply that reaches this view is enumerated', () => {
         if (new RegExp(`(?<![.\\w$])${call}\\(`).test(src)) found.push(call);
       }
     }
-    assert.deepStrictEqual([...new Set(found)].sort(), [...new Set(REPLIES.map(r => r.call))].sort(),
+    assert.deepStrictEqual([...new Set(found)].sort(),
+      [...new Set([...REPLIES, ...ENTRIES].map(r => r.call))].sort(),
       'the client calls into this view from somewhere this file does not list, or a listed '
       + 'call no longer exists. Add the row and the test that drives it, or remove the row.');
+  });
+
+  // And an entry is named with the file it is called from, so moving the call
+  // fails here rather than passing on the strength of the name alone.
+  test('every entry is called from the file this file says it is called from', () => {
+    for (const entry of ENTRIES) {
+      const src = read(...entry.from.split('/'));
+      assert.ok(new RegExp(`(?<![.\\w$])${entry.call}\\(`).test(src),
+        `${entry.from} no longer calls ${entry.call}`);
+    }
   });
 
   test('every reply is on the case this file says it is on', () => {

--- a/test/unit/routines-view-doors.test.js
+++ b/test/unit/routines-view-doors.test.js
@@ -265,11 +265,11 @@ function shellMarkup() {
   assert.ok(panel, 'index.html no longer carries the routines view panel');
   // THE SIDEBAR IS CUT OUT OF THE PAGE TOO, and that is a correction rather
   // than tidiness. It used to be written here, which made the destination
-  // check below unfalsifiable: the editor resolves where a save goes by
-  // asking whether the shell has BOTH a rail entry called routines and a panel
-  // called sidebar-routines, and a test that supplies that panel itself
-  // answers its own question. Rename the panel in index.html and the editor
-  // silently starts landing saves on the team chart, with this file green.
+  // check below unfalsifiable: the editor resolves where a save goes by asking
+  // whether the shell has BOTH a rail entry called routines and the view panel
+  // the router shows by that name, and a test that supplies either of them
+  // itself answers its own question. Rename either in index.html and the
+  // editor silently starts landing saves on the team chart, this file green.
   const sidebar = /<aside class="sidebar"[\s\S]*?<\/aside>/.exec(INDEX_SRC);
   assert.ok(sidebar, 'index.html no longer carries a sidebar');
   return '<!doctype html><html><body>' + rail[0] + sidebar[0]
@@ -315,7 +315,7 @@ describe('the ways this list gets drawn, pressed', () => {
     w.drawn = 0;
     const realRender = w.renderRoutines;
     w.renderRoutines = () => { w.drawn++; realRender(); };
-    for (const name of ['renderAgentList', 'renderOrgChart', 'renderRoutinesSidebar', 'renderConvoList']) {
+    for (const name of ['renderAgentList', 'renderOrgChart', 'renderConvoList']) {
       w[name] = () => {};
     }
     w.d = { type: 'agents', agents: w.agents };
@@ -409,8 +409,8 @@ describe('the ways this list gets drawn, pressed', () => {
     // to the team panel in silence.
     assert.ok(doc.querySelector('[data-nav="routines"]'),
       'index.html carries no routines rail entry, so the editor cannot reach this view');
-    assert.ok(doc.getElementById('sidebar-routines'),
-      'index.html carries no routines sidebar panel, so the editor cannot reach this view');
+    assert.ok(doc.getElementById('view-routines'),
+      'index.html carries no routines view panel, so the editor cannot reach this view');
 
     w.skills = [{ id: 'sk', name: 'Compile the ops summary', slug: 'ops', assignedAgents: [{ id: 'piper', name: 'Piper' }] }];
     w.skillsLoaded = true;
@@ -539,12 +539,14 @@ describe('every reply that reaches this view is enumerated', () => {
 describe('the shell can actually show what it navigates to', () => {
   // THE BUG THIS CATCHES, and it is a silent one rather than a throw. The
   // routines section has no sidebar panel of its own; its panel is the team
-  // one, which already carries a Routines section inside it. There IS an
-  // element called sidebar-routines, NESTED in the team panel, so revealing it
-  // by name succeeds, throws nothing, and leaves the reader looking at an
-  // empty sidebar because the parent stayed hidden. So the assertion is not
-  // that an element was found: it is that what was revealed can actually be
-  // seen.
+  // one, resolved through the router's own map. There used to be an empty
+  // element under the routines name NESTED in the team panel, left there by
+  // the listing the team sidebar carried, so revealing it by name succeeded,
+  // threw nothing, and left the reader looking at an empty sidebar because the
+  // parent stayed hidden. The listing and the element are both gone; the
+  // assertion that caught it stays, because the map can name a nested panel
+  // again. It is not that an element was found: it is that what was revealed
+  // can actually be seen.
   test('every section the rail carries reveals a sidebar the reader can see', () => {
     const { doc, w, dom } = shell();
     // Both cut out of app.js and run, so the mapping under test is the one

--- a/test/unit/routines-view-doors.test.js
+++ b/test/unit/routines-view-doors.test.js
@@ -343,6 +343,46 @@ function appPiece(pattern, label) {
   return m[1];
 }
 
+// A shell with two agents and a real profile panel, cut out of index.html. The
+// second agent is what makes a scope observable at all: on a workspace with one
+// agent, a scoped list and an unscoped one are the same list.
+function twoAgentShell() {
+  const { w, doc, dom } = shell();
+  const profilePanel = /<div id="view-profile"[\s\S]*?<\/div>\s*<\/div>/.exec(INDEX_SRC);
+  assert.ok(profilePanel, 'index.html no longer carries a profile panel');
+  doc.body.insertAdjacentHTML('beforeend', profilePanel[0]);
+  w.eval(PROFILE_VIEW_SRC);
+  w.agents = [
+    w.agents[0],
+    { id: 'ted', displayName: 'Ted', colour: '#6BC67E', icon: 'T', status: 'onTeam',
+      routines: [{ ...ROUTINE, name: 'Reconcile the delivery log' }] },
+  ];
+  w.conversations = [];
+  w.skills = [];
+  w.formatTimeAgo = () => 'a while ago';
+  w.getGuide = () => ({ id: 'doc' });
+  w.showView = () => {};
+  w.setNavState = () => {};
+  w.switchNav = () => {};
+  w.startConversation = () => {};
+  w.addToTeam = () => {};
+  w.openConversation = () => {};
+  w.selectSkill = () => {};
+  w.addRoutineForAgent = () => {};
+  return { w, doc, dom };
+}
+
+// Arrive by the route a reader takes: render that agent's profile and press a
+// routine row on it. Never by calling the destination function, which would say
+// nothing about whether any row reaches it.
+function pressProfileRow(w, doc, agentId) {
+  w.showProfile(agentId);
+  const row = doc.querySelector('#profile-content .profile-card-item[onclick^="showRoutinesForAgent"]');
+  assert.ok(row, `the profile for ${agentId} carries no routine row that opens this list`);
+  row.click();
+  return row;
+}
+
 describe('the ways this list gets drawn, pressed', () => {
   test('the roster arriving from the server draws the list', () => {
     const { w, dom } = shell();
@@ -421,33 +461,8 @@ describe('the ways this list gets drawn, pressed', () => {
   // that never clears is a list that has silently lost rows the next time
   // somebody arrives from the rail.
   test('a routine row on a profile opens this list scoped to that agent', () => {
-    const { w, doc, dom } = shell();
-    const profilePanel = /<div id="view-profile"[\s\S]*?<\/div>\s*<\/div>/.exec(INDEX_SRC);
-    assert.ok(profilePanel, 'index.html no longer carries a profile panel');
-    doc.body.insertAdjacentHTML('beforeend', profilePanel[0]);
-    w.eval(PROFILE_VIEW_SRC);
-    w.agents = [
-      w.agents[0],
-      { id: 'ted', displayName: 'Ted', colour: '#6BC67E', icon: 'T', status: 'onTeam',
-        routines: [{ ...ROUTINE, name: 'Reconcile the delivery log' }] },
-    ];
-    w.conversations = [];
-    w.skills = [];
-    w.formatTimeAgo = () => 'a while ago';
-    w.getGuide = () => ({ id: 'doc' });
-    w.showView = () => {};
-    w.setNavState = () => {};
-    w.switchNav = () => {};
-    w.startConversation = () => {};
-    w.addToTeam = () => {};
-    w.openConversation = () => {};
-    w.selectSkill = () => {};
-    w.addRoutineForAgent = () => {};
-
-    w.showProfile('piper');
-    const row = doc.querySelector('#profile-content .profile-card-item[onclick^="showRoutinesForAgent"]');
-    assert.ok(row, 'the profile carries no routine row that opens this list');
-    row.click();
+    const { w, doc, dom } = twoAgentShell();
+    pressProfileRow(w, doc, 'piper');
     let listed = doc.getElementById('routines-content').textContent;
     assert.match(listed, /Compile the ops summary/, 'the list does not carry the agent whose row was pressed');
     assert.ok(!listed.includes('Reconcile the delivery log'),
@@ -458,6 +473,68 @@ describe('the ways this list gets drawn, pressed', () => {
     listed = doc.getElementById('routines-content').textContent;
     assert.match(listed, /Reconcile the delivery log/,
       'the rail entry inherited the last profile\'s scope, so the list has lost rows');
+    dom.window.close();
+  });
+
+  // A DELETE CONFIRMATION DOES NOT SURVIVE A CHANGE OF SCOPE, and this is a
+  // destructive action rather than a cosmetic one.
+  //
+  // The pending delete is a POSITION in the list, and the scope decides what
+  // the list contains, so a confirmation opened against one list addresses a
+  // different routine under the next. The render only drops the index when it
+  // falls off the end, so whenever the next list is long enough the reader is
+  // shown a confirmation they never asked for, naming a routine they never
+  // pointed at, and confirming it deletes that one.
+  //
+  // Driven in the direction that RE-AIMS rather than the one that merely
+  // strands: the confirmation is opened on the first row of the whole-team
+  // list, which belongs to one agent, and the reader then arrives scoped to
+  // another agent whose own list is long enough to have a first row.
+  test('a delete confirmation cannot be re-aimed by arriving from somewhere else', () => {
+    const { w, doc, dom } = twoAgentShell();
+    w.sent = [];
+    w.ws = { send: (m) => w.sent.push(JSON.parse(m)) };
+
+    w.renderRoutines();
+    doc.querySelectorAll('[data-routines-action="delete"]')[0].click();
+    const confirmation = doc.querySelector('.confirm-card');
+    assert.ok(confirmation, 'sanity: pressing Delete did not open a confirmation');
+    assert.match(doc.getElementById('routines-content').textContent, /Compile the ops summary/,
+      'sanity: the confirmation is not the one the reader opened');
+
+    pressProfileRow(w, doc, 'ted');
+    assert.strictEqual(doc.querySelector('.confirm-card'), null,
+      'a confirmation the reader never opened is on the page, aimed at another agent\'s routine');
+
+    // And the control behind it cannot act either, which is the half that
+    // matters: a stale confirmation that is merely invisible would still
+    // delete when the next Enter reaches it.
+    w.routinesConfirmDelete();
+    assert.deepStrictEqual(w.sent, [],
+      'a routine was deleted that the reader never asked to delete');
+    dom.window.close();
+  });
+
+  // The scope is a filter, and a filter with nothing left to show must not be
+  // mistaken for a workspace with nothing in it. The empty state speaks for the
+  // whole team: it says nothing is scheduled and offers a picker spanning every
+  // agent. Nothing on this page names the scope, so under one that reads as a
+  // claim about the workspace, and the claim is false.
+  test('a scoped list that empties does not say the workspace is empty', () => {
+    const { w, doc, dom } = twoAgentShell();
+    pressProfileRow(w, doc, 'piper');
+    assert.match(doc.getElementById('routines-content').textContent, /Compile the ops summary/,
+      'sanity: the scoped list is not showing the agent it was opened for');
+
+    // The agent's last routine goes, and the roster comes back without it.
+    w.agents = w.agents.map(a => (a.id === 'piper' ? { ...a, routines: [] } : a));
+    w.renderRoutines();
+
+    const shown = doc.getElementById('routines-content').textContent;
+    assert.ok(!/No routines yet/.test(shown),
+      'the page says the workspace has nothing scheduled while another agent still does');
+    assert.match(shown, /Reconcile the delivery log/,
+      'the filter had nothing left to show and was drawn empty rather than dropped');
     dom.window.close();
   });
 

--- a/test/unit/routines-view.test.js
+++ b/test/unit/routines-view.test.js
@@ -239,8 +239,14 @@ describe('what this card proves by pressing, and what it proves by calling', () 
     // that accepted either would accept the one that rebuilds it.
     assert.match(appPiece(/^\s*else if\(nav==='skills'\) \{(.*)\}\s*$/m, "switchNav's skills arm"),
       /(?<![.\w$])renderSkillsIfEmpty\(/, 'the Skills opener reveals a panel without drawing into it');
+    // The Routines arm is pinned to the ONE DESTINATION FUNCTION rather than
+    // to renderRoutines, and pinned to the argument as well. That function
+    // reveals the panel, sets the rail and draws, and its argument is the
+    // scope: the rail asks for the whole team, so it must pass no agent. An
+    // arm that passed one would open the rail entry on a filtered list.
     assert.match(appPiece(/else if\(nav==='routines'\)\s*\{([\s\S]*?)\}/, "switchNav's routines arm"),
-      /(?<![.\w$])renderRoutines\(/, 'the Routines opener reveals a panel without drawing into it');
+      /(?<![.\w$])showRoutinesForAgent\(null\)/,
+      'the Routines opener reveals a panel without drawing into it, or opens it scoped');
   });
 });
 

--- a/test/unit/team-sidebar.test.js
+++ b/test/unit/team-sidebar.test.js
@@ -1,0 +1,270 @@
+'use strict';
+// The team panel: the agent roster, and nothing else.
+//
+// WHY THIS FILE IS A SWEEP AND NOT A LIST OF TESTS.
+//
+// Removing a listing is the easy half. The half that costs somebody a day is
+// what the listing leaves behind: a render function nothing calls, a formatter
+// with no caller, an empty element in the page that another module is quietly
+// using as a sentinel. A listing left unreferenced is the shape the next
+// person re-wires when they need something like it, and a helper left behind
+// is the shape they re-wire it out of.
+//
+// So this file enumerates two things and checks both against the source:
+//
+//   SWEPT  what went, asserted absent everywhere rather than absent from the
+//          one file somebody remembered to look in
+//   KEPT   what the listing touched that survives, each with the reason it
+//          survives, so a reader can tell a decision from an oversight
+//
+// And the panel itself is PRESSED: the roster arrives through the real client
+// dispatch, cut out of app.js and run, into the real sidebar markup, cut out
+// of index.html. A copy of either in this file would keep passing after the
+// page stopped carrying it.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { JSDOM } = require('jsdom');
+
+const ROOT = path.join(__dirname, '..', '..');
+const read = (...parts) => fs.readFileSync(path.join(ROOT, ...parts), 'utf-8');
+const APP_SRC = read('public', 'app.js');
+const INDEX_SRC = read('public', 'index.html');
+const TEAM_SRC = read('public', 'views', 'team.js');
+
+// ===== THE SWEEP =====
+
+// Gone, and gone from everywhere. Each row names the symbol and what it was,
+// so a reader coming back to this does not have to reconstruct why it is
+// listed. `where` is the tree the symbol must not appear in: the client for
+// markup and behaviour, the suite and the instruments for anything that
+// propped it up, because a mutation harness still naming a deleted guard is a
+// check that silently stopped checking.
+const SWEPT = [
+  {
+    name: 'renderRoutinesSidebar',
+    was: 'the listing itself, in views/team.js, and its call in the roster dispatch',
+  },
+  {
+    name: 'formatScheduleShort',
+    was: 'the schedule words the listing showed, in app.js. The listing was its only caller, '
+      + 'and the profile\'s new Routines box takes its words from routines-model instead, '
+      + 'so the whole surface has one vocabulary rather than two.',
+  },
+  {
+    name: 'sidebar-routines',
+    was: 'the empty element the listing rendered into, nested inside the team panel',
+  },
+];
+
+// Touched by the listing and still here, each with the reason. An unlisted
+// survivor reads as something nobody looked at.
+const KEPT = [
+  {
+    name: 'addRoutine',
+    where: 'public/views/routines.js',
+    why: 'the unscoped way into the editor. The listing carried one and so does the routines '
+      + 'view\'s empty state; removing the listing removes one of two doors, not the only one.',
+  },
+  {
+    name: '.re-link',
+    where: 'public/styles/views/routine-editor.css',
+    why: 'the listing borrowed this class for its Add control, which is the pattern the card '
+      + 'objected to. It belongs to the routine editor, which still uses it on the '
+      + 'confirmation step\'s Edit link.',
+  },
+  {
+    name: 'SIDEBAR_FOR',
+    where: 'public/app.js',
+    why: 'the routines section still has no sidebar panel of its own and still reveals the '
+      + 'team one. The scope list that will give it one is carded separately.',
+  },
+];
+
+function filesUnder(dir, keep, skip) {
+  const out = [];
+  const walk = (rel) => {
+    for (const entry of fs.readdirSync(path.join(ROOT, rel), { withFileTypes: true })) {
+      if (entry.name === 'vendor' || entry.name === 'node_modules') continue;
+      if (skip && skip.has(rel + '/' + entry.name)) continue;
+      const next = `${rel}/${entry.name}`;
+      if (entry.isDirectory()) walk(next);
+      else if (keep(entry.name)) out.push(next);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+// Everywhere a swept name could still be named: the client, the suite, and the
+// scripts that run against both.
+//
+// THE MUTATION HARNESS IS THE ONE EXCLUSION, and it is the check working
+// rather than a hole in it. What this card leaves behind is a rule about
+// ABSENCE, and an absence no instrument can break is an absence no instrument
+// is checking, so the harness's job here is to write the swept element back
+// into the page and require this file to notice. It names the thing it
+// reinstates, necessarily. Excluding anything wider would let a swept name
+// come back through a test.
+const NOT_SEARCHED = new Set(['test/tools']);
+
+function sweptSearchPaths() {
+  const isSource = (name) => /\.(js|html|css|json)$/.test(name);
+  return [
+    ...filesUnder('public', isSource),
+    ...filesUnder('test', isSource, NOT_SEARCHED),
+    ...filesUnder('scripts', isSource),
+  ];
+}
+
+describe('the routines listing left nothing behind', () => {
+  // THE CHECK THAT MAKES THE REMOVAL A REMOVAL. A function left in place with
+  // no caller passes every behavioural test in this file: nothing renders it,
+  // so nothing sees it. This is the only assertion that can tell "removed"
+  // from "unreferenced".
+  test('nothing swept is named anywhere in the client, the suite or the instruments', () => {
+    for (const swept of SWEPT) {
+      const survivors = sweptSearchPaths().filter((rel) => (
+        path.join(ROOT, rel) !== __filename
+        && fs.readFileSync(path.join(ROOT, rel), 'utf-8').includes(swept.name)
+      ));
+      assert.deepStrictEqual(survivors, [],
+        `${swept.name} was ${swept.was}, and is still named in ${survivors.join(', ')}`);
+    }
+  });
+
+  test('everything kept says where it lives and why', () => {
+    for (const kept of KEPT) {
+      assert.ok(kept.why && kept.why.length > 40,
+        `${kept.name} is kept without a reason, which reads as something nobody looked at`);
+      assert.ok(read(...kept.where.split('/')).includes(kept.name),
+        `${kept.name} is listed as kept and ${kept.where} no longer names it`);
+    }
+  });
+
+  // The listing's own stylesheet rules. A rule with nothing to match is dead
+  // in the way that is hardest to see, because no test ever renders it.
+  test('the listing took its stylesheet rules with it', () => {
+    const styles = filesUnder('public/styles', (n) => n.endsWith('.css'))
+      .map(rel => read(...rel.split('/').filter(Boolean)))
+      .join('\n');
+    for (const selector of ['.routine-item', '.routine-name', '.avatar.xxs']) {
+      assert.ok(!styles.includes(selector),
+        `${selector} was only ever matched by the sidebar listing and is still in the stylesheet`);
+    }
+  });
+});
+
+// ===== PRESSING THE PANEL =====
+
+// The real sidebar, cut out of the real page. The roster is delivered through
+// the real dispatch. Nothing about the panel is written here, so a panel that
+// starts carrying something again fails this rather than agreeing with it.
+function shellMarkup() {
+  const sidebar = /<aside class="sidebar"[\s\S]*?<\/aside>/.exec(INDEX_SRC);
+  assert.ok(sidebar, 'index.html no longer carries a sidebar');
+  return '<!doctype html><html><body>' + sidebar[0] + '</body></html>';
+}
+
+function appPiece(pattern, label) {
+  const m = APP_SRC.match(pattern);
+  assert.ok(m && m[1] && m[1].trim(), `app.js no longer carries ${label}`);
+  return m[1];
+}
+
+const ROUTINE = { name: 'Compile the ops summary', schedule: 'every day at 07:00', state: null };
+
+function shell() {
+  const dom = new JSDOM(shellMarkup(), { runScripts: 'dangerously' });
+  const w = dom.window;
+  w.eval(TEAM_SRC);
+  w.agents = [
+    {
+      id: 'piper', displayName: 'Piper', role: 'Ops', colour: '#E87A5A', icon: 'P',
+      status: 'onTeam', type: 'specialist',
+      routines: [ROUTINE, { name: 'Draft the stand-up notes', schedule: 'every day at 08:30', state: null }],
+    },
+    { id: 'ted', displayName: 'Ted', role: 'Inventory', colour: '#6BC67E', icon: 'T', status: 'onTeam', type: 'specialist' },
+  ];
+  w.convoState = {};
+  w.conversations = [];
+  w.agentLastActivity = {};
+  w.esc = (s) => String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  w.formatTimeAgo = () => 'a while ago';
+  w.getTeamAgents = () => w.agents.filter(a => a.status === 'onTeam' && a.type !== 'platform');
+  w.getPlatformAgents = () => w.agents.filter(a => a.type === 'platform');
+  w.renderOrgChart = () => {};
+  w.renderConvoList = () => {};
+  w.renderRoutines = () => {};
+  // Every swept global, stubbed BY THE NAME THE SWEEP LISTS rather than
+  // written out here, and only where nothing already answers to it.
+  //
+  // WITHOUT THIS THESE TESTS FAIL FOR THE WRONG REASON IN BOTH DIRECTIONS.
+  // Against the code before this card the listing renders, reaches for the
+  // schedule formatter on the global, and throws, so the assertion about what
+  // the panel shows is never reached and the red says nothing. Against the
+  // code after it, nothing reads the stub at all. What fails these tests is
+  // the panel's contents, which is what they are about.
+  for (const swept of SWEPT) {
+    if (!/^[A-Za-z_$][\w$]*$/.test(swept.name)) continue;
+    if (typeof w[swept.name] !== 'undefined') continue;
+    w[swept.name] = (value) => value;
+  }
+  return { w, doc: w.document, dom };
+}
+
+// The roster arriving, through the dispatch that delivers it, into the page.
+function deliverRoster(w) {
+  const body = appPiece(/case 'agents':([\s\S]*?)\bbreak;/, 'the roster case of the client dispatch');
+  w.d = { type: 'agents', agents: w.agents };
+  w.eval(`(function () {${body}\n})()`);
+}
+
+describe('the team panel shows the agent roster and nothing else', () => {
+  test('a roster full of routines draws no routine in the team panel', () => {
+    const { w, doc, dom } = shell();
+    deliverRoster(w);
+    const panel = doc.getElementById('sidebar-team');
+    assert.ok(panel, 'index.html no longer carries a team panel');
+    const shown = panel.textContent.replace(/\s+/g, ' ').trim();
+    assert.match(shown, /Piper/, 'sanity: the roster is on the page');
+    for (const routine of w.agents[0].routines) {
+      assert.ok(!shown.includes(routine.name),
+        `the team panel still lists "${routine.name}", which is the listing this card removes`);
+    }
+    assert.ok(!/Routines/.test(shown), 'the team panel still carries a Routines heading');
+    assert.ok(!/7:00|07:00|8:30|08:30/.test(shown),
+      'the team panel still shows a schedule, so the listing is drawn somewhere in it');
+    dom.window.close();
+  });
+
+  // AC-A2, and it is a check on what was NOT built as much as what was
+  // removed. The locked mock replaced the listing with a per-agent count pill;
+  // the owner overruled that, so an agent row carries a name and a working
+  // state and no number at all.
+  test('no agent row carries a routine count', () => {
+    const { w, doc, dom } = shell();
+    deliverRoster(w);
+    for (const row of doc.querySelectorAll('#agent-list .agent-status-item')) {
+      const text = row.textContent.replace(/\s+/g, ' ').trim();
+      assert.ok(!/\d/.test(text),
+        `an agent row reads "${text}", and a number on a row is the count pill the owner overruled`);
+      assert.strictEqual(row.querySelector('.rcount'), null, 'an agent row carries a count pill');
+    }
+    dom.window.close();
+  });
+
+  // The panel's own contents, enumerated rather than sampled. "Nothing else"
+  // is a claim about everything the panel holds, so it is asserted against
+  // everything the panel holds.
+  test('the team panel holds its header and its roster and no third thing', () => {
+    const { w, doc, dom } = shell();
+    deliverRoster(w);
+    const panel = doc.getElementById('sidebar-team');
+    const children = [...panel.children].map(el => el.id || el.className);
+    assert.deepStrictEqual(children, ['sidebar-team-header', 'agent-list'],
+      'the team panel carries something beyond its header and its roster');
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
Three changes to the agent surfaces, batched because they share them. None changes what a run does, what is stored, or who may do it. One commit each, plus two follow-ups described below.

**Take the routines listing off the team sidebar.** It was the third listing of the same data, showing less than either of the others, with an Add control in a pattern that exists nowhere else in the app. It goes and nothing replaces it. Sweeping behind it was the substantial part: a schedule formatter with one caller, the empty element the listing rendered into, stylesheet rules nothing else matched, and one entry point. The element turned out to be doing hidden work: the routine editor resolved its save destination by checking that element existed, so that check now asks for the view panel the router actually shows.

**Split the agent profile into Skills, Routines and Configuration.** The Routines box carries a name and a schedule and no outcome. That deletes a defect rather than fixing it: the profile used to print raw internal status words such as `interrupted`, and outcomes belong to the routines list, which already owns their words and their tone. The test that guards it drives every status a run record can carry through the page and reads that list out of the scheduler rather than restating it. Add routine appears only while an agent has none, so it teaches the feature once; the box itself never disappears. A row opens the routines list scoped to that agent, through one destination function both routes now run through.

**Name the guide through a slot rather than a literal.** Four sentences named a specific agent that a workspace may not have: the guide is found by type, never by name, so a workspace whose platform agent is called something else was told to talk to somebody it does not have. The fourth sentence was found while fixing the three that were reported. They now live in one object with the name substituted rather than concatenated, and the test workspace's guide has a deliberately different name, because with the default name a hard-coded literal passes on a coincidence.

## Two things the scope brought with it

Scoping the routines list introduced a state the list did not have before, and two things it touched had to be made safe.

**A change of scope must not re-aim a delete.** The list holds a pending delete as a position in the list, and the scope decides what the list contains. Open a delete confirmation on the whole-team list, then arrive at the list scoped to an agent by pressing a routine row on their profile: the render only drops the pending index when it falls off the end of the new list, so whenever the new list is long enough the reader is shown a confirmation they never opened, naming a routine they never pointed at, and confirming it deletes that one. Arriving now clears the pending confirmation, and the pending refusal with it.

**A filter with nothing left to show is dropped rather than drawn empty.** When a scoped list empties, because the agent's last routine was deleted from it, the empty state that follows speaks for the whole team: it says nothing is scheduled and offers a picker spanning every agent, while other agents still have routines. Nothing on the page names the scope, so a reader has no way to tell the emptiness is the filter's doing. The scope drops and the whole list is shown, which is true.

## Three proofs that could not fail

Each of these passed, and each would have passed against the defect it was written to catch.

The team sidebar's "no way into the editor" check looked for a control in a document nothing had rendered the roster into, so it inspected an empty panel. What the panel holds once drawn is proven where the roster is delivered through the real dispatch into the real markup; the doors file now carries the source claim only.

The editor's save-destination test fabricated view panels named after the sections it wanted to reach, and the shipped page has neither: the team section is shown by the home panel. It now asks the router's own arm which panel a section shows and looks for that panel in the shipped page.

The profile's Routines box promised in a comment that a schedule the model has no plain words for falls back to the stored string, and no test drove one. A routine written by hand carries exactly such a schedule, and without the fallback its row shows an empty line. It is now driven.

## Verification

Every commit went through `npm run precommit` (coverage, typecheck, styles, reference check, guard mutations, fixture provenance) and `scripts/red-first.js --base origin/main`, proven each time.

Nineteen new guard mutations, each turning a named test red. Five of them write an absent thing back, because a rule whose whole content is "nothing does this" cannot otherwise be mutated. Six pre-existing mutations were repaired against the changed source rather than deleted, and one was removed with the entry point it guarded.

One deviation, stated because it matters: the final red-first run drove the unit suite rather than the full `npm test`, skipping one test. That test spawns and signals red-first child processes and is unreliable when run inside red-first itself. Four process-spawning tests flake on this machine under load and none of them loads any file in this diff. CI ran the full suite green on Node 22 and 24.

## A copy conflict, resolved and recorded

The design source draws the empty Routines box as "Give one of Ted's skills a schedule and he runs it without being asked." That carries a pronoun for an agent, which this change forbids everywhere else. Shipped as "Give one of {name}'s skills a schedule and it runs without being asked", where "it" is the schedule. The design wording and the requirement cannot both hold, and the deviation is one word.