### PR TITLE
Leave no test suite running when the reverting check exits

### DIFF
--- a/.review/red-first-orphans-evidence.md
+++ b/.review/red-first-orphans-evidence.md
@@ -1,0 +1,254 @@
+# What the reverting check left behind, measured before and after
+
+`scripts/red-first.js` spawns its test command detached. Detached means the
+command heads its own process group, which is what lets a whole subtree be
+ended together, and it also means the group outlives this process unless
+something ends it. Nothing did, on three of the four ways out.
+
+**This file is a dated record of runs on one machine, not a source of truth.**
+Every claim below is re-measured by a named test in
+`test/unit/red-first-orphans.test.js` on every run, and those tests print the
+process table they measured whether they pass or fail. If this file and the
+suite ever disagree, the suite is right.
+
+Reproduce all of it with:
+
+    node --test test/unit/red-first-orphans.test.js
+
+Figures below were taken on macOS on 2026-08-25, against `origin/main` at
+`afb63ef`.
+
+---
+
+## Why this project's own reverting check cannot prove any of it
+
+Every criterion here is a PROHIBITION: no suite outlives the tool. The usual
+proof in this repository is to take the source away and watch a test go red,
+and that proof does not work on a prohibition. Removing the ending makes these
+tests fail because a function they call has vanished, not because a suite
+survived, and a test failing for a missing symbol would fail exactly as loudly
+if the prohibition were perfectly kept.
+
+Two of the tests below show that failure mode plainly. In the `before` run,
+`AC-5, AC-6` and `AC-5: a run that has not spawned its suite yet` die with
+`runRecordPath is not a function`. **Those two lines are not evidence of
+anything** and are left in rather than trimmed, because a reader needs to see
+the difference between a test that noticed a leak and a test that noticed a
+missing export. The refusal criteria are proven further down instead, by
+changes that keep the mechanism and remove only the behaviour.
+
+There is a second reason, particular to this file. The tool cannot be pointed at
+its own branch to check this without doing the very thing being measured: a run
+starts two more suites, which is what the branch exists to stop.
+
+So the prohibitions are proven the other way round. **The forbidden act is
+committed, one change at a time, and the run records which named test noticed.**
+
+---
+
+## Before: each exit driven against the tool as it was
+
+The stand-in suite is a shell that starts a background child, detaches that
+child's stdio so the shell is not held open by it, and exits. That is the shape
+of a package runner, and the child of the child is what was being left behind.
+Note `PPID 1` in the tables: the leftovers had been reparented to init, which is
+what an orphan looks like.
+
+```
+▶ no suite outlives the tool
+  ✖ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (5375.369375ms)
+  ℹ immediately after the tool exited:
+98441=alive 98440=gone 98455=alive 98454=gone
+PID  PPID  PGID COMMAND
+98441     1 98440 sleep 600674
+98455     1 98454 sleep 600674
+  ℹ after settling:
+98441=alive 98440=gone 98455=alive 98454=gone
+PID  PPID  PGID COMMAND
+98441     1 98440 sleep 600674
+98455     1 98454 sleep 600674
+  ✖ AC-2: an error exit leaves no suite running (5353.364ms)
+  ℹ immediately after the tool exited:
+98547=alive 98546=gone
+PID  PPID  PGID COMMAND
+98547     1 98546 sleep 600674
+  ℹ after settling:
+98547=alive 98546=gone
+PID  PPID  PGID COMMAND
+98547     1 98546 sleep 600674
+  ✖ AC-3: a signal during the FIRST run leaves no suite running (5365.254ms)
+  ℹ with the first run in flight:
+98641=alive 98640=alive
+PID  PPID  PGID COMMAND
+98640 98627 98640 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; sleep 30
+98641 98640 98640 sleep 600674
+  ℹ the tool exited with code null signal SIGTERM
+  ℹ after the tool exited:
+98641=alive 98640=alive
+PID  PPID  PGID COMMAND
+98640     1 98640 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; sleep 30
+98641 98640 98640 sleep 600674
+  ✖ AC-1: an exit taken while a suite is running leaves nothing behind either (5347.10525ms)
+  ℹ immediately after the exit:
+98717=alive 98716=alive
+PID  PPID  PGID COMMAND
+98716     1 98716 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; sleep 30
+98717 98716 98716 sleep 600674
+  ℹ after settling:
+98717=alive 98716=alive
+PID  PPID  PGID COMMAND
+98716     1 98716 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; sleep 30
+98717 98716 98716 sleep 600674
+✖ no suite outlives the tool (21442.560875ms)
+▶ starting on top of a run that is still going
+  ✖ AC-5, AC-6: a second start is refused, and the refusal names the run it found (237.476875ms)
+  ✖ AC-5: a run that has not spawned its suite yet is live too (147.695791ms)
+✖ starting on top of a run that is still going (385.364792ms)
+▶ cleanup reaches what this tool started, and stops there
+  ✖ AC-8: a suite this tool did not start is left alone, and is still working afterwards (5353.160084ms)
+  ℹ foreign suite before: 98896=alive
+PID  PPID  PGID COMMAND
+98896 98380 98896 sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-98380-1787669102472; sleep 0.2; done # sleep 600674 counted 1
+✖ cleanup reaches what this tool started, and stops there (5354.562834ms)
+ℹ tests 7
+ℹ suites 3
+ℹ pass 0
+ℹ fail 7
+```
+
+Seven of seven red. Two of them for the wrong reason, as set out above.
+
+## After
+
+```
+▶ no suite outlives the tool
+  ✔ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (504.6955ms)
+  ℹ immediately after the tool exited:
+92031=gone 92030=gone 92045=gone 92044=gone (no process table: ps is unavailable here)
+  ℹ after settling:
+92031=gone 92030=gone 92045=gone 92044=gone (no process table: ps is unavailable here)
+  ✔ AC-2: an error exit leaves no suite running (557.494ms)
+  ℹ immediately after the tool exited:
+92132=gone 92131=gone (no process table: ps is unavailable here)
+  ℹ after settling:
+92132=gone 92131=gone (no process table: ps is unavailable here)
+  ✔ AC-3: a signal during the FIRST run leaves no suite running (1659.407875ms)
+  ℹ with the first run in flight:
+92229=alive 92228=alive
+PID  PPID  PGID COMMAND
+92228 92215 92228 /bin/sh -c sleep 600244 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-91968-1787668932885.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-91968-1787668932885.pids"; sleep 30
+92229 92228 92228 sleep 600244
+  ℹ the tool exited with code 130 signal null
+  ℹ after the tool exited:
+92229=gone 92228=gone (no process table: ps is unavailable here)
+  ✔ AC-1: an exit taken while a suite is running leaves nothing behind either (1053.746791ms)
+  ℹ immediately after the exit:
+92313=gone 92312=gone (no process table: ps is unavailable here)
+  ℹ after settling:
+92313=gone 92312=gone (no process table: ps is unavailable here)
+✔ no suite outlives the tool (3776.40125ms)
+▶ starting on top of a run that is still going
+  ✔ AC-5, AC-6: a second start is refused, and the refusal names the run it found (929.386625ms)
+  ℹ record: {"pid":92372,"group":92385,"tests":"sleep 600244 >/dev/null 2>&1 & echo $! >> \"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids\"; echo $$ >> \"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids\"; sleep 25","repo":"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-rIsEoX","startedAt":"2026-08-25T14:42:15.664Z"}
+  ℹ second start said: [red-first] REFUSED: a run of this tool is still live in this repository: process group 92385 running sleep 600244 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids"; sleep 25, started 2026-08-25T14:42:15.664Z by red first pid 92372. Starting now would add a second suite to this machine rather than replace the first. End that run, or delete /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-run-35e4b9e8c19f33c6.json if it has already gone.
+  ✔ AC-5: a run that has not spawned its suite yet is live too (213.880458ms)
+  ℹ outcome: refused: a run of this tool is still live in this repository: red first pid 92453 running npm test, with no suite under it yet, started 2026-08-25T14:42:16.530Z by red first pid 92453. Starting now would add a second suite to this machine rather than replace the first. End that run, or delete /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-run-e3529a94bd7ebf49.json if it has already gone.
+✔ starting on top of a run that is still going (1143.4755ms)
+▶ cleanup reaches what this tool started, and stops there
+  ✔ AC-8: a suite this tool did not start is left alone, and is still working afterwards (892.710291ms)
+  ℹ foreign suite before: 92505=alive
+PID  PPID  PGID COMMAND
+92505 91968 92505 sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-91968-1787668936749; sleep 0.2; done # sleep 600244 counted 1
+  ℹ foreign suite after: 92505=alive
+PID  PPID  PGID COMMAND
+92505 91968 92505 sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-91968-1787668936749; sleep 0.2; done # sleep 600244 counted 3 then 4
+✔ cleanup reaches what this tool started, and stops there (892.948875ms)
+ℹ tests 7
+ℹ suites 3
+ℹ pass 7
+ℹ fail 0
+```
+
+Note the durations. The whole file takes 27.2 seconds before and 5.9 seconds
+after, because five of its tests each spend five seconds waiting for processes
+that never go away.
+
+---
+
+## Breaking it on purpose
+
+Each change below was applied ALONE to `scripts/red-first.js`, the file's tests
+were run, and the source was restored. Restores were made by copying a backup
+taken outside the repository, never by `git checkout`, because a checkout would
+have erased uncommitted work and left a clean tree that proved nothing. Every
+run's restore was verified by digest.
+
+To repeat any row, make the change, run `node --test
+test/unit/red-first-orphans.test.js`, and put the file back. The rows list the
+enclosing suite names alongside the tests, because a failing test fails its
+suite; the named tests are the measurements.
+
+One row needs a second edit to repeat it. `leftovers cleared by matching command
+lines across the machine` pins `LONG` in the test file to a fixed `654321` and
+matches on `sleep 654321`, so that a pattern kill made while reproducing this
+can reach nothing but the processes the run itself started. That is the whole
+reason the stand in suites sleep for an odd number of seconds.
+
+| Change made | Tests that turned red |
+|---|---|
+| the whole of this change taken back out of the tool | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error exit leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool`; `starting on top of a run that is still going` |
+| the 'exit' backstop removed, leaving only the function's own finally | `AC-1: an exit taken while a suite is running leaves nothing behind either`; `no suite outlives the tool` |
+| the signal listeners moved back to after the first run | `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `no suite outlives the tool`; `starting on top of a run that is still going` |
+| the direct child signalled instead of the whole group | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error exit leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool` |
+| leftovers cleared by matching command lines across the machine | `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there` |
+| the refusal removed, so a second start runs | `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `starting on top of a run that is still going` |
+| the refusal keeps refusing but names nothing | `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `starting on top of a run that is still going` |
+| the run record left behind after the run ends | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `no suite outlives the tool` |
+| a live run with no suite under it treated as gone | `AC-5: a run that has not spawned its suite yet is live too`; `starting on top of a run that is still going` |
+
+The first row is the whole change removed. It is included for shape rather than
+as proof, for the reason given above: two of the ten it turns red are red
+because an export vanished.
+
+**Two rows are worth reading twice, because each one caught a defect in a test
+rather than in the source.** Both were silent on the first pass of this table,
+and both were found by running the change rather than by reading it.
+
+`leftovers cleared by matching command lines across the machine` turned nothing
+red at first. The pattern kill had worked: the foreign suite was dead. The test
+asked whether its pid could still be signalled, and the answer was yes, because
+the dead process was the test's own child and had not been reaped, so it sat
+there defunct with a pid that `kill(pid, 0)` still accepted. **A liveness answer
+that a corpse satisfies is a proxy for the property, in the test for the one
+criterion that exists to stop this fix becoming the next defect.** The foreign
+suite now counts out loud into a file, and the test requires the count to advance
+after the tool has been and gone. A corpse does not count.
+
+`the run record left behind after the run ends` also turned nothing red at
+first. The only test that looked at the record ended its run with a signal, and
+the signal path cleared the record whatever the ordinary path did. A record left
+behind after a normal exit names a pid that is gone, and the refusal at the top
+of the tool would then refuse every later start in that repository until
+somebody deleted the file by hand: the guard against piling on load becoming an
+outage of its own. The normal-exit test now asserts the record has gone.
+
+---
+
+## What is not covered, stated because the refusal is built on it
+
+**SIGKILL of the tool itself.** The kernel delivers it to nothing, so no
+listener runs and a group started by a run ended that way outlives it. That is
+the case the refusal exists for: the next start finds the record, sees the group
+still alive, and says so rather than adding a second suite.
+
+**A run in a different checkout.** The record is per repository, so a suite
+running under another worktree is neither seen nor refused. That is deliberate.
+Refusing across checkouts means reading and acting on processes this tool did
+not start, which is the overreach the eighth criterion forbids.
+
+**A recycled pid.** The refusal is a judgement about numbers, and a pid whose
+owner has gone can in principle be reused. The error that produces is a refusal
+that should not have happened, which costs a developer one message naming a file
+to delete. The other error direction costs everyone on the machine another full
+suite. The window is kept small by clearing the record on every exit the process
+can see.

--- a/.review/red-first-orphans-evidence.md
+++ b/.review/red-first-orphans-evidence.md
@@ -2,10 +2,10 @@
 
 `scripts/red-first.js` spawns its test command detached. Detached means the
 command heads its own process group, which is what lets a whole subtree be
-ended together, and it also means the group outlives this process unless
-something ends it. Nothing did, on three of the four ways out.
+ended together; it also means the group survives this process unless something
+ends it. Nothing did, on three of the four ways out.
 
-**This file is a dated record of runs on one machine, not a source of truth.**
+**This file is a dated record of runs on two machines, not a source of truth.**
 Every claim below is re-measured by a named test in
 `test/unit/red-first-orphans.test.js` on every run, and those tests print the
 process table they measured whether they pass or fail. If this file and the
@@ -15,8 +15,12 @@ Reproduce all of it with:
 
     node --test test/unit/red-first-orphans.test.js
 
-Figures below were taken on macOS on 2026-08-25, against `origin/main` at
-`afb63ef`.
+Figures were taken on 2026-08-25 against `origin/main` at `afb63ef`, on macOS
+and, for the platform difference that macOS cannot show, in a `node:22-bookworm`
+container:
+
+    docker run --rm -v "$PWD":/repo:ro -w /repo node:22-bookworm \
+      node --test test/unit/red-first-orphans.test.js
 
 ---
 
@@ -29,13 +33,12 @@ tests fail because a function they call has vanished, not because a suite
 survived, and a test failing for a missing symbol would fail exactly as loudly
 if the prohibition were perfectly kept.
 
-Two of the tests below show that failure mode plainly. In the `before` run,
-`AC-5, AC-6` and `AC-5: a run that has not spawned its suite yet` die with
-`runRecordPath is not a function`. **Those two lines are not evidence of
-anything** and are left in rather than trimmed, because a reader needs to see
+The `before` run below shows that failure mode plainly: several of its lines are
+red for a missing export rather than for a leak. **Those lines are not evidence
+of anything** and are left in rather than trimmed, because a reader needs to see
 the difference between a test that noticed a leak and a test that noticed a
-missing export. The refusal criteria are proven further down instead, by
-changes that keep the mechanism and remove only the behaviour.
+missing function. Each criterion is proven further down instead, by a change
+that keeps the mechanism and removes only the behaviour.
 
 There is a second reason, particular to this file. The tool cannot be pointed at
 its own branch to check this without doing the very thing being measured: a run
@@ -46,132 +49,343 @@ committed, one change at a time, and the run records which named test noticed.**
 
 ---
 
+## The defect macOS could not show
+
+`kill(-pgid, 0)` asks whether a process group exists. It does not ask whether
+anything in it is still running, and on Linux those are different questions: a
+process that has exited keeps its entry, and its group with it, until its parent
+collects it. On the signal and exit paths this tool's own direct child is
+exactly that. It dies from the SIGTERM at once, and the event loop that would
+collect it is blocked in the listener doing the waiting.
+
+So the first version of this change, measured only on macOS where `killpg`
+filters exited members out of the same question, behaved differently in
+continuous integration than it did here. Both runs below are the same test
+against the same two commits, in a Linux container:
+
+| `scripts/red-first.js` | interrupt to exit | the tool's stderr |
+|---|---|---|
+| the first version of this change | **571 ms** | `WARNING: process group 187 survived being ended and may still be running` |
+| this version | **27 ms** | empty |
+
+The grace is 500 ms. The first row is that grace being spent in full on a corpse
+and then reporting it as a survivor, on every Ctrl-C. Nothing had survived: init
+collects the entry the moment the tool exits.
+
+The same mistake, one layer up, was in this file's own AC-8 check, where a
+pattern kill passed because the process it had killed still answered
+`kill(pid, 0)`. Both are fixed by asking the process table for a state instead,
+which is why `running()` in the test file and `groupRunning()` in the tool now
+share a rule: **an entry that has exited is gone.**
+
+---
+
 ## Before: each exit driven against the tool as it was
 
+Lines in the transcripts below are cut at 150 characters, because the stand-in
+suites carry the path of their own pid file in argv and the tables are otherwise
+unreadable. Nothing else in them is edited.
+
 The stand-in suite is a shell that starts a background child, detaches that
-child's stdio so the shell is not held open by it, and exits. That is the shape
-of a package runner, and the child of the child is what was being left behind.
-Note `PPID 1` in the tables: the leftovers had been reparented to init, which is
-what an orphan looks like.
+child's stdio so the shell is not held open by it, writes its own process table
+while both are alive, and exits. That is the shape of a package runner, and the
+child of the child is what was being left behind. Note `PPID 1` and state `S` in
+the after-tables: the leftovers had been reparented to init and were running.
 
 ```
 ▶ no suite outlives the tool
-  ✖ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (5375.369375ms)
-  ℹ immediately after the tool exited:
-98441=alive 98440=gone 98455=alive 98454=gone
-PID  PPID  PGID COMMAND
-98441     1 98440 sleep 600674
-98455     1 98454 sleep 600674
-  ℹ after settling:
-98441=alive 98440=gone 98455=alive 98454=gone
-PID  PPID  PGID COMMAND
-98441     1 98440 sleep 600674
-98455     1 98454 sleep 600674
-  ✖ AC-2: an error exit leaves no suite running (5353.364ms)
-  ℹ immediately after the tool exited:
-98547=alive 98546=gone
-PID  PPID  PGID COMMAND
-98547     1 98546 sleep 600674
-  ℹ after settling:
-98547=alive 98546=gone
-PID  PPID  PGID COMMAND
-98547     1 98546 sleep 600674
-  ✖ AC-3: a signal during the FIRST run leaves no suite running (5365.254ms)
+  ✖ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (859.462291ms)
+  ℹ with the suite live, written by the runner itself:
+PID  PPID  PGID STAT COMMAND
+ 7683  7621  7683 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-normal […]
+ 7685  7683  7683 S    sleep 600480
+  PID  PPID  PGID STAT COMMAND
+ 7746  7621  7746 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-normal […]
+ 7758  7746  7746 S    sleep 600480
+  ℹ once the tool had exited:
+7685=running 7683=gone 7758=running 7746=gone
+PID  PPID  PGID STAT COMMAND
+ 7685     1  7683 S    sleep 600480
+ 7758     1  7746 S    sleep 600480
+  ✖ AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for (767.5565ms)
+  ℹ with the stubborn suite live:
+PID  PPID  PGID STAT COMMAND
+ 8084  8016  8084 Ss   /bin/sh -c trap '' TERM; sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first- […]
+ 8085  8084  8084 S    sleep 600480
+  PID  PPID  PGID STAT COMMAND
+ 8144  8016  8144 Ss   /bin/sh -c trap '' TERM; sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first- […]
+ 8156  8144  8144 S    sleep 600480
+  ℹ once the tool had exited:
+8085=running 8084=gone 8156=running 8144=gone
+PID  PPID  PGID STAT COMMAND
+ 8085     1  8084 S    sleep 600480
+ 8156     1  8144 S    sleep 600480
+  ✖ AC-2: an error raised while a suite is in flight leaves no suite running (478.990417ms)
+  ℹ once the error had taken the process down:
+8435=running 8434=running
+PID  PPID  PGID STAT COMMAND
+ 8434     1  8434 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflig […]
+ 8435  8434  8434 S    sleep 600480
+  ✖ AC-2: an error out of the run itself also leaves no suite running (799.046291ms)
+  ℹ with the suite live, written by the runner itself:
+PID  PPID  PGID STAT COMMAND
+ 8676  8616  8676 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-error- […]
+ 8677  8676  8676 S    sleep 600480
+  ℹ once the tool had exited:
+8677=running 8676=gone
+PID  PPID  PGID STAT COMMAND
+ 8677     1  8676 S    sleep 600480
+  ✖ AC-3: a signal during the FIRST run leaves no suite running (705.931417ms)
   ℹ with the first run in flight:
