### PR TITLE
Put the routines empty state's message inside its own box

### DIFF
--- a/public/styles/views/routines.css
+++ b/public/styles/views/routines.css
@@ -16,9 +16,7 @@
    overnight teaches its user to stop trusting amber. */
 
 .routines-content { max-width: 640px; padding: 32px; }
-/* The lead sentence, now the header's subtitle rather than a paragraph below
-   it. The same role the Skills pane's state line plays in the same block, and
-   the same size: this card moved a component and moved no type size. */
+/* The list header's subtitle: the scoped sentence above the populated list. */
 .routines-subtitle { font-size: var(--body); color: var(--text-2); }
 
 /* The list */
@@ -70,8 +68,12 @@
 .confirm-card p { margin: 0 0 16px; font-size: var(--caption); color: var(--text-2); line-height: 1.65; }
 .confirm-actions { display: flex; gap: 8px; }
 
-/* The empty state: one job, so one primary action and nothing competing. */
+/* The empty state: one job, so one primary action and nothing competing. The
+   state line heads the box it sits in, the same treatment the confirmation
+   card above gives its own heading, so the pane reads as one thing: what is
+   true, what to do about it, and the control that does it. */
 .routines-empty-card { text-align: center; padding: 44px 24px; }
+.routines-empty-state { font-size: var(--body); font-weight: 700; color: var(--text-1); margin: 0 0 8px; }
 .routines-empty-actions { justify-content: center; }
 .routines-empty-aside { text-align: center; margin-top: 16px; }
 

--- a/public/styles/views/skills.css
+++ b/public/styles/views/skills.css
@@ -12,10 +12,10 @@
 .agent-chip-name { font-size: var(--body); font-weight: 500; color: var(--text-1); }
 .agent-chip-role { font-size: var(--caption); color: var(--text-2); }
 
-/* The pane a workspace with no skills opens onto. The state line sits in the
-   header, under the section's own name, the way a selected skill's kind does.
-   The card below it is the settings card the routines empty state already
-   uses, so the two read as one pattern rather than two. */
-.skills-empty-state { font-size: var(--body); color: var(--text-2); }
+/* The pane a workspace with no skills opens onto. The card is the settings
+   card the routines empty state already uses, so the two read as one pattern
+   rather than two, and the state line heads it the same way: bold, inside the
+   box, above the sentence that explains it. */
+.skills-empty-state { font-size: var(--body); font-weight: 700; color: var(--text-1); margin: 0 0 8px; }
 .skills-empty-card { text-align: center; padding: 44px 24px; }
 .skills-empty-actions { justify-content: center; }

