### PR TITLE
Three small fixes: reserved icon, scheduling from a skill page, and a rollback that was never proven

### DIFF
--- a/lib/agents/discovery.js
+++ b/lib/agents/discovery.js
@@ -28,6 +28,25 @@ const AGENT_INSTRUCTIONS_MAX = 20000;
 
 function invalidateAgentCache() { _agentCache = null; _agentCacheTime = 0; }
 
+// The glyph the platform guide wears, reserved for it. docs/AGENTS.md tells a
+// user it is reserved, and scaffold/rundock-guide.md is what actually wears it.
+// Named here because the rotation below has to be able to exclude it.
+const GUIDE_RESERVED_ICON = '⬡';
+
+// The avatar handed to an agent whose file declares no `icon`, in rotation.
+//
+// THE RESERVED GLYPH IS NOT IN IT, and that is the whole point of this array
+// being a named constant rather than a literal inside the assignment. It used
+// to carry the hexagon at index 6, so the seventh icon-less agent in a
+// workspace was handed the guide's own glyph and the two became
+// indistinguishable in the org chart and the sidebar. Seven glyphs that are
+// always somebody else's beats eight that occasionally lie.
+//
+// Exported so a test can read the same array the assignment indexes into.
+// Reading a copy, or the source text, is what would let the glyph return the
+// next time somebody extends this.
+const AUTO_ASSIGNED_ICONS = ['★', '✎', '◎', '▦', '◇', '✦', '△'];
+
 function discoverAgents() {
   // No workspace selected yet: nothing to discover. Guards path.join(null,…),
   // which otherwise throws and crashes GET /api/agents before a workspace is
@@ -40,7 +59,6 @@ function discoverAgents() {
   const agentsDir = path.join(ws, '.claude', 'agents');
   const claudeMdPath = path.join(ws, 'CLAUDE.md');
   const colours = ['#E87A5A', '#6B9EF0', '#6BC67E', '#E8A84C', '#A07AE8', '#E87AAC', '#5BCFC4', '#E8A07A'];
-  const icons = ['★', '✎', '◎', '▦', '◇', '✦', '⬡', '△'];
   let colourIdx = 0;
 
   if (fs.existsSync(agentsDir)) {
@@ -131,7 +149,7 @@ function discoverAgents() {
           instructions: instructions.substring(0, AGENT_INSTRUCTIONS_MAX),
           isDefault,
           colour: meta.colour || colours[colourIdx % colours.length],
-          icon: meta.icon || icons[colourIdx % icons.length],
+          icon: meta.icon || AUTO_ASSIGNED_ICONS[colourIdx % AUTO_ASSIGNED_ICONS.length],
           fileName: file
         });
         colourIdx++;
@@ -208,7 +226,7 @@ function discoverAgents() {
       instructions: '',
       isDefault: false,
       colour: '#6B8A9E',
-      icon: '⬡',
+      icon: GUIDE_RESERVED_ICON,
       fileName: null
     });
   }