-98641=alive 98640=alive
-PID  PPID  PGID COMMAND
-98640 98627 98640 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; sleep 30
-98641 98640 98640 sleep 600674
-  ℹ the tool exited with code null signal SIGTERM
-  ℹ after the tool exited:
-98641=alive 98640=alive
-PID  PPID  PGID COMMAND
-98640     1 98640 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-98380-1787669091406.pids"; sleep 30
-98641 98640 98640 sleep 600674
-  ✖ AC-1: an exit taken while a suite is running leaves nothing behind either (5347.10525ms)
-  ℹ immediately after the exit:
-98717=alive 98716=alive
-PID  PPID  PGID COMMAND
-98716     1 98716 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; sleep 30
-98717 98716 98716 sleep 600674
-  ℹ after settling:
-98717=alive 98716=alive
-PID  PPID  PGID COMMAND
-98716     1 98716 /bin/sh -c sleep 600674 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflight-98380-1787669096739.pids"; sleep 30
-98717 98716 98716 sleep 600674
-✖ no suite outlives the tool (21442.560875ms)
+8931=running 8930=running
+PID  PPID  PGID STAT COMMAND
+ 8930  8916  8930 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal […]
+ 8931  8930  8930 S    sleep 600480
+  ℹ the tool exited with code null signal SIGTERM after 4ms
+  ℹ its stderr was: (empty)
+  ℹ once the tool had exited:
+8931=running 8930=running
+PID  PPID  PGID STAT COMMAND
+ 8930     1  8930 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal […]
+ 8931  8930  8930 S    sleep 600480
+  ✖ AC-1: an exit taken while a suite is running leaves nothing behind either (647.51075ms)
+  ℹ once the exit had been taken:
+9032=running 9031=running
+PID  PPID  PGID STAT COMMAND
+ 9031     1  9031 Ss   /bin/sh -c sleep 600480 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-inflig […]
+ 9032  9031  9031 S    sleep 600480
+✖ no suite outlives the tool (4259.993333ms)
+▶ telling a process that has exited from one that is still running
+  ✖ a group whose remaining members have all exited is judged gone (1.611542ms)
+  ✖ a group that no longer exists is gone without consulting the process table (10.300708ms)
+✖ telling a process that has exited from one that is still running (12.359708ms)
 ▶ starting on top of a run that is still going
-  ✖ AC-5, AC-6: a second start is refused, and the refusal names the run it found (237.476875ms)
-  ✖ AC-5: a run that has not spawned its suite yet is live too (147.695791ms)
-✖ starting on top of a run that is still going (385.364792ms)
+  ✖ AC-5, AC-6: a second start is refused, and the refusal names the run it found (471.16375ms)
+  ✖ AC-5: a run that has not spawned its suite yet is live too (424.704333ms)
+✖ starting on top of a run that is still going (896.124666ms)
+▶ a suite the tool could not end
+  ✖ AC-5: the run record is kept naming it, so the next start has something to refuse on (458.873667ms)
+  ℹ stderr: 
+✖ a suite the tool could not end (459.014625ms)
+▶ two starts at once against one repository
+  ✖ AC-5: exactly one runs and the other is refused, however close together they are (6488.314ms)
+  ℹ first said:  [red-first] restoring the source, keeping the tests
+  ℹ second said: [red-first] NOT-DISCRIMINATING: the tests pass with the source reverted, so they do not discriminate this change and would have gone  […]
+✖ two starts at once against one repository (6488.564459ms)
 ▶ cleanup reaches what this tool started, and stops there
-  ✖ AC-8: a suite this tool did not start is left alone, and is still working afterwards (5353.160084ms)
-  ℹ foreign suite before: 98896=alive
-PID  PPID  PGID COMMAND
-98896 98380 98896 sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-98380-1787669102472; sleep 0.2; done # sleep 600674 counted 1
-✖ cleanup reaches what this tool started, and stops there (5354.562834ms)
-ℹ tests 7
-ℹ suites 3
+  ✖ AC-8: a suite this tool did not start is left alone, and is still working afterwards (543.768541ms)
+  ℹ foreign suite before: 9876=running
+PID  PPID  PGID STAT COMMAND
+ 9876  7459  9876 Ss   sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-7459-17876 […]
+✖ cleanup reaches what this tool started, and stops there (544.032875ms)
+ℹ tests 13
+ℹ suites 6
 ℹ pass 0
-ℹ fail 7
+ℹ fail 13
 ```
 
-Seven of seven red. Two of them for the wrong reason, as set out above.
-
-## After
+## After, on macOS
 
 ```
 ▶ no suite outlives the tool
-  ✔ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (504.6955ms)
-  ℹ immediately after the tool exited:
-92031=gone 92030=gone 92045=gone 92044=gone (no process table: ps is unavailable here)
-  ℹ after settling:
-92031=gone 92030=gone 92045=gone 92044=gone (no process table: ps is unavailable here)
-  ✔ AC-2: an error exit leaves no suite running (557.494ms)
-  ℹ immediately after the tool exited:
-92132=gone 92131=gone (no process table: ps is unavailable here)
-  ℹ after settling:
-92132=gone 92131=gone (no process table: ps is unavailable here)
-  ✔ AC-3: a signal during the FIRST run leaves no suite running (1659.407875ms)
+  ✔ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (1201.477125ms)
+  ℹ with the suite live, written by the runner itself:
+PID  PPID  PGID STAT COMMAND
+10310 10294 10310 Ss   /bin/sh -c sleep 600273 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-normal […]
+10311 10310 10310 S    sleep 600273
+  PID  PPID  PGID STAT COMMAND
+10338 10294 10338 Ss   /bin/sh -c sleep 600273 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-normal […]
+10339 10338 10338 S    sleep 600273
+  ℹ once the tool had exited:
+10311=gone 10310=gone 10339=gone 10338=gone
+(process table empty: none of these pids exist)
+  ✔ AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for (2598.710542ms)
+  ℹ with the stubborn suite live:
+PID  PPID  PGID STAT COMMAND
+10450 10436 10450 Ss   /bin/sh -c trap '' TERM; sleep 600273 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first- […]
+10451 10450 10450 S    sleep 600273
+  PID  PPID  PGID STAT COMMAND
+10495 10436 10495 Ss   /bin/sh -c trap '' TERM; sleep 600273 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first- […]
+10496 10495 10495 S    sleep 600273
+  ℹ once the tool had exited:
+10451=gone 10450=gone 10496=gone 10495=gone
+(process table empty: none of these pids exist)
+  ✔ AC-2: an error raised while a suite is in flight leaves no suite running (886.594958ms)
+  ℹ once the error had taken the process down:
+10627=gone 10626=gone
+(process table empty: none of these pids exist)
+  ✔ AC-2: an error out of the run itself also leaves no suite running (1050.5975ms)
+  ℹ with the suite live, written by the runner itself:
+PID  PPID  PGID STAT COMMAND
+10701 10688 10701 Ss   /bin/sh -c sleep 600273 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-error- […]
+10702 10701 10701 S    sleep 600273
+  ℹ once the tool had exited:
+10702=gone 10701=gone
+(process table empty: none of these pids exist)
+  ✔ AC-3: a signal during the FIRST run leaves no suite running (983.100917ms)
   ℹ with the first run in flight:
-92229=alive 92228=alive
-PID  PPID  PGID COMMAND
-92228 92215 92228 /bin/sh -c sleep 600244 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-91968-1787668932885.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal-91968-1787668932885.pids"; sleep 30
-92229 92228 92228 sleep 600244
-  ℹ the tool exited with code 130 signal null
-  ℹ after the tool exited:
-92229=gone 92228=gone (no process table: ps is unavailable here)
-  ✔ AC-1: an exit taken while a suite is running leaves nothing behind either (1053.746791ms)
-  ℹ immediately after the exit:
-92313=gone 92312=gone (no process table: ps is unavailable here)
-  ℹ after settling:
-92313=gone 92312=gone (no process table: ps is unavailable here)
-✔ no suite outlives the tool (3776.40125ms)
+10826=running 10825=running
+PID  PPID  PGID STAT COMMAND
+10825 10794 10825 Ss   /bin/sh -c sleep 600273 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-signal […]
+10826 10825 10825 S    sleep 600273
+  ℹ the tool exited with code 130 signal null after 178ms
+  ℹ its stderr was: (empty)
+  ℹ once the tool had exited:
+10826=gone 10825=gone
+(process table empty: none of these pids exist)
+  ✔ AC-1: an exit taken while a suite is running leaves nothing behind either (776.423417ms)
+  ℹ once the exit had been taken:
+10935=gone 10934=gone
+(process table empty: none of these pids exist)
+✔ no suite outlives the tool (7498.617708ms)
+▶ telling a process that has exited from one that is still running
+  ✔ a group whose remaining members have all exited is judged gone (7.703084ms)
+  ✔ a group that no longer exists is gone without consulting the process table (20.842917ms)
+✔ telling a process that has exited from one that is still running (28.933416ms)
 ▶ starting on top of a run that is still going