--- a/public/views/routines.js
+++ b/public/views/routines.js
@@ -323,8 +323,10 @@ function routinesScopeName() {
  * now heads itself the way every other view that lists things does, instead of
  * the way the view that CONFIGURES things does.
  *
- * `subtitle` is passed in rather than resolved here because the empty pane's
- * subtitle is its own state line, exactly as the Skills pane's is.
+ * `subtitle` is passed in rather than resolved here because the list header
+ * and the empty pane's header are the same call with a different argument:
+ * the list passes its scoped sentence, and the empty pane passes nothing,
+ * because its state line lives in the box below rather than in the header.
  */
 function headerHtml(subtitle) {
   const model = routinesModel();
@@ -353,9 +355,13 @@ function listHeaderHtml() {
 // `add` opens the picker that spans every agent's skills and names which agent
 // runs each one. `build-skill` opens a conversation with the guide, which is
 // what the routine editor's own zero-skills offer already does.
+//
+// NEITHER CARRIES AN ARROW. No other call to action in the app does, so a
+// control decorated differently from every other control of its kind would
+// read as a different kind of control.
 const EMPTY_ACTIONS = {
-  'add-routine': { marker: 'add', onclick: 'addRoutine()', arrow: true },
-  'build-skill': { marker: 'build-skill', onclick: 'routineEditorBuildSkill()', arrow: false },
+  'add-routine': { marker: 'add', onclick: 'addRoutine()' },
+  'build-skill': { marker: 'build-skill', onclick: 'routineEditorBuildSkill()' },
 };
 
 // Whether the skill list has arrived. NOT the same as it being empty: an empty
@@ -368,9 +374,6 @@ function skillsHaveArrived() {
 
 function emptyHtml() {
   const model = routinesModel();
-  const arrow = '<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"'
-    + ' stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">'
-    + '<line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>';
   // WHICH VARIANT IS THE MODEL'S DECISION, not this file's. All this does is
   // hand it what the shell knows: the skills, whether they have arrived, and
   // whether there is a guide to fulfil an offer that names one.
@@ -385,15 +388,19 @@ function emptyHtml() {
   });
   const action = state.actionKind ? EMPTY_ACTIONS[state.actionKind] : null;
 
-  // The state line is the subtitle here, as it is on the Skills pane: an empty
-  // list is not "every scheduled skill across your team".
-  let h = headerHtml(state.lead)
+  // THE STATE LINE IS IN THE BOX, WITH THE ACTION IT BELONGS BESIDE. It used
+  // to be the header's subtitle, so the pane read as a loose sentence sitting
+  // above a card rather than as one thing. The header carries the title only
+  // now; the box carries the whole message, what is true and what to do about
+  // it, in one place.
+  let h = headerHtml(null)
     + '<div class="settings-card flow routines-empty-card">'
+    + `<p class="routines-empty-state">${esc(state.lead)}</p>`
     + `<p class="settings-lead">${esc(state.body)}</p>`;
   if (action && state.action) {
     h += '<div class="card-actions routines-empty-actions">'
       + `<button class="settings-btn-primary" type="button" data-routines-action="${action.marker}"`
-      + ` onclick="${action.onclick}">${esc(state.action)}${action.arrow ? arrow : ''}</button>`
+      + ` onclick="${action.onclick}">${esc(state.action)}</button>`
       + '</div>';
   }
   h += '</div>';

--- a/public/views/skills.js
+++ b/public/views/skills.js
@@ -117,14 +117,18 @@ function renderSkillsEmpty(loading) {
     guideName: guide ? (guide.displayName || guide.name || null) : null,
   });
 
+  // THE STATE LINE IS IN THE BOX, WITH THE ACTION IT BELONGS BESIDE, THE SAME
+  // FIX THE ROUTINES PANE MADE TO THE SAME PATTERN. It used to be the
+  // header's subtitle, so the pane read as a sentence above a card rather
+  // than as one thing.
   let h = `<div class="profile-header">
       <div class="profile-avatar skill-avatar">${BOLT_SVG}</div>
       <div>
         <div class="profile-name">${esc(model.TITLE)}</div>
-        ${state.lead ? `<div class="skills-empty-state">${esc(state.lead)}</div>` : ''}
       </div>
     </div>
     <div class="settings-card flow skills-empty-card">
+      ${state.lead ? `<p class="skills-empty-state">${esc(state.lead)}</p>` : ''}
       <p class="settings-lead">${esc(state.body)}</p>`;
   if (state.action) {
     // Skills are built by talking to the agent that builds them; this screen

--- a/test/tools/mutate-routines-guards.js
+++ b/test/tools/mutate-routines-guards.js
@@ -865,7 +865,7 @@ const MUTATIONS = [
     '    + (subtitle ? `<div class="routines-subtitle">${esc(subtitle)}</div>` : \'\')',
     "    + ''"],
   [VIEW, 'the empty pane takes its own state line rather than the sentence about a full list',
-    '  let h = headerHtml(state.lead)',
+    '  let h = headerHtml(null)',
     '  let h = listHeaderHtml()'],
   [MODEL, 'the scoped subtitle names the agent rather than repeating the unscoped sentence',
     "      subtitle: agentName ? LEAD.scopedLead.replace('{agent}', () => agentName) : LEAD.lead,",

--- a/test/unit/routines-view.test.js
+++ b/test/unit/routines-view.test.js
@@ -1345,6 +1345,21 @@ describe('the header is the skills view\'s header', () => {
     dom.window.close();
   });
 
+  // AC-C2, on the populated header. The subtitle is a subtitle: it takes the
+  // body size, not the title size above it, so it cannot be mistaken for a
+  // second heading.
+  test('the subtitle resolves to the body size, not the title size', () => {
+    const { doc, dom } = styled();
+    const size = (el) => {
+      assert.ok(el, 'an element this compares is not on the page');
+      return dom.window.getComputedStyle(el).fontSize;
+    };
+    const subtitle = size(routinesHeader(doc).querySelector('.routines-subtitle'));
+    assert.notStrictEqual(subtitle, size(routinesHeader(doc).querySelector('.profile-name')),
+      'the subtitle is set at the title size, which is a type size this card was not asked to move');
+    dom.window.close();
+  });
+
   // AC-C3 AT THE SURFACE, WHICH IT COULD NOT BE UNTIL A SCOPE EXISTED. The
   // header used to read a scope global of its own, because nothing set one;
   // the destination function every way into this view goes through now does.
@@ -1403,34 +1418,94 @@ describe('the header is the skills view\'s header', () => {
     dom.window.close();
   });
 
-  // The empty pane heads itself the same way, with its own state line as the
-  // subtitle: an empty list is not every scheduled skill across the team.
-  test('the empty pane carries the same header, with its state line under it', () => {
+  // The empty pane carries the same header, but the header carries the title
+  // alone now: the state line moved into the box below it, so the header has
+  // nothing left to say about the state of the list.
+  test('the empty pane carries the same header, with the title alone', () => {
     const { doc, dom } = styled([], { skills: [] });
     const header = routinesHeader(doc);
     assert.ok(header, 'the empty pane lost the header');
     assert.ok(header.querySelector('.profile-avatar.skill-avatar svg'));
     assert.strictEqual(text(header.querySelector('.profile-name')), 'Routines');
-    assert.strictEqual(text(header.querySelector('.routines-subtitle')), 'No routines yet.');
+    assert.strictEqual(header.querySelector('.routines-subtitle'), null,
+      'the state line is still the header\'s subtitle, so the pane reads as a sentence above a '
+      + 'card rather than as a member of it');
     dom.window.close();
   });
 
-  // AC-C2 on the other half of the header, and the half a size is easiest to
-  // move on. The subtitle is a subtitle: it takes the body size the skills
-  // pane gives its own, and not the title size above it. Read off both
-  // rendered elements in one document, so moving either one fails this.
-  test('the subtitle resolves to the size the skills pane gives its own', () => {
+  // THE STATE LINE AND THE ACTION ARE ONE THING, PROVEN AGAINST WHAT THE PAGE
+  // RESOLVES. A box whose class name is right but which paints no padding is
+  // not a box a reader sees as one, so this reads the computed style rather
+  // than trusting the class name, and then proves containment with
+  // `contains`, which cannot be satisfied by two elements that merely sit
+  // near each other in the markup.
+  //
+  // PADDING, NOT BACKGROUND. jsdom cannot resolve a custom property inside a
+  // `background` shorthand, so `background: var(--card)` reads back as no
+  // colour at all whether or not the rule is even in the cascade: a proof
+  // built on it would pass and fail for reasons that have nothing to do with
+  // this card. Padding is a literal px value in the shipped rule, so it
+  // resolves the same way a browser resolves it.
+  test('the state line and the action are inside the box, not above it', () => {
+    const { doc, dom } = styled([]);
+    const box = doc.querySelector('#routines-content .routines-empty-card');
+    assert.ok(box, 'the empty state has no box');
+    const boxStyle = dom.window.getComputedStyle(box);
+    assert.notStrictEqual(boxStyle.paddingTop, '0px',
+      'sanity: the card resolves no padding, so this is not the box a reader sees');
+    assert.strictEqual(boxStyle.textAlign, 'center',
+      'sanity: the card resolves none of its own rule, so this is not the box a reader sees');
+
+    const stateLine = doc.querySelector('#routines-content .routines-empty-state');
+    assert.ok(stateLine, 'the state line is not on the page');
+    assert.strictEqual(text(stateLine), 'No routines yet.');
+    assert.ok(box.contains(stateLine), 'the state line sits outside the box');
+
+    const action = doc.querySelector('[data-routines-action="add"]');
+    assert.ok(action, 'the action is not on the page');
+    assert.ok(box.contains(action), 'the action sits outside the box the state line is in');
+    dom.window.close();
+  });
+
+  // The state line's own size, now that it lives in the box rather than the
+  // header: still the body size the skills pane gives its own state line, and
+  // still not the title size, so moving it did not also change what it looks
+  // like.
+  test('the state line resolves to the same size the skills pane gives its own', () => {
     const { doc, w, dom } = styled([], { skills: [] });
     w.renderSkillsEmpty(false);
     const size = (el) => {
       assert.ok(el, 'an element this compares is not on the page');
       return dom.window.getComputedStyle(el).fontSize;
     };
-    const subtitle = size(routinesHeader(doc).querySelector('.routines-subtitle'));
-    assert.strictEqual(subtitle, size(doc.querySelector('#skill-detail-content .skills-empty-state')),
-      'the two panes give their subtitles different sizes, so they are not one component');
-    assert.notStrictEqual(subtitle, size(routinesHeader(doc).querySelector('.profile-name')),
-      'the subtitle is set at the title size, which is a type size this card was not asked to move');
+    const routinesState = size(doc.querySelector('#routines-content .routines-empty-state'));
+    assert.strictEqual(routinesState, size(doc.querySelector('#skill-detail-content .skills-empty-state')),
+      'the two panes give their state lines different sizes, so they are not one pattern');
+    assert.notStrictEqual(routinesState, size(routinesHeader(doc).querySelector('.profile-name')),
+      'the state line is set at the title size, which is a type size this card was not asked to move');
+    dom.window.close();
+  });
+
+  // NO CALL TO ACTION IN THESE EMPTY STATES CARRIES AN ARROW. A control
+  // decorated differently from every other control of its kind reads as a
+  // different kind of control, and the SVG a browser actually draws is what is
+  // checked, not a source-level mention of one.
+  test('the add-routine action carries no arrow', () => {
+    const { doc, dom } = styled([]);
+    const action = doc.querySelector('[data-routines-action="add"]');
+    assert.ok(action, 'the action is not on the page');
+    assert.strictEqual(action.querySelectorAll('svg').length, 0,
+      'the add-routine action carries a glyph no other control of its kind has');
+    dom.window.close();
+  });
+
+  test('the build-a-skill action carries no arrow either', () => {
+    const { doc, w, dom } = styled([], { skills: [] });
+    w.getGuide = () => ({ id: 'archivist', displayName: 'Wren', type: 'platform' });
+    w.renderRoutines();
+    const action = doc.querySelector('[data-routines-action="build-skill"]');
+    assert.ok(action, 'the action is not on the page');
+    assert.strictEqual(action.querySelectorAll('svg').length, 0);
     dom.window.close();
   });
 

--- a/test/unit/skills-empty.test.js
+++ b/test/unit/skills-empty.test.js
@@ -261,6 +261,38 @@ describe('the pane a workspace with no skills opens onto', () => {
     dom.window.close();
   });
 
+  // THE ROUTINES CARD FOUND THIS PANE'S OWN STATE LINE OUTSIDE ITS BOX TOO,
+  // WRITTEN IN THE SAME PASS. Proven by real DOM containment rather than by a
+  // class name that happens to appear on both elements: two elements that
+  // merely sit near each other in the markup cannot satisfy `contains`.
+  test('the state line and the action live inside the same box', () => {
+    const { w, doc, dom } = shell({ skills: [] });
+    w.renderSkills();
+    const box = doc.querySelector('#skill-detail-content .skills-empty-card');
+    assert.ok(box, 'the empty state has no box');
+
+    const stateLine = doc.querySelector('#skill-detail-content .skills-empty-state');
+    assert.ok(stateLine, 'the state line is not on the page');
+    assert.strictEqual(stateLine.textContent.trim(), STATE_LINE);
+    assert.ok(box.contains(stateLine), 'the state line sits outside the box');
+
+    const buttons = doc.querySelectorAll('#skill-detail-content button');
+    assert.strictEqual(buttons.length, 1);
+    assert.ok(box.contains(buttons[0]), 'the action sits outside the box the state line is in');
+    dom.window.close();
+  });
+
+  // No other call to action in the app carries an arrow, and this pane's
+  // action must not diverge from that either.
+  test('the action carries no arrow', () => {
+    const { w, doc, dom } = shell({ skills: [] });
+    w.renderSkills();
+    const buttons = doc.querySelectorAll('#skill-detail-content button');
+    assert.strictEqual(buttons.length, 1);
+    assert.strictEqual(buttons[0].querySelectorAll('svg').length, 0);
+    dom.window.close();
+  });
+
   test('a skill arriving replaces the empty pane with that skill', () => {
     const { w, doc, dom } = shell({ skills: [] });
     w.renderSkills();


### PR DESCRIPTION
The routines empty state read as two separate things: a sentence sitting above a card, then the card itself with the button in it. The sentence is now the first line inside the card, next to the button, so the pane reads as one thing.

The Add routine button also carried an arrow that no other button in the app has. It is removed, so every empty-state action looks the same kind of control.

The Skills empty state had the identical structural issue (its own state line sitting above its card rather than inside it), since it was built from the same pattern in the same pass. It gets the same fix here so the two panes stay in agreement.

Separately: a previous change already fixed the sidebar plus opening the routine editor on the wrong section. I verified this on the current main branch: opening the editor from the sidebar now correctly lands on the Routines section, not Team. No change was needed there.

## Test plan

- New and updated unit tests cover both empty-state fixes: the state line and the action are proven to sit inside the same box (checked against the page's own resolved layout, not just a class name), and no empty-state button renders an arrow.
- Full test suite passes locally.
- Manual verification that opening the routine editor from the sidebar plus lands on Routines, confirmed by reading the current navigation table in the merged code.