@@ -363,4 +381,5 @@ module.exports = {
   readNormalisedFile, extractFrontmatterText, titleCase,
   parseAgentFrontmatter, parseCapabilities, parseRoutines, parsePrompts, parseSkills,
   AGENT_CACHE_TTL, AGENT_INSTRUCTIONS_MAX,
+  AUTO_ASSIGNED_ICONS, GUIDE_RESERVED_ICON,
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:refs": "node scripts/check-internal-refs.js",
     "precommit": "node scripts/precommit-gate.js",
     "red-first": "node scripts/red-first.js",
-    "mutate:guards": "node test/tools/mutate-render-guards.js --markdown && node test/tools/mutate-routine-editor-guards.js --markdown && node test/tools/mutate-routines-guards.js --markdown && node test/tools/mutate-run-detail-guards.js --markdown && node test/tools/mutate-nav-guards.js --markdown",
+    "mutate:guards": "node test/tools/mutate-render-guards.js --markdown && node test/tools/mutate-routine-editor-guards.js --markdown && node test/tools/mutate-routines-guards.js --markdown && node test/tools/mutate-run-detail-guards.js --markdown && node test/tools/mutate-nav-guards.js --markdown && node test/tools/mutate-workspace-rollback-guards.js --markdown",
     "check:fixture": "node test/tools/regenerate-benign-before.js --check",
     "lint:styles": "node test/tools/style-drift.js",
     "typecheck": "tsc -p tsconfig.server.json && tsc -p tsconfig.client.json",

--- a/public/views/routine-editor.js
+++ b/public/views/routine-editor.js
@@ -49,12 +49,22 @@
 
   function freshState(input) {
     return {
-      step: 'pick',
+      // Almost always 'pick', because almost every door has nothing chosen
+      // yet. The skill page is the exception: the reader chose the skill by
+      // being on its page, so opening on the picker would ask again.
+      step: (input && input.step) || 'pick',
       agentId: (input && input.agentId) || null,
       agentName: (input && input.agentName) || null,
       skills: (input && input.skills) || [],
       zone: (input && input.zone) || null,
-      selectedKey: null,
+      // The skill page this was opened from, if any. It owns the breadcrumb,
+      // because a breadcrumb belongs to the door rather than to the state:
+      // the skill door can carry an agent as well, and "Back to Piper" on a
+      // press that came from a skill page is a label naming somewhere the
+      // press does not go.
+      originSkillId: (input && input.originSkillId) || null,
+      originSkillName: (input && input.originSkillName) || null,
+      selectedKey: (input && input.selectedKey) || null,
       frequency: 'day',
       time: '09:00',
       // The default is the only value this release can honour. It is read from
@@ -218,10 +228,15 @@
     const choice = m.skillChoices({ skills: state.skills, agentId: state.agentId });
     const option = selectedOption();
     let h = '';
-    // The breadcrumb names the agent it returns to, and returns to that
-    // agent. Rendered only when there IS one, so the label can never name a
+    // The breadcrumb belongs to the DOOR that opened the editor, not to what
+    // the state happens to carry. The skill door can carry an agent as well,
+    // so the skill is asked first; then the agent; otherwise none. Rendered
+    // only when there is somewhere to name, so the label can never name a
     // destination this editor does not have.
-    if (state.agentId && state.agentName) {
+    if (state.originSkillId && state.originSkillName) {
+      h += `<a class="profile-back" data-routine-editor="back" data-back-to-skill="${escText(state.originSkillId)}"
+        onclick="routineEditorLeave()">&#8592; Back to ${escText(state.originSkillName)}</a>`;
+    } else if (state.agentId && state.agentName) {
       h += `<a class="profile-back" data-routine-editor="back" data-back-to="${escText(state.agentId)}"
         onclick="routineEditorLeave()">&#8592; Back to ${escText(state.agentName)}</a>`;
     }
@@ -242,9 +257,12 @@
   /**
    * Open the editor, scoped to an agent or not.
    *
-   * Two entries reach this. From an agent's page `agentId` is set and the
-   * picker is that agent's. From the routines view it is not, so every agent's
-   * skills are offered and each row names which agent runs it.
+   * Three doors reach this. From an agent's page, and from the routines panel
+   * which inherits that page's scope, `agentId` is set and the picker is that
+   * agent's. From the routines view it is not, so every agent's skills are
+   * offered and each row names which agent runs it. From a skill's own page it
+   * is set only when exactly one agent has that skill, so the skill door is
+   * the one that can carry both a skill and an agent, or a skill and no agent.
    */
   function openRoutineEditor(input) {
     state = freshState(input);
@@ -269,6 +287,19 @@
   }
 
   /**
+   * Ask for the skill list when the editor was opened before it arrived.
+   *
+   * ONE LINE IN ONE PLACE, because every door that can open the editor ahead
+   * of the reply needs it and a copy per door is a door that silently stops
+   * asking the day somebody edits only the other one.
+   */
+  function requestSkillsIfMissing(loaded) {
+    if (loaded) return;
+    if (typeof ws === 'undefined' || !ws) return;
+    ws.send(JSON.stringify({ type: 'get_skills' }));
+  }
+
+  /**
    * Open the editor from an agent's page, scoped to that agent.
    *
    * Passing no id opens the agent-agnostic picker, which is the entry from
@@ -287,7 +318,7 @@
       loading: !loaded,
       zone: browserTimezone(),
     });
-    if (!loaded && typeof ws !== 'undefined' && ws) ws.send(JSON.stringify({ type: 'get_skills' }));
+    requestSkillsIfMissing(loaded);
   }
 
   /**
@@ -302,6 +333,63 @@
     state.skills = list || [];
     state.loading = false;
     renderRoutineEditor();
+  }
+
+  /**
+   * Open the editor from a skill's own page.
+   *
+   * TWO OUTCOMES, AND THE SECOND ONE IS WHY THIS IS NOT A ONE-LINER.
+   *
+   * One agent has the skill: nothing is ambiguous, so the editor opens on the
+   * schedule step with that skill and that agent already chosen. The reader
+   * pressed a control that said "Schedule this skill" and lands on the step
+   * that schedules it.
+   *
+   * Several agents have it: the editor opens the agent-agnostic picker with
+   * nothing selected, because choosing an agent on the reader's behalf would
+   * be a guess wearing the shape of a decision. They would only discover which
+   * agent they had been given by reading the routine afterwards.
+   *
+   * The pressed skill's rows come FIRST in that picker, one per agent that
+   * could run it. The reader chose the skill by being on its page, so the only
+   * thing left to choose is the agent, and they should never have to find the
+   * skill a second time to do it.
+   *
+   * Either way the breadcrumb goes back to the skill, because that is where
+   * the press came from.
+   *
+   * NO LOADING PATH, AND THAT IS A FACT ABOUT THE DOOR RATHER THAN AN
+   * OMISSION. This door is a control on a skill's own detail page, and that
+   * page is rendered from the skill list. There is no skill page to press
+   * before the list has arrived, so the state the other doors guard against
+   * cannot be reached from here.
+   */
+  function addRoutineForSkill(skillId) {
+    const list = (typeof skills !== 'undefined' && skills) ? skills : [];
+    const skill = list.filter(s => s.id === skillId)[0] || null;
+    const assigned = (skill && skill.assignedAgents) || [];
+    // Exactly one, and never "the first of several".
+    const only = assigned.length === 1 ? assigned[0] : null;
+    // The agent's name comes from the ROSTER, the way the agent door resolves
+    // it, so both doors put the same words in the same field for the same
+    // agent. A skill's assignedAgents entry carries a name of its own, and the
+    // two vocabularies drift: the roster resolves a display name and this does
+    // not have to agree with it.
+    const roster = typeof agents !== 'undefined' && agents ? agents : [];
+    const rostered = only ? roster.filter(a => a.id === only.id)[0] : null;
+    openRoutineEditor({
+      agentId: only ? only.id : null,
+      agentName: only ? ((rostered && rostered.displayName) || only.name || null) : null,
+      // Scoped to the one skill when the agent came with it. Otherwise every
+      // skill, which is what makes the picker agent-agnostic, with the pressed
+      // one first so the reader is never asked to find it again.
+      skills: only ? [skill] : (skill ? [skill].concat(list.filter(s => s.id !== skill.id)) : list),
+      step: only ? 'schedule' : 'pick',
+      selectedKey: only ? `${skill.id}:${only.id}` : null,
+      originSkillId: skill ? skill.id : null,
+      originSkillName: skill ? skill.name : null,
+      zone: browserTimezone(),
+    });
   }
 
   function addRoutine() { addRoutineForAgent(null); }
@@ -414,11 +502,36 @@
    * model of where things are from being shown one.
    */
   function routineEditorLeave() {
+    const skillId = state && state.originSkillId;
     const agentId = state && state.agentId;
     state = null;
+    // The skill page first, because the skill door can also carry an agent and
+    // the breadcrumb it rendered names the skill.
+    //
+    // ONLY IF THAT PAGE CAN STILL BE OPENED, and this is a dead end rather
+    // than a detail. selectSkill returns doing nothing when the id is not in
+    // the list, and the list is replaced whenever a skill is saved in the
+    // background or the workspace changes while the editor is open. State is
+    // already null by then, so every control in the editor answers nothing:
+    // the reader is left looking at a screen that has stopped working, with
+    // the rail as the only way out. Falling through costs one condition.
+    if (skillId && canSelectSkill(skillId)) { selectSkill(skillId); return; }
     if (agentId && typeof showProfile === 'function') { showProfile(agentId); return; }
-    // Opened without an agent, so there is no profile to go back to.
+    // No skill to go back to and no agent, so the list of routines it is.
     if (typeof switchNav === 'function') switchNav(routinesListNav());
+  }
+
+  /**
+   * Whether the skill page for this id can still be opened.
+   *
+   * Asked of the LIST rather than of selectSkill, because selectSkill reports
+   * nothing back: it returns identically whether it drew a page or found no
+   * such skill, so a caller cannot tell the difference afterwards.
+   */
+  function canSelectSkill(skillId) {
+    if (typeof selectSkill !== 'function') return false;
+    const list = (typeof skills !== 'undefined' && skills) ? skills : [];
+    return list.some(s => s.id === skillId);
   }
 
   /**
@@ -485,7 +598,7 @@
   }
 
   return {
-    openRoutineEditor, addRoutineForAgent, addRoutine, browserTimezone,
+    openRoutineEditor, addRoutineForAgent, addRoutineForSkill, addRoutine, browserTimezone,
     routinesListNav, routineEditorSaved, routineEditorFailed, routineEditorSkillsArrived,
     renderRoutineEditor, routineEditorHtml,
     routineEditorPick, routineEditorStep, routineEditorSetField, routineEditorRunOn,

--- a/public/views/skills.js
+++ b/public/views/skills.js
@@ -207,6 +207,40 @@ function selectSkill(id) {
     </div></div>`;
   }
 
+  // Schedule this skill, from the skill's own page.
+  //
+  // SECONDARY WEIGHT, DELIBERATELY. The primary way to make a routine is the
+  // routines surface, which is where somebody who has decided to schedule
+  // something goes. This is the other order: looking at a skill you already
+  // trust and thinking of the schedule second. A shortcut for a reader who is
+  // already here, not a competing front door.
+  //
+  // ONLY WHERE AN AGENT HAS THE SKILL, and the unassigned case is not the same
+  // as the shared one. A routine runs a skill AS an agent, and the picker is
+  // built by walking each skill's assigned agents, so a skill nobody has
+  // produces no row and can never appear in it. Offering the control anyway
+  // meant a reader pressing "Schedule this skill" landed either on an offer to
+  // build a skill, while looking at one, or on a list of every other skill
+  // with the one they pressed missing. A control that does not lead where its
+  // label says teaches a wrong model of the app, which is worse than no
+  // control: the reader believes the label.
+  //
+  // The card above already carries the step this reader actually needs, which
+  // is to give the skill an agent, so nothing is lost by leaving this out.
+  //
+  // AND SAYING NOTHING HERE ABOUT WHY THE CONTROL IS ABSENT IS ALSO DELIBERATE,
+  // not an oversight to be repaired by adding a sentence: a reader meets this
+  // same gap from the other side in the unassigned-skill messaging, and half an
+  // answer in each place is how one surface ends up saying two different things.
+  if (s.assignedAgents.length) {
+    h += `<div class="profile-card"><div class="profile-card-section">
+      <div class="profile-section-label">Schedule</div>
+      <div class="profile-card-text" style="padding-bottom:10px">Give this skill a schedule and your agents take it from there.</div>
+      <button class="settings-btn" type="button" data-skills-action="schedule-skill"
+        data-skill-id="${esc(s.id)}" onclick="addRoutineForSkill('${esc(s.id)}')">Schedule this skill</button>
+    </div></div>`;
+  }
+
   // Collapsible instructions card
   if (s.instructions) {
     const instructionsId = `skill-instructions-${s.id}`;

--- a/test/integration/workspace-rollback-poll.test.js
+++ b/test/integration/workspace-rollback-poll.test.js
@@ -1,0 +1,223 @@
+'use strict';
+// Integration: a workspace switch that fails puts the file-tree poll back.
+//
+// WHY THIS FILE EXISTS. When opening a workspace throws, handleSetWorkspace
+// rolls the root back and re-arms the file-tree poll, and the comment at that
+// call site claims the poll then works against the workspace rolled back to.
+// The only test covering it stubbed armFileTreeWatcher to a counter, which
+// proves the call site is reached and nothing whatever about whether polling
+// still works. The belief was the thing under test, so the test reproduced it.
+//
+// So nothing here is stubbed. The server is the real one, the failure is a
+// real filesystem error raised inside the open path, and the detection is a
+// real external write observed on the wire.
+//
+// HOW THE FAILURE IS PRODUCED, and why it has to be this one. The pre-flight
+// guard refuses a `.rundock` that is not a directory BEFORE openWorkspace is
+// called, so it cannot be the trigger: nothing has been armed at that point
+// and there is nothing to roll back. The trigger has to throw INSIDE the open
+// path and after arming has baselined against the about-to-fail directory.
+// A `.rundock/state.json` that is a directory does exactly that: every read of
+// it is caught and yields an empty state, so the open path decides the
+// workspace mode is unset and writes it, and that write raises EISDIR with
+// nothing above it to catch. A directory where a file belongs is what a
+// half-finished restore or a confused sync client leaves behind.
+//
+// WHAT DISCRIMINATES THE RE-ARM, checked by deleting it rather than assumed.
+// The rollback also calls invalidateAgentCache, which cascades into the tree
+// cache, so the poll does eventually recover on its own: the tick after the
+// rollback rebuilds the tree, finds it differs from the baseline taken in the
+// failed workspace, and pushes it. That is why the detection test below is
+// NOT the proof of the re-arm. The proof is the quiet test: with the re-arm,
+// the rollback re-baselines against the surviving workspace and it stays
+// silent until something actually changes. Without it, a workspace nobody
+// touched announces itself on the next tick. Both are named at the top of
+// their own test.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const h = require('../helpers/harness.js');
+
+// Short enough that the suite is not dominated by real sleeping, long enough
+// that a loaded machine still completes a stat pass inside one interval.
+const POLL_MS = 120;
+// A push is allowed up to one full interval of latency, plus the walk.
+const PUSH_WINDOW_MS = POLL_MS * 4;
+
+let client;
+/** The directory the switch will fail on. */
+let poisoned;
+/**
+ * The message index taken BEFORE the failed switch is sent.
+ *
+ * WHY IT IS TAKEN HERE AND NOT WHERE IT IS USED. The quiet assertion below is
+ * the one that discriminates the re-arm, and without the re-arm the spurious
+ * push lands on the next poll tick, uniformly nought to one interval after the
+ * rollback. An index captured at the start of that later test opens the window
+ * AFTER the event it is measuring, so a tick landing in the gap is recorded in
+ * this test's span, which never looks at file_tree, and the quiet test stays
+ * green with the guard deleted. A window that starts after the signal is a
+ * window the signal escapes through.
+ */
+let beforeTheFailedSwitch = null;
+
+before(async () => {
+  await h.boot({ env: { RUNDOCK_TREE_POLL_MS: String(POLL_MS) } });
+  client = await h.connect();
+  // Boot scaffolds the workspace, which bumps directory mtimes. Let that
+  // drain so a quiet assertion is not measuring the server's own start-up.
+  await h.delay(PUSH_WINDOW_MS);
+});
+
+after(async () => {
+  await h.shutdown();
+  // The suite made this directory, so the suite removes it. The mutation
+  // harness runs this file once per guard, so a fixture left behind here is
+  // left behind several times per gate run.
+  if (poisoned) { try { fs.rmSync(poisoned, { recursive: true, force: true }); } catch (e) { /* best effort */ } }
+});
+
+/** Every path in a tree payload, folders and files alike. */
+function treePaths(nodes, out = []) {
+  for (const n of nodes || []) {
+    out.push(n.path);
+    if (n.children) treePaths(n.children, out);
+  }
+  return out;
+}
+
+function pushesSince(since) {
+  return client.messages.slice(since).filter(m => m.type === 'file_tree');
+}
+
+/**
+ * A directory that is a real workspace in every way the pre-flight guard can
+ * see, and that raises a real error part way through being opened.
+ */
+function makePoisonedWorkspace() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rundock-open-fails-'));
+  // `.rundock` IS a directory, so the pre-flight guard lets this through and
+  // the failure happens inside the open path, which is the case under test.
+  fs.mkdirSync(path.join(dir, '.rundock', 'state.json'), { recursive: true });
+  return dir;
+}
+
+describe('a workspace switch that fails leaves the poll watching the workspace that survived', () => {
+  test('the failure is real, and the server says so and stays where it was', async () => {
+    poisoned = makePoisonedWorkspace();
+    const since = client.messages.length;
+    // Shared with the quiet test, which must count from here rather than from
+    // its own start. Nothing sends a tree on the failing path: the open throws
+    // before it reaches its own file_tree send, and the handler runs to
+    // completion in one turn of the message loop, so no tick can interleave.
+    // Any file_tree at all from this index onwards is the poll talking.
+    beforeTheFailedSwitch = since;
+    client.send({ type: 'set_workspace', path: poisoned });
+
+    const { msg } = await client.waitFor(m => m.type === 'workspace_error', {
+      since, timeout: 15000, label: 'workspace_error for the switch that could not complete',
+    });
+    // The message carries the underlying error rather than a synthesised one,
+    // which is what says the failure came from the filesystem and not from a
+    // branch written to make this test pass.
+    assert.match(msg.message, /^Could not open workspace: /);
+    assert.match(msg.message, /EISDIR|illegal operation on a directory/i,
+      `the open must have failed on the real filesystem error; got: ${msg.message}`);
+
+    assert.strictEqual(h.internal.getWorkspace(), h.workspaceDir,
+      'the root must be the workspace that survived, not the one that could not be opened');
+
+    // No workspace_set: a switch that failed must not also look like one that
+    // worked.
+    assert.deepStrictEqual(
+      client.messages.slice(since).filter(m => m.type === 'workspace_set').map(m => m.path),
+      [], 'a failed switch must not announce a workspace',
+    );
+  });
+
+  // THIS is the test the re-arm is proven by, and it goes red when the
+  // re-arm is deleted from the rollback path. Arming re-baselines the poll
+  // against the workspace that survived; without it the baseline still
+  // describes the workspace that failed to open, and the next tick reports the
+  // difference as though somebody had changed something.
+  test('the workspace that survived is quiet, because the rollback re-baselined the poll', async () => {
+    assert.notStrictEqual(beforeTheFailedSwitch, null,
+      'the window has to be anchored before the switch, or this proves nothing');
+    await h.delay(POLL_MS * 6);
+    const pushes = pushesSince(beforeTheFailedSwitch);
+    assert.strictEqual(
+      pushes.length, 0,
+      'nothing was touched, so a rolled-back workspace must produce zero file_tree pushes, saw '
+      + `${pushes.length}. A push here means the poll is still baselined against the workspace `
+      + 'that failed to open. Counted from before the switch was sent, so a push landing in the '
+      + 'moments between the rollback and this test is counted rather than missed.',
+    );
+  });
+
+  // The property the comment at the call site claims, measured on the
+  // wire against a real write by something that is not Rundock.
+  test('an external write to the restored workspace is still detected', async () => {
+    const since = client.messages.length;
+    const wroteAt = Date.now();
+    fs.writeFileSync(
+      path.join(h.workspaceDir, 'written-after-the-failed-switch.md'),
+      '# Not created through Rundock\n',
+    );
+
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since,
+      // The generous timeout is a HANG GUARD, not the bound. A test that only
+      // waits proves whatever the machine happened to do, so the detection
+      // interval is asserted below as a number instead. Left long so a slow
+      // runner fails on the bound with a measurement in the message rather
+      // than on a timeout with nothing in it.
+      timeout: PUSH_WINDOW_MS + 2000,
+      label: 'unrequested file_tree push after an external write to the restored workspace',
+    });
+    const elapsed = Date.now() - wroteAt;
+    assert.ok(
+      treePaths(msg.tree).includes('written-after-the-failed-switch.md'),
+      'the push must describe the workspace rolled back to, not the one that failed to open',
+    );
+    assert.ok(elapsed <= PUSH_WINDOW_MS,
+      `this is the detection bound the test enforces: the push must `
+      + `arrive within ${PUSH_WINDOW_MS}ms of the write, which is four poll intervals. It took `
+      + `${elapsed}ms. A server ignoring the configured interval and polling on its default `
+      + 'would fail here rather than pass on a long timeout.');
+  });
+
+  // Cheap, and worth recording. The scheduler's lifecycle now runs on
+  // workspace set and unset, so a failed switch stops the ticker for the
+  // workspace being left and the rollback has to start one again. A rollback
+  // that restored the root and left no scheduler would be a workspace whose
+  // routines silently stop firing until the next restart, which is exactly the
+  // fault that put the lifecycle in setWorkspaceRoot in the first place.
+  test('the scheduler is running, and against the workspace that survived', () => {
+    assert.strictEqual(h.internal.schedulerRunning(), true,
+      'the rollback goes through setWorkspaceRoot, so the surviving workspace must have a scheduler');
+    // THE SECOND HALF, because "a scheduler is running" on its own is a proxy
+    // for the property that matters here. A ticker running against the
+    // directory that failed to open would satisfy the line above and be
+    // exactly the fault. The tick reads the workspace root at tick time, so
+    // the root IS the binding, and this is the whole of what was observed.
+    assert.strictEqual(h.internal.getWorkspace(), h.workspaceDir,
+      'the root a tick will read is the workspace that survived, not the one that failed');
+  });
+
+  // A failed switch must not leave the previous workspace's tree poisoned by
+  // the one that failed either. Asked of the tree a client requests, which is
+  // the other consumer of the same cache.
+  test('a requested tree describes the workspace that survived', async () => {
+    const since = client.messages.length;
+    client.send({ type: 'get_files' });
+    const { msg } = await client.waitFor(m => m.type === 'file_tree', {
+      since, timeout: 8000, label: 'file_tree in reply to get_files after the failed switch',
+    });
+    const paths = treePaths(msg.tree);
+    assert.ok(paths.includes('written-after-the-failed-switch.md'),
+      'the requested tree must be the surviving workspace, complete with what was written to it');
+  });
+});

--- a/test/tools/mutate-routine-editor-guards.js
+++ b/test/tools/mutate-routine-editor-guards.js
@@ -58,6 +58,15 @@ const APP = { src: path.join(ROOT, 'public', 'app.js'), suite: 'test/unit/routin
 const HANDLER = { src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'), suite: 'test/unit/routine-write.test.js' };
 // The agent profile, which renders the only way into the scoped editor.
 const PROFILE = { src: path.join(ROOT, 'public', 'views', 'profile.js'), suite: 'test/unit/routine-editor-view.test.js' };
+// The door that starts from a skill rather than from an agent, a list or a
+// panel. Watched by the file that PRESSES the doors rather than by the view
+// suite, because an entry point is tested by the surface a user touches: aimed
+// at the view suite these mutations would report a guard nobody holds, when
+// what they would really be reporting is a proof pointed at the wrong place.
+//
+// The team sidebar target that used to sit here went with the door it watched.
+const SKILL_DOOR = { src: path.join(ROOT, 'public', 'views', 'routine-editor.js'), suite: 'test/unit/routine-editor-doors.test.js' };
+const SKILLS_PAGE = { src: path.join(ROOT, 'public', 'views', 'skills.js'), suite: 'test/unit/routine-editor-doors.test.js' };
 // The data model's write path, where a routine becomes bytes in a file.
 const ROUTINES = { src: path.join(ROOT, 'lib', 'agents', 'routines.js'), suite: 'test/unit/routine-write.test.js' };
 // The same file, watched by the suite that owns the timezone a schedule was
@@ -189,8 +198,14 @@ const MUTATIONS = [
   [VIEW, 'a skill list that has not arrived is not an empty one',
     '    if (state.loading) {',
     '    if (state.loading && false) {'],
+  // Every door that can open the editor before the skill list has landed goes
+  // through this one asker, so deleting the send takes the ask away from all
+  // of them at once. It used to be a line copied into each door, which the
+  // harness refused to mutate the moment there was more than one copy: a
+  // search text matching two places would break whichever came first and prove
+  // nothing about either.
   [VIEW, 'the editor asks for the skill list it is missing',
-    "    if (!loaded && typeof ws !== 'undefined' && ws) ws.send(JSON.stringify({ type: 'get_skills' }));\n",
+    "    ws.send(JSON.stringify({ type: 'get_skills' }));\n",
     ''],
   [VIEW, 'the skill list fills in when it arrives',
     '    state.skills = list || [];\n    state.loading = false;',
@@ -198,9 +213,50 @@ const MUTATIONS = [
   [VIEW, 'the breadcrumb returns to the agent it names',
     "    if (agentId && typeof showProfile === 'function') { showProfile(agentId); return; }\n",
     ''],
+  // ===== THE DOOR THAT STARTS FROM A SKILL =====
+  // THE ONE THAT MATTERS. A skill can belong to more than one agent, and
+  // taking the first is a guess wearing the shape of a decision: the reader
+  // would only discover which agent they had been given by reading the routine
+  // afterwards. This writes the guess in and requires a test to go red for it.
+  [SKILL_DOOR, 'an agent is carried only when exactly one has the skill',
+    '    const only = assigned.length === 1 ? assigned[0] : null;',
+    '    const only = assigned[0] || null;'],
+  [SKILL_DOOR, 'a skill with one agent skips the step there is nothing to pick on',
+    "      step: only ? 'schedule' : 'pick',",
+    "      step: 'pick',"],
+  [SKILL_DOOR, 'the breadcrumb belongs to the skill the editor was opened from',
+    '    if (state.originSkillId && state.originSkillName) {',
+    '    if (false) {'],
+  // The dead end. Without the check, leaving by the breadcrumb calls
+  // selectSkill for a skill that has gone from the list, which returns doing
+  // nothing, and state is already null: the editor stays on screen with every
+  // control answering nothing.
+  [SKILL_DOOR, 'the skill breadcrumb leaves even when the skill has gone',
+    '    if (skillId && canSelectSkill(skillId)) { selectSkill(skillId); return; }',
+    "    if (skillId && typeof selectSkill === 'function') { selectSkill(skillId); return; }"],
+  // Agent-agnostic, but the reader is not asked to find the skill they
+  // pressed a second time.
+  [SKILL_DOOR, 'the pressed skill is ordered first in the agent-agnostic picker',
+    '      skills: only ? [skill] : (skill ? [skill].concat(list.filter(s => s.id !== skill.id)) : list),',
+    '      skills: only ? [skill] : list,'],
+  [SKILL_DOOR, 'leaving by that breadcrumb goes back to the skill it names',
+    '    if (skillId && canSelectSkill(skillId)) { selectSkill(skillId); return; }\n',
+    ''],
+  [SKILLS_PAGE, 'a skill page offers a way to schedule the skill',
+    ' data-skills-action="schedule-skill"',
+    ' data-skills-action="not-a-door"'],
+  // The control is offered only where it can lead somewhere. A skill nobody
+  // has produces no row in the picker, so the control would be a label
+  // promising something the reader cannot reach.
+  [SKILLS_PAGE, 'the way in is offered only where an agent has the skill',
+    '  if (s.assignedAgents.length) {\n    h += `<div class="profile-card">'
+    + '<div class="profile-card-section">\n      <div class="profile-section-label">Schedule</div>',
+    '  if (true) {\n    h += `<div class="profile-card">'
+    + '<div class="profile-card-section">\n      <div class="profile-section-label">Schedule</div>'],
+
   [VIEW, 'the breadcrumb names an agent only when there is one to return to',
-    '    if (state.agentId && state.agentName) {',
-    '    if (state.agentName || true) {'],
+    '    } else if (state.agentId && state.agentName) {',
+    '    } else if (state.agentName || true) {'],
 
   // The dispatch. Each of these deletes one call the client makes into the
   // editor, which is the accident these tests exist to catch.
@@ -332,7 +388,7 @@ function run() {
   // Both files are read up front and both are restored in the same finally, so
   // a throw part way through cannot leave either one mutated.
   const originals = new Map();
-  for (const target of [MODEL, VIEW, APP, HANDLER, PROFILE, ROUTINES, ROUTINES_TZ]) originals.set(target, fs.readFileSync(target.src, 'utf8'));
+  for (const target of [MODEL, VIEW, APP, HANDLER, PROFILE, SKILL_DOOR, SKILLS_PAGE, ROUTINES, ROUTINES_TZ]) originals.set(target, fs.readFileSync(target.src, 'utf8'));
   const results = [];
   try {
     for (const [target, label, guard, without] of MUTATIONS) {

--- a/test/tools/mutate-workspace-rollback-guards.js
+++ b/test/tools/mutate-workspace-rollback-guards.js
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+'use strict';
+// Take the failed-switch rollback apart a step at a time and report which
+// tests notice.
+//
+// WHY THIS EXISTS AS A FILE RATHER THAN AS A CLAIM IN A REPORT
+//
+// This exists because the rollback was BELIEVED to work and nothing proved
+// it. The only test covering it stubbed the arming call to
+// a counter, so it proved the call site was reached and nothing about whether
+// polling still worked against the workspace rolled back to. A report saying
+// "I deleted the re-arm and a test went red" is the same kind of evidence: it
+// is a claim about a tree nobody else can identify. This is that deletion,
+// written down so anyone can run it.
+//
+// THE ONE THIS FILE EXISTS FOR. The rollback's last step re-arms the file-tree
+// poll. It is the newest and least proven step of the three and it sits last
+// precisely so a throw in it cannot skip the two before it. Deleting it leaves
+// the poll baselined against the workspace that failed to open, so a workspace
+// nobody touched announces itself on the next tick.
+//
+// AND THE TWO STEPS BESIDE IT, because a mutation aimed at one guard proves
+// nothing about its neighbours, and the rollback is a block that shares one
+// catch. Restoring the root is what the whole rollback is for; clearing the
+// caches is what stops the previous workspace being served the failed one's
+// agents and files.
+//
+//   node test/tools/mutate-workspace-rollback-guards.js            # report
+//   node test/tools/mutate-workspace-rollback-guards.js --markdown # as a table
+//
+// The file is restored afterwards, including when a run throws.
+//
+// The harness is the same shape as mutate-routines-guards.js and is
+// deliberately a second copy rather than a shared module, for the reason
+// stated there: pulling them together means editing an instrument already in
+// the gate, and mixing that refactor into a change is how a gate quietly stops
+// checking what it used to.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const os = require('node:os');
+const { preflight } = require('../helpers/temp-root.js');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+// The handler that guards the open path and rolls it back, watched by the file
+// that drives a real open failure through the real server and then measures
+// the poll on the wire. Watched from anywhere else, these lines can be deleted
+// with every test green.
+const HANDLER = {
+  src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'workspace.js'),
+  suite: 'test/integration/workspace-rollback-poll.test.js',
+};
+
+// [target, label, the guard as it is written, what it becomes without it]
+const MUTATIONS = [
+  // THE ONE THIS FILE EXISTS FOR.
+  [HANDLER, 'the rollback re-arms the file-tree poll against the workspace that survived',
+    '      ctx.workspace.armFileTreeWatcher();\n    } catch (rollbackErr)',
+    '    } catch (rollbackErr)'],
+  // The step the whole rollback is for.
+  [HANDLER, 'the rollback puts the previous root back',
+    '      ctx.workspace.setWorkspaceRoot(previousRoot);\n',
+    ''],
+  // A failure that is swallowed leaves the client with no reply at all, which
+  // is the state this whole guard was written to end.
+  [HANDLER, 'a switch that could not complete says so',
+    "    ws.send(JSON.stringify({ type: 'workspace_error', message: 'Could not open workspace: ' + e.message }));\n",
+    ''],
+];
+
+// Guards in this block that are deliberately NOT mutated, each with the
+// reason. A named exclusion is a decision; an unnamed one is a harness that
+// quietly checks less than it claims.
+const NOT_MUTATED = [
+  {
+    what: "the rollback's `ctx.agents.invalidateAgentCache()`",
+    why: 'every cache it clears is bounded by the same two-second time to live, and the tree '
+      + 'cache it also clears is cleared again by the arming call on the very next line. So a '
+      + 'test of it is a race against a timer: run slow and it passes with the line deleted. A '
+      + 'mutation nothing can honestly discharge is noise in an instrument whose whole value is '
+      + 'that a red line means something. Left here as a named gap rather than as a green row.',
+  },
+];
+
+// The reporter is named explicitly rather than left to the default, which
+// varies with whether stdout is a TTY.
+const REPORTER = ['--test-reporter=spec', '--test-reporter-destination=stdout'];
+
+function redTests(suite) {
+  let out = '';
+  let failed = false;
+  try {
+    out = execFileSync('node', ['--test', ...REPORTER, suite],
+      { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) {
+    failed = true;
+    out = (e.stdout || '') + (e.stderr || '');
+  }
+  const marker = out.indexOf('failing tests:');
+  if (marker === -1) {
+    if (!failed) return [];
+    throw new Error(
+      'the suite failed but its output carries no "failing tests:" summary, so no '
+      + 'test names could be read. The spec reporter\'s format is what this parses; '
+      + 'if it changed, fix this parser rather than trusting the empty result.');
+  }
+  const names = [];
+  for (const line of out.slice(marker).split('\n')) {
+    const m = /^✖ (.+?) \(\d/.exec(line.trim());
+    if (m && !names.includes(m[1])) names.push(m[1]);
+  }
+  return names;
+}
+
+function run() {
+  const targets = [HANDLER];
+  const originals = new Map();
+  for (const target of targets) originals.set(target, fs.readFileSync(target.src, 'utf8'));
+  const results = [];
+  try {
+    for (const [target, label, guard, without] of MUTATIONS) {
+      const original = originals.get(target);
+      const matches = original.split(guard).length - 1;
+      if (matches === 0) {
+        results.push({ label, applied: false, red: [] });
+        continue;
+      }
+      // A GUARD THAT MATCHES MORE THAN ONCE IS REFUSED RATHER THAN TAKING THE
+      // FIRST. String.replace takes the first occurrence, so a search text
+      // that also appears somewhere else quietly breaks the wrong code and
+      // reports on whatever that turns red. This file's target holds three
+      // separate arming calls, so the refusal is load-bearing here rather
+      // than theoretical.
+      if (matches > 1) {
+        results.push({ label, applied: false, ambiguous: matches, red: [] });
+        continue;
+      }
+      fs.writeFileSync(target.src, original.replace(guard, without));
+      results.push({ label, applied: true, matches, red: redTests(target.suite) });
+      fs.writeFileSync(target.src, original);
+    }
+  } finally {
+    for (const [target, original] of originals) fs.writeFileSync(target.src, original);
+  }
+  return results;
+}
+
+function report(results, markdown) {
+  let failed = 0;
+  const lines = [];
+  for (const { label, applied, red, ambiguous, matches } of results) {
+    if (ambiguous) {
+      failed++;
+      const why = `the guard text matches ${ambiguous} places, so it would break whichever came first`;
+      lines.push(markdown ? `| ${label} | ${ambiguous} | **${why}** | |` : `${label}\n  AMBIGUOUS: ${why}`);
+      continue;
+    }
+    if (!applied) {
+      failed++;
+      lines.push(markdown
+        ? `| ${label} | 0 | **the guard text was not found, so nothing was mutated** | |`
+        : `${label}\n  THE GUARD TEXT WAS NOT FOUND, so nothing was mutated`);
+      continue;
+    }
+    if (red.length === 0) {
+      failed++;
+      lines.push(markdown ? `| ${label} | ${matches} | **nothing turned red** | |` : `${label}\n  NOTHING TURNED RED`);
+      continue;
+    }
+    // The match count travels with the result. A guard text that matched once
+    // is a guard that was addressed; the harness refuses anything else, so
+    // printing it turns "addressed exactly once" from a claim into a reading.
+    lines.push(markdown
+      ? `| ${label} | ${matches} | ${red.length} | ${red.map((n) => `\`${n}\``).join('<br>')} |`
+      : `${label}\n  found in ${matches} place\n  ${red.length} red\n${red.map((n) => `    - ${n}`).join('\n')}`);
+  }
+  if (markdown) {
+    console.log('| Guard broken | Places found | Tests red | Which |');
+    console.log('|---|---|---|---|');
+    for (const line of lines) console.log(line);
+  } else {
+    for (const line of lines) console.log(`\n${line}`);
+  }
+  return failed;
+}
+
+// REFUSE TO START ON A MACHINE THAT WOULD MISREPORT. Same reason as the other
+// mutation harnesses: this runs a suite per guard, so it is a heavy producer
+// of fixtures, and write failures on a full disk surface as red tests, which
+// is exactly what this instrument reports as an unguarded guard.
+function requireSaneTempRoot() {
+  const verdict = preflight(os.tmpdir());
+  if (verdict.ok) return;
+  console.error(verdict.message);
+  process.exit(2);
+}
+
+if (require.main === module) {
+  requireSaneTempRoot();
+  if (process.argv.includes('--preflight-only')) process.exit(0);
+  const failed = report(run(), process.argv.includes('--markdown'));
+  if (failed) {
+    console.error(`\n${failed} mutation(s) proved nothing. A guard no test notices is not guarded,`
+      + ' and a mutation that could break more than one place proves nothing about either.');
+    process.exit(1);
+  }
+}
+
+module.exports = { MUTATIONS, NOT_MUTATED, run };

--- a/test/tools/mutate-workspace-rollback-guards.observed.md
+++ b/test/tools/mutate-workspace-rollback-guards.observed.md
@@ -1,0 +1,29 @@
+# The failed-switch rollback, observed
+
+What the harness reports when it takes the failed-switch rollback apart a step at a time. Recorded because a note saying the harness ran does not say what it found, and the guard it deletes is a whitespace-sensitive string in a file that a reader of the change alone never sees.
+
+Reproduce with:
+
+```
+node test/tools/mutate-workspace-rollback-guards.js --markdown
+```
+
+Observed on the tree this file is committed in, against `lib/protocol/handlers/workspace.js`:
+
+| Guard broken | Places found | Tests red | Which |
+|---|---|---|---|
+| the rollback re-arms the file-tree poll against the workspace that survived | 1 | 1 | `the workspace that survived is quiet, because the rollback re-baselined the poll` |
+| the rollback puts the previous root back | 1 | 4 | `the failure is real, and the server says so and stays where it was`<br>`an external write to the restored workspace is still detected`<br>`the scheduler is running, and against the workspace that survived`<br>`a requested tree describes the workspace that survived` |
+| a switch that could not complete says so | 1 | 1 | `the failure is real, and the server says so and stays where it was` |
+
+## What the two columns are for
+
+**Places found** is one for every guard. The harness refuses to mutate a search text that matches more than once, because replacing the first occurrence would break whichever code came first and prove nothing about either. One is what says the guard was addressed rather than approximated.
+
+**Tests red** names the test that went red for each deletion. The first row is the one this file exists for: deleting the re-arm leaves the poll baselined against the workspace that failed to open, and the quiet test is what notices.
+
+## What this record cannot do
+
+It is a reading taken at one moment, and a file cannot keep itself true. What keeps it true is that the harness runs inside the commit gate on every change, so a guard that stops being addressed exactly once, or a deletion that stops turning anything red, fails the gate rather than quietly disagreeing with this page.
+
+One step of the rollback is deliberately not mutated, and the harness records that as a named gap rather than a passing row. Every cache it clears is bounded by the same two second time to live, and the tree cache it also clears is cleared again by the arming call on the next line, so a test of it would be a race against a timer that passes whenever the machine runs slow.

--- a/test/unit/agent-icon-rotation.test.js
+++ b/test/unit/agent-icon-rotation.test.js
@@ -1,0 +1,119 @@
+'use strict';
+// The glyph the guide reserves cannot be handed to somebody else's agent.
+//
+// An agent with no `icon` of its own is given one from a fixed rotation. The
+// rotation carried the hexagon, and docs/AGENTS.md reserves that hexagon for
+// the platform guide, so the seventh icon-less agent in a workspace was handed
+// the guide's own glyph and the two became indistinguishable in the org chart
+// and the sidebar.
+//
+// THE RESERVED GLYPH IS A LITERAL HERE, NOT A CONSTANT READ FROM THE CODE.
+// The first draft of this file read it from the module under test. With no
+// such export the comparison was against undefined, every icon differed from
+// it, and the whole behavioural test passed against the unfixed code: a proof
+// that could not fail. The glyph is the fact this file is about, so it is
+// written down here, and the code's own constant is checked AGAINST it.
+//
+// TWO PROOFS, AND THEY PROVE DIFFERENT THINGS.
+//
+// The first drives discovery over a roster of icon-less agents long enough to
+// exhaust the rotation, and reads the icons off the agents a user would see.
+// That is the surface: a rotation is only ever met through an assigned icon.
+//
+// The second reads the rotation itself, because the first can only ever fail
+// once somebody has already shipped a collision. A rotation extended by one
+// more glyph next year is a new roster length, and the behavioural test would
+// have to have guessed it. Reading the array the assignment indexes into is
+// what makes the removal permanent rather than merely done.
+const { test, describe, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const discovery = require('../../lib/agents/discovery.js');
+const { _internal: srv } = require('../../server.js');
+const { makeWorkspace, agentFile, cleanup } = require('../helpers/workspace.js');
+
+after(cleanup);
+
+const ROOT = path.join(__dirname, '..', '..');
+
+// U+2B21 WHITE HEXAGON, the glyph docs/AGENTS.md reserves for the guide.
+const RESERVED = '⬡';
+
+// Long enough to run past the end of the rotation whatever its length, so the
+// test does not encode the count it is checking. File order is not guaranteed
+// by readdirSync, which is why every assertion below is about the SET of
+// glyphs handed out rather than about which agent got which.
+const ROSTER = 12;
+
+describe('the auto-assign rotation and the glyph the guide reserves', () => {
+  test('no icon-less agent is ever handed the guide\'s glyph', () => {
+    const agents = {};
+    for (let i = 0; i < ROSTER; i++) {
+      const slug = `filler-${String(i).padStart(2, '0')}`;
+      agents[slug] = agentFile({ name: slug, role: 'Filler', type: 'specialist', order: i + 1 });
+    }
+    // THE PREMISE, ASSERTED RATHER THAN ASSUMED. This roster only exercises
+    // the rotation while the fixtures declare no icon of their own. The
+    // builder does not write one today; the day it does, every assertion below
+    // would be about the fixture rather than about the rotation and would pass
+    // whatever the rotation contained.
+    for (const [slug, content] of Object.entries(agents)) {
+      assert.ok(!/^icon:/m.test(content),
+        `${slug} declares its own icon, so this roster no longer exercises the rotation`);
+    }
+    srv.setWorkspace(makeWorkspace({ agents }));
+
+    const discovered = discovery.discoverAgents().filter(a => a.id.startsWith('filler-'));
+    assert.strictEqual(discovered.length, ROSTER, 'sanity: every filler agent was discovered');
+
+    // THE SANITY CHECK PROVES WHAT IT CLAIMS. "Every agent has some icon" was
+    // the first version, and it holds just as well when the icons came from
+    // anywhere at all, which would leave the collision assertion below vacuous.
+    // These two say the icons came from the rotation and that the whole of it
+    // was walked, which is what makes the absence below meaningful.
+    const handed = discovered.map(a => a.icon);
+    const rotation = discovery.AUTO_ASSIGNED_ICONS;
+    for (const icon of handed) {
+      assert.ok(rotation.includes(icon),
+        `an icon-less agent was handed ${icon}, which is not in the rotation at all`);
+    }
+    assert.deepStrictEqual([...new Set(handed)].sort(), [...rotation].sort(),
+      `a roster of ${ROSTER} is longer than the rotation, so every glyph in it must have been `
+      + 'handed out; anything missing means the rotation was not the source');
+
+    const collided = discovered.filter(a => a.icon === RESERVED).map(a => a.id);
+    assert.deepStrictEqual(collided, [],
+      `an icon-less agent was handed ${RESERVED}, which the guide reserves, so the two are `
+      + 'indistinguishable in the org chart and the sidebar');
+  });
+
+  test('the reserved glyph is absent from the rotation, so it cannot be added back', () => {
+    // Read from the exported array the assignment indexes into, NOT from a
+    // copy and not from the source text. A test that reads its own copy stays
+    // green while the real rotation grows a reserved glyph back.
+    const rotation = discovery.AUTO_ASSIGNED_ICONS;
+    assert.ok(Array.isArray(rotation) && rotation.length > 0,
+      'the rotation the assignment uses is exported, so a test can read the same array');
+    assert.ok(!rotation.includes(RESERVED),
+      `${RESERVED} is reserved for the guide and must not be in the rotation; `
+      + `found ${JSON.stringify(rotation)}`);
+    // Every glyph in it is distinct, which is the property the rotation exists
+    // for and the one a careless edit breaks alongside the reserved glyph.
+    assert.strictEqual(new Set(rotation).size, rotation.length, 'the rotation repeats a glyph');
+  });
+
+  test('the glyph the code reserves is the glyph the guide actually wears', () => {
+    // Three places name it and they must not drift: the constant, the guide's
+    // own scaffolded file, and the page that tells a user it is reserved.
+    assert.strictEqual(discovery.GUIDE_RESERVED_ICON, RESERVED,
+      'the constant the code reserves by is not the glyph this file is about');
+    const scaffold = fs.readFileSync(path.join(ROOT, 'scaffold', 'rundock-guide.md'), 'utf-8');
+    assert.match(scaffold, new RegExp(`^icon: ${RESERVED}$`, 'm'),
+      'the guide the scaffold ships does not wear the glyph the code reserves for it');
+    const doc = fs.readFileSync(path.join(ROOT, 'docs', 'AGENTS.md'), 'utf-8');
+    assert.ok(doc.includes(RESERVED),
+      'the page that tells a user which glyph is reserved does not name this one');
+  });
+});

--- a/test/unit/client-namespace.test.js
+++ b/test/unit/client-namespace.test.js
@@ -190,6 +190,7 @@ const MANIFEST = {
   "routine-editor.js": [
     "addRoutine",
     "addRoutineForAgent",
+    "addRoutineForSkill",
     "browserTimezone",
     "openRoutineEditor",
     "renderRoutineEditor",

--- a/test/unit/routine-editor-doors.test.js
+++ b/test/unit/routine-editor-doors.test.js
@@ -38,6 +38,7 @@ const ROUTINES_MODEL_SRC = read('public', 'routines-model.js');
 const ROUTINES_SRC = read('public', 'views', 'routines.js');
 const SCOPE_MODEL_SRC = read('public', 'routines-scope-model.js');
 const PANEL_SRC = read('public', 'views', 'routines-panel.js');
+const SKILLS_VIEW_SRC = read('public', 'views', 'skills.js');
 const APP_SRC = read('public', 'app.js');
 const INDEX_SRC = read('public', 'index.html');
 
@@ -79,6 +80,18 @@ const DOORS = [
     scoped: true,
     pressedBy: 'the panel door opens the editor on whatever the panel is scoped to',
   },
+  // The fifth door, and the only one that starts from the SKILL rather than
+  // from an agent, a list or a panel. It is scoped only when exactly one agent
+  // has the skill; a skill two agents share opens the agent-agnostic picker
+  // instead, and a skill nobody has offers no door at all, both pressed by
+  // their own tests below.
+  {
+    call: 'addRoutineForSkill',
+    file: 'views/skills.js',
+    surface: 'the Schedule this skill control on a skill\'s own page',
+    scoped: 'only when exactly one agent has the skill',
+    pressedBy: 'the skill door opens the editor at the schedule step for that skill',
+  },
 ];
 
 // Doors that exist in the flow but are deliberately not pressed here, each
@@ -94,7 +107,7 @@ const NOT_PRESSED = [
 
 // Where the client can call into the editor from. Everything the editor
 // exports that OPENS it; the rest of its surface is reached from inside.
-const ENTRY_CALLS = ['addRoutine', 'addRoutineForAgent', 'openRoutineEditor'];
+const ENTRY_CALLS = ['addRoutine', 'addRoutineForAgent', 'addRoutineForSkill', 'openRoutineEditor'];
 
 function clientFiles() {
   const out = [];
@@ -176,6 +189,7 @@ function shellMarkup() {
     + '<div id="profile-content"></div>'
     + '<div id="view-routine-editor"><div id="routine-editor-content"></div></div>'
     + '<div id="view-routines"><div id="routines-content"></div></div>'
+    + '<div id="view-skills"><div id="skill-detail-content"></div></div>'
     + '</body></html>';
 }
 
@@ -191,6 +205,7 @@ function shell() {
   w.eval(SCOPE_MODEL_SRC);
   w.eval(ROUTINES_SRC);
   w.eval(PANEL_SRC);
+  w.eval(SKILLS_VIEW_SRC);
 
   w.agents = [
     {
@@ -201,6 +216,8 @@ function shell() {
     { id: 'doc', displayName: 'Doc', colour: '#6BC67E', icon: 'D', status: 'active', runtime: 'claude' },
   ];
   w.conversations = [];
+  w.currentSkillId = null;
+  w.currentView = 'skills';
   w.skills = [
     { id: 'ops-summary', slug: 'ops-summary', name: 'Compile the ops summary',
       assignedAgents: [{ id: 'piper', name: 'Piper' }] },
@@ -337,6 +354,202 @@ describe('the doors, pressed', () => {
   // walks below no longer touch that panel at all and would not notice it
   // coming back.
   //
+  // THE DOOR THAT STARTS FROM A SKILL.
+  //
+  // A skill page is where somebody decides they trust a skill, which is the
+  // moment they want it on a schedule. Pressed here, never called: the whole
+  // reason this file exists is that calling the handler is what let four
+  // entry points look covered while nothing touched their controls.
+  test('the skill door opens the editor at the schedule step for that skill', () => {
+    const { doc, w, dom } = shell();
+    w.selectSkill = w.RundockSkillsView.selectSkill;
+    w.selectSkill('ops-summary');
+
+    // SECONDARY WEIGHT IS PART OF WHAT THIS CONTROL IS, so it is asserted
+    // rather than left to the eye. Promoting it to the primary button would
+    // otherwise keep every test green.
+    const control = doc.querySelector('[data-skills-action="schedule-skill"]');
+    assert.ok(control.classList.contains('settings-btn'),
+      'the control carries the secondary button class');
+    assert.ok(!control.classList.contains('settings-btn-primary'),
+      'the routines surface is the primary way in; this one is the shortcut, not a rival front door');
+
+    press(doc, '[data-skills-action="schedule-skill"]');
+
+    // Step one is already done, so the editor opens on step two with the
+    // skill named in the sentence rather than on a list of one.
+    assert.ok(doc.querySelector('select[data-routine-field="frequency"]'),
+      'the skill door lands on the schedule step, not on the picker');
+    assert.match(editorText(doc), /Compile the ops summary/);
+    assert.strictEqual(doc.querySelector('[data-skill-key]'), null,
+      'nothing is left to pick, so no picker is drawn');
+
+    // And the agent is the one that has it, carried all the way to the save
+    // rather than asserted off internal state.
+    choose(doc, w, 'frequency', 'day');
+    choose(doc, w, 'time', '09:00');
+    press(doc, '.re-actions .settings-btn-primary');
+    press(doc, '[data-routine-editor="save"]');
+    assert.strictEqual(w.sent.length, 1);
+    assert.strictEqual(w.sent[0].agentId, 'piper',
+      'one agent has this skill, so no choice was needed and none was invented');
+    assert.strictEqual(w.sent[0].routine.skill, 'ops-summary');
+    dom.window.close();
+  });
+
+  // A skill can be assigned to more than one agent. Taking the first is a
+  // guess wearing the shape of a decision, so the ambiguous case opens the
+  // agent-agnostic picker that already exists for it and lets the reader say
+  // which agent.
+  test('a skill two agents share opens the agent-agnostic picker rather than guessing', () => {
+    const { doc, w, dom } = shell();
+    // The pressed skill is deliberately NOT first in the workspace list, so
+    // the ordering assertion below can fail. With it first the assertion would
+    // hold whether or not anything ordered it.
+    w.skills = [
+      { id: 'reading-digest', slug: 'reading-digest', name: 'Refresh the reading digest',
+        assignedAgents: [{ id: 'doc', name: 'Doc' }] },
+      { id: 'ops-summary', slug: 'ops-summary', name: 'Compile the ops summary',
+        assignedAgents: [{ id: 'piper', name: 'Piper' }, { id: 'doc', name: 'Doc' }] },
+    ];
+    w.selectSkill = w.RundockSkillsView.selectSkill;
+    w.selectSkill('ops-summary');
+
+    press(doc, '[data-skills-action="schedule-skill"]');
+
+    // Not the schedule step: nothing has been decided, so nothing is shown as
+    // decided.
+    assert.strictEqual(doc.querySelector('select[data-routine-field="frequency"]'), null,
+      'an ambiguous skill must not land on the schedule step, which would mean an agent was chosen');
+    assert.match(editorText(doc), /Pick a skill any of your agents already has/,
+      'the agent-agnostic lead, which is the picker that already exists for this case');
+    // The whole picker is offered and nothing is selected, because choosing an
+    // agent on the reader's behalf would be a guess. What that owes them is
+    // that the skill they pressed is not something they have to find again,
+    // so its rows come first.
+    assert.deepStrictEqual(
+      [...doc.querySelectorAll('[data-skill-key]')].map(r => r.getAttribute('data-skill-key')),
+      ['ops-summary:piper', 'ops-summary:doc', 'reading-digest:doc'],
+      'the pressed skill\'s rows come first, one per agent that could run it, and every other '
+      + 'skill is still offered because the picker stays agent-agnostic',
+    );
+    assert.strictEqual(doc.querySelector('.re-row.sel'), null,
+      'nothing is preselected, because preselecting one of two agents is the guess this avoids');
+
+    // The reader resolves it, and the agent they chose is the one that is saved.
+    press(doc, '[data-skill-key="ops-summary:doc"]');
+    press(doc, '.re-actions .settings-btn-primary');
+    choose(doc, w, 'frequency', 'day');
+    press(doc, '.re-actions .settings-btn-primary');
+    press(doc, '[data-routine-editor="save"]');
+    assert.strictEqual(w.sent[0].agentId, 'doc');
+    dom.window.close();
+  });
+
+  // The case that made this control lie. A routine runs a skill AS an agent,
+  // and the picker is built by walking each skill's assigned agents, so a
+  // skill nobody has produces no row and can never be reached through it.
+  // Pressing the control on such a skill used to land the reader on an offer
+  // to build a skill, while they were looking at one, or on a list of every
+  // other skill with the one they pressed missing.
+  test('a skill no agent has offers no way to schedule it', () => {
+    const { doc, w, dom } = shell();
+    w.skills = [
+      { id: 'unclaimed', slug: 'unclaimed', name: 'Nobody has this one', assignedAgents: [] },
+      { id: 'ops-summary', slug: 'ops-summary', name: 'Compile the ops summary',
+        assignedAgents: [{ id: 'piper', name: 'Piper' }] },
+    ];
+    w.selectSkill = w.RundockSkillsView.selectSkill;
+    w.selectSkill('unclaimed');
+
+    assert.strictEqual(doc.querySelector('[data-skills-action="schedule-skill"]'), null,
+      'a control that cannot lead where its label says must not be on the page at all');
+
+    // And the page still says what to do instead, which is to give it an agent.
+    assert.match(doc.getElementById('skill-detail-content').textContent,
+      /Want to assign this to a specific agent\?/,
+      'the step this reader actually needs is still offered');
+
+    // The control returns as soon as an agent has it, so this is a guard on
+    // the state rather than the control having been dropped.
+    w.selectSkill('ops-summary');
+    assert.ok(doc.querySelector('[data-skills-action="schedule-skill"]'),
+      'a skill an agent has still offers the way in');
+    dom.window.close();
+  });
+
+  // The breadcrumb belongs to the door that opened the editor, and this door
+  // came from a skill. A control reading "Back to Piper" here would be the
+  // exact fault the agent breadcrumb was written to stop: a label that names
+  // a destination the press does not go to.
+  test('the skill door\'s breadcrumb returns to the skill, not to the agent', () => {
+    const { doc, w, dom } = shell();
+    w.selectSkill = w.RundockSkillsView.selectSkill;
+    w.selectSkill('ops-summary');
+    press(doc, '[data-skills-action="schedule-skill"]');
+
+    const back = doc.querySelector('[data-routine-editor="back"]');
+    assert.ok(back, 'the skill door renders a breadcrumb');
+    assert.match(back.textContent, /Compile the ops summary/,
+      'the label names the skill the editor was opened from');
+
+    w.currentSkillId = null;
+    press(doc, '[data-routine-editor="back"]');
+    assert.strictEqual(w.currentSkillId, 'ops-summary', 'and the press goes where the label says');
+    assert.strictEqual(w.navigatedTo, null);
+    dom.window.close();
+  });
+
+  // THE DEAD END, and it is reachable without doing anything unusual. The
+  // skill list is replaced whenever a skill is saved in the background or the
+  // workspace changes, and the editor can be open across either. Leaving by
+  // the breadcrumb then called selectSkill for a skill that is no longer in
+  // the list, which returns doing nothing, while state had already been
+  // nulled. Every control in the editor answers nothing from that moment, and
+  // the rail is the only way out.
+  test('the skill breadcrumb still leaves when the skill has gone from the list', () => {
+    const { doc, w, dom } = shell();
+    w.selectSkill = w.RundockSkillsView.selectSkill;
+    w.selectSkill('ops-summary');
+    press(doc, '[data-skills-action="schedule-skill"]');
+
+    // The workspace changed under the open editor.
+    w.skills = [];
+    w.currentSkillId = null;
+    w.profileShown = null;
+
+    press(doc, '[data-routine-editor="back"]');
+
+    // This door carried an agent, so that is the nearest place the reader
+    // meant to be.
+    assert.strictEqual(w.currentSkillId, null, 'the skill page cannot be opened, so it was not');
+    assert.strictEqual(w.profileShown, 'piper',
+      'the press must still land somewhere rather than leaving a dead editor on screen');
+    dom.window.close();
+  });
+
+  test('a skill door carrying no agent falls through to the routines list', () => {
+    const { doc, w, dom } = shell();
+    // Two agents have it, so the door carries no agent to fall back to.
+    w.skills = [
+      { id: 'ops-summary', slug: 'ops-summary', name: 'Compile the ops summary',
+        assignedAgents: [{ id: 'piper', name: 'Piper' }, { id: 'doc', name: 'Doc' }] },
+    ];
+    w.selectSkill = w.RundockSkillsView.selectSkill;
+    w.selectSkill('ops-summary');
+    press(doc, '[data-skills-action="schedule-skill"]');
+
+    w.skills = [];
+    w.currentSkillId = null;
+    w.navigatedTo = null;
+
+    press(doc, '[data-routine-editor="back"]');
+    assert.strictEqual(w.profileShown, null, 'no agent was carried, so there is no profile to show');
+    assert.strictEqual(w.navigatedTo, 'routines',
+      'with no skill and no agent the reader still leaves, to the list of routines');
+    dom.window.close();
+  });
+
   // ASSERTED AGAINST THE SOURCE AND NOT AGAINST THIS FILE'S DOM. An earlier
   // version of this test looked for the control in a document nothing had
   // rendered the roster into, which is an assertion that cannot fail for the


### PR DESCRIPTION
Three small, unrelated changes on one branch. They touch three different files and none of them changes what a run does, what is stored, or who may do it.

## Keep the guide's own glyph out of the icons handed to other agents

An agent whose file sets no `icon` is given one from a fixed rotation. That rotation included the hexagon the platform guide wears, so the seventh icon-less agent in a workspace was handed the guide's glyph and the two became indistinguishable in the org chart and the sidebar.

The rotation is now a named constant with that glyph removed, and the glyph the guide reserves is named once and read from there rather than written out at each place that needs it.

Removing it is one line. The test is the part that matters: it reads the same array the assignment indexes into, so the glyph cannot come back the next time somebody extends the rotation. A test that read its own copy of the list would stay green while the real one grew it back.

## Schedule a skill from the skill's own page

Scheduling used to start from an agent or from the routines list. Somebody looking at a skill they already trust had to go and find an agent first, so the page where the decision is actually made offered no way to act on it.

The skill page now carries a **Schedule this skill** control at secondary weight. Where exactly one agent has the skill there is nothing to choose, so the editor opens on the schedule step with the skill and that agent already set.

Where more than one agent has the skill there is a real decision and it is not the code's to make. Taking the first assigned agent would be a guess wearing the shape of a decision, and the only way to find out would be to read the routine afterwards. That case opens the picker that names an agent on every row and lets the reader say which one. Nothing is preselected.

Where no agent has the skill the control is not rendered at all. A routine runs a skill as an agent, and the picker is built by walking each skill's assigned agents, so a skill nobody has can never appear in it. Offering the control anyway meant pressing it landed the reader on an offer to build a skill, while they were looking at one, or on a list of every other skill with the one they pressed missing. The card above it already carries the step that reader needs, which is to give the skill an agent.

The breadcrumb returns to the skill, because that is where the press came from. A control that names a destination it does not go to teaches a wrong model of where things are.

This adds a new way into the routine editor, so it is added to the file that enumerates every way in, along with the tests that press it. That file exists because four entry points once went untested on a single change, each found by a separate review, and it fails by name until a new one is listed with the test that presses its surface.

## Prove a failed workspace switch leaves the file tree still watching

When opening a workspace throws, the server rolls the root back and re-arms the poll that notices changes made outside the app. The comment at that call site claimed the poll then worked against the workspace rolled back to. The only test covering it replaced the arming call with a counter, so it proved the call site was reached and nothing about whether polling still worked. The belief was the thing under test, so the test reproduced it.

No behaviour changes here. What changes is that the claim is now checked.

Nothing is stubbed. The failure is a real filesystem error raised inside the open path, after arming has already baselined against the directory that is about to fail, and the detection is a real write by something that is not the app, observed on the wire.

Two properties, and they are not the same one:

- **A write is still noticed.** This is what the comment claims.
- **A workspace nobody touched stays silent.** This is what proves the re-arm. The rollback also clears the caches, so the poll does recover on its own, one spurious push later. Only the silence goes red when the re-arm is deleted.

A mutation harness beside it deletes each step of the rollback in turn and requires a test to go red for it, so the deletion is something anyone can run rather than a claim in a description like this one. The one step it cannot honestly test is recorded as a named gap rather than as a passing row: every cache that step clears is bounded by the same two second time to live, and the tree cache it also clears is cleared again on the very next line, so a test of it would be a race against a timer that passes when the machine is slow.

## Also here

`mutate:guards` refused two existing mutations once the skill page door landed:
one search text matched two places, and one no longer matched at all. Both were the harness working. The first is fixed by giving the two doors one shared asker for the skill list instead of a copied line, so deleting the send takes the ask away from every door at once; the second by addressing the branch the breadcrumb chain now has. Five mutations are added for the new guards and each turns a named test red.

## Known unrelated flakiness

Three tests fail intermittently under full suite parallelism, on this branch and on `main` alike, and all three fail in their own setup rather than in an assertion about the behaviour under test. They are being fixed separately. If CI goes red on one of these, re-running is the right response:

- `red-first.test.js` → "a test command that traps SIGINT does not hold the tree hostage"
- `process-lifecycle.test.js` → "an idle process is reaped instead of living for the whole session"
- `codex-*` → "the zombie turn's late output never leaks into the follow-up's reply"

## Merged with main

The rail section became a property of the view rather than something each destination sets, so the skill route inherits it instead of naming one. The doors list and the mutation targets are unions of both sides: the row for the team sidebar goes because the surface it named is gone, checked by grep rather than assumed, and the row for the skill page joins the profile, empty state and panel doors.