-  ✔ AC-5, AC-6: a second start is refused, and the refusal names the run it found (929.386625ms)
-  ℹ record: {"pid":92372,"group":92385,"tests":"sleep 600244 >/dev/null 2>&1 & echo $! >> \"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids\"; echo $$ >> \"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids\"; sleep 25","repo":"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-rIsEoX","startedAt":"2026-08-25T14:42:15.664Z"}
-  ℹ second start said: [red-first] REFUSED: a run of this tool is still live in this repository: process group 92385 running sleep 600244 >/dev/null 2>&1 & echo $! >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids"; echo $$ >> "/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-refuse-91968-1787668935577.pids"; sleep 25, started 2026-08-25T14:42:15.664Z by red first pid 92372. Starting now would add a second suite to this machine rather than replace the first. End that run, or delete /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-run-35e4b9e8c19f33c6.json if it has already gone.
-  ✔ AC-5: a run that has not spawned its suite yet is live too (213.880458ms)
-  ℹ outcome: refused: a run of this tool is still live in this repository: red first pid 92453 running npm test, with no suite under it yet, started 2026-08-25T14:42:16.530Z by red first pid 92453. Starting now would add a second suite to this machine rather than replace the first. End that run, or delete /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-run-e3529a94bd7ebf49.json if it has already gone.
-✔ starting on top of a run that is still going (1143.4755ms)
+  ✔ AC-5, AC-6: a second start is refused, and the refusal names the run it found (935.23ms)
+  ℹ record: {"pid":11006,"group":11019,"tests":"sleep 600273 >/dev/null 2>&1 & echo $! >> \"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first […]
+  ℹ second start said: [red-first] REFUSED: a run of this tool is still live in this repository: process group 11019 running sleep 600273 >/dev/null 2 […]
+  ℹ the first run's stderr was: (empty)
+  ✔ AC-5: a run that has not spawned its suite yet is live too (707.475708ms)
+  ℹ the record the tool wrote: {"pid":10243,"group":null,"tests":"this command is never spawned","repo":"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000g […]
+  ℹ second start said: [red-first] REFUSED: a run of this tool is still live in this repository: red first pid 10243 running this command is never spa […]
+✔ starting on top of a run that is still going (1642.983375ms)
+▶ a suite the tool could not end
+  ✔ AC-5: the run record is kept naming it, so the next start has something to refuse on (809.741834ms)
+  ℹ stderr: [red-first] WARNING: process group 11212 survived being ended and is still running; nothing further here can reach it, and the run record  […]
+[red-first] WARNING: process group 11226 survived being ended and is still running; nothing further here can reach it, and the run record has been lef […]
+  ℹ record kept: {"pid":11199,"group":11212,"tests":"sleep 600273 >/dev/null 2>&1 & echo $! >> \"/var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red- […]
+✔ a suite the tool could not end (809.912917ms)
+▶ two starts at once against one repository
+  ✔ AC-5: exactly one runs and the other is refused, however close together they are (7130.746125ms)
+  ℹ first said:  [red-first] NOT-DISCRIMINATING: the tests pass with the source reverted, so they do not discriminate this change and would have gone  […]
+  ℹ second said: [red-first] REFUSED: a run of this tool is still live in this repository: red first pid 11288 running sleep 600273 >/dev/null 2>&1 &  […]
+✔ two starts at once against one repository (7131.004ms)
 ▶ cleanup reaches what this tool started, and stops there
-  ✔ AC-8: a suite this tool did not start is left alone, and is still working afterwards (892.710291ms)
-  ℹ foreign suite before: 92505=alive
-PID  PPID  PGID COMMAND
-92505 91968 92505 sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-91968-1787668936749; sleep 0.2; done # sleep 600244 counted 1
-  ℹ foreign suite after: 92505=alive
-PID  PPID  PGID COMMAND
-92505 91968 92505 sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-91968-1787668936749; sleep 0.2; done # sleep 600244 counted 3 then 4
-✔ cleanup reaches what this tool started, and stops there (892.948875ms)
-ℹ tests 7
-ℹ suites 3
-ℹ pass 7
+  ✔ AC-8: a suite this tool did not start is left alone, and is still working afterwards (1100.966209ms)
+  ℹ foreign suite before: 11487=running
+PID  PPID  PGID STAT COMMAND
+11487 10243 11487 Ss   sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-10243-1787 […]
+  ℹ foreign suite after: 11487=running
+PID  PPID  PGID STAT COMMAND
+11487 10243 11487 Ss   sh -c n=0; while :; do n=$((n+1)); echo $n > /var/folders/d2/8vgzjqz958j6bvckjtt726ww0000gn/T/red-first-orphans-beat-10243-1787 […]
+✔ cleanup reaches what this tool started, and stops there (1101.180625ms)
+ℹ tests 13
+ℹ suites 6
+ℹ pass 13
 ℹ fail 0
 ```
 
-Note the durations. The whole file takes 27.2 seconds before and 5.9 seconds
-after, because five of its tests each spend five seconds waiting for processes
-that never go away.
+## After, in a Linux container
+
+```
+▶ no suite outlives the tool
+  ✔ AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child (321.916292ms)
+  ℹ with the suite live, written by the runner itself:
+PID    PPID    PGID STAT COMMAND
+     42      32      42 Ss   /bin/sh -c sleep 600013 >/dev/null 2>&1 & echo $! >> "/tmp/red-first-orphans-normal-13-1787674346395"; echo $$ >> "/tmp/r […]
+     43      42      42 S    sleep 600013
+    PID    PPID    PGID STAT COMMAND
+     50      32      50 Ss   /bin/sh -c sleep 600013 >/dev/null 2>&1 & echo $! >> "/tmp/red-first-orphans-normal-13-1787674346395"; echo $$ >> "/tmp/r […]
+     51      50      50 S    sleep 600013
+  ℹ once the tool had exited:
+43=gone 42=gone 51=gone 50=gone
+PID    PPID    PGID STAT COMMAND
+     43       1      42 Z    [sleep] <defunct>
+     51       1      50 Z    [sleep] <defunct>
+  ✔ AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for (1409.124084ms)
+  ℹ with the stubborn suite live:
+PID    PPID    PGID STAT COMMAND
+     86      76      86 Ss   /bin/sh -c trap '' TERM; sleep 600013 >/dev/null 2>&1 & echo $! >> "/tmp/red-first-orphans-stubborn-13-1787674346667"; ec […]
+     87      86      86 S    sleep 600013
+    PID    PPID    PGID STAT COMMAND
+    103      76     103 Ss   /bin/sh -c trap '' TERM; sleep 600013 >/dev/null 2>&1 & echo $! >> "/tmp/red-first-orphans-stubborn-13-1787674346667"; ec […]
+    104     103     103 S    sleep 600013
+  ℹ once the tool had exited:
+87=gone 86=gone 104=gone 103=gone
+PID    PPID    PGID STAT COMMAND
+     87       1      86 Z    [sleep] <defunct>
+    104       1     103 Z    [sleep] <defunct>
+  ✔ AC-2: an error raised while a suite is in flight leaves no suite running (217.856ms)
+  ℹ once the error had taken the process down:
+149=gone 148=gone
+PID    PPID    PGID STAT COMMAND
+    148       1     148 Zs   [sh] <defunct>
+    149       1     148 Z    [sleep] <defunct>
+  ✔ AC-2: an error out of the run itself also leaves no suite running (151.491542ms)
+  ℹ with the suite live, written by the runner itself:
+PID    PPID    PGID STAT COMMAND
+    180     170     180 Ss   /bin/sh -c sleep 600013 >/dev/null 2>&1 & echo $! >> "/tmp/red-first-orphans-error-13-1787674348281"; echo $$ >> "/tmp/re […]
+    181     180     180 S    sleep 600013
+  ℹ once the tool had exited:
+181=gone 180=gone
+PID    PPID    PGID STAT COMMAND
+    181       1     180 Z    [sleep] <defunct>
+  ✔ AC-3: a signal during the FIRST run leaves no suite running (224.052459ms)
+  ℹ with the first run in flight:
+218=running 217=running
+PID    PPID    PGID STAT COMMAND
+    217     207     217 Ss   /bin/sh -c sleep 600013 >/dev/null 2>&1 & echo $! >> "/tmp/red-first-orphans-signal-13-1787674348441"; echo $$ >> "/tmp/r […]
+    218     217     217 S    sleep 600013
+  ℹ the tool exited with code 130 signal null after 27ms
+  ℹ its stderr was: (empty)
+  ℹ once the tool had exited:
+218=gone 217=gone
+PID    PPID    PGID STAT COMMAND
+    217       1     217 Zs   [sh] <defunct>
+  ✔ AC-1: an exit taken while a suite is running leaves nothing behind either (198.727625ms)
+  ℹ once the exit had been taken:
+254=gone 253=gone
+PID    PPID    PGID STAT COMMAND
+    253       1     253 Zs   [sh] <defunct>
+    254       1     253 Z    [sleep] <defunct>
+✔ no suite outlives the tool (2525.215793ms)
+▶ telling a process that has exited from one that is still running
+  ✔ a group whose remaining members have all exited is judged gone (2.5155ms)
+  ✔ a group that no longer exists is gone without consulting the process table (9.242125ms)
+✔ telling a process that has exited from one that is still running (12.3465ms)
+▶ starting on top of a run that is still going
+  ✔ AC-5, AC-6: a second start is refused, and the refusal names the run it found (248.055917ms)
+  ℹ record: {"pid":278,"group":288,"tests":"sleep 600013 >/dev/null 2>&1 & echo $! >> \"/tmp/red-first-orphans-refuse-13-1787674348877\"; echo $$ >> \ […]
+  ℹ second start said: [red-first] REFUSED: a run of this tool is still live in this repository: process group 288 running sleep 600013 >/dev/null 2>& […]
+  ℹ the first run's stderr was: (empty)
+  ✔ AC-5: a run that has not spawned its suite yet is live too (129.228ms)
+  ℹ the record the tool wrote: {"pid":13,"group":null,"tests":"this command is never spawned","repo":"/tmp/red-first-orphans-veHjJt","startedAt":"2026 […]
+  ℹ second start said: [red-first] REFUSED: a run of this tool is still live in this repository: red first pid 13 running this command is never spawne […]
+✔ starting on top of a run that is still going (377.735458ms)
+▶ a suite the tool could not end
+  ✔ AC-5: the run record is kept naming it, so the next start has something to refuse on (147.594584ms)
+  ℹ stderr: [red-first] WARNING: process group 356 survived being ended and is still running; nothing further here can reach it, and the run record ha […]
+[red-first] WARNING: process group 361 survived being ended and is still running; nothing further here can reach it, and the run record has been left  […]
+  ℹ record kept: {"pid":346,"group":356,"tests":"sleep 600013 >/dev/null 2>&1 & echo $! >> \"/tmp/red-first-orphans-survivor-13-1787674349253\"; echo  […]
+✔ a suite the tool could not end (147.8185ms)
+▶ two starts at once against one repository
+  ✔ AC-5: exactly one runs and the other is refused, however close together they are (6246.855461ms)
+  ℹ first said:  [red-first] NOT-DISCRIMINATING: the tests pass with the source reverted, so they do not discriminate this change and would have gone  […]
+  ℹ second said: [red-first] REFUSED: a run of this tool is still live in this repository: red first pid 379 running sleep 600013 >/dev/null 2>&1 & ec […]
+✔ two starts at once against one repository (6247.501545ms)
+▶ cleanup reaches what this tool started, and stops there
+  ✔ AC-8: a suite this tool did not start is left alone, and is still working afterwards (327.345292ms)
+  ℹ foreign suite before: 429=running
+PID    PPID    PGID STAT COMMAND
+    429      13     429 Ss   sh -c n=0; while :; do n=$((n+1)); echo $n > /tmp/red-first-orphans-beat-13-1787674355653; sleep 0.2; done # sleep 600013 […]
+  ℹ foreign suite after: 429=running
+PID    PPID    PGID STAT COMMAND
+    429      13     429 Ss   sh -c n=0; while :; do n=$((n+1)); echo $n > /tmp/red-first-orphans-beat-13-1787674355653; sleep 0.2; done # sleep 600013 […]
+✔ cleanup reaches what this tool started, and stops there (327.780667ms)
+ℹ tests 13
+ℹ suites 6
+ℹ pass 13
+ℹ fail 0
+```
+
+The after-tables read `(process table empty: none of these pids exist)`. That
+wording is the correction of a false statement in the previous version of this
+file, which said the table could not be captured. `ps -p` exits non-zero when
+none of the listed pids exist, and that is a successful lookup finding nothing,
+not `ps` failing to run; the helper now separates the two and reserves the
+unavailable wording for a spawn failure.
 
 ---
 
@@ -192,27 +406,42 @@ One row needs a second edit to repeat it. `leftovers cleared by matching command
 lines across the machine` pins `LONG` in the test file to a fixed `654321` and
 matches on `sleep 654321`, so that a pattern kill made while reproducing this
 can reach nothing but the processes the run itself started. That is the whole
-reason the stand in suites sleep for an odd number of seconds.
+reason the stand-in suites sleep for an odd number of seconds.
+
+macOS:
 
 | Change made | Tests that turned red |
 |---|---|
-| the whole of this change taken back out of the tool | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error exit leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool`; `starting on top of a run that is still going` |
-| the 'exit' backstop removed, leaving only the function's own finally | `AC-1: an exit taken while a suite is running leaves nothing behind either`; `no suite outlives the tool` |
+| the whole of this change taken back out of the tool | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error out of the run itself also leaves no suite running`; `AC-2: an error raised while a suite is in flight leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `AC-5: exactly one runs and the other is refused, however close together they are`; `AC-5: the run record is kept naming it, so the next start has something to refuse on`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `a group that no longer exists is gone without consulting the process table`; `a group whose remaining members have all exited is judged gone`; `a suite the tool could not end`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool`; `starting on top of a run that is still going`; `telling a process that has exited from one that is still running`; `two starts at once against one repository` |
+| the 'exit' backstop removed, leaving only the function's own finally | `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error raised while a suite is in flight leaves no suite running`; `no suite outlives the tool` |
 | the signal listeners moved back to after the first run | `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `no suite outlives the tool`; `starting on top of a run that is still going` |
-| the direct child signalled instead of the whole group | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error exit leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool` |
+| the direct child signalled instead of the whole group | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error out of the run itself also leaves no suite running`; `AC-2: an error raised while a suite is in flight leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: exactly one runs and the other is refused, however close together they are`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool`; `starting on top of a run that is still going`; `two starts at once against one repository` |
+| the escalation from SIGTERM to SIGKILL removed | `AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for`; `no suite outlives the tool` |
+| an exited member counted as a running one | `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error raised while a suite is in flight leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `a group whose remaining members have all exited is judged gone`; `no suite outlives the tool`; `starting on top of a run that is still going`; `telling a process that has exited from one that is still running` |
 | leftovers cleared by matching command lines across the machine | `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `cleanup reaches what this tool started, and stops there` |
-| the refusal removed, so a second start runs | `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `starting on top of a run that is still going` |
+| the refusal removed, so a second start runs | `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `AC-5: exactly one runs and the other is refused, however close together they are`; `starting on top of a run that is still going`; `two starts at once against one repository` |
 | the refusal keeps refusing but names nothing | `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `starting on top of a run that is still going` |
-| the run record left behind after the run ends | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `no suite outlives the tool` |
-| a live run with no suite under it treated as gone | `AC-5: a run that has not spawned its suite yet is live too`; `starting on top of a run that is still going` |
+| the run record left behind after the run ends | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-2: an error out of the run itself also leaves no suite running`; `AC-2: an error raised while a suite is in flight leaves no suite running`; `AC-5: a run that has not spawned its suite yet is live too`; `AC-5: exactly one runs and the other is refused, however close together they are`; `AC-5: the run record is kept naming it, so the next start has something to refuse on`; `a suite the tool could not end`; `no suite outlives the tool`; `starting on top of a run that is still going`; `two starts at once against one repository` |
+| a live run with no suite under it treated as gone | `AC-5: a run that has not spawned its suite yet is live too`; `AC-5: exactly one runs and the other is refused, however close together they are`; `starting on top of a run that is still going`; `two starts at once against one repository` |
+| the record given back even when a group survived ending | `AC-5: the run record is kept naming it, so the next start has something to refuse on`; `a suite the tool could not end` |
+| the claim written without an exclusive create | `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: a run that has not spawned its suite yet is live too`; `AC-5: exactly one runs and the other is refused, however close together they are`; `starting on top of a run that is still going`; `two starts at once against one repository` |
 
 The first row is the whole change removed. It is included for shape rather than
-as proof, for the reason given above: two of the ten it turns red are red
+as proof, for the reason given above: several of the tests it turns red are red
 because an export vanished.
 
-**Two rows are worth reading twice, because each one caught a defect in a test
-rather than in the source.** Both were silent on the first pass of this table,
-and both were found by running the change rather than by reading it.
+The zombie rule is the one row whose consequence differs by platform, so it was
+run again in the Linux container. There it also reddens every path that ends a
+live suite, because the corpse keeps the group looking alive for the whole grace
+and the ending then announces a survivor that is not one:
+
+| Change made | Tests that turned red, in a Linux container |
+|---|---|
+| an exited member counted as a running one | `AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner's own child`; `AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for`; `AC-1: an exit taken while a suite is running leaves nothing behind either`; `AC-2: an error out of the run itself also leaves no suite running`; `AC-2: an error raised while a suite is in flight leaves no suite running`; `AC-3: a signal during the FIRST run leaves no suite running`; `AC-5, AC-6: a second start is refused, and the refusal names the run it found`; `AC-5: exactly one runs and the other is refused, however close together they are`; `AC-8: a suite this tool did not start is left alone, and is still working afterwards`; `a group whose remaining members have all exited is judged gone`; `cleanup reaches what this tool started, and stops there`; `no suite outlives the tool`; `starting on top of a run that is still going`; `telling a process that has exited from one that is still running`; `two starts at once against one repository` |
+
+**Three rows caught a defect in a test rather than in the source.** All three
+were silent until the change was actually run, and none of them could have been
+found by reading the diff.
 
 `leftovers cleared by matching command lines across the machine` turned nothing
 red at first. The pattern kill had worked: the foreign suite was dead. The test
@@ -230,7 +459,14 @@ the signal path cleared the record whatever the ordinary path did. A record left
 behind after a normal exit names a pid that is gone, and the refusal at the top
 of the tool would then refuse every later start in that repository until
 somebody deleted the file by hand: the guard against piling on load becoming an
-outage of its own. The normal-exit test now asserts the record has gone.
+outage of its own. Every exit test now asserts the record has gone.
+
+`the escalation from SIGTERM to SIGKILL removed` turned nothing red either,
+because every stand-in suite in the file died on the first signal. A child that
+ignores SIGTERM is the only case where the escalation is what keeps a suite from
+outliving the tool, and the criterion it answers to is unconditional. There is
+now a stand-in that sets TERM to ignored before starting its background child,
+which inherits the ignored disposition across exec.
 
 ---
 
@@ -246,9 +482,16 @@ running under another worktree is neither seen nor refused. That is deliberate.
 Refusing across checkouts means reading and acting on processes this tool did
 not start, which is the overreach the eighth criterion forbids.
 
+**The alarm, where the process table cannot be read.** Telling a corpse from a
+survivor needs `ps`, and a sandbox that blocks spawning leaves the tool unable
+to tell. It stays quiet there rather than warning, because the alternative is an
+alarm that fires on every ordinary interrupt on Linux, and one that cries wolf
+is one nobody reads. The cost is that a genuine survivor is not announced on
+such a machine either. Everything else, including the ending itself, works
+unchanged.
+
 **A recycled pid.** The refusal is a judgement about numbers, and a pid whose
 owner has gone can in principle be reused. The error that produces is a refusal
 that should not have happened, which costs a developer one message naming a file
 to delete. The other error direction costs everyone on the machine another full
-suite. The window is kept small by clearing the record on every exit the process
-can see.
+suite.

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -35,9 +35,28 @@
  * Exit 0 only when discrimination is proven. Every other outcome is non-zero
  * and names itself, because "it failed" cannot distinguish a weak test from a
  * broken suite, and treating those alike is how a check stops being read.
+ *
+ * WHAT IT LEAVES BEHIND
+ *
+ * Nothing, on any exit this process can see. The test command is spawned
+ * detached and therefore heads its own process group; that group is ended when
+ * its run finishes, when a terminating signal arrives, and again from an 'exit'
+ * listener that catches the ordinary return and the uncaught throw alike. Only
+ * groups this run started are ever signalled, so a suite or a mutation harness
+ * belonging to somebody else is never touched however alike the command lines
+ * look.
+ *
+ * A run in progress is recorded outside the repository, and a start made while
+ * one is still live is refused rather than allowed to add a second suite to the
+ * machine. That refusal exists because retrying an inconclusive check used to
+ * do exactly that, three suites deep, and the retries were the response to the
+ * load the retries were creating.
  */
 
 const { execFileSync, spawn } = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 
 // What marks a file as a test rather than the thing under test.
@@ -165,6 +184,127 @@ function restoreTo(repo, ref, files) {
   }
 }
 
+// How long a process group started here gets to end on its own before it is
+// ended outright. Short on purpose. The politeness is worth something, since a
+// test runner given the chance will close its reporters and flush its output,
+// but the group being waited on is only ever one this run started, and nothing
+// this tool spawns has a restore step to skip. The cost of waiting longer is
+// paid by a developer watching the tool refuse to exit.
+const END_GRACE_MS = 500;
+
+// A pause that blocks rather than yields.
+//
+// It has to block, because the last place the ending below runs is an 'exit'
+// listener. By then the event loop has finished and a timer would never fire,
+// so anything asynchronous there is the same as no wait at all.
+function pause(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Is any process still in this group?
+//
+// Signal 0 asks the kernel whether the target exists without sending anything.
+// EPERM is a yes: the group is there and this process may not signal it, which
+// is a different answer from the group being gone.
+//
+// The reason this is safe to ask about a NUMBER rather than a live handle: a
+// process group id is not reused while the group still has a member. A group
+// this run created and has not yet watched empty is therefore still this run's
+// group, not a stranger that inherited its number.
+function groupAlive(pgid) {
+  try { process.kill(-pgid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+}
+
+/**
+ * End one process group, and say whether it is gone.
+ *
+ * A NEGATIVE pid signals the whole group, which is the point rather than a
+ * detail. The test command is spawned detached, so it heads its own group, and
+ * a package runner starts children inside that group; ending the direct child
+ * alone leaves those children running, which is how a check that had already
+ * printed its conclusion kept a full suite on the machine.
+ *
+ * Ending a group BY NUMBER is also what keeps the remedy from becoming the next
+ * defect. The obvious way to clear leftovers is to match command lines across
+ * the machine and kill what matches, and that reaches processes this tool never
+ * started: a suite in another checkout, or a mutation harness partway through
+ * rewriting a file it restores in a `finally` that a killed process never runs.
+ * A group id names processes by where they came from rather than by what they
+ * look like, so nothing outside this run can be caught by it however similar it
+ * looks.
+ *
+ * @returns {boolean} whether the group is gone afterwards
+ */
+function endGroup(pgid, graceMs = END_GRACE_MS) {
+  if (!groupAlive(pgid)) return true;
+  try { process.kill(-pgid, 'SIGTERM'); } catch (e) { /* gone since the check */ }
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline && groupAlive(pgid)) pause(25);
+  if (!groupAlive(pgid)) return true;
+  try { process.kill(-pgid, 'SIGKILL'); } catch (e) { /* gone since the check */ }
+  pause(25);
+  return !groupAlive(pgid);
+}
+
+/**
+ * Where a run in progress is recorded, so the next start can see it.
+ *
+ * OUTSIDE the repository, unlike the gate record this file also writes. That
+ * record describes a TREE and belongs beside the tree it describes; this one
+ * describes PROCESSES on one machine, and means nothing in another checkout of
+ * the same commit. Keeping it out of the working tree also keeps it clear of
+ * the cleanliness check this tool makes of the repository it is pointed at: a
+ * file written inside would have to be ignored by every repository the tool is
+ * ever run against, including the throwaway ones its own tests build, and a
+ * repository that had not been told to ignore it would find the tool refusing
+ * its own record.
+ *
+ * Keyed by the resolved repository path, so two checkouts are two records.
+ */
+function runRecordPath(repo) {
+  const key = crypto.createHash('sha256').update(path.resolve(repo)).digest('hex').slice(0, 16);
+  return path.join(os.tmpdir(), `red-first-run-${key}.json`);
+}
+
+/**
+ * A run of this tool that is still going in this repository, or null.
+ *
+ * Both halves are asked about, because between the two suites there are moments
+ * when the tool is alive with nothing under it. Either half being alive means
+ * starting now would put a second suite on this machine, or a second reverter
+ * on the same working tree.
+ *
+ * A record whose run has gone is stale and says nothing. That happens after a
+ * reboot, or after an ending nothing can catch, and it is overwritten rather
+ * than treated as a refusal: a stale file that refuses every start until
+ * somebody deletes it is its own outage.
+ *
+ * THE BOUND, since this is a check made on numbers. A pid or a group id whose
+ * owner has gone can in principle be reused by something unrelated, and this
+ * would then report a live run that is not one. The consequence is a refusal
+ * that should not have happened, which costs a developer one message naming a
+ * file to delete; the consequence of the other error direction is another full
+ * suite on a machine that already has one. The window is kept small by clearing
+ * the record on every exit this process can see, so a record only survives an
+ * ending that skipped all of them.
+ */
+function liveRun(repo) {
+  const file = runRecordPath(repo);
+  let record;
+  try { record = JSON.parse(fs.readFileSync(file, 'utf8')); } catch (e) { return null; }
+  if (!record || typeof record !== 'object') return null;
+  const group = Number(record.group);
+  const pid = Number(record.pid);
+  const groupLive = Number.isInteger(group) && group > 0 && groupAlive(group);
+  const pidLive = Number.isInteger(pid) && pid > 0 && processAlive(pid);
+  if (!groupLive && !pidLive) return null;
+  return { ...record, file, groupLive, pidLive };
+}
+
+function processAlive(pid) {
+  try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+}
+
 /**
  * @returns {{outcome: 'proven'|'not-discriminating'|'inconclusive'|'not-provable'|'refused',
  *            reason: string, passedWithChange: boolean|null,
@@ -178,6 +318,29 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
     testsPassedWithChange: null, testsFailedWithoutChange: null, namesFailedWithoutChange: [],
     source: [], tests: [], limitation: LIMITATION, ...extra,
   });
+
+  // Asked before anything else, because the cost of getting this wrong is paid
+  // by every process on the machine rather than by this one.
+  //
+  // A check that comes back inconclusive invites a retry, and a retry used to
+  // mean another full suite on top of the one still running from the attempt
+  // before. Three concurrent suites and a load average of 178 is what that
+  // reached; the tool was manufacturing the condition it was retrying against.
+  // Refusing costs the developer a message. Not refusing costs everyone.
+  //
+  // It also stops a second run reverting the same working tree underneath the
+  // first, which no amount of restoring afterwards would put right.
+  const live = liveRun(repo);
+  if (live) {
+    const what = live.groupLive
+      ? `process group ${live.group} running ${live.tests}`
+      : `red first pid ${live.pid} running ${live.tests}, with no suite under it yet`;
+    return result('refused', 'a run of this tool is still live in this '
+      + `repository: ${what}, started ${live.startedAt} by red first pid ${live.pid}. `
+      + 'Starting now would add a second suite to this machine rather than '
+      + `replace the first. End that run, or delete ${live.file} if it has `
+      + 'already gone.');
+  }
 
   // A dirty tree is refused, not tidied. This rewrites tracked files and puts
   // them back, so it must never run where it cannot tell its own edits from
@@ -210,14 +373,52 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
       + 'nothing to take away', { source: [], tests: testFiles });
   }
 
-  // The child is tracked so a signal handler can end it. This used to be
-  // spawnSync, which blocks the event loop for the whole life of the child, so
-  // the handler could not run until the child chose to exit. A test command
-  // that traps or ignores SIGINT therefore held the source reverted for as long
-  // as it kept running, while AC-4 claims restoration happens whatever happens.
-  // Documenting the gap did not discharge the criterion. An independent
-  // reviewer refused it twice, correctly.
-  let child = null;
+  // The process groups this run has started and not yet watched end.
+  //
+  // A SET of group ids rather than one child handle, because "what this run is
+  // responsible for" is the question every exit path has to answer, and two of
+  // those paths run where a handle is no use: the signal listeners, and the
+  // 'exit' listener, which is reached after the event loop has stopped. A
+  // number can be signalled from any of them.
+  //
+  // Nothing outside this set is ever signalled. That is the whole of the
+  // scoping: a group id names processes by the run that created them.
+  const startedGroups = new Set();
+
+  const recordFile = runRecordPath(repo);
+  const startedAt = new Date().toISOString();
+  let recordWritten = false;
+
+  // The record the NEXT start reads. Written when this run commits to spawning
+  // and rewritten whenever the live group changes, so what it names is what is
+  // actually running rather than what was running when the tool began.
+  const writeRunRecord = (group) => {
+    try {
+      fs.writeFileSync(recordFile, JSON.stringify({
+        pid: process.pid, group: group || null, tests, repo: path.resolve(repo), startedAt,
+      }, null, 2) + '\n');
+      recordWritten = true;
+    } catch (e) {
+      // Loud, because the refusal above is only as good as this write. A run
+      // that cannot record itself still works; the next one just will not be
+      // refused, and the developer should know that before they retry.
+      console.error('[red-first] could not record this run at '
+        + `${recordFile} (${e.message}); a concurrent start will not be refused`);
+    }
+  };
+
+  const clearRunRecord = () => {
+    if (!recordWritten) return;
+    // Only ever this run's own record. Reading it back before removing it costs
+    // one syscall and means a record written by somebody else, in the window
+    // where two starts raced past the refusal, is left for its owner.
+    try {
+      const held = JSON.parse(fs.readFileSync(recordFile, 'utf8'));
+      if (Number(held && held.pid) !== process.pid) return;
+    } catch (e) { return; }
+    try { fs.rmSync(recordFile, { force: true }); } catch (e) { /* nothing left to clear */ }
+    recordWritten = false;
+  };
 
   const spawnRun = () => new Promise((resolve, reject) => {
     // NODE_TEST_CONTEXT must not reach the child. A nested `node --test` that
@@ -232,103 +433,171 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
     // may have children of its own.
     const kid = spawn(tests, { cwd: repo, shell: true, env, detached: true,
       stdio: ['ignore', 'pipe', 'pipe'] });
-    child = kid;
+    // The child heads its own group, so its pid IS the group id. Recorded here
+    // rather than on any later event, because from this line on there is a
+    // group on this machine that nothing else knows about, and every exit
+    // between here and the next line has to be able to find it.
+    if (kid.pid) {
+      startedGroups.add(kid.pid);
+      writeRunRecord(kid.pid);
+    }
     let text = '';
     kid.stdout.on('data', (b) => { text += b.toString(); });
     kid.stderr.on('data', (b) => { text += b.toString(); });
-    kid.on('error', (e) => { child = null; reject(e); });
+    kid.on('error', (e) => { reject(e); });
     kid.on('close', (code) => {
-      child = null;
       resolve({ ok: code === 0, pass: countFrom(text, 'pass'), fail: countFrom(text, 'fail'), names: namesFrom(text) });
     });
   });
+
+  /**
+   * End every group this run started, and forget each one once it has gone.
+   *
+   * ONE definition of the ending, called from after each run, from the signal
+   * listeners and from the 'exit' listener, rather than three that can drift
+   * apart. The previous version had the ending in the signal path only, which
+   * is exactly why the other exits leaked.
+   */
+  const endStartedGroups = () => {
+    const survived = [];
+    for (const pgid of [...startedGroups]) {
+      if (!endGroup(pgid)) survived.push(pgid);
+      startedGroups.delete(pgid);
+    }
+    if (survived.length) {
+      // console.error rather than the injected log, which defaults to silence.
+      // A group that outlived SIGKILL is the failure this whole file exists to
+      // prevent, and it must not be able to happen quietly.
+      console.error('[red-first] WARNING: process group(s) '
+        + `${survived.join(', ')} survived being ended and may still be running; `
+        + 'nothing further here can reach them');
+    }
+  };
 
   // The runner is injectable so a test can make the reverted run throw while
   // the first run passes, which is the only way to reach the restore by the
   // path a real failure would take. The first version of that test used a
   // command that always failed, so it never got past the first run and would
-  // have passed with the restore deleted.
+  // have passed with the restore deleted. An injected runner spawns nothing,
+  // so it starts no group and there is nothing for the ending below to find.
   const run = runner
     ? async () => ({ ok: !!(await runner()), pass: null, fail: null, names: [] })
     : spawnRun;
 
-  /** End the child and everything it started. Best effort by necessity. */
-  const endChild = () => {
-    const kid = child;
-    if (!kid || kid.killed || kid.exitCode !== null) return;
-    try { process.kill(-kid.pid, 'SIGTERM'); } catch (e) { /* group already gone */ }
-    try { process.kill(-kid.pid, 'SIGKILL'); } catch (e) { /* already dead */ }
+  // Reaped the moment a run is over rather than at the end of the tool.
+  //
+  // A run being over means the direct child has closed, which does NOT mean the
+  // group is empty: a package runner starts children that outlive it, and those
+  // are what was still on the machine after a check had printed its conclusion.
+  // Ending the group here also means the reverted run does not share the
+  // machine with whatever the first run left, which is half of what made the
+  // measured load compound.
+  const runAndEnd = async () => {
+    try { return await run(); } finally { endStartedGroups(); }
   };
 
-  // WITH the change first. A suite failing for its own reasons makes a failure
-  // without the change meaningless, and reporting that as proof would turn a
-  // broken suite into evidence.
-  log('running the tests with the change');
-  const withChange = await run();
-  const passedWithChange = withChange.ok;
-  if (!passedWithChange) {
-    return result('inconclusive', 'the tests do not pass with the change in '
-      + 'place, so a failure without it proves nothing',
-    { passedWithChange: false, source: sourceFiles, tests: testFiles });
-  }
-
-  log('restoring the source, keeping the tests');
-  let failedWithoutChange = null;
-  let withoutChange = { ok: null, pass: null, fail: null, names: [] };
-
-  // try/finally does not survive a signal: Node's default handling terminates
-  // without unwinding, which would abandon the tree mid-revert. Registering a
-  // listener is what disables that default, and the listener restores before
-  // exiting in case the finally is never reached. Both paths call the same
-  // function, and restoring an already-restored tree is a no-op.
+  // EVERY way this process can end, wired before the first suite starts.
   //
-  // The event loop stays free because the test command runs through an
-  // asynchronous spawn, so this handler executes while the child is still
-  // alive rather than waiting for it to agree to exit.
+  // The signal listeners used to go on after the first run, once the reverted
+  // run was about to begin. That left the first full suite, which is the
+  // longest window the tool has, with no handler at all: Node's default
+  // handling for a terminating signal ends the process without unwinding, so
+  // the detached group created moments earlier was simply abandoned. Measured
+  // rather than deduced. A signal sent during the first run left both the
+  // runner and its child alive and reparented to init.
+  //
+  // The ordinary return and the error out of this function are covered by the
+  // `finally` at the bottom, which ends the groups before anything else it
+  // does. Both used to leak because the ending lived in the signal path alone
+  // and neither of them goes through it.
+  //
+  // 'exit' is the backstop behind that, and what it covers is narrower than it
+  // looks: the exit that does not unwind at all, where something else in the
+  // process stops while a suite is in flight and no `finally` of this tool's
+  // ever runs. Taking this listener away leaves `an exit taken while a suite is
+  // running` red and every other test green, which is the measurement that says
+  // what it is for. Listeners here may only do synchronous work, which is why
+  // the ending blocks rather than awaits.
+  //
+  // WHAT NONE OF THIS COVERS, stated because the refusal above is built on it:
+  // SIGKILL of this process, which the kernel delivers to nothing. A group
+  // started by a run ended that way outlives it, and what stops the next start
+  // piling a second suite on top is the refusal, not this.
+  const onExit = () => { endStartedGroups(); clearRunRecord(); };
   const onSignal = () => {
-    // Kill the child FIRST. The restore is pointless while a test command is
-    // still writing to the tree, and a trapping child would otherwise outlive
-    // this process and keep working against a reverted source.
-    endChild();
+    // End the suite FIRST. The restore is pointless while a test command is
+    // still writing to the tree, and a child that ignores signals would
+    // otherwise outlive this process and keep working against reverted source.
+    endStartedGroups();
     try { restoreTo(repo, 'HEAD', sourceFiles); } catch (e) { /* exiting anyway */ }
+    clearRunRecord();
     process.exit(130);
   };
-  process.on('SIGINT', onSignal);
-  process.on('SIGTERM', onSignal);
+  const SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
+  process.on('exit', onExit);
+  for (const signal of SIGNALS) process.on(signal, onSignal);
+
+  // Written before the first spawn as well as at it, so a start that races this
+  // one is refused during the gap between the two rather than waved through.
+  writeRunRecord(null);
 
   try {
-    restoreTo(repo, mergeBase, sourceFiles);
-    withoutChange = await run();
-    failedWithoutChange = !withoutChange.ok;
+    // WITH the change first. A suite failing for its own reasons makes a
+    // failure without the change meaningless, and reporting that as proof would
+    // turn a broken suite into evidence.
+    log('running the tests with the change');
+    const withChange = await runAndEnd();
+    const passedWithChange = withChange.ok;
+    if (!passedWithChange) {
+      return result('inconclusive', 'the tests do not pass with the change in '
+        + 'place, so a failure without it proves nothing',
+      { passedWithChange: false, source: sourceFiles, tests: testFiles });
+    }
+
+    log('restoring the source, keeping the tests');
+    let failedWithoutChange = null;
+    let withoutChange = { ok: null, pass: null, fail: null, names: [] };
+
+    try {
+      restoreTo(repo, mergeBase, sourceFiles);
+      withoutChange = await runAndEnd();
+      failedWithoutChange = !withoutChange.ok;
+    } finally {
+      // Unconditional. A tool that can leave a repository half-reverted is
+      // worse than no tool, because the next person debugs a tree nobody put
+      // there on purpose.
+      restoreTo(repo, 'HEAD', sourceFiles);
+    }
+
+    const counts = {
+      testsPassedWithChange: withChange.pass,
+      testsFailedWithoutChange: withoutChange.fail,
+      namesFailedWithoutChange: withoutChange.names || [],
+    };
+
+    if (git(repo, ['status', '--porcelain'])) {
+      return result('refused', 'the tree did not come back clean after restoring; '
+        + 'inspect before trusting any result', { source: sourceFiles, tests: testFiles });
+    }
+
+    if (!failedWithoutChange) {
+      return result('not-discriminating', 'the tests pass with the source '
+        + 'reverted, so they do not discriminate this change and would have gone '
+        + 'green against the defect they were written for',
+      { passedWithChange: true, failedWithoutChange: false, source: sourceFiles, tests: testFiles, ...counts });
+    }
+
+    return result('proven', 'the tests fail without the change and pass with it',
+      { passedWithChange: true, failedWithoutChange: true, source: sourceFiles, tests: testFiles, ...counts });
   } finally {
-    // Unconditional. A tool that can leave a repository half-reverted is worse
-    // than no tool, because the next person debugs a tree nobody put there on
-    // purpose.
-    restoreTo(repo, 'HEAD', sourceFiles);
-    process.off('SIGINT', onSignal);
-    process.off('SIGTERM', onSignal);
+    // Ending comes first here, so a throw from anything after it cannot leave a
+    // suite behind. This runs on every return above and on any error out of
+    // them, which is what makes the ordinary exits as covered as the signals.
+    endStartedGroups();
+    clearRunRecord();
+    process.off('exit', onExit);
+    for (const signal of SIGNALS) process.off(signal, onSignal);
   }
-
-  const counts = {
-    testsPassedWithChange: withChange.pass,
-    testsFailedWithoutChange: withoutChange.fail,
-    namesFailedWithoutChange: withoutChange.names || [],
-  };
-
-  if (git(repo, ['status', '--porcelain'])) {
-    return result('refused', 'the tree did not come back clean after restoring; '
-      + 'inspect before trusting any result', { source: sourceFiles, tests: testFiles });
-  }
-
-  if (!failedWithoutChange) {
-    return result('not-discriminating', 'the tests pass with the source '
-      + 'reverted, so they do not discriminate this change and would have gone '
-      + 'green against the defect they were written for',
-    { passedWithChange: true, failedWithoutChange: false, source: sourceFiles, tests: testFiles, ...counts });
-  }
-
-  return result('proven', 'the tests fail without the change and pass with it',
-    { passedWithChange: true, failedWithoutChange: true, source: sourceFiles, tests: testFiles, ...counts });
 }
 
 /**
@@ -341,7 +610,6 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
  * found wanting" invites the reader to assume the kinder one.
  */
 function recordOutcome(repo, outcome) {
-  const fs = require('node:fs');
   const file = path.join(repo, '.precommit-gate.json');
   if (!fs.existsSync(file)) return false;
   let record;
@@ -399,4 +667,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { redFirst, recordOutcome, restoreTo, isTest, namesFrom, TEST_DIRS, TEST_FILENAME_MARKERS, NAME_LIMIT, LIMITATION };
+module.exports = { redFirst, recordOutcome, restoreTo, isTest, namesFrom, runRecordPath, liveRun, endGroup, groupAlive, TEST_DIRS, TEST_FILENAME_MARKERS, NAME_LIMIT, END_GRACE_MS, LIMITATION };

--- a/scripts/red-first.js
+++ b/scripts/red-first.js
@@ -39,12 +39,11 @@
  * WHAT IT LEAVES BEHIND
  *
  * Nothing, on any exit this process can see. The test command is spawned
- * detached and therefore heads its own process group; that group is ended when
- * its run finishes, when a terminating signal arrives, and again from an 'exit'
- * listener that catches the ordinary return and the uncaught throw alike. Only
- * groups this run started are ever signalled, so a suite or a mutation harness
- * belonging to somebody else is never touched however alike the command lines
- * look.
+ * detached and therefore heads its own process group, and only groups this run
+ * started are ever signalled, so a suite or a mutation harness belonging to
+ * somebody else is never touched however alike the command lines look. Which
+ * path ends the group on which kind of exit is set out once, above the
+ * listeners in redFirst, rather than summarised differently here.
  *
  * A run in progress is recorded outside the repository, and a start made while
  * one is still live is refused rather than allowed to add a second suite to the
@@ -53,7 +52,7 @@
  * load the retries were creating.
  */
 
-const { execFileSync, spawn } = require('node:child_process');
+const { execFileSync, spawn, spawnSync } = require('node:child_process');
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -191,6 +190,7 @@ function restoreTo(repo, ref, files) {
 // this tool spawns has a restore step to skip. The cost of waiting longer is
 // paid by a developer watching the tool refuse to exit.
 const END_GRACE_MS = 500;
+const POLL_MS = 50;
 
 // A pause that blocks rather than yields.
 //
@@ -201,22 +201,89 @@ function pause(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-// Is any process still in this group?
-//
-// Signal 0 asks the kernel whether the target exists without sending anything.
-// EPERM is a yes: the group is there and this process may not signal it, which
-// is a different answer from the group being gone.
-//
-// The reason this is safe to ask about a NUMBER rather than a live handle: a
-// process group id is not reused while the group still has a member. A group
-// this run created and has not yet watched empty is therefore still this run's
-// group, not a stranger that inherited its number.
-function groupAlive(pgid) {
-  try { process.kill(-pgid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+/**
+ * Does this target still exist?
+ *
+ * A NEGATIVE number asks about a whole process group, a positive one about a
+ * single process; the rule is the same for both, which is why there is one
+ * function. Signal 0 asks the kernel without sending anything, and EPERM is a
+ * yes: the target is there and this process may not signal it, which is a
+ * different answer from the target being gone.
+ *
+ * EXISTING IS NOT THE SAME AS RUNNING, and the difference is the whole of the
+ * defect below this line. See groupRunning.
+ */
+function exists(target) {
+  try { process.kill(target, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+}
+
+// The process state that means "already exited, still listed". A process whose
+// parent has not collected it keeps its entry in the table, and its process
+// group with it. Every other state is a process that is still on the machine.
+const EXITED_STATE = 'Z';
+
+/**
+ * The members of a process group, as {pid, state}, or null if this machine will
+ * not say.
+ *
+ * Spawning is allowed here even from a signal or 'exit' listener because it is
+ * synchronous, which is also why it is asked only when the cheap question above
+ * has already answered "something is there".
+ *
+ * The whole table is listed and filtered here rather than asked for by group,
+ * because the flag that selects a process group is not the same one on every
+ * platform and picking the wrong one silently selects by something else.
+ */
+function psGroupMembers(pgid) {
+  const out = spawnSync('ps', ['-e', '-o', 'pgid=,pid=,stat='],
+    { encoding: 'utf8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'] });
+  if (out.error || typeof out.stdout !== 'string') return null;
+  if (out.status !== 0 && !out.stdout.trim()) return null;
+  const members = [];
+  for (const line of out.stdout.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    if (parts.length < 3) continue;
+    if (Number(parts[0]) !== pgid) continue;
+    members.push({ pid: Number(parts[1]), state: parts[2] });
+  }
+  return members;
 }
 
 /**
- * End one process group, and say whether it is gone.
+ * Is anything in this process group still RUNNING, as opposed to merely listed?
+ *
+ * @returns {boolean|null} true running, false gone, null this machine will not say
+ *
+ * THE DISTINCTION IS THE DEFECT, and it is a platform difference that a macOS
+ * measurement cannot show. When this process signals its own direct child and
+ * then waits, the child dies at once but stays in the table until this process
+ * collects it, which it cannot do while the event loop is blocked in the wait.
+ * On Linux that corpse is still a member of its process group, so asking the
+ * kernel whether the group exists keeps answering yes for the entire grace,
+ * the group is then SIGKILLed for no reason, the ending reports that it
+ * survived, and an alarm meant for a genuine leak fires on every interrupt.
+ * macOS filters exited members out of the same question, so none of it shows
+ * there. Continuous integration runs on Linux.
+ *
+ * So the group is asked about by its members and their states, and a group
+ * whose remaining members have all exited is gone.
+ *
+ * The reader is a parameter so the decision can be driven on any machine,
+ * including one whose sandbox blocks spawning, rather than only on the platform
+ * that happens to produce corpses.
+ */
+function groupRunning(pgid, readMembers = psGroupMembers) {
+  // Cheap first, and on macOS it is usually the only question asked.
+  if (!exists(-pgid)) return false;
+  const members = readMembers(pgid);
+  if (members === null) return null;
+  return members.some(m => !String(m.state).startsWith(EXITED_STATE));
+}
+
+/**
+ * End one process group, and say what became of it.
+ *
+ * @returns {'gone'|'running'|'unknown'}
  *
  * A NEGATIVE pid signals the whole group, which is the point rather than a
  * detail. The test command is spawned detached, so it heads its own group, and
@@ -233,17 +300,23 @@ function groupAlive(pgid) {
  * look like, so nothing outside this run can be caught by it however similar it
  * looks.
  *
- * @returns {boolean} whether the group is gone afterwards
+ * SIGTERM first and SIGKILL after the grace, because a child that ignores
+ * SIGTERM is the only case where anything but the escalation keeps a suite from
+ * outliving this process, and the criterion it answers to is unconditional.
  */
-function endGroup(pgid, graceMs = END_GRACE_MS) {
-  if (!groupAlive(pgid)) return true;
+function endGroup(pgid) {
+  if (groupRunning(pgid) === false) return 'gone';
   try { process.kill(-pgid, 'SIGTERM'); } catch (e) { /* gone since the check */ }
-  const deadline = Date.now() + graceMs;
-  while (Date.now() < deadline && groupAlive(pgid)) pause(25);
-  if (!groupAlive(pgid)) return true;
+  const deadline = Date.now() + END_GRACE_MS;
+  while (Date.now() < deadline) {
+    if (groupRunning(pgid) === false) return 'gone';
+    pause(POLL_MS);
+  }
   try { process.kill(-pgid, 'SIGKILL'); } catch (e) { /* gone since the check */ }
-  pause(25);
-  return !groupAlive(pgid);
+  pause(POLL_MS);
+  const after = groupRunning(pgid);
+  if (after === false) return 'gone';
+  return after === null ? 'unknown' : 'running';
 }
 
 /**
@@ -266,43 +339,79 @@ function runRecordPath(repo) {
   return path.join(os.tmpdir(), `red-first-run-${key}.json`);
 }
 
+function readRunRecord(file) {
+  try {
+    const held = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return held && typeof held === 'object' ? held : null;
+  } catch (e) { return null; }
+}
+
 /**
- * A run of this tool that is still going in this repository, or null.
+ * Is the run this record describes still going?
  *
  * Both halves are asked about, because between the two suites there are moments
- * when the tool is alive with nothing under it. Either half being alive means
- * starting now would put a second suite on this machine, or a second reverter
- * on the same working tree.
+ * when the tool is alive with nothing under it, and after an ending nothing can
+ * catch there are moments when a suite is alive with no tool over it. Either
+ * one means starting now would put a second suite on this machine, or a second
+ * reverter on the same working tree.
  *
- * A record whose run has gone is stale and says nothing. That happens after a
- * reboot, or after an ending nothing can catch, and it is overwritten rather
- * than treated as a refusal: a stale file that refuses every start until
- * somebody deletes it is its own outage.
- *
- * THE BOUND, since this is a check made on numbers. A pid or a group id whose
+ * THE BOUND, since this is a judgement about numbers. A pid or a group id whose
  * owner has gone can in principle be reused by something unrelated, and this
  * would then report a live run that is not one. The consequence is a refusal
  * that should not have happened, which costs a developer one message naming a
  * file to delete; the consequence of the other error direction is another full
- * suite on a machine that already has one. The window is kept small by clearing
- * the record on every exit this process can see, so a record only survives an
- * ending that skipped all of them.
+ * suite on a machine that already has one.
  */
-function liveRun(repo) {
-  const file = runRecordPath(repo);
-  let record;
-  try { record = JSON.parse(fs.readFileSync(file, 'utf8')); } catch (e) { return null; }
-  if (!record || typeof record !== 'object') return null;
-  const group = Number(record.group);
-  const pid = Number(record.pid);
-  const groupLive = Number.isInteger(group) && group > 0 && groupAlive(group);
-  const pidLive = Number.isInteger(pid) && pid > 0 && processAlive(pid);
-  if (!groupLive && !pidLive) return null;
-  return { ...record, file, groupLive, pidLive };
+function runIsLive(held) {
+  const pid = Number(held.pid);
+  if (Number.isInteger(pid) && pid > 0 && exists(pid)) return true;
+  const group = Number(held.group);
+  if (!Number.isInteger(group) || group <= 0) return false;
+  return groupRunning(group) !== false;
 }
 
-function processAlive(pid) {
-  try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+/**
+ * Take ownership of this repository for the length of this run, or report the
+ * run that already holds it.
+ *
+ * CLAIMED BEFORE ANY OTHER WORK, and with an exclusive create rather than a
+ * read followed by a write. The first version read the record at the top of the
+ * run and did not write one until after three git commands had finished, so two
+ * starts a few milliseconds apart both saw an empty machine, both proceeded,
+ * and both reverted the same working tree, checking files out from under each
+ * other. That is the case the refusal exists to prevent, and the check that was
+ * meant to prevent it had a window in the middle of it.
+ *
+ * On EEXIST the holder is read and judged: a live run wins and this start is
+ * refused, a record whose run has gone is stale and is replaced. A stale file
+ * that refused every start until somebody deleted it would be its own outage.
+ */
+function claimRun(repo, tests) {
+  const file = runRecordPath(repo);
+  const record = {
+    pid: process.pid, group: null, tests,
+    repo: path.resolve(repo), startedAt: new Date().toISOString(),
+  };
+  const body = () => JSON.stringify(record, null, 2) + '\n';
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      fs.writeFileSync(file, body(), { flag: 'wx' });
+      return { ok: true, file, record };
+    } catch (e) {
+      if (e.code !== 'EEXIST') {
+        // Loud, because the refusal is only as good as this write. A run that
+        // cannot record itself still works; the next one just will not be
+        // refused, and whoever retries should know that before they do.
+        console.error('[red-first] could not record this run at '
+          + `${file} (${e.message}); a concurrent start will not be refused`);
+        return { ok: true, file, record, unrecorded: true };
+      }
+      const held = readRunRecord(file);
+      if (held && runIsLive(held)) return { ok: false, file, live: { ...held, file } };
+      try { fs.rmSync(file, { force: true }); } catch (e2) { /* someone else got there */ }
+    }
+  }
+  return { ok: false, file, live: { ...(readRunRecord(file) || {}), file } };
 }
 
 /**
@@ -312,15 +421,16 @@ function processAlive(pid) {
  *            testsFailedWithoutChange: number|null, namesFailedWithoutChange: string[],
  *            source: string[], tests: string[], limitation: string}}
  */
-async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null }) {
+async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = null,
+  groupEnder = endGroup }) {
   const result = (outcome, reason, extra = {}) => ({
     outcome, reason, passedWithChange: null, failedWithoutChange: null,
     testsPassedWithChange: null, testsFailedWithoutChange: null, namesFailedWithoutChange: [],
     source: [], tests: [], limitation: LIMITATION, ...extra,
   });
 
-  // Asked before anything else, because the cost of getting this wrong is paid
-  // by every process on the machine rather than by this one.
+  // Claimed before anything else, because the cost of getting this wrong is
+  // paid by every process on the machine rather than by this one.
   //
   // A check that comes back inconclusive invites a retry, and a retry used to
   // mean another full suite on top of the one still running from the attempt
@@ -329,11 +439,15 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
   // Refusing costs the developer a message. Not refusing costs everyone.
   //
   // It also stops a second run reverting the same working tree underneath the
-  // first, which no amount of restoring afterwards would put right.
-  const live = liveRun(repo);
-  if (live) {
-    const what = live.groupLive
-      ? `process group ${live.group} running ${live.tests}`
+  // first, which no amount of restoring afterwards would put right. That is why
+  // the claim sits ahead of the git commands rather than after them, and why it
+  // is a create rather than a read: see claimRun.
+  const claim = claimRun(repo, tests);
+  if (!claim.ok) {
+    const live = claim.live;
+    const group = Number(live.group);
+    const what = Number.isInteger(group) && group > 0
+      ? `process group ${group} running ${live.tests}`
       : `red first pid ${live.pid} running ${live.tests}, with no suite under it yet`;
     return result('refused', 'a run of this tool is still live in this '
       + `repository: ${what}, started ${live.startedAt} by red first pid ${live.pid}. `
@@ -342,80 +456,70 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
       + 'already gone.');
   }
 
-  // A dirty tree is refused, not tidied. This rewrites tracked files and puts
-  // them back, so it must never run where it cannot tell its own edits from
-  // someone else's.
-  if (git(repo, ['status', '--porcelain'])) {
-    return result('refused', 'the working tree has uncommitted changes, and this '
-      + 'rewrites tracked files; commit or stash first');
-  }
+  const recordFile = claim.file;
+  const claimed = claim.record;
+  let recordWritten = !claim.unrecorded;
 
-  const mergeBase = git(repo, ['merge-base', base, 'HEAD']);
-  // --no-renames, and it is not a detail. With rename detection on, a renamed
-  // file is reported once, under its NEW path. restoreTo then asks whether that
-  // path exists at the base, finds it does not, and deletes it. The reverted
-  // run fails with a module-not-found for an unrelated reason, and the tool
-  // reports "proven" for tests that discriminate nothing: the one error
-  // direction it must never take. Forced off here rather than trusted to the
-  // developer's diff.renames config.
-  const changed = git(repo, ['diff', '--no-renames', '--name-only', mergeBase, 'HEAD'])
-    .split('\n').filter(Boolean);
-  const testFiles = changed.filter(isTest);
-  const sourceFiles = changed.filter(f => !isTest(f));
-
-  if (!changed.length) return result('not-provable', `nothing changed against ${base}`);
-  if (!testFiles.length) {
-    return result('not-provable', 'the change adds no tests, so there is nothing '
-      + 'to prove; that is its own finding', { source: sourceFiles, tests: [] });
-  }
-  if (!sourceFiles.length) {
-    return result('not-provable', 'the change touches no source, so there is '
-      + 'nothing to take away', { source: [], tests: testFiles });
-  }
-
-  // The process groups this run has started and not yet watched end.
+  // The process group this run started and has not yet watched end.
   //
-  // A SET of group ids rather than one child handle, because "what this run is
-  // responsible for" is the question every exit path has to answer, and two of
-  // those paths run where a handle is no use: the signal listeners, and the
-  // 'exit' listener, which is reached after the event loop has stopped. A
-  // number can be signalled from any of them.
+  // A NUMBER rather than a child handle, because "what this run is responsible
+  // for" is the question every exit path has to answer, and two of those paths
+  // run where a handle is no use: the signal listeners, and the 'exit'
+  // listener, which is reached after the event loop has stopped. A number can
+  // be signalled from any of them.
   //
-  // Nothing outside this set is ever signalled. That is the whole of the
-  // scoping: a group id names processes by the run that created them.
-  const startedGroups = new Set();
+  // ONE of them, not a collection: the two suites are sequential and the ending
+  // below clears this before the next spawn, so a second group never coexists
+  // with the first. Nothing outside this number is ever signalled, which is the
+  // whole of the scoping.
+  let startedGroup = null;
 
-  const recordFile = runRecordPath(repo);
-  const startedAt = new Date().toISOString();
-  let recordWritten = false;
+  // Groups this run signalled and could not confirm gone.
+  const survived = [];
 
-  // The record the NEXT start reads. Written when this run commits to spawning
-  // and rewritten whenever the live group changes, so what it names is what is
-  // actually running rather than what was running when the tool began.
+  // What the reverted run would have to put back. Empty until the diff has been
+  // read, which matters because the signal listener runs from the moment it is
+  // registered, including during the git commands below.
+  let sourceFiles = [];
+
+  // The record the NEXT start reads, updated as the live group changes so that
+  // what it names is what is actually running.
   const writeRunRecord = (group) => {
+    if (claim.unrecorded) return;
     try {
-      fs.writeFileSync(recordFile, JSON.stringify({
-        pid: process.pid, group: group || null, tests, repo: path.resolve(repo), startedAt,
-      }, null, 2) + '\n');
+      fs.writeFileSync(recordFile,
+        JSON.stringify({ ...claimed, group: group || null }, null, 2) + '\n');
       recordWritten = true;
     } catch (e) {
-      // Loud, because the refusal above is only as good as this write. A run
-      // that cannot record itself still works; the next one just will not be
-      // refused, and the developer should know that before they retry.
-      console.error('[red-first] could not record this run at '
+      console.error('[red-first] could not update this run at '
         + `${recordFile} (${e.message}); a concurrent start will not be refused`);
     }
   };
 
-  const clearRunRecord = () => {
+  /**
+   * Give the claim back, unless this run knows it left something behind.
+   *
+   * A GROUP THAT OUTLIVED SIGKILL IS THE ONE CASE WHERE THE RECORD MUST STAY.
+   * That is the exact situation the refusal exists for, and removing the record
+   * there would let the next start add a second suite on top of the one this
+   * run has just failed to end. So the record is rewritten to name the survivor
+   * and left in place; only a run that ended everything it started gives the
+   * claim back.
+   *
+   * Only ever this run's own record. Reading it back before removing it costs
+   * one syscall and means a record belonging to somebody else is left alone.
+   */
+  const releaseRun = () => {
     if (!recordWritten) return;
-    // Only ever this run's own record. Reading it back before removing it costs
-    // one syscall and means a record written by somebody else, in the window
-    // where two starts raced past the refusal, is left for its owner.
-    try {
-      const held = JSON.parse(fs.readFileSync(recordFile, 'utf8'));
-      if (Number(held && held.pid) !== process.pid) return;
-    } catch (e) { return; }
+    const held = readRunRecord(recordFile);
+    if (!held || Number(held.pid) !== process.pid) return;
+    if (survived.length) {
+      try {
+        fs.writeFileSync(recordFile, JSON.stringify(
+          { ...claimed, group: survived[0], survivedEnding: true }, null, 2) + '\n');
+      } catch (e) { /* the next start reads whatever is there */ }
+      return;
+    }
     try { fs.rmSync(recordFile, { force: true }); } catch (e) { /* nothing left to clear */ }
     recordWritten = false;
   };
@@ -438,7 +542,7 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
     // group on this machine that nothing else knows about, and every exit
     // between here and the next line has to be able to find it.
     if (kid.pid) {
-      startedGroups.add(kid.pid);
+      startedGroup = kid.pid;
       writeRunRecord(kid.pid);
     }
     let text = '';
@@ -451,27 +555,41 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
   });
 
   /**
-   * End every group this run started, and forget each one once it has gone.
+   * End the group this run started, and forget it once it has gone.
    *
-   * ONE definition of the ending, called from after each run, from the signal
+   * ONE definition of the ending, called after each run, from the signal
    * listeners and from the 'exit' listener, rather than three that can drift
    * apart. The previous version had the ending in the signal path only, which
    * is exactly why the other exits leaked.
+   *
+   * The ending itself is a parameter, because SIGKILL cannot be survived on
+   * demand and this branch, which announces a survivor and holds on to the run
+   * record because of it, has no other way to be reached by a test. What an
+   * injected ending changes is whether the suite is really ended; what it
+   * leaves alone is everything this function then does about it.
+   *
+   * THE ALARM FIRES ONLY ON A KNOWN SURVIVOR. 'unknown' means the group id
+   * still answers and this machine would not say what is in it, which happens
+   * where spawning `ps` is blocked. Warning then would fire on every ordinary
+   * interrupt on Linux, where this process's own killed child stays listed
+   * until this process exits, and an alarm that cries wolf on every Ctrl-C is
+   * one nobody reads. The bound that buys: where no process table can be read,
+   * a genuine survivor is not announced either.
    */
-  const endStartedGroups = () => {
-    const survived = [];
-    for (const pgid of [...startedGroups]) {
-      if (!endGroup(pgid)) survived.push(pgid);
-      startedGroups.delete(pgid);
-    }
-    if (survived.length) {
-      // console.error rather than the injected log, which defaults to silence.
-      // A group that outlived SIGKILL is the failure this whole file exists to
-      // prevent, and it must not be able to happen quietly.
-      console.error('[red-first] WARNING: process group(s) '
-        + `${survived.join(', ')} survived being ended and may still be running; `
-        + 'nothing further here can reach them');
-    }
+  const endStartedGroup = () => {
+    if (startedGroup === null) return;
+    const pgid = startedGroup;
+    startedGroup = null;
+    const outcome = groupEnder(pgid);
+    if (outcome !== 'running') return;
+    survived.push(pgid);
+    // console.error rather than the injected log, which defaults to silence.
+    // A group that outlived SIGKILL is the failure this whole file exists to
+    // prevent, and it must not be able to happen quietly.
+    console.error(`[red-first] WARNING: process group ${pgid} survived being `
+      + 'ended and is still running; nothing further here can reach it, and '
+      + 'the run record has been left in place naming it so the next start '
+      + 'refuses rather than adding a second suite');
   };
 
   // The runner is injectable so a test can make the reverted run throw while
@@ -484,7 +602,7 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
     ? async () => ({ ok: !!(await runner()), pass: null, fail: null, names: [] })
     : spawnRun;
 
-  // Reaped the moment a run is over rather than at the end of the tool.
+  // Ended the moment a run is over rather than at the end of the tool.
   //
   // A run being over means the direct child has closed, which does NOT mean the
   // group is empty: a package runner starts children that outlive it, and those
@@ -493,10 +611,10 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
   // machine with whatever the first run left, which is half of what made the
   // measured load compound.
   const runAndEnd = async () => {
-    try { return await run(); } finally { endStartedGroups(); }
+    try { return await run(); } finally { endStartedGroup(); }
   };
 
-  // EVERY way this process can end, wired before the first suite starts.
+  // EVERY way this process can end, wired before any work at all.
   //
   // The signal listeners used to go on after the first run, once the reverted
   // run was about to begin. That left the first full suite, which is the
@@ -506,42 +624,66 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
   // rather than deduced. A signal sent during the first run left both the
   // runner and its child alive and reparented to init.
   //
-  // The ordinary return and the error out of this function are covered by the
-  // `finally` at the bottom, which ends the groups before anything else it
-  // does. Both used to leak because the ending lived in the signal path alone
-  // and neither of them goes through it.
-  //
-  // 'exit' is the backstop behind that, and what it covers is narrower than it
-  // looks: the exit that does not unwind at all, where something else in the
-  // process stops while a suite is in flight and no `finally` of this tool's
-  // ever runs. Taking this listener away leaves `an exit taken while a suite is
-  // running` red and every other test green, which is the measurement that says
-  // what it is for. Listeners here may only do synchronous work, which is why
-  // the ending blocks rather than awaits.
+  // WHICH PATH IS RESPONSIBLE FOR WHAT, stated once here and nowhere else. The
+  // `finally` below ends the group on an ordinary return and on an error out of
+  // the body. The signal listeners cover SIGINT, SIGTERM and SIGHUP. The 'exit'
+  // listener covers only an exit that never unwinds the `await`, where
+  // something else in the process stops while a suite is in flight and no
+  // `finally` of this tool's ever runs; taking that listener away leaves `an
+  // exit taken while a suite is running` red and every other test green, which
+  // is the measurement that says what it is for. Listeners there may only do
+  // synchronous work, which is why the ending blocks rather than awaits.
   //
   // WHAT NONE OF THIS COVERS, stated because the refusal above is built on it:
   // SIGKILL of this process, which the kernel delivers to nothing. A group
   // started by a run ended that way outlives it, and what stops the next start
   // piling a second suite on top is the refusal, not this.
-  const onExit = () => { endStartedGroups(); clearRunRecord(); };
+  const onExit = () => { endStartedGroup(); releaseRun(); };
   const onSignal = () => {
     // End the suite FIRST. The restore is pointless while a test command is
     // still writing to the tree, and a child that ignores signals would
     // otherwise outlive this process and keep working against reverted source.
-    endStartedGroups();
+    endStartedGroup();
     try { restoreTo(repo, 'HEAD', sourceFiles); } catch (e) { /* exiting anyway */ }
-    clearRunRecord();
+    releaseRun();
     process.exit(130);
   };
   const SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'];
   process.on('exit', onExit);
   for (const signal of SIGNALS) process.on(signal, onSignal);
 
-  // Written before the first spawn as well as at it, so a start that races this
-  // one is refused during the gap between the two rather than waved through.
-  writeRunRecord(null);
-
   try {
+    // A dirty tree is refused, not tidied. This rewrites tracked files and puts
+    // them back, so it must never run where it cannot tell its own edits from
+    // someone else's.
+    if (git(repo, ['status', '--porcelain'])) {
+      return result('refused', 'the working tree has uncommitted changes, and this '
+        + 'rewrites tracked files; commit or stash first');
+    }
+
+    const mergeBase = git(repo, ['merge-base', base, 'HEAD']);
+    // --no-renames, and it is not a detail. With rename detection on, a renamed
+    // file is reported once, under its NEW path. restoreTo then asks whether
+    // that path exists at the base, finds it does not, and deletes it. The
+    // reverted run fails with a module-not-found for an unrelated reason, and
+    // the tool reports "proven" for tests that discriminate nothing: the one
+    // error direction it must never take. Forced off here rather than trusted
+    // to the developer's diff.renames config.
+    const changed = git(repo, ['diff', '--no-renames', '--name-only', mergeBase, 'HEAD'])
+      .split('\n').filter(Boolean);
+    const testFiles = changed.filter(isTest);
+    sourceFiles = changed.filter(f => !isTest(f));
+
+    if (!changed.length) return result('not-provable', `nothing changed against ${base}`);
+    if (!testFiles.length) {
+      return result('not-provable', 'the change adds no tests, so there is nothing '
+        + 'to prove; that is its own finding', { source: sourceFiles, tests: [] });
+    }
+    if (!sourceFiles.length) {
+      return result('not-provable', 'the change touches no source, so there is '
+        + 'nothing to take away', { source: [], tests: testFiles });
+    }
+
     // WITH the change first. A suite failing for its own reasons makes a
     // failure without the change meaningless, and reporting that as proof would
     // turn a broken suite into evidence.
@@ -593,8 +735,8 @@ async function redFirst({ repo, base = 'main', tests, log = () => {}, runner = n
     // Ending comes first here, so a throw from anything after it cannot leave a
     // suite behind. This runs on every return above and on any error out of
     // them, which is what makes the ordinary exits as covered as the signals.
-    endStartedGroups();
-    clearRunRecord();
+    endStartedGroup();
+    releaseRun();
     process.off('exit', onExit);
     for (const signal of SIGNALS) process.off(signal, onSignal);
   }
@@ -667,4 +809,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { redFirst, recordOutcome, restoreTo, isTest, namesFrom, runRecordPath, liveRun, endGroup, groupAlive, TEST_DIRS, TEST_FILENAME_MARKERS, NAME_LIMIT, END_GRACE_MS, LIMITATION };
+module.exports = { redFirst, recordOutcome, restoreTo, isTest, namesFrom, runRecordPath, groupRunning, TEST_DIRS, TEST_FILENAME_MARKERS, NAME_LIMIT, LIMITATION };

--- a/test/unit/red-first-orphans.test.js
+++ b/test/unit/red-first-orphans.test.js
@@ -1,0 +1,451 @@
+'use strict';
+// What the tool leaves behind after it is gone.
+//
+// Written BEFORE the fix, and it has to be, because none of these can be proven
+// the way this project normally proves a test: by reverting the source and
+// watching the test go red. Every criterion here is a PROHIBITION, "no suite
+// outlives the tool", and taking the fix away makes these tests fail because
+// the mechanism they call has vanished rather than because a suite survived.
+// A prohibition is proven the other way round: commit the forbidden act, run
+// the test, watch it go red for the reason it names. That was done for each
+// case below and the run is recorded in .review/red-first-orphans-evidence.md.
+//
+// WHAT WAS MEASURED, which is why this file exists at all. The tool spawns its
+// test command detached, and a package runner starts children of its own. On a
+// normal exit two suites were left running; on an error exit one; on a signal
+// arriving during the FIRST run, both the shell and its child, because the
+// signal handlers were installed only once the reverted run was about to
+// start and Node's default handling terminates without unwinding. A developer
+// whose check came back inconclusive and retried therefore added a whole suite
+// to the machine each time.
+//
+// THE SECOND EDGE, which is why the last test here is not optional. The obvious
+// remedy for a leak like this is a pattern kill across the machine, and that
+// reaches processes this tool never started. `a suite this tool did not start
+// is left alone, and is still working afterwards` fails if the cleanup ever
+// widens that far, and it is paired with an assertion that the tool's OWN
+// leftovers really did go, so that doing nothing at all cannot pass it either.
+// It asks whether the foreign suite is still WORKING rather than whether its
+// pid can still be signalled, for a reason its own comment gives at length.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawn, spawnSync } = require('node:child_process');
+
+const { redFirst, runRecordPath } = require('../../scripts/red-first.js');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'red-first.js');
+
+// How long the stand-in suites below sleep for. Deliberately an odd number of
+// seconds rather than a round one: reproducing the `AC-8` measurement by hand
+// means matching these processes on their command line, and a round duration
+// would match a stranger's sleep on a shared machine as well as this file's.
+const LONG = 600000 + (process.pid % 997);
+
+// A throwaway repository whose branch ADDS a source file and a test that needs
+// it, so the reverted run genuinely fails and the tool takes its ordinary path
+// through both runs rather than short-circuiting.
+function repo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'red-first-orphans-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+  git('init', '-q');
+  // Named explicitly: `git init` takes its branch name from init.defaultBranch,
+  // so a fixture that says nothing gets whatever the host is configured for.
+  git('symbolic-ref', 'HEAD', 'refs/heads/main');
+  git('config', 'user.email', 't@example.com');
+  git('config', 'user.name', 'T');
+  git('config', 'diff.renames', 'false');
+  fs.mkdirSync(path.join(dir, 'test'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'lib.js'), 'module.exports.a = () => 1;\n');
+  fs.writeFileSync(path.join(dir, 'test', 'check.js'), 'module.exports = () => {};\n');
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  git('checkout', '-q', '-b', 'change');
+  fs.writeFileSync(path.join(dir, 'lib2.js'), 'module.exports.b = () => 2;\n');
+  fs.writeFileSync(path.join(dir, 'test', 'check.js'),
+    "module.exports = () => { require('../lib2.js'); };\n");
+  git('add', '-A');
+  git('commit', '-q', '-m', 'the change');
+  return dir;
+}
+
+// Where a run leaves the pids it started, OUTSIDE the repository, because
+// anything written inside it dirties the tree the tool is about to check.
+function pidFile(name) {
+  return path.join(os.tmpdir(), `red-first-orphans-${name}-${process.pid}-${Date.now()}.pids`);
+}
+
+function pidsIn(file) {
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map(Number);
+}
+
+const alive = (pid) => { try { process.kill(pid, 0); return true; } catch (e) { return false; } };
+
+const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function until(predicate, ms = 5000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await wait(50);
+  }
+  return predicate();
+}
+
+// The process table for a set of pids, when this machine will give one. Under a
+// command sandbox that blocks spawning, `ps` is unavailable and the liveness
+// answer below is the whole record. Liveness is what every assertion here uses;
+// the table is printed alongside it so a reader of a run has the same view the
+// measurements were taken from.
+function table(pids) {
+  const live = pids.map(p => `${p}=${alive(p) ? 'alive' : 'gone'}`).join(' ');
+  if (!pids.length) return '(no pids recorded)';
+  try {
+    const out = execFileSync('ps', ['-o', 'pid,ppid,pgid,command', '-p', pids.join(',')],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    return `${live}\n${out}`;
+  } catch (e) {
+    return `${live} (no process table: ps is unavailable here)`;
+  }
+}
+
+// A test command shaped like a package runner: it starts a child of its own,
+// detaches that child's stdio so the runner is not held open by it, and then
+// finishes. The child stays in the runner's process group, which is what makes
+// this the case AC-4 names: ending the direct child alone leaves the child of
+// the child running.
+//
+// `$!` is the background child, `$$` the shell itself. Both are recorded so a
+// failure can say which of the two survived.
+function packageRunnerLeaving(file, tail = 'exit 0') {
+  return `sleep ${LONG} >/dev/null 2>&1 & echo $! >> ${JSON.stringify(file)}; `
+    + `echo $$ >> ${JSON.stringify(file)}; ${tail}`;
+}
+
+// Nothing here may end a process it did not start, including in its own
+// cleanup, so every teardown signals only the pids this file recorded.
+function reap(pids) {
+  for (const pid of pids) {
+    try { process.kill(-pid, 'SIGKILL'); } catch (e) { /* not a group leader */ }
+    try { process.kill(pid, 'SIGKILL'); } catch (e) { /* already gone */ }
+  }
+}
+
+function cli(dir, tests) {
+  return spawnSync(process.execPath,
+    [SCRIPT, '--repo', dir, '--base', 'main', '--tests', tests], { encoding: 'utf8' });
+}
+
+describe('no suite outlives the tool', () => {
+  test('AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner\'s own child', async (t) => {
+    const dir = repo();
+    const file = pidFile('normal');
+    try {
+      const r = cli(dir, packageRunnerLeaving(file));
+      // The run really did complete rather than dying early, or the absence of
+      // survivors would prove nothing about a normal exit.
+      assert.match(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|INCONCLUSIVE)/,
+        `the tool must have reached a conclusion\n${r.stdout}\n${r.stderr}`);
+
+      const pids = pidsIn(file);
+      // Two runs, each leaving a background child and a shell.
+      assert.ok(pids.length >= 2, `the runner must have started something to leave behind: ${pids}`);
+      t.diagnostic(`immediately after the tool exited:\n${table(pids)}`);
+
+      await until(() => pids.every(p => !alive(p)));
+      const survivors = pids.filter(alive);
+      t.diagnostic(`after settling:\n${table(pids)}`);
+      assert.deepStrictEqual(survivors, [],
+        `a normal exit left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+
+      // The record of a run that has finished must go with it. Left behind, it
+      // names a pid that is gone, and the refusal at the top of the tool would
+      // turn every later start in this repository into a refusal until somebody
+      // deleted the file by hand. The guard against piling on load must not
+      // become an outage of its own.
+      assert.strictEqual(fs.existsSync(runRecordPath(dir)), false,
+        `a finished run left its record at ${runRecordPath(dir)}`);
+    } finally {
+      reap(pidsIn(file));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('AC-2: an error exit leaves no suite running', async (t) => {
+    const dir = repo();
+    const file = pidFile('error');
+    try {
+      // The runner destroys the repository's git directory once it has started
+      // its background child, so the restore that follows throws and the tool
+      // leaves by its error path rather than by returning an outcome. This is
+      // the exit nobody thinks to check, which is why it is driven here rather
+      // than reasoned about.
+      const r = cli(dir, packageRunnerLeaving(file, 'rm -rf .git; exit 0'));
+      assert.notStrictEqual(r.status, 0, 'the tool must have failed');
+      assert.doesNotMatch(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|REFUSED)/,
+        `the tool must have crashed rather than concluded\n${r.stdout}`);
+
+      const pids = pidsIn(file);
+      assert.ok(pids.length >= 1, `the runner must have started something to leave behind: ${pids}`);
+      t.diagnostic(`immediately after the tool exited:\n${table(pids)}`);
+
+      await until(() => pids.every(p => !alive(p)));
+      const survivors = pids.filter(alive);
+      t.diagnostic(`after settling:\n${table(pids)}`);
+      assert.deepStrictEqual(survivors, [],
+        `an error exit left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+    } finally {
+      reap(pidsIn(file));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('AC-3: a signal during the FIRST run leaves no suite running', async (t) => {
+    // The first run is the longest window the tool has and it was the one with
+    // no handler at all: the listeners went on after it, so a signal arriving
+    // while the first suite ran took Node's default handling, which terminates
+    // without unwinding and abandons a detached process group.
+    const dir = repo();
+    const file = pidFile('signal');
+    let pids = [];
+    try {
+      const kid = spawn(process.execPath,
+        [SCRIPT, '--repo', dir, '--base', 'main', '--tests', packageRunnerLeaving(file, 'sleep 30')],
+        { stdio: ['ignore', 'pipe', 'pipe'] });
+      const exited = new Promise(resolve => kid.on('exit', (code, signal) => resolve({ code, signal })));
+
+      const started = await until(() => pidsIn(file).length >= 2, 15000);
+      assert.strictEqual(started, true, 'the first run must be in flight before it is signalled');
+      pids = pidsIn(file);
+      t.diagnostic(`with the first run in flight:\n${table(pids)}`);
+
+      kid.kill('SIGTERM');
+      const how = await exited;
+      t.diagnostic(`the tool exited with code ${how.code} signal ${how.signal}`);
+
+      await until(() => pids.every(p => !alive(p)));
+      const survivors = pids.filter(alive);
+      t.diagnostic(`after the tool exited:\n${table(pids)}`);
+      assert.deepStrictEqual(survivors, [],
+        `a signal during the first run left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+    } finally {
+      reap(pids.concat(pidsIn(file)));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  test('AC-1: an exit taken while a suite is running leaves nothing behind either', async (t) => {
+    // The exit that does not unwind.
+    //
+    // Every other normal-exit path here leaves through the function's own
+    // `finally`, so the ending in that `finally` is enough for them and the
+    // 'exit' listener behind it is never reached. This is the case that needs
+    // the listener: something else in the process decides to stop while a suite
+    // is in flight, the awaited call never settles, and no `finally` of this
+    // tool's ever runs. Driven rather than argued, because a backstop nothing
+    // reaches is not a backstop, it is a comment.
+    const dir = repo();
+    const file = pidFile('inflight');
+    let pids = [];
+    try {
+      const driver = `
+        const { redFirst } = require(${JSON.stringify(SCRIPT)});
+        redFirst({ repo: ${JSON.stringify(dir)}, base: 'main',
+                   tests: ${JSON.stringify(packageRunnerLeaving(file, 'sleep 30'))} })
+          .catch(() => {});
+        const fs = require('node:fs');
+        setInterval(() => {
+          const started = fs.existsSync(${JSON.stringify(file)})
+            && fs.readFileSync(${JSON.stringify(file)}, 'utf8').trim().split('\\n').length >= 2;
+          if (started) process.exit(0);
+        }, 50);
+      `;
+      const r = spawnSync(process.execPath, ['-e', driver], { encoding: 'utf8', timeout: 60000 });
+      assert.strictEqual(r.status, 0, `the driver must have exited on purpose\n${r.stdout}\n${r.stderr}`);
+
+      pids = pidsIn(file);
+      assert.ok(pids.length >= 2, `a suite must have been in flight when it exited: ${pids}`);
+      t.diagnostic(`immediately after the exit:\n${table(pids)}`);
+
+      await until(() => pids.every(p => !alive(p)));
+      const survivors = pids.filter(alive);
+      t.diagnostic(`after settling:\n${table(pids)}`);
+      assert.deepStrictEqual(survivors, [],
+        `an exit taken mid-run left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+    } finally {
+      reap(pids.concat(pidsIn(file)));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('starting on top of a run that is still going', () => {
+  test('AC-5, AC-6: a second start is refused, and the refusal names the run it found', async (t) => {
+    // Driven end to end against a real first run rather than a hand-written
+    // record, because a hand-written one only proves the reader can read the
+    // test's idea of a record.
+    const dir = repo();
+    const file = pidFile('refuse');
+    let first = null;
+    let pids = [];
+    try {
+      first = spawn(process.execPath,
+        [SCRIPT, '--repo', dir, '--base', 'main', '--tests', packageRunnerLeaving(file, 'sleep 25')],
+        { stdio: ['ignore', 'pipe', 'pipe'] });
+      const firstExited = new Promise(resolve => first.on('exit', resolve));
+
+      const started = await until(() => pidsIn(file).length >= 2, 15000);
+      assert.strictEqual(started, true, 'the first run must have a live suite before the second starts');
+      pids = pidsIn(file);
+
+      const record = runRecordPath(dir);
+      assert.strictEqual(fs.existsSync(record), true,
+        `the live run must be recorded somewhere the next start can read: ${record}`);
+      const written = JSON.parse(fs.readFileSync(record, 'utf8'));
+      t.diagnostic(`record: ${JSON.stringify(written)}`);
+
+      const second = cli(dir, 'echo this must never run');
+      t.diagnostic(`second start said: ${second.stdout.trim()}`);
+      assert.notStrictEqual(second.status, 0, 'a second start must not exit 0');
+      assert.match(second.stdout, /REFUSED/, second.stdout);
+
+      // AC-6: named, not merely refused. A refusal that says "something is
+      // running" leaves the reader with the same pkill they would have reached
+      // for anyway, which is the second defect this card exists to avoid.
+      assert.match(second.stdout, new RegExp(`\\b${written.group}\\b`),
+        `the refusal must name the process group it found\n${second.stdout}`);
+      assert.match(second.stdout, /sleep 25/,
+        `the refusal must name the command that is running\n${second.stdout}`);
+      assert.match(second.stdout, new RegExp(`\\b${written.pid}\\b`),
+        `the refusal must name the run that owns it\n${second.stdout}`);
+
+      // And the first run is left alone by the refusal: refusing must not be a
+      // disguised way of clearing somebody else's work.
+      assert.strictEqual(alive(written.group), true,
+        'the refusal must not end the run it found');
+
+      first.kill('SIGTERM');
+      await firstExited;
+      first = null;
+      await until(() => pids.every(p => !alive(p)));
+      assert.strictEqual(fs.existsSync(record), false,
+        'the record must not outlive the run it describes, or every later start is refused');
+    } finally {
+      if (first) first.kill('SIGKILL');
+      reap(pids.concat(pidsIn(file)));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  test('AC-5: a run that has not spawned its suite yet is live too', async (t) => {
+    // The gap between a run starting and its first suite existing. A start made
+    // in that gap has no group to find, and letting it through would put two
+    // reverters on one working tree, each checking files out from under the
+    // other. Covered here rather than by racing two real runs, because the gap
+    // is a few milliseconds wide and a test that has to hit it would be a flake
+    // rather than a check.
+    //
+    // The record is written by hand, and the thing under test is the reader of
+    // it. The process it names is a real live one, so the liveness answer is
+    // measured rather than stubbed.
+    const dir = repo();
+    const holder = spawn('sh', ['-c', `sleep ${LONG}`], { detached: true, stdio: 'ignore' });
+    holder.unref();
+    try {
+      await until(() => alive(holder.pid));
+      fs.writeFileSync(runRecordPath(dir), JSON.stringify({
+        pid: holder.pid, group: null, tests: 'npm test',
+        repo: dir, startedAt: new Date().toISOString(),
+      }));
+
+      const r = await redFirst({ repo: dir, base: 'main', tests: 'true' });
+      t.diagnostic(`outcome: ${r.outcome}: ${r.reason}`);
+      assert.strictEqual(r.outcome, 'refused', r.reason);
+      assert.match(r.reason, new RegExp(`\\b${holder.pid}\\b`),
+        'the refusal must name the run it found even with no suite under it');
+      assert.match(r.reason, /no suite under it yet/, r.reason);
+    } finally {
+      reap([holder.pid]);
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('cleanup reaches what this tool started, and stops there', () => {
+  test('AC-8: a suite this tool did not start is left alone, and is still working afterwards', async (t) => {
+    // The remedy that suggests itself for the leak above is a pattern kill
+    // across the machine. That is how a neighbour's mutation harness was ended
+    // mid-rewrite, and a harness killed that way skips the restore in its
+    // `finally`, so one tool's orphan becomes another tool's silently broken
+    // guard in a checkout whose owner saw neither event.
+    //
+    // THE FOREIGN SUITE IS CHECKED BY WHAT IT DOES, not by whether its pid can
+    // still be signalled. Those are different questions and the difference is
+    // not academic: this test was first written the second way, and a pattern
+    // kill passed it. The process had been killed, but it was the test's own
+    // child and had not been reaped, so it sat there defunct with a pid that
+    // `kill(pid, 0)` still accepted. A liveness answer that a corpse satisfies
+    // is exactly the proxy-for-the-property fault the reverting check exists to
+    // catch, and it was in the test for the criterion that matters most here.
+    //
+    // So the foreign suite counts, out loud, into a file. A count that advances
+    // after the tool has been and gone is a process still executing.
+    //
+    // Its command line also carries the same text as the tool's own leftovers,
+    // so nothing can pass this by matching on a command line and calling the
+    // match narrow.
+    const dir = repo();
+    const file = pidFile('foreign');
+    const beat = path.join(os.tmpdir(), `red-first-orphans-beat-${process.pid}-${Date.now()}`);
+    const foreign = spawn('sh',
+      ['-c', `n=0; while :; do n=$((n+1)); echo $n > ${beat}; sleep 0.2; done # sleep ${LONG}`],
+      { detached: true, stdio: 'ignore' });
+    foreign.unref();
+    const beats = () => {
+      try { return Number(fs.readFileSync(beat, 'utf8').trim()); } catch (e) { return 0; }
+    };
+    try {
+      const ticking = await until(() => beats() > 0, 10000);
+      assert.strictEqual(ticking, true, 'the foreign suite must be working to begin with');
+      t.diagnostic(`foreign suite before: ${table([foreign.pid])} counted ${beats()}`);
+
+      const r = cli(dir, packageRunnerLeaving(file));
+      assert.match(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|INCONCLUSIVE)/,
+        `the tool must have run\n${r.stdout}\n${r.stderr}`);
+
+      const pids = pidsIn(file);
+      assert.ok(pids.length >= 2, `the tool must have left something of its own to clean up: ${pids}`);
+
+      // Paired on purpose. Without the first assertion, cleanup that does
+      // nothing at all passes this test; without the second, a pattern kill
+      // passes it. Only cleanup scoped to what this tool started passes both.
+      await until(() => pids.every(p => !alive(p)));
+      assert.deepStrictEqual(pids.filter(alive), [],
+        'the tool must really have cleaned up its own, or this proves nothing');
+
+      const before = beats();
+      const advanced = await until(() => beats() > before, 10000);
+      t.diagnostic(`foreign suite after: ${table([foreign.pid])} counted ${before} then ${beats()}`);
+      assert.strictEqual(advanced, true,
+        `the tool ended or stopped a process it never started (pid ${foreign.pid}); `
+        + `its count stood still at ${before}`);
+    } finally {
+      reap(pidsIn(file));
+      reap([foreign.pid]);
+      fs.rmSync(file, { force: true });
+      fs.rmSync(beat, { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/red-first-orphans.test.js
+++ b/test/unit/red-first-orphans.test.js
@@ -19,14 +19,21 @@
 // whose check came back inconclusive and retried therefore added a whole suite
 // to the machine each time.
 //
-// THE SECOND EDGE, which is why the last test here is not optional. The obvious
+// THE SECOND EDGE, which is why the AC-8 test here is not optional. The obvious
 // remedy for a leak like this is a pattern kill across the machine, and that
-// reaches processes this tool never started. `a suite this tool did not start
-// is left alone, and is still working afterwards` fails if the cleanup ever
-// widens that far, and it is paired with an assertion that the tool's OWN
-// leftovers really did go, so that doing nothing at all cannot pass it either.
-// It asks whether the foreign suite is still WORKING rather than whether its
-// pid can still be signalled, for a reason its own comment gives at length.
+// reaches processes this tool never started. It asks whether the foreign suite
+// is still WORKING rather than whether its pid can still be signalled, for a
+// reason its own comment gives at length.
+//
+// EXISTING IS NOT RUNNING, AND IT IS THE SAME MISTAKE TWICE. A pid that answers
+// `kill(pid, 0)` may be a process that has already exited and is only waiting
+// to be collected. This file made that mistake once, in the AC-8 check, where a
+// pattern kill passed because the corpse still answered; the tool made it too,
+// in its own liveness probe, where a corpse kept a group looking alive for the
+// whole grace on Linux. So `running()` below asks the process table for a state
+// and treats an exited entry as gone, which is what lets every assertion here
+// be made IMMEDIATELY after the tool exits rather than after a settling window
+// that would also forgive a tool that signalled and walked away.
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
@@ -35,7 +42,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync, spawn, spawnSync } = require('node:child_process');
 
-const { redFirst, runRecordPath } = require('../../scripts/red-first.js');
+const { redFirst, runRecordPath, groupRunning } = require('../../scripts/red-first.js');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'red-first.js');
 
@@ -44,6 +51,17 @@ const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'red-first.js');
 // means matching these processes on their command line, and a round duration
 // would match a stranger's sleep on a shared machine as well as this file's.
 const LONG = 600000 + (process.pid % 997);
+
+// The tool's own alarm for a group it could not end. Asserted against on every
+// path that ends a live suite, because a warning nobody looks at is how a false
+// alarm on every interrupt goes unnoticed, and a real one goes unnoticed with
+// it.
+const SURVIVOR_WARNING = /survived being ended/;
+
+function noWarning(stderr, where) {
+  assert.doesNotMatch(String(stderr), SURVIVOR_WARNING,
+    `${where}: the tool reported a survivor when everything it started was ended\n${stderr}`);
+}
 
 // A throwaway repository whose branch ADDS a source file and a test that needs
 // it, so the reverted run genuinely fails and the tool takes its ordinary path
@@ -72,10 +90,10 @@ function repo() {
   return dir;
 }
 
-// Where a run leaves the pids it started, OUTSIDE the repository, because
-// anything written inside it dirties the tree the tool is about to check.
-function pidFile(name) {
-  return path.join(os.tmpdir(), `red-first-orphans-${name}-${process.pid}-${Date.now()}.pids`);
+// Scratch paths OUTSIDE the repository, because anything written inside it
+// dirties the tree the tool is about to check.
+function scratch(name) {
+  return path.join(os.tmpdir(), `red-first-orphans-${name}-${process.pid}-${Date.now()}`);
 }
 
 function pidsIn(file) {
@@ -83,11 +101,31 @@ function pidsIn(file) {
   return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map(Number);
 }
 
-const alive = (pid) => { try { process.kill(pid, 0); return true; } catch (e) { return false; } };
+/**
+ * Is this pid a process that is still RUNNING, rather than one that has exited
+ * and not yet been collected?
+ *
+ * `kill(pid, 0)` alone cannot tell the two apart, and the difference is the
+ * whole point here: the tool ends its own direct child while its event loop is
+ * blocked, so on Linux that child is briefly an entry in the table with nothing
+ * behind it. Counting that as a survivor would fail every assertion below for a
+ * process that is already dead.
+ *
+ * Where the process table cannot be read at all, the strict answer is given, so
+ * this never quietly forgives a genuine leak.
+ */
+function running(pid) {
+  try { process.kill(pid, 0); } catch (e) { if (e.code !== 'EPERM') return false; }
+  const out = spawnSync('ps', ['-o', 'stat=', '-p', String(pid)], { encoding: 'utf8' });
+  if (out.error) return true;
+  const state = String(out.stdout || '').trim().split('\n')[0].trim();
+  if (!state) return false;
+  return !state.startsWith('Z');
+}
 
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
-async function until(predicate, ms = 5000) {
+async function until(predicate, ms = 15000) {
   const deadline = Date.now() + ms;
   while (Date.now() < deadline) {
     if (predicate()) return true;
@@ -96,34 +134,57 @@ async function until(predicate, ms = 5000) {
   return predicate();
 }
 
-// The process table for a set of pids, when this machine will give one. Under a
-// command sandbox that blocks spawning, `ps` is unavailable and the liveness
-// answer below is the whole record. Liveness is what every assertion here uses;
-// the table is printed alongside it so a reader of a run has the same view the
-// measurements were taken from.
+/**
+ * The process table for a set of pids.
+ *
+ * `ps -p` exits non-zero when none of the listed pids exist, which is a
+ * successful lookup that found nothing, not a failure to run ps. Reporting the
+ * second when it was the first put a false statement about the environment into
+ * the committed evidence: it said the table could not be captured in a run
+ * where ps was producing tables seconds later.
+ */
 function table(pids) {
-  const live = pids.map(p => `${p}=${alive(p) ? 'alive' : 'gone'}`).join(' ');
   if (!pids.length) return '(no pids recorded)';
-  try {
-    const out = execFileSync('ps', ['-o', 'pid,ppid,pgid,command', '-p', pids.join(',')],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-    return `${live}\n${out}`;
-  } catch (e) {
-    return `${live} (no process table: ps is unavailable here)`;
+  const live = pids.map(p => `${p}=${running(p) ? 'running' : 'gone'}`).join(' ');
+  const out = spawnSync('ps', ['-o', 'pid,ppid,pgid,stat,command', '-p', pids.join(',')],
+    { encoding: 'utf8' });
+  if (out.error) {
+    return `${live}\n(no process table: ps could not be run here: ${out.error.code})`;
   }
+  const text = String(out.stdout || '').trim();
+  const rows = text.split('\n').filter(Boolean);
+  // One line is the column header on its own, which is what ps prints when
+  // nothing matches.
+  if (rows.length <= 1) return `${live}\n(process table empty: none of these pids exist)`;
+  return `${live}\n${text}`;
 }
 
-// A test command shaped like a package runner: it starts a child of its own,
-// detaches that child's stdio so the runner is not held open by it, and then
-// finishes. The child stays in the runner's process group, which is what makes
-// this the case AC-4 names: ending the direct child alone leaves the child of
-// the child running.
-//
-// `$!` is the background child, `$$` the shell itself. Both are recorded so a
-// failure can say which of the two survived.
-function packageRunnerLeaving(file, tail = 'exit 0') {
-  return `sleep ${LONG} >/dev/null 2>&1 & echo $! >> ${JSON.stringify(file)}; `
-    + `echo $$ >> ${JSON.stringify(file)}; ${tail}`;
+/**
+ * A test command shaped like a package runner: it starts a child of its own,
+ * detaches that child's stdio so the runner is not held open by it, and then
+ * finishes. The child stays in the runner's process group, which is what makes
+ * this the case AC-4 names: ending the direct child alone leaves the child of
+ * the child running.
+ *
+ * `$!` is the background child, `$$` the shell itself. Both are recorded so a
+ * failure can say which of the two survived.
+ *
+ * `before` makes the runner write its own process table while both are still
+ * alive, which is the only moment a before-table can be taken when the tool is
+ * driven synchronously.
+ *
+ * `ignoreTerm` sets TERM to ignored in the shell before the child is started.
+ * An ignored disposition survives fork and exec, so the child ignores SIGTERM
+ * too, and only the escalation to SIGKILL can end it.
+ */
+function packageRunnerLeaving(file, opts = {}) {
+  const { tail = 'exit 0', ignoreTerm = false, before = null } = opts;
+  const trap = ignoreTerm ? "trap '' TERM; " : '';
+  const snap = before
+    ? `ps -o pid,ppid,pgid,stat,command -p "$!,$$" >> ${JSON.stringify(before)} 2>&1; `
+    : '';
+  return `${trap}sleep ${LONG} >/dev/null 2>&1 & echo $! >> ${JSON.stringify(file)}; `
+    + `echo $$ >> ${JSON.stringify(file)}; ${snap}${tail}`;
 }
 
 // Nothing here may end a process it did not start, including in its own
@@ -140,12 +201,17 @@ function cli(dir, tests) {
     [SCRIPT, '--repo', dir, '--base', 'main', '--tests', tests], { encoding: 'utf8' });
 }
 
+function readBefore(file) {
+  try { return fs.readFileSync(file, 'utf8').trim(); } catch (e) { return '(not written)'; }
+}
+
 describe('no suite outlives the tool', () => {
   test('AC-1, AC-4, AC-7: a normal exit leaves no suite running, including the runner\'s own child', async (t) => {
     const dir = repo();
-    const file = pidFile('normal');
+    const file = scratch('normal');
+    const before = scratch('normal-before');
     try {
-      const r = cli(dir, packageRunnerLeaving(file));
+      const r = cli(dir, packageRunnerLeaving(file, { before }));
       // The run really did complete rather than dying early, or the absence of
       // survivors would prove nothing about a normal exit.
       assert.match(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|INCONCLUSIVE)/,
@@ -154,13 +220,17 @@ describe('no suite outlives the tool', () => {
       const pids = pidsIn(file);
       // Two runs, each leaving a background child and a shell.
       assert.ok(pids.length >= 2, `the runner must have started something to leave behind: ${pids}`);
-      t.diagnostic(`immediately after the tool exited:\n${table(pids)}`);
+      t.diagnostic(`with the suite live, written by the runner itself:\n${readBefore(before)}`);
+      t.diagnostic(`once the tool had exited:\n${table(pids)}`);
 
-      await until(() => pids.every(p => !alive(p)));
-      const survivors = pids.filter(alive);
-      t.diagnostic(`after settling:\n${table(pids)}`);
+      // Asserted with no settling window. Anything still running at the moment
+      // the tool is gone is a survivor; a tool that signalled its group and
+      // walked away without waiting would fail here, which a window would have
+      // forgiven.
+      const survivors = pids.filter(running);
       assert.deepStrictEqual(survivors, [],
         `a normal exit left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+      noWarning(r.stderr, 'normal exit');
 
       // The record of a run that has finished must go with it. Left behind, it
       // names a pid that is gone, and the refusal at the top of the tool would
@@ -172,37 +242,132 @@ describe('no suite outlives the tool', () => {
     } finally {
       reap(pidsIn(file));
       fs.rmSync(file, { force: true });
+      fs.rmSync(before, { force: true });
       fs.rmSync(runRecordPath(dir), { force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test('AC-2: an error exit leaves no suite running', async (t) => {
+  test('AC-1: a suite that ignores SIGTERM is ended anyway, which is what the escalation is for', async (t) => {
+    // The only case where the escalation from SIGTERM to SIGKILL is what keeps
+    // a suite from outliving the tool. Every other stand-in in this file dies
+    // on the first signal, so without this one the escalation could be deleted
+    // and nothing here would notice, while the criterion it answers to is
+    // unconditional.
+    //
+    // The shell sets TERM to ignored before starting its background child, and
+    // an ignored disposition survives exec, so the `sleep` ignores SIGTERM as
+    // well. It is the shape a test runner takes when it traps the signal to
+    // flush its reporters and then does not finish.
     const dir = repo();
-    const file = pidFile('error');
+    const file = scratch('stubborn');
+    const before = scratch('stubborn-before');
     try {
-      // The runner destroys the repository's git directory once it has started
-      // its background child, so the restore that follows throws and the tool
-      // leaves by its error path rather than by returning an outcome. This is
-      // the exit nobody thinks to check, which is why it is driven here rather
-      // than reasoned about.
-      const r = cli(dir, packageRunnerLeaving(file, 'rm -rf .git; exit 0'));
+      const r = cli(dir, packageRunnerLeaving(file, { ignoreTerm: true, before }));
+      assert.match(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|INCONCLUSIVE)/,
+        `the tool must have reached a conclusion\n${r.stdout}\n${r.stderr}`);
+
+      const pids = pidsIn(file);
+      assert.ok(pids.length >= 2, `the runner must have started something to leave behind: ${pids}`);
+      t.diagnostic(`with the stubborn suite live:\n${readBefore(before)}`);
+      t.diagnostic(`once the tool had exited:\n${table(pids)}`);
+
+      const survivors = pids.filter(running);
+      assert.deepStrictEqual(survivors, [],
+        `a suite that ignores SIGTERM outlived the tool: ${survivors.join(', ')}`);
+      noWarning(r.stderr, 'stubborn suite');
+    } finally {
+      reap(pidsIn(file));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(before, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('AC-2: an error raised while a suite is in flight leaves no suite running', async (t) => {
+    // The error exit that matters, and the one the first version of this test
+    // missed. Destroying the repository after the run had closed produced an
+    // error, but by then the ending after the run had already cleared the
+    // group, so the test could not tell "the error path cleans up" from "every
+    // run end cleans up". Here the exception is raised while the first suite is
+    // still running, so the only thing that can end the group is the path an
+    // error takes out of the process.
+    const dir = repo();
+    const file = scratch('inflight-error');
+    let pids = [];
+    try {
+      const driver = `
+        const { redFirst } = require(${JSON.stringify(SCRIPT)});
+        redFirst({ repo: ${JSON.stringify(dir)}, base: 'main',
+                   tests: ${JSON.stringify(packageRunnerLeaving(file, { tail: `sleep 30` }))} })
+          .catch(() => {});
+        const fs = require('node:fs');
+        const t = setInterval(() => {
+          const started = fs.existsSync(${JSON.stringify(file)})
+            && fs.readFileSync(${JSON.stringify(file)}, 'utf8').trim().split('\\n').length >= 2;
+          if (!started) return;
+          clearInterval(t);
+          throw new Error('raised while a suite was in flight');
+        }, 50);
+      `;
+      const r = spawnSync(process.execPath, ['-e', driver], { encoding: 'utf8', timeout: 60000 });
+      assert.notStrictEqual(r.status, 0, `the driver must have failed\n${r.stdout}\n${r.stderr}`);
+      assert.match(r.stderr, /raised while a suite was in flight/,
+        `the tool must have left by the error, not by returning\n${r.stderr}`);
+
+      pids = pidsIn(file);
+      assert.ok(pids.length >= 2, `a suite must have been in flight: ${pids}`);
+      t.diagnostic(`once the error had taken the process down:\n${table(pids)}`);
+
+      const survivors = pids.filter(running);
+      assert.deepStrictEqual(survivors, [],
+        `an error exit left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+      noWarning(r.stderr, 'error exit in flight');
+      assert.strictEqual(fs.existsSync(runRecordPath(dir)), false,
+        'an error exit must still give the claim back');
+    } finally {
+      reap(pids.concat(pidsIn(file)));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('AC-2: an error out of the run itself also leaves no suite running', async (t) => {
+    // The other shape of error exit, kept because it reaches the outer
+    // `finally` rather than the exit listener: the runner destroys the
+    // repository's git directory once it has started its background child, so
+    // the restore that follows throws.
+    const dir = repo();
+    const file = scratch('error');
+    const before = scratch('error-before');
+    try {
+      const r = cli(dir, packageRunnerLeaving(file, { tail: 'rm -rf .git; exit 0', before }));
       assert.notStrictEqual(r.status, 0, 'the tool must have failed');
-      assert.doesNotMatch(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|REFUSED)/,
+      // Pinned to the exception, not merely to a non-zero status: an
+      // inconclusive result is also non-zero and is an ordinary return.
+      assert.match(r.stderr, /\[red-first\][\s\S]*Error/,
+        `the tool must have printed the thrown error\n${r.stderr}`);
+      assert.doesNotMatch(r.stdout, /\[red-first\] (PROVEN|NOT-DISCRIMINATING|REFUSED|INCONCLUSIVE)/,
         `the tool must have crashed rather than concluded\n${r.stdout}`);
 
       const pids = pidsIn(file);
       assert.ok(pids.length >= 1, `the runner must have started something to leave behind: ${pids}`);
-      t.diagnostic(`immediately after the tool exited:\n${table(pids)}`);
+      t.diagnostic(`with the suite live, written by the runner itself:\n${readBefore(before)}`);
+      t.diagnostic(`once the tool had exited:\n${table(pids)}`);
 
-      await until(() => pids.every(p => !alive(p)));
-      const survivors = pids.filter(alive);
-      t.diagnostic(`after settling:\n${table(pids)}`);
+      const survivors = pids.filter(running);
       assert.deepStrictEqual(survivors, [],
         `an error exit left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+      noWarning(r.stderr, 'error exit');
+      assert.strictEqual(fs.existsSync(runRecordPath(dir)), false,
+        'an error exit must still give the claim back');
     } finally {
       reap(pidsIn(file));
       fs.rmSync(file, { force: true });
+      fs.rmSync(before, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
@@ -213,34 +378,45 @@ describe('no suite outlives the tool', () => {
     // while the first suite ran took Node's default handling, which terminates
     // without unwinding and abandons a detached process group.
     const dir = repo();
-    const file = pidFile('signal');
+    const file = scratch('signal');
     let pids = [];
     try {
       const kid = spawn(process.execPath,
-        [SCRIPT, '--repo', dir, '--base', 'main', '--tests', packageRunnerLeaving(file, 'sleep 30')],
+        [SCRIPT, '--repo', dir, '--base', 'main',
+          '--tests', packageRunnerLeaving(file, { tail: 'sleep 30' })],
         { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stderr = '';
+      kid.stderr.on('data', (b) => { stderr += b.toString(); });
       const exited = new Promise(resolve => kid.on('exit', (code, signal) => resolve({ code, signal })));
 
-      const started = await until(() => pidsIn(file).length >= 2, 15000);
+      const started = await until(() => pidsIn(file).length >= 2);
       assert.strictEqual(started, true, 'the first run must be in flight before it is signalled');
       pids = pidsIn(file);
       t.diagnostic(`with the first run in flight:\n${table(pids)}`);
 
+      const sentAt = Date.now();
       kid.kill('SIGTERM');
       const how = await exited;
-      t.diagnostic(`the tool exited with code ${how.code} signal ${how.signal}`);
+      const took = Date.now() - sentAt;
+      t.diagnostic(`the tool exited with code ${how.code} signal ${how.signal} after ${took}ms`);
+      t.diagnostic(`its stderr was: ${stderr.trim() || '(empty)'}`);
+      t.diagnostic(`once the tool had exited:\n${table(pids)}`);
 
-      await until(() => pids.every(p => !alive(p)));
-      const survivors = pids.filter(alive);
-      t.diagnostic(`after the tool exited:\n${table(pids)}`);
+      const survivors = pids.filter(running);
       assert.deepStrictEqual(survivors, [],
         `a signal during the first run left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+      // The alarm must stay quiet here. It did not on Linux before the ending
+      // learned to tell an exited entry from a running one, and an interrupt is
+      // the most common way this tool is stopped.
+      noWarning(stderr, 'signal during the first run');
     } finally {
       reap(pids.concat(pidsIn(file)));
       fs.rmSync(file, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
   test('AC-1: an exit taken while a suite is running leaves nothing behind either', async (t) => {
     // The exit that does not unwind.
     //
@@ -252,13 +428,13 @@ describe('no suite outlives the tool', () => {
     // tool's ever runs. Driven rather than argued, because a backstop nothing
     // reaches is not a backstop, it is a comment.
     const dir = repo();
-    const file = pidFile('inflight');
+    const file = scratch('inflight');
     let pids = [];
     try {
       const driver = `
         const { redFirst } = require(${JSON.stringify(SCRIPT)});
         redFirst({ repo: ${JSON.stringify(dir)}, base: 'main',
-                   tests: ${JSON.stringify(packageRunnerLeaving(file, 'sleep 30'))} })
+                   tests: ${JSON.stringify(packageRunnerLeaving(file, { tail: 'sleep 30' }))} })
           .catch(() => {});
         const fs = require('node:fs');
         setInterval(() => {
@@ -272,13 +448,12 @@ describe('no suite outlives the tool', () => {
 
       pids = pidsIn(file);
       assert.ok(pids.length >= 2, `a suite must have been in flight when it exited: ${pids}`);
-      t.diagnostic(`immediately after the exit:\n${table(pids)}`);
+      t.diagnostic(`once the exit had been taken:\n${table(pids)}`);
 
-      await until(() => pids.every(p => !alive(p)));
-      const survivors = pids.filter(alive);
-      t.diagnostic(`after settling:\n${table(pids)}`);
+      const survivors = pids.filter(running);
       assert.deepStrictEqual(survivors, [],
         `an exit taken mid-run left ${survivors.length} process(es) running: ${survivors.join(', ')}`);
+      noWarning(r.stderr, 'exit taken mid-run');
     } finally {
       reap(pids.concat(pidsIn(file)));
       fs.rmSync(file, { force: true });
@@ -288,22 +463,70 @@ describe('no suite outlives the tool', () => {
   });
 });
 
+describe('telling a process that has exited from one that is still running', () => {
+  test('a group whose remaining members have all exited is judged gone', () => {
+    // The decision on its own, driven on any machine rather than only on the
+    // platform that produces the corpses. On Linux a process this tool has just
+    // killed stays listed as a member of its group until its parent collects
+    // it, which the tool cannot do while it is blocked in a signal listener; a
+    // probe that asks only whether the group id answers therefore keeps saying
+    // "alive" for the whole grace and then reports a survivor that is a corpse.
+    const holder = spawn('sh', ['-c', `sleep ${LONG}`], { detached: true, stdio: 'ignore' });
+    holder.unref();
+    try {
+      const pgid = holder.pid;
+      assert.strictEqual(groupRunning(pgid, () => [{ pid: pgid, state: 'S' }]), true,
+        'a member in any state but exited is a running group');
+      assert.strictEqual(groupRunning(pgid, () => [{ pid: pgid, state: 'Z+' }]), false,
+        'a group whose only member has exited is gone');
+      assert.strictEqual(groupRunning(pgid, () => [{ pid: pgid, state: 'Z' }, { pid: pgid + 1, state: 'S' }]), true,
+        'one running member among the corpses keeps the group alive');
+      assert.strictEqual(groupRunning(pgid, () => []), false,
+        'a group the table does not list at all is gone');
+      assert.strictEqual(groupRunning(pgid, () => null), null,
+        'a machine that will not say gives neither answer');
+    } finally {
+      reap([holder.pid]);
+    }
+  });
+
+  test('a group that no longer exists is gone without consulting the process table', async () => {
+    // The cheap question is asked first, which cannot be seen in the answer:
+    // where both agree they agree. What separates them is the spawn, so that is
+    // what is observed.
+    const gone = spawn('sh', ['-c', 'exit 0'], { detached: true, stdio: 'ignore' });
+    await new Promise(resolve => gone.on('exit', resolve));
+    const cleared = await until(() => {
+      try { process.kill(-gone.pid, 0); return false; } catch (e) { return true; }
+    }, 5000);
+    assert.strictEqual(cleared, true, 'the fixture group must be gone before this is asked');
+
+    let asked = 0;
+    const answer = groupRunning(gone.pid, () => { asked += 1; return null; });
+    assert.strictEqual(answer, false);
+    assert.strictEqual(asked, 0, 'the process table must not be read when the group has gone');
+  });
+});
+
 describe('starting on top of a run that is still going', () => {
   test('AC-5, AC-6: a second start is refused, and the refusal names the run it found', async (t) => {
     // Driven end to end against a real first run rather than a hand-written
     // record, because a hand-written one only proves the reader can read the
     // test's idea of a record.
     const dir = repo();
-    const file = pidFile('refuse');
+    const file = scratch('refuse');
     let first = null;
     let pids = [];
     try {
       first = spawn(process.execPath,
-        [SCRIPT, '--repo', dir, '--base', 'main', '--tests', packageRunnerLeaving(file, 'sleep 25')],
+        [SCRIPT, '--repo', dir, '--base', 'main',
+          '--tests', packageRunnerLeaving(file, { tail: 'sleep 25' })],
         { stdio: ['ignore', 'pipe', 'pipe'] });
+      let firstStderr = '';
+      first.stderr.on('data', (b) => { firstStderr += b.toString(); });
       const firstExited = new Promise(resolve => first.on('exit', resolve));
 
-      const started = await until(() => pidsIn(file).length >= 2, 15000);
+      const started = await until(() => pidsIn(file).length >= 2);
       assert.strictEqual(started, true, 'the first run must have a live suite before the second starts');
       pids = pidsIn(file);
 
@@ -330,13 +553,18 @@ describe('starting on top of a run that is still going', () => {
 
       // And the first run is left alone by the refusal: refusing must not be a
       // disguised way of clearing somebody else's work.
-      assert.strictEqual(alive(written.group), true,
+      assert.strictEqual(running(written.group), true,
         'the refusal must not end the run it found');
 
       first.kill('SIGTERM');
       await firstExited;
       first = null;
-      await until(() => pids.every(p => !alive(p)));
+      t.diagnostic(`the first run's stderr was: ${firstStderr.trim() || '(empty)'}`);
+      noWarning(firstStderr, 'first run torn down with SIGTERM');
+
+      const survivors = pids.filter(running);
+      assert.deepStrictEqual(survivors, [],
+        `tearing the first run down left ${survivors.join(', ')} running`);
       assert.strictEqual(fs.existsSync(record), false,
         'the record must not outlive the run it describes, or every later start is refused');
     } finally {
@@ -347,35 +575,155 @@ describe('starting on top of a run that is still going', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
   test('AC-5: a run that has not spawned its suite yet is live too', async (t) => {
     // The gap between a run starting and its first suite existing. A start made
     // in that gap has no group to find, and letting it through would put two
     // reverters on one working tree, each checking files out from under the
-    // other. Covered here rather than by racing two real runs, because the gap
-    // is a few milliseconds wide and a test that has to hit it would be a flake
-    // rather than a check.
+    // other.
     //
-    // The record is written by hand, and the thing under test is the reader of
-    // it. The process it names is a real live one, so the liveness answer is
-    // measured rather than stubbed.
+    // Driven against the record the tool itself writes, held open with the
+    // injectable runner, rather than against a record this test composed: a
+    // fixture built to agree with the test would stay green while the real
+    // write drifted away from it.
     const dir = repo();
-    const holder = spawn('sh', ['-c', `sleep ${LONG}`], { detached: true, stdio: 'ignore' });
-    holder.unref();
+    let release = null;
+    const gate = new Promise(resolve => { release = resolve; });
     try {
-      await until(() => alive(holder.pid));
-      fs.writeFileSync(runRecordPath(dir), JSON.stringify({
-        pid: holder.pid, group: null, tests: 'npm test',
-        repo: dir, startedAt: new Date().toISOString(),
-      }));
+      const firstRun = redFirst({
+        repo: dir, base: 'main', tests: 'this command is never spawned',
+        runner: () => gate.then(() => true),
+      });
 
-      const r = await redFirst({ repo: dir, base: 'main', tests: 'true' });
-      t.diagnostic(`outcome: ${r.outcome}: ${r.reason}`);
-      assert.strictEqual(r.outcome, 'refused', r.reason);
-      assert.match(r.reason, new RegExp(`\\b${holder.pid}\\b`),
-        'the refusal must name the run it found even with no suite under it');
-      assert.match(r.reason, /no suite under it yet/, r.reason);
+      const record = runRecordPath(dir);
+      const appeared = await until(() => fs.existsSync(record));
+      assert.strictEqual(appeared, true, `the run must record itself before it spawns: ${record}`);
+      const written = JSON.parse(fs.readFileSync(record, 'utf8'));
+      t.diagnostic(`the record the tool wrote: ${JSON.stringify(written)}`);
+      assert.strictEqual(written.group, null, 'no suite has been started yet');
+      assert.strictEqual(written.pid, process.pid, 'the record names the running tool');
+
+      const second = cli(dir, 'echo this must never run');
+      t.diagnostic(`second start said: ${second.stdout.trim()}`);
+      assert.notStrictEqual(second.status, 0, 'a second start must not exit 0');
+      assert.match(second.stdout, /REFUSED/, second.stdout);
+      assert.match(second.stdout, /no suite under it yet/, second.stdout);
+      assert.match(second.stdout, new RegExp(`\\b${process.pid}\\b`),
+        `the refusal must name the run it found\n${second.stdout}`);
+
+      release();
+      await firstRun;
+      assert.strictEqual(fs.existsSync(record), false,
+        'the claim must be given back when the run ends');
     } finally {
-      reap([holder.pid]);
+      if (release) release();
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('a suite the tool could not end', () => {
+  test('AC-5: the run record is kept naming it, so the next start has something to refuse on', async (t) => {
+    // The one exit where the tool KNOWS it left a suite behind was also the one
+    // that erased the record the next start would need in order to refuse. That
+    // is the AC-5 scenario arriving by the only route the tool can see coming,
+    // and giving the claim back there would let the next run add a second suite
+    // on top of the one this run just failed to end.
+    //
+    // SIGKILL cannot be survived on demand, so the ending is injected: one that
+    // reports the group still running and leaves it alone. Nothing here is
+    // pretended, then. The suite really does outlive the run, which is the
+    // situation, and what is under test is everything the run does about it.
+    // The ending that would normally have dealt with it is covered by the
+    // stubborn-suite test above.
+    const dir = repo();
+    const file = scratch('survivor');
+    let pids = [];
+    try {
+      const driver = `
+        const { redFirst } = require(${JSON.stringify(SCRIPT)});
+        redFirst({ repo: ${JSON.stringify(dir)}, base: 'main',
+                   tests: ${JSON.stringify(packageRunnerLeaving(file))},
+                   groupEnder: () => 'running' })
+          .then((r) => { console.log('OUTCOME ' + r.outcome); process.exit(0); })
+          .catch((e) => { console.error(e); process.exit(1); });
+      `;
+      const r = spawnSync(process.execPath, ['-e', driver], { encoding: 'utf8', timeout: 60000 });
+      assert.strictEqual(r.status, 0, `${r.stdout}\n${r.stderr}`);
+      t.diagnostic(`stderr: ${r.stderr.trim()}`);
+
+      pids = pidsIn(file);
+      assert.ok(pids.length >= 1, `the runner must have started something: ${pids}`);
+
+      // The alarm fires, and names the group, because here the tool genuinely
+      // cannot tell that it ended it.
+      assert.match(r.stderr, SURVIVOR_WARNING,
+        `a group the tool could not confirm gone must be announced\n${r.stderr}`);
+
+      const record = runRecordPath(dir);
+      assert.strictEqual(fs.existsSync(record), true,
+        'the record must be kept when the tool knows it may have left a suite behind');
+      const held = JSON.parse(fs.readFileSync(record, 'utf8'));
+      t.diagnostic(`record kept: ${JSON.stringify(held)}`);
+      assert.strictEqual(held.survivedEnding, true, 'the record says why it was kept');
+      assert.ok(pids.includes(held.group),
+        `the kept record must name a group this run started, got ${held.group} of ${pids}`);
+      assert.match(r.stderr, new RegExp(`\\b${held.group}\\b`),
+        'the warning names the same group the record does');
+    } finally {
+      reap(pidsIn(file));
+      fs.rmSync(file, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('two starts at once against one repository', () => {
+  test('AC-5: exactly one runs and the other is refused, however close together they are', async (t) => {
+    // The window the first version of the refusal left open. It read the record
+    // at the top of the run and did not write one until three git commands
+    // later, so two starts a few milliseconds apart both saw an empty machine
+    // and both went on to revert the SAME working tree, checking files out from
+    // under each other. Nothing about the tree can be put right afterwards by a
+    // tool that does not know the other one is there.
+    const dir = repo();
+    const fileA = scratch('raceA');
+    const fileB = scratch('raceB');
+    try {
+      const start = (file) => new Promise((resolve) => {
+        const kid = spawn(process.execPath,
+          [SCRIPT, '--repo', dir, '--base', 'main',
+            '--tests', packageRunnerLeaving(file, { tail: 'sleep 3' })],
+          { stdio: ['ignore', 'pipe', 'pipe'] });
+        let out = '';
+        let err = '';
+        kid.stdout.on('data', (b) => { out += b.toString(); });
+        kid.stderr.on('data', (b) => { err += b.toString(); });
+        kid.on('exit', (code) => resolve({ code, out, err }));
+      });
+
+      const [a, b] = await Promise.all([start(fileA), start(fileB)]);
+      t.diagnostic(`first said:  ${a.out.trim().split('\n').pop()}`);
+      t.diagnostic(`second said: ${b.out.trim().split('\n').pop()}`);
+
+      const refused = [a, b].filter(x => /REFUSED: a run of this tool is still live/.test(x.out));
+      const concluded = [a, b].filter(x => /\[red-first\] (PROVEN|NOT-DISCRIMINATING|INCONCLUSIVE)/.test(x.out));
+      assert.strictEqual(refused.length, 1,
+        `exactly one start must be refused\n${a.out}\n---\n${b.out}`);
+      assert.strictEqual(concluded.length, 1,
+        `exactly one start must reach a conclusion\n${a.out}\n---\n${b.out}`);
+
+      const pids = pidsIn(fileA).concat(pidsIn(fileB));
+      assert.deepStrictEqual(pids.filter(running), [],
+        `neither start may leave a suite behind: ${pids.filter(running).join(', ')}`);
+      assert.strictEqual(fs.existsSync(runRecordPath(dir)), false,
+        'the claim must be given back once both have finished');
+    } finally {
+      reap(pidsIn(fileA).concat(pidsIn(fileB)));
+      fs.rmSync(fileA, { force: true });
+      fs.rmSync(fileB, { force: true });
       fs.rmSync(runRecordPath(dir), { force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -406,8 +754,8 @@ describe('cleanup reaches what this tool started, and stops there', () => {
     // so nothing can pass this by matching on a command line and calling the
     // match narrow.
     const dir = repo();
-    const file = pidFile('foreign');
-    const beat = path.join(os.tmpdir(), `red-first-orphans-beat-${process.pid}-${Date.now()}`);
+    const file = scratch('foreign');
+    const beat = scratch('beat');
     const foreign = spawn('sh',
       ['-c', `n=0; while :; do n=$((n+1)); echo $n > ${beat}; sleep 0.2; done # sleep ${LONG}`],
       { detached: true, stdio: 'ignore' });
@@ -430,9 +778,9 @@ describe('cleanup reaches what this tool started, and stops there', () => {
       // Paired on purpose. Without the first assertion, cleanup that does
       // nothing at all passes this test; without the second, a pattern kill
       // passes it. Only cleanup scoped to what this tool started passes both.
-      await until(() => pids.every(p => !alive(p)));
-      assert.deepStrictEqual(pids.filter(alive), [],
+      assert.deepStrictEqual(pids.filter(running), [],
         'the tool must really have cleaned up its own, or this proves nothing');
+      noWarning(r.stderr, 'run beside a foreign suite');
 
       const before = beats();
       const advanced = await until(() => beats() > before, 10000);
@@ -445,6 +793,7 @@ describe('cleanup reaches what this tool started, and stops there', () => {
       reap([foreign.pid]);
       fs.rmSync(file, { force: true });
       fs.rmSync(beat, { force: true });
+      fs.rmSync(runRecordPath(dir), { force: true });
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
The reverting check spawns its test command detached, which puts that command and everything it starts into their own process group. That is what lets a whole subtree be ended together, and it also means the group outlives the tool unless the tool ends it.

It did not, on three of the four ways out. A normal exit left the suite running. So did an error exit. So did a signal arriving during the first run, because the signal listeners were installed only once the first run had finished, and Node's default handling for a terminating signal ends the process without unwinding.

The cost compounded in the worst possible shape. A result that comes back inconclusive invites a retry, and each retry started another full suite on top of the ones already running. Three concurrent suites and a load average of 178 is what that reached, with the tool making the condition it was retrying against.

The group is now ended when its run finishes, when a terminating signal arrives, and from an exit listener behind both of those for the exit that unwinds nothing at all. A suite that ignores SIGTERM is ended by the escalation to SIGKILL, which is the only case where anything but that escalation keeps a suite from outliving the tool, and which now has a test that drives it.

Ending a group asks what is running in it rather than whether its number still answers, and those are different questions. A process that has exited keeps its entry, and its process group with it, until its parent collects it, and on the signal and exit paths the tool ends its own child and then waits with the event loop blocked, so that child is exactly such an entry. On Linux the group therefore looked alive for the whole grace, was ended a second time for nothing, and was announced as a survivor on every interrupt. macOS filters exited members out of the same question, which is why the first version of this change measured clean here and would not have been in continuous integration. Driven in a Linux container, the interrupt took 571ms and printed the warning before, and takes 27ms and prints nothing now.

The same mistake sat one layer up, in the test that guards the neighbour criterion, where a machine wide pattern kill passed because the process it had killed still answered. Both now ask the process table for a state, which is also what lets every assertion about what outlived the tool be made at once, rather than after a settling window that would have forgiven a tool that signalled its group and walked away.

Cleanup is scoped by process group id, and that part is deliberate rather than incidental. The remedy that suggests itself for leftovers is to match command lines across the machine and kill what matches, and that reaches a neighbour: a suite in another checkout, or a mutation harness partway through rewriting a file it restores in a block that a killed process never runs. A test leaves a foreign suite running with the same text in its command line and requires it to still be counting afterwards.

A run claims its repository with an exclusive create before any other work, so two starts milliseconds apart cannot both proceed to revert the same tree, and a start made while one is live is refused naming the process group, the command and the run that owns it. A run that could not end its suite keeps its record instead of giving it back, naming what survived, because that is the one exit where the next start most needs something to refuse on.

None of this can be proven by the reverting check itself. These criteria are prohibitions, and taking the source away makes a test fail because the code went rather than because a suite survived. They are proven the other way round instead, by putting each defect back on its own and recording which named test noticed. The table, the process tables before and after on both platforms, and the reproduction steps are committed in the review folder beside the change.

Three rows of that table caught a defect in a test rather than in the source, and all three were silent until the change was run. The check on the foreign suite accepted a corpse. The run record was cleared on the signal path but not the ordinary one, and no test looked, so a record left behind would have refused every later start in that repository until somebody deleted it by hand. And the escalation to SIGKILL was executed by nothing, because every stand in suite died on the first signal.

One thing this cannot cover, stated because the refusal is built on it: a kill of the tool that the kernel delivers to nothing, where no listener runs at all. The refusal is what stops the next start piling a second suite on top of what that leaves. Telling a corpse from a survivor also needs a readable process table, so where spawning is blocked the tool stays quiet rather than raising an alarm it cannot stand behind, and the evidence file says so.