### PR TITLE
Make a release two commands, not one push a protected branch refuses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Before opening a PR:
 ### Conventions
 
 - **No build step.** Rundock ships plain JS. No transpilation, no bundling, no minification. Keep it that way.
-- **Changelog entries go under `## Unreleased`.** New entries accumulate at the top of `CHANGELOG.md` under a single `## Unreleased` heading. Start the body with a `**Name:** <release name>` line so the release script can promote it to a titled heading at release time. The release script auto-promotes `## Unreleased` to `## X.Y.Z: <Name> (YYYY-MM-DD)` when you run `npm run release -- X.Y.Z`. Entries follow the structure and voice rules in [Changelog entry standards](#changelog-entry-standards) below.
+- **Changelog entries go under `## Unreleased`.** New entries accumulate at the top of `CHANGELOG.md` under a single `## Unreleased` heading. Start the body with a `**Name:** <release name>` line so the release script can promote it to a titled heading at release time. The release script auto-promotes `## Unreleased` to `## X.Y.Z: <Name> (YYYY-MM-DD)` when you run `npm run release -- prepare X.Y.Z`. Entries follow the structure and voice rules in [Changelog entry standards](#changelog-entry-standards) below.
 - **No new dependencies** without discussion. The two-dependency footprint is deliberate.
 - **Vanilla JS only.** No frameworks, no TypeScript. The codebase is readable without tooling.
 - **Commit messages:** Start with a verb in imperative mood. Keep the first line under 72 characters. Examples: `fix permission card timeout race condition`, `add workspace mode toggle to settings panel`.

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -409,21 +409,31 @@ function buildRecord({ tree, branch, at }) {
 
 // The release commit's footprint.
 //
-// scripts/release.js bumps the version, promotes the changelog, and commits
-// directly to main. That is by design and the card plan states the constraint:
-// it is the only thing allowed on top of a gated SHA, release.js checks the
-// gate BEFORE creating it, and it touches these two files and nothing else.
+// scripts/release.js bumps the version and promotes the changelog. It is the
+// only thing allowed on top of a gated SHA: release.js checks the gate BEFORE
+// creating it, and it touches these two files and nothing else.
 //
 // The exception is defined by WHAT IS STAGED rather than by an environment
 // variable or the name of the calling process, because a guard any caller can
 // announce its way past is not a guard.
 //
 // RESIDUAL RISK, stated rather than left implicit: this also lets a
-// hand-edited changelog or a hand-edited version reach the default branch
-// without a branch. That is judged acceptable, because neither is code, both
-// are visible in the one place people read before a release, and the
-// alternative is a gate that blocks the release tool it ships beside.
+// hand-edited changelog or a hand-edited version through without the checks.
+// That is judged acceptable, because neither is code, both are visible in the
+// one place people read before a release, and the alternative is a gate that
+// blocks the release tool it ships beside.
 const RELEASE_FOOTPRINT = ['package.json', 'CHANGELOG.md'];
+
+// Where that commit is made. It used to be the default branch, and the
+// protection on main now refuses a direct push, so release.js commits the bump
+// on `release/<version>` and puts it through a pull request instead. The
+// exception follows the commit to the branch it is made on.
+//
+// Exact rather than a prefix: this is the name prepare builds, and a rule that
+// admitted anything beginning with the word would be a name anybody could
+// adopt to skip the checks. The default branch keeps the exception too, for the
+// hand-edited version or changelog the residual risk above describes.
+const RELEASE_BRANCH_RE = /^release\/\d+\.\d+\.\d+$/;
 
 /** Paths staged for the next commit. */
 function stagedPaths(root = ROOT) {
@@ -449,6 +459,8 @@ function refusal({ record, tree, branch, mainBranch, staged = [] }) {
     if (isReleaseCommit(staged)) return null;
     return { code: 'on-default-branch', message: `refusing to commit directly to ${mainBranch}. Branch first.` };
   }
+  // The release commit, on the branch release:prepare makes it on.
+  if (RELEASE_BRANCH_RE.test(branch) && isReleaseCommit(staged)) return null;
   if (!record) {
     return { code: 'no-record', message: `the checks have not been run against this tree. ${rerun}` };
   }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -516,7 +516,9 @@ if (require.main === module) {
     console.log('');
     logStep('done', `${version} is prepared on ${result.branch}: ${result.pullRequest || 'the pull request is open'}`);
     logStep('done', 'The required checks run on that pull request. Review it and merge it.');
+    logStep('done', 'Once it has merged: git checkout main && git pull');
     logStep('done', `Then tag the merged commit with: npm run release -- tag ${version}`);
+    logStep('done', 'Nothing is tagged until that runs, so a mistake here is a branch to delete.');
   } else if (subcommand === 'tag') {
     const version = versionFor('tag');
     try {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -3,24 +3,39 @@
 /**
  * Release script for Rundock (tag-and-let-CI-build model).
  *
- * Bumps the version, promotes the CHANGELOG `## Unreleased` block to a versioned
- * heading, commits, pushes main, and pushes a `v<version>` tag. The GitHub Actions
- * release workflow (.github/workflows/release.yml) then builds, signs, notarises,
- * and publishes a DRAFT GitHub release for that tag. Building no longer happens on
- * your laptop.
+ * A release is three commands, and the gaps between them are the point.
  *
- * After this script: watch the Actions run, then review and publish the draft
- * release. Update the Rundock Site download links once the release is published.
+ *   npm run release:gate                    # the full gauntlet, on the candidate
+ *   npm run release -- prepare <version>    # bump, promote the changelog, open a pull request
+ *   ...review and merge that pull request...
+ *   npm run release -- tag <version>        # tag the merged commit, which starts the build
+ *   ...watch the build, review the draft it publishes...
+ *   npm run release -- publish <version>    # publish the reviewed draft
  *
- * Usage:
- *   npm run release -- <version>     (e.g. npm run release -- 0.8.14)
+ * WHY IT IS NOT ONE COMMAND. It used to be: bump, commit, push main, tag. main
+ * requires status checks with admin enforcement, so that push is rejected every
+ * time and the command could never finish. Teaching it to open a pull request
+ * and wait would keep one command at the cost of burying a real approval point,
+ * so the split is where the human already was.
  *
- * Recovery: if the CI build fails (e.g. an expired Apple agreement), fix the cause
- * and re-run the workflow on the same tag (gh run rerun, or the Actions UI). There
- * is no need to revert main: the bump + tag stay, and CI publishes once it passes.
+ * The gate governs the commit being released and is checked in `prepare`,
+ * before the bump commit exists. It is deliberately NOT re-checked in `tag`:
+ * the tagged commit is always one past the gated one, because the bump sits on
+ * top of it, and it only touches package.json and CHANGELOG.md. What `tag`
+ * checks instead is that the reviewed commit really is on origin/main.
  *
- * No Apple/signing credentials are needed locally any more; those live in GitHub
- * Secrets are provided by the CI environment (see the repository CI settings).
+ * `tag` is the irreversible step. Everything before it can be deleted and done
+ * again; the tag starts the GitHub Actions workflow that builds, signs,
+ * notarises, and publishes a DRAFT release. Building does not happen on your
+ * laptop, and no Apple or signing credentials are needed locally: those live in
+ * the CI environment.
+ *
+ * Recovery: if the CI build fails (e.g. an expired Apple agreement), fix the
+ * cause and re-run the workflow on the same tag (gh run rerun, or the Actions
+ * UI). There is no need to revert main: the bump and the tag stay, and CI
+ * publishes once it passes.
+ *
+ * Update the Rundock Site download links once the release is published.
  */
 
 const { execFileSync } = require('child_process');
@@ -57,17 +72,6 @@ const git = gitIn(ROOT);
 // ---------------------------------------------------------------------------
 // Steps
 // ---------------------------------------------------------------------------
-
-function getVersion() {
-  const version = process.argv[2];
-  if (!version) {
-    fail('version', 'Usage: npm run release -- <version> (e.g. npm run release -- 0.8.14)');
-  }
-  if (!/^\d+\.\d+\.\d+$/.test(version)) {
-    fail('version', `Invalid version "${version}". Expected semver MAJOR.MINOR.PATCH (e.g. 0.8.14).`);
-  }
-  return version;
-}
 
 // Must be on main, fully clean tree, in sync with origin, and the tag must not
 // already exist. Runs BEFORE any file is modified so a failed pre-flight leaves
@@ -478,34 +482,57 @@ function tagRelease(version, { root = ROOT, git = gitIn(root), log = logStep } =
   return { tag, sha: merged };
 }
 
-function commitTagPush(version) {
-  const tag = `v${version}`;
-  try {
-    git(['add', 'package.json', 'CHANGELOG.md'], { stdio: 'inherit' });
-    git(['commit', '-m', `chore: release ${version}`], { stdio: 'inherit' });
-    git(['push', 'origin', 'main'], { stdio: 'inherit' });
-    git(['tag', tag], { stdio: 'inherit' });
-    git(['push', 'origin', tag], { stdio: 'inherit' });
-  } catch (err) {
-    fail('push', `git commit/tag/push failed: ${err.message}`);
-  }
-  logStep('push', `Committed, pushed main, and pushed tag ${tag}`);
-}
-
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
+const USAGE = [
+  'Usage:',
+  '  npm run release -- prepare <version>   bump, promote the changelog, and open the release pull request',
+  '  npm run release -- tag <version>       after that pull request merges, tag the merged commit',
+  '  npm run release -- publish <version>   publish the draft release CI built for that tag',
+].join('\n');
+
 // Guarded so the changelog helpers are requireable (by tests and by
 // scripts/release-notes.js) without starting a release.
 if (require.main === module) {
-  if (process.argv[2] === 'publish') {
-    // npm run release -- publish <version>
-    // Publishes the reviewed draft, binding the tag before the draft flip.
-    const version = process.argv[3];
-    if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
-      fail('publish', 'Usage: npm run release -- publish <version> (e.g. npm run release -- publish 0.11.7)');
+  const [subcommand, arg] = process.argv.slice(2);
+
+  const versionFor = (step) => {
+    if (!arg || !/^\d+\.\d+\.\d+$/.test(arg)) {
+      fail(step, `Usage: npm run release -- ${step} <version> (e.g. npm run release -- ${step} 0.12.0)`);
     }
+    return arg;
+  };
+
+  if (subcommand === 'prepare') {
+    const version = versionFor('prepare');
+    let result;
+    try {
+      result = prepareRelease(version);
+    } catch (err) {
+      fail('prepare', err.message);
+    }
+    console.log('');
+    logStep('done', `${version} is prepared on ${result.branch}: ${result.pullRequest || 'the pull request is open'}`);
+    logStep('done', 'The required checks run on that pull request. Review it and merge it.');
+    logStep('done', `Then tag the merged commit with: npm run release -- tag ${version}`);
+  } else if (subcommand === 'tag') {
+    const version = versionFor('tag');
+    try {
+      tagRelease(version);
+    } catch (err) {
+      fail('tag', err.message);
+    }
+    console.log('');
+    logStep('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
+    logStep('done', `Watch the build:   https://github.com/${REPO}/actions`);
+    logStep('done', `Review the draft:  https://github.com/${REPO}/releases`);
+    logStep('done', `Then publish with: npm run release -- publish ${version}  (binds the tag before flipping the draft flag)`);
+    logStep('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+  } else if (subcommand === 'publish') {
+    // Publishes the reviewed draft, binding the tag before the draft flip.
+    const version = versionFor('publish');
     try {
       const result = publishRelease(version);
       console.log('');
@@ -514,35 +541,13 @@ if (require.main === module) {
     } catch (err) {
       fail('publish', err.message);
     }
+  } else if (/^\d+\.\d+\.\d+$/.test(subcommand || '')) {
+    // The form this script used to take. It pushed the bump straight to main,
+    // which a protected branch refuses, so it cannot be made to work: say what
+    // replaced it rather than start something that dies halfway through.
+    fail('usage', `A release is now two commands, because the bump goes through a pull request like any other change.\n${USAGE}`);
   } else {
-    const version = getVersion();
-    try {
-      preflight(version);
-    } catch (err) {
-      fail('preflight', err.message);
-    }
-    // The gate governs the SHA being tagged: check it BEFORE the version-bump
-    // commit is created (that commit only adds package.json + CHANGELOG.md on
-    // top of the gated code).
-    try {
-      requireGatePass(git(['rev-parse', 'HEAD']).trim());
-    } catch (err) {
-      fail('gate', err.message);
-    }
-    setVersion(version);
-    try {
-      promoteUnreleasedChangelog(version);
-    } catch (err) {
-      fail('changelog', err.message);
-    }
-    commitTagPush(version);
-
-    console.log('');
-    logStep('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
-    logStep('done', `Watch the build:   https://github.com/${REPO}/actions`);
-    logStep('done', `Review the draft:  https://github.com/${REPO}/releases`);
-    logStep('done', `Then publish with: npm run release -- publish ${version}  (binds the tag before flipping the draft flag)`);
-    logStep('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+    fail('usage', `${subcommand ? `Unknown subcommand "${subcommand}".` : 'No subcommand given.'}\n${USAGE}`);
   }
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -288,6 +288,113 @@ function promoteUnreleasedChangelog(version, { root = ROOT, log = logStep } = {}
   return newHeading;
 }
 
+// ---------------------------------------------------------------------------
+// Prepare subcommand
+// ---------------------------------------------------------------------------
+
+// Default transport for `gh` invocations that are not API calls. Injected as an
+// option so the prepare flow can be exercised without reaching GitHub, which is
+// the same arrangement publishRelease uses for its API transport.
+function ghCli(root = ROOT) {
+  return (args) => execFileSync('gh', args, { cwd: root, encoding: 'utf8' });
+}
+
+// Short, factual, and held to the same writing rules as anything committed:
+// this text is published under the project's name.
+function pullRequestBody(version, { gatedSha, heading, branch }) {
+  const entry = heading.replace(/^##\s*/, '');
+  return [
+    `Version bump and changelog promotion for ${version}, and nothing else. The commit sits on top of ${gatedSha.slice(0, 9)}, which is the commit the release gate passed on.`,
+    '',
+    `Promoted changelog heading: ${entry}`,
+    `Full entry: https://github.com/${REPO}/blob/${branch}/CHANGELOG.md`,
+    '',
+    `Branch protection requires the checks on this pull request to pass before it can merge, so there is nothing further to run locally. Once it has merged, \`npm run release -- tag ${version}\` tags the merged commit on main, and that tag is what starts the build, sign, notarise and draft publish workflow.`,
+    '',
+  ].join('\n');
+}
+
+// Everything up to the point a human has to look at something: preflight, gate
+// check, version bump, changelog promotion, a commit on `release/<version>`,
+// the branch pushed, and a pull request opened against main. It does not push
+// to main and it does not tag. Throws so it is unit-testable; the main flow
+// converts to fail().
+function prepareRelease(version, { root = ROOT, git = gitIn(root), gh = ghCli(root), log = logStep } = {}) {
+  preflight(version, { root, git });
+
+  // The gate governs the SHA being released: check it BEFORE the version-bump
+  // commit is created, because that commit only adds package.json and
+  // CHANGELOG.md on top of the gated code.
+  const gatedSha = git(['rev-parse', 'HEAD']).trim();
+  requireGatePass(gatedSha, { root });
+
+  const branch = `release/${version}`;
+  if (git(['branch', '--list', branch]).trim()) {
+    throw new Error(`Branch ${branch} already exists locally. Delete it, or finish the release it belongs to.`);
+  }
+  if (git(['ls-remote', '--heads', 'origin', branch]).trim()) {
+    throw new Error(`Branch ${branch} already exists on the remote. An earlier prepare got that far; review its pull request rather than starting again.`);
+  }
+
+  // The push is the boundary between what can be wound back and what cannot.
+  // Before it, the only changes anywhere are the ones made below, because the
+  // preflight proved the tree was clean, so a failure restores exactly what
+  // this function wrote and nothing of anyone else's. After it, the branch is
+  // on the remote and somebody may already be reading it, so the failure says
+  // what exists rather than tidying it away.
+  let pushed = false;
+  try {
+    git(['checkout', '-b', branch], { stdio: 'pipe' });
+    setVersion(version, { root, log });
+    const heading = promoteUnreleasedChangelog(version, { root, log });
+    git(['add', 'package.json', 'CHANGELOG.md'], { stdio: 'pipe' });
+    git(['commit', '-m', `chore: release ${version}`], { stdio: 'pipe' });
+    git(['push', '-u', 'origin', branch], { stdio: 'pipe' });
+    pushed = true;
+    log('prepare', `Pushed ${branch}`);
+
+    const out = gh([
+      'pr', 'create',
+      '--base', 'main',
+      '--head', branch,
+      '--title', `Prepare the ${version} release`,
+      '--body', pullRequestBody(version, { gatedSha, heading, branch }),
+    ]);
+    const pullRequest = String(out || '').trim().split('\n').filter(Boolean).pop() || '';
+    log('prepare', `Opened ${pullRequest || 'the pull request'}`);
+    return { branch, gatedSha, heading, pullRequest };
+  } catch (err) {
+    if (pushed) {
+      throw new Error(
+        `${err.message}\n\nThe branch ${branch} is pushed and carries the release commit, but the pull request was not opened. ` +
+        `Open it against main by hand, or delete the branch and run prepare again. No tag exists either way.`
+      );
+    }
+    const restored = restoreMain(branch, { git });
+    throw new Error(
+      `${err.message}\n\n${restored}`
+    );
+  }
+}
+
+// Put the repository back on main as the preflight found it. Safe only because
+// the preflight refuses a dirty tree, so the sole thing discarded here is the
+// version bump and changelog promotion this run just wrote.
+function restoreMain(branch, { git }) {
+  try {
+    git(['checkout', '--force', 'main'], { stdio: 'pipe' });
+    if (git(['branch', '--list', branch]).trim()) {
+      git(['branch', '-D', branch], { stdio: 'pipe' });
+    }
+    return 'Nothing was pushed. The working tree is back on main as it was, and no tag exists.';
+  } catch (err) {
+    return (
+      `Nothing was pushed, and winding the working tree back failed as well: ${err.message}. ` +
+      `Check "git status" and "git branch" before running prepare again.`
+    );
+  }
+}
+
 function commitTagPush(version) {
   const tag = `v${version}`;
   try {
@@ -356,4 +463,12 @@ if (require.main === module) {
   }
 }
 
-module.exports = { extractChangelogEntry, promoteUnreleasedChangelog, requireGatePass, publishRelease, ghApiArgs };
+module.exports = {
+  extractChangelogEntry,
+  promoteUnreleasedChangelog,
+  preflight,
+  requireGatePass,
+  prepareRelease,
+  publishRelease,
+  ghApiArgs,
+};

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -36,7 +36,7 @@ const REPO = 'liamdarmody/rundock';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function log(step, msg) {
+function logStep(step, msg) {
   console.log(`[release:${step}] ${msg}`);
 }
 
@@ -45,9 +45,14 @@ function fail(step, msg) {
   process.exit(1);
 }
 
-function git(args, opts = {}) {
-  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8', ...opts });
+// A git runner bound to one repository. Every step takes its runner as an
+// option so the release flow can be exercised end to end against a throwaway
+// repository in a temp directory rather than against this checkout.
+function gitIn(root) {
+  return (args, opts = {}) => execFileSync('git', args, { cwd: root, encoding: 'utf8', ...opts });
 }
+
+const git = gitIn(ROOT);
 
 // ---------------------------------------------------------------------------
 // Steps
@@ -66,36 +71,37 @@ function getVersion() {
 
 // Must be on main, fully clean tree, in sync with origin, and the tag must not
 // already exist. Runs BEFORE any file is modified so a failed pre-flight leaves
-// the working tree untouched.
-function preflight(version) {
+// the working tree untouched. Throws so it is unit-testable; the main flow
+// converts to fail().
+function preflight(version, { root = ROOT, git = gitIn(root) } = {}) {
   let branch;
   try {
     branch = git(['symbolic-ref', '--short', 'HEAD']).trim();
   } catch (err) {
-    fail('preflight', `Could not determine current branch: ${err.message}`);
+    throw new Error(`Could not determine current branch: ${err.message}`);
   }
   if (branch !== 'main') {
-    fail('preflight', `Must be on main to release (currently on "${branch}").`);
+    throw new Error(`Must be on main to release (currently on "${branch}").`);
   }
 
   const status = git(['status', '--porcelain']).trim();
   if (status) {
-    fail('preflight', `Working tree is not clean. Commit or stash changes before releasing:\n${status}`);
+    throw new Error(`Working tree is not clean. Commit or stash changes before releasing:\n${status}`);
   }
 
   try {
     git(['fetch', 'origin', 'main'], { stdio: 'pipe' });
   } catch (err) {
-    fail('preflight', `git fetch origin main failed: ${err.message}`);
+    throw new Error(`git fetch origin main failed: ${err.message}`);
   }
   const behind = git(['rev-list', '--count', 'HEAD..origin/main']).trim();
   if (parseInt(behind, 10) > 0) {
-    fail('preflight', `Local main is ${behind} commit(s) behind origin/main. Pull before releasing.`);
+    throw new Error(`Local main is ${behind} commit(s) behind origin/main. Pull before releasing.`);
   }
 
   const tag = `v${version}`;
   if (git(['tag', '-l', tag]).trim()) {
-    fail('preflight', `Tag ${tag} already exists locally. Choose a new version or delete the tag.`);
+    throw new Error(`Tag ${tag} already exists locally. Choose a new version or delete the tag.`);
   }
 }
 
@@ -192,8 +198,8 @@ function publishRelease(version, { api = ghApi, log = (msg) => console.log(`[rel
   return { id: draft.id, tag, url: published.html_url };
 }
 
-function setVersion(version) {
-  const pkgPath = path.join(ROOT, 'package.json');
+function setVersion(version, { root = ROOT, log = logStep } = {}) {
+  const pkgPath = path.join(root, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
   pkg.version = version;
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
@@ -234,29 +240,34 @@ function extractChangelogEntry(version, changelogText) {
 // Promote the `## Unreleased` heading to the versioned heading for this release.
 // If `## ${version}:` already exists, no-op. If neither exists, abort: we must
 // not release without notes. The release name is read from a `**Name:**` line.
-function promoteUnreleasedChangelog(version) {
-  const changelogPath = path.join(ROOT, 'CHANGELOG.md');
+// Returns the versioned heading it wrote, or the one already present, so the
+// caller can quote it without re-parsing the file. Throws so it is
+// unit-testable; the main flow converts to fail().
+function promoteUnreleasedChangelog(version, { root = ROOT, log = logStep } = {}) {
+  const changelogPath = path.join(root, 'CHANGELOG.md');
   if (!fs.existsSync(changelogPath)) {
-    fail('changelog', `CHANGELOG.md not found at ${changelogPath}`);
+    throw new Error(`CHANGELOG.md not found at ${changelogPath}`);
   }
   const original = fs.readFileSync(changelogPath, 'utf8');
 
-  const versionHeadingRe = new RegExp(`^## ${version.replace(/\./g, '\\.')}:`, 'm');
-  if (versionHeadingRe.test(original)) {
+  const versionHeadingRe = new RegExp(`^## ${version.replace(/\./g, '\\.')}:.*$`, 'm');
+  const alreadyPromoted = original.match(versionHeadingRe);
+  if (alreadyPromoted) {
     log('changelog', `Versioned heading for ${version} already present, skipping promotion`);
-    return;
+    return alreadyPromoted[0];
   }
 
   const unreleasedRe = /^## Unreleased[ \t]*$/m;
   if (!unreleasedRe.test(original)) {
-    fail(
-      'changelog',
+    throw new Error(
       `No "## Unreleased" block and no "## ${version}:" block in CHANGELOG.md. ` +
       `Add release notes under "## Unreleased" before running release.`
     );
   }
 
-  const entry = extractChangelogEntry('Unreleased');
+  // Parse the block we already have in memory rather than re-reading the file,
+  // which is what makes this work against any root, not only this checkout.
+  const entry = extractChangelogEntry('Unreleased', original);
   const nameMatch = entry && entry.body.match(/^\s*\*\*Name:\*\*\s*(.+?)\s*$/m);
   let name;
   if (nameMatch) {
@@ -274,6 +285,7 @@ function promoteUnreleasedChangelog(version) {
 
   fs.writeFileSync(changelogPath, updated, 'utf8');
   log('changelog', `Promoted "## Unreleased" to "${newHeading}"`);
+  return newHeading;
 }
 
 function commitTagPush(version) {
@@ -287,7 +299,7 @@ function commitTagPush(version) {
   } catch (err) {
     fail('push', `git commit/tag/push failed: ${err.message}`);
   }
-  log('push', `Committed, pushed main, and pushed tag ${tag}`);
+  logStep('push', `Committed, pushed main, and pushed tag ${tag}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -307,14 +319,18 @@ if (require.main === module) {
     try {
       const result = publishRelease(version);
       console.log('');
-      log('done', `v${version} is live: ${result.url || `https://github.com/${REPO}/releases`}`);
-      log('done', 'Site download links resolve via /releases/latest; no bump needed.');
+      logStep('done', `v${version} is live: ${result.url || `https://github.com/${REPO}/releases`}`);
+      logStep('done', 'Site download links resolve via /releases/latest; no bump needed.');
     } catch (err) {
       fail('publish', err.message);
     }
   } else {
     const version = getVersion();
-    preflight(version);
+    try {
+      preflight(version);
+    } catch (err) {
+      fail('preflight', err.message);
+    }
     // The gate governs the SHA being tagged: check it BEFORE the version-bump
     // commit is created (that commit only adds package.json + CHANGELOG.md on
     // top of the gated code).
@@ -324,15 +340,19 @@ if (require.main === module) {
       fail('gate', err.message);
     }
     setVersion(version);
-    promoteUnreleasedChangelog(version);
+    try {
+      promoteUnreleasedChangelog(version);
+    } catch (err) {
+      fail('changelog', err.message);
+    }
     commitTagPush(version);
 
     console.log('');
-    log('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
-    log('done', `Watch the build:   https://github.com/${REPO}/actions`);
-    log('done', `Review the draft:  https://github.com/${REPO}/releases`);
-    log('done', `Then publish with: npm run release -- publish ${version}  (binds the tag before flipping the draft flag)`);
-    log('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
+    logStep('done', `Tagged v${version}. GitHub Actions is now building, signing, notarising, and publishing a DRAFT release.`);
+    logStep('done', `Watch the build:   https://github.com/${REPO}/actions`);
+    logStep('done', `Review the draft:  https://github.com/${REPO}/releases`);
+    logStep('done', `Then publish with: npm run release -- publish ${version}  (binds the tag before flipping the draft flag)`);
+    logStep('done', `If CI fails (e.g. expired Apple agreement): fix it and re-run the workflow on tag v${version}: no need to revert main.`);
   }
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -395,6 +395,89 @@ function restoreMain(branch, { git }) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Tag subcommand
+// ---------------------------------------------------------------------------
+
+// Run after the prepare pull request has been reviewed and merged. It cannot
+// assume the merge landed just because it was asked to run, so it reads the
+// state of `origin/main` and refuses unless the release commit is actually
+// there. Tagging is the irreversible half of a release: the tag is what starts
+// the build, sign, notarise and draft publish workflow.
+//
+// THE GATE IS DELIBERATELY NOT RE-RUN HERE. The tagged commit is always one
+// past the gated one, because the bump commit sits on top of it, so a gate
+// check at this point would be gating a commit that only touches package.json
+// and CHANGELOG.md. The gate check happens once, in prepare, against the
+// pre-bump commit, which is where it has always happened.
+//
+// Throws so it is unit-testable; the main flow converts to fail().
+function tagRelease(version, { root = ROOT, git = gitIn(root), log = logStep } = {}) {
+  const tag = `v${version}`;
+
+  // On main, clean tree, not behind origin, and the tag not already local.
+  preflight(version, { root, git });
+
+  // The tag must land on the reviewed commit, so local main has to BE that
+  // commit rather than merely contain it: the preflight rules out being behind,
+  // and this rules out being ahead.
+  const head = git(['rev-parse', 'HEAD']).trim();
+  const merged = git(['rev-parse', 'origin/main']).trim();
+  if (head !== merged) {
+    throw new Error(
+      `Local main is at ${head.slice(0, 9)} but origin/main is at ${merged.slice(0, 9)}. ` +
+      `The tag must land on the reviewed commit, so local main must carry nothing of its own.`
+    );
+  }
+
+  let pkg;
+  try {
+    pkg = JSON.parse(git(['show', `${merged}:package.json`]));
+  } catch (err) {
+    throw new Error(`Could not read package.json at origin/main: ${err.message}`);
+  }
+  if (pkg.version !== version) {
+    throw new Error(
+      `package.json at origin/main is ${pkg.version}, not ${version}. ` +
+      `The prepare pull request for ${version} has not merged yet: run "npm run release -- prepare ${version}" first, then merge it.`
+    );
+  }
+
+  // The version alone is not proof the release commit landed. A tree with the
+  // bump but no promoted heading would publish a release with empty notes,
+  // which is the failure the changelog promotion exists to prevent.
+  const changelog = git(['show', `${merged}:CHANGELOG.md`]);
+  const headingRe = new RegExp(`^## ${version.replace(/\./g, '\\.')}:`, 'm');
+  if (!headingRe.test(changelog)) {
+    throw new Error(
+      `CHANGELOG.md at origin/main has no "## ${version}:" heading, so the changelog promotion is not on main. ` +
+      `Tagging now would publish a release with no notes.`
+    );
+  }
+
+  if (git(['ls-remote', '--tags', 'origin', `refs/tags/${tag}`]).trim()) {
+    throw new Error(`Tag ${tag} already exists on the remote. Choose a new version, or recut deliberately by deleting it first.`);
+  }
+
+  git(['tag', tag], { stdio: 'pipe' });
+  try {
+    git(['push', 'origin', tag], { stdio: 'pipe' });
+  } catch (err) {
+    // Leave nothing tagged anywhere. A local tag left behind would make the
+    // next attempt fail the preflight instead of retrying the push.
+    let cleanup = 'The local tag has been removed, so nothing is tagged anywhere.';
+    try {
+      git(['tag', '-d', tag], { stdio: 'pipe' });
+    } catch (deleteErr) {
+      cleanup = `The local tag could not be removed either (${deleteErr.message}); delete it with "git tag -d ${tag}" before trying again.`;
+    }
+    throw new Error(`Pushing ${tag} failed: ${err.message}\n\n${cleanup}`);
+  }
+
+  log('tag', `Tagged ${tag} on ${merged.slice(0, 9)} and pushed it`);
+  return { tag, sha: merged };
+}
+
 function commitTagPush(version) {
   const tag = `v${version}`;
   try {
@@ -469,6 +552,7 @@ module.exports = {
   preflight,
   requireGatePass,
   prepareRelease,
+  tagRelease,
   publishRelease,
   ghApiArgs,
 };

--- a/test/unit/precommit-gate.test.js
+++ b/test/unit/precommit-gate.test.js
@@ -387,11 +387,12 @@ describe('the default branch is read from the remote, not assumed', () => {
 });
 
 describe('the release commit is the one thing allowed on the default branch', () => {
-  // scripts/release.js bumps the version, promotes the changelog and commits
-  // straight to main. That is by design, and on the day this guard merged it
-  // stopped `npm run release` dead: the version was bumped, the changelog
-  // promoted, and the commit refused. A gate that blocks the release tool
-  // shipping beside it is not protecting anything.
+  // release.js used to commit the bump straight to main, and on the day this
+  // guard merged it stopped the release dead: the version was bumped, the
+  // changelog promoted, and the commit refused. A gate that blocks the release
+  // tool shipping beside it is not protecting anything. That commit is now made
+  // on a release branch instead, and the exception below stays for the
+  // hand-edited version or changelog that still reaches main without one.
   const onMain = (staged) => refusal({
     record: null, tree: TREE, branch: MAIN, mainBranch: MAIN, staged,
   });
@@ -433,6 +434,53 @@ describe('the release commit is the one thing allowed on the default branch', ()
   });
 });
 
+describe('the release commit is admitted on the branch it is now made on', () => {
+  // The release commit moved. main is protected and refuses a direct push, so
+  // release.js commits the bump on `release/<version>` and puts it through a
+  // pull request. The exception has to follow it there, or the tool ships
+  // beside a gate that blocks it, which is the state this exception was written
+  // to prevent in the first place.
+  const onReleaseBranch = (staged, branch = 'release/0.12.0') => refusal({
+    record: null, tree: TREE, branch, mainBranch: MAIN, staged,
+  });
+
+  test('the release footprint needs no record on a release branch', () => {
+    assert.strictEqual(onReleaseBranch(['package.json', 'CHANGELOG.md']), null);
+    assert.strictEqual(onReleaseBranch(['package.json']), null);
+    assert.strictEqual(onReleaseBranch(['CHANGELOG.md']), null);
+  });
+
+  test('anything else alongside it still needs a record', () => {
+    // Same rule as on the default branch: the exception is the footprint, not
+    // the branch name. A source file riding along faces the normal checks.
+    assert.strictEqual(onReleaseBranch(['package.json', 'server.js']).code, 'no-record');
+    assert.strictEqual(onReleaseBranch(['server.js']).code, 'no-record');
+  });
+
+  test('an empty staging area is not a release commit here either', () => {
+    assert.strictEqual(onReleaseBranch([]).code, 'no-record');
+  });
+
+  test('only the exact branch release.js creates is admitted', () => {
+    // `release/<semver>` is the name prepare builds and nothing else. A branch
+    // that merely starts with the word would be a name anybody could adopt to
+    // skip the checks.
+    assert.strictEqual(onReleaseBranch(['package.json'], 'release/next').code, 'no-record');
+    assert.strictEqual(onReleaseBranch(['package.json'], 'release/0.12.0-rc1').code, 'no-record');
+    assert.strictEqual(onReleaseBranch(['package.json'], 'releases/0.12.0').code, 'no-record');
+    assert.strictEqual(onReleaseBranch(['package.json'], 'fix/release/0.12.0').code, 'no-record');
+  });
+
+  test('a record still wins where one exists', () => {
+    // The exception is a floor, not a ceiling: an ordinary commit on a release
+    // branch with a matching record proceeds as it always would.
+    assert.strictEqual(refusal({
+      record: { ...ok, branch: 'release/0.12.0' }, tree: TREE,
+      branch: 'release/0.12.0', mainBranch: MAIN, staged: ['server.js'],
+    }), null);
+  });
+});
+
 describe('the release commit, through the real entry point on real git', () => {
   // Everything above hands refusal() a staged array built by hand, which is a
   // double for what stagedPaths() returns. That proves the decision and not the
@@ -464,6 +512,43 @@ describe('the release commit, through the real entry point on real git', () => {
 
       const { code, out } = spawnGate(['--verify'], dir);
       assert.strictEqual(code, 0, `the release commit must be admitted, got: ${out}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the real hook admits the release commit on a release branch, with no record', () => {
+    // The path the release actually takes now: the bump is committed on
+    // release/<version> and reaches main through a pull request. Asserted
+    // through the real entry point because the branch name comes from git here,
+    // not from an argument written by hand.
+    const { dir, run } = repoOnDefaultBranch();
+    try {
+      run('checkout', '-q', '-b', 'release/1.0.1');
+      const pkg = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+      pkg.version = '1.0.1';
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2));
+      fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), '# Changelog\n\n## 1.0.1 (today)\n');
+      run('add', 'package.json', 'CHANGELOG.md');
+
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.strictEqual(code, 0, `the release commit must be admitted, got: ${out}`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('the real hook refuses a source file riding along on a release branch', () => {
+    const { dir, run } = repoOnDefaultBranch();
+    try {
+      run('checkout', '-q', '-b', 'release/1.0.1');
+      fs.writeFileSync(path.join(dir, 'CHANGELOG.md'), '# Changelog\n\n## 1.0.1 (today)\n');
+      fs.writeFileSync(path.join(dir, 'server.js'), '// snuck in\n');
+      run('add', 'CHANGELOG.md', 'server.js');
+
+      const { code, out } = spawnGate(['--verify'], dir);
+      assert.notStrictEqual(code, 0, 'a source file on a release branch faces the normal checks');
+      assert.match(out, /checks have not been run/);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit/release-prepare-tag.test.js
+++ b/test/unit/release-prepare-tag.test.js
@@ -1,0 +1,286 @@
+'use strict';
+// The two halves of a release cut, exercised against a real repository.
+//
+// Why the split exists: `main` requires status checks with admin enforcement,
+// so a release step that pushes straight to `main` cannot complete. It bumped
+// the version, promoted the changelog, committed, and died on the rejected
+// push. The bump now travels through a pull request like any other change, and
+// the tag is a second command run after that pull request has merged.
+//
+// These tests build a throwaway repository with a real bare origin in a temp
+// directory and run the real functions against it, so the assertions are about
+// what git actually holds afterwards rather than about which commands were
+// called. The one thing stubbed is the pull request creation, which is the
+// only step that would reach GitHub.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { prepareRelease } = require('../../scripts/release.js');
+const { GATE_FILE_NAME } = require('../../scripts/release-gate.js');
+
+const CHANGELOG = `# Changelog
+
+## Unreleased
+
+**Name:** Foundations
+
+### Fixed
+
+- A user visible fix.
+
+## 0.11.8: Previous Release (2026-08-20)
+
+- Older notes.
+`;
+
+let dir;
+let origin;
+let work;
+
+function run(cmd, args, cwd) {
+  return execFileSync(cmd, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+// A git runner bound to one repository, matching the shape the release steps
+// take as an option.
+function gitAt(root) {
+  return (args) => run('git', args, root);
+}
+
+const inWork = (args) => gitAt(work)(args).trim();
+const inOrigin = (args) => gitAt(origin)(args).trim();
+
+// Records every call and reports success, standing in for `gh pr create`.
+function fakeGh(result = 'https://github.com/liamdarmody/rundock/pull/999\n') {
+  const calls = [];
+  const gh = (args) => {
+    calls.push(args);
+    if (result instanceof Error) throw result;
+    return result;
+  };
+  gh.calls = calls;
+  return gh;
+}
+
+function writeGateRecord(sha, { live = true } = {}) {
+  fs.writeFileSync(path.join(work, GATE_FILE_NAME), JSON.stringify({
+    sha, live, passedAt: '2026-08-26T09:00:00Z', wallClockSeconds: 900, steps: [],
+  }));
+}
+
+function gateOnHead() {
+  writeGateRecord(inWork(['rev-parse', 'HEAD']));
+}
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-flow-'));
+  origin = path.join(dir, 'origin.git');
+  work = path.join(dir, 'work');
+
+  run('git', ['init', '--bare', '--initial-branch=main', origin], dir);
+  run('git', ['init', '--initial-branch=main', work], dir);
+  const git = gitAt(work);
+  git(['config', 'user.email', 'release-test@example.com']);
+  git(['config', 'user.name', 'Release Test']);
+  git(['config', 'commit.gpgsign', 'false']);
+
+  fs.writeFileSync(path.join(work, 'package.json'), JSON.stringify({ name: 'rundock', version: '0.11.8' }, null, 2) + '\n');
+  fs.writeFileSync(path.join(work, 'CHANGELOG.md'), CHANGELOG);
+  // The gate record is ignored in the real repository, and has to be here too:
+  // an untracked file makes the tree dirty, which the preflight refuses.
+  fs.writeFileSync(path.join(work, '.gitignore'), `${GATE_FILE_NAME}\n`);
+  git(['add', '-A']);
+  git(['commit', '-m', 'initial']);
+  git(['remote', 'add', 'origin', origin]);
+  git(['push', '-u', 'origin', 'main']);
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('release:prepare puts the version bump through a pull request', () => {
+  test('no gate record: refuses before touching anything', () => {
+    const gh = fakeGh();
+    const mainBefore = inOrigin(['rev-parse', 'main']);
+
+    assert.throws(() => prepareRelease('0.12.0', { root: work, gh, log: () => {} }), /release:gate/);
+
+    assert.strictEqual(inOrigin(['rev-parse', 'main']), mainBefore, 'origin/main untouched');
+    assert.strictEqual(inWork(['status', '--porcelain']), '', 'working tree untouched');
+    assert.strictEqual(gh.calls.length, 0, 'no pull request attempted');
+  });
+
+  test('a gate record for another commit: refuses, naming both commits', () => {
+    writeGateRecord('deadbeefcafe');
+    assert.throws(
+      () => prepareRelease('0.12.0', { root: work, gh: fakeGh(), log: () => {} }),
+      /deadbeefcafe/
+    );
+  });
+
+  test('a gate record without live smoke: refuses', () => {
+    writeGateRecord(inWork(['rev-parse', 'HEAD']), { live: false });
+    assert.throws(
+      () => prepareRelease('0.12.0', { root: work, gh: fakeGh(), log: () => {} }),
+      /live/i
+    );
+  });
+
+  test('main receives no commit at all: the bump lands only on the release branch', () => {
+    gateOnHead();
+    const mainBefore = inOrigin(['rev-parse', 'main']);
+    const localMainBefore = inWork(['rev-parse', 'main']);
+
+    prepareRelease('0.12.0', { root: work, gh: fakeGh(), log: () => {} });
+
+    assert.strictEqual(inOrigin(['rev-parse', 'main']), mainBefore, 'origin/main did not move');
+    assert.strictEqual(inWork(['rev-parse', 'main']), localMainBefore, 'local main did not move');
+    assert.strictEqual(
+      inOrigin(['rev-parse', 'refs/heads/release/0.12.0']),
+      inWork(['rev-parse', 'HEAD']),
+      'the release branch is pushed and matches the local branch'
+    );
+  });
+
+  test('nothing is tagged: tagging is the second command, after the merge', () => {
+    gateOnHead();
+    prepareRelease('0.12.0', { root: work, gh: fakeGh(), log: () => {} });
+
+    assert.strictEqual(inWork(['tag', '-l']), '', 'no local tag');
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'no tag on the remote');
+  });
+
+  test('the branch commit carries the bump and the promoted changelog heading', () => {
+    gateOnHead();
+    prepareRelease('0.12.0', { root: work, gh: fakeGh(), log: () => {} });
+
+    const pkg = JSON.parse(inOrigin(['show', 'refs/heads/release/0.12.0:package.json']));
+    assert.strictEqual(pkg.version, '0.12.0');
+
+    const changelog = gitAt(origin)(['show', 'refs/heads/release/0.12.0:CHANGELOG.md']);
+    assert.match(changelog, /^## 0\.12\.0: Foundations \(\d{4}-\d{2}-\d{2}\)$/m, 'heading promoted and named');
+    assert.ok(!/^## Unreleased\s*$/m.test(changelog), 'the Unreleased heading is gone');
+    assert.ok(!/\*\*Name:\*\*/.test(changelog), 'the Name line is consumed by the heading');
+
+    const touched = inWork(['show', '--name-only', '--format=', 'HEAD']).split('\n').filter(Boolean).sort();
+    assert.deepStrictEqual(touched, ['CHANGELOG.md', 'package.json'], 'the release commit touches nothing else');
+  });
+
+  test('the pull request targets main from the release branch', () => {
+    gateOnHead();
+    const gh = fakeGh();
+    const result = prepareRelease('0.12.0', { root: work, gh, log: () => {} });
+
+    assert.strictEqual(gh.calls.length, 1, 'exactly one pull request');
+    const args = gh.calls[0];
+    assert.deepStrictEqual(args.slice(0, 2), ['pr', 'create']);
+    assert.strictEqual(args[args.indexOf('--base') + 1], 'main');
+    assert.strictEqual(args[args.indexOf('--head') + 1], 'release/0.12.0');
+    assert.match(result.pullRequest, /pull\/999/, 'the pull request URL is reported back');
+  });
+
+  test('the pull request text says the version, the gated commit, and what runs next', () => {
+    gateOnHead();
+    const gatedSha = inWork(['rev-parse', 'HEAD']);
+    const gh = fakeGh();
+    prepareRelease('0.12.0', { root: work, gh, log: () => {} });
+
+    const args = gh.calls[0];
+    const title = args[args.indexOf('--title') + 1];
+    const body = args[args.indexOf('--body') + 1];
+    assert.match(title, /0\.12\.0/);
+    assert.match(body, /0\.12\.0/);
+    assert.ok(body.includes(gatedSha.slice(0, 9)), 'the gated commit is named');
+    assert.match(body, /npm run release -- tag 0\.12\.0/, 'the next command is spelled out');
+    assert.match(body, /CHANGELOG\.md/, 'the promoted entry is linked');
+  });
+
+  test('the pull request text reads as public project writing', () => {
+    // Whatever this script posts under the project name is held to the same
+    // rules as anything committed: no em or en dashes, no session links, no
+    // generator byline, and no text addressing the person who runs it as a
+    // third party.
+    gateOnHead();
+    const gh = fakeGh();
+    prepareRelease('0.12.0', { root: work, gh, log: () => {} });
+    const args = gh.calls[0];
+    const text = `${args[args.indexOf('--title') + 1]}\n${args[args.indexOf('--body') + 1]}`;
+
+    // Written as escapes so the check that scans this repository for the same
+    // characters does not match the assertion looking for them.
+    assert.ok(!/[\u2014\u2013]/.test(text), 'no em or en dashes');
+    assert.ok(!/claude\.ai|Claude-Session|Generated with/i.test(text), 'no session link or generator byline');
+    assert.ok(!/\bLiam\b|\bthe owner\b|\bthe maintainer\b/i.test(text), 'nobody is addressed as a third party');
+  });
+
+  test('a release branch already on the remote is refused rather than pushed over', () => {
+    gateOnHead();
+    inWork(['branch', 'release/0.12.0']);
+    inWork(['push', 'origin', 'release/0.12.0']);
+    inWork(['branch', '-D', 'release/0.12.0']);
+
+    const gh = fakeGh();
+    assert.throws(
+      () => prepareRelease('0.12.0', { root: work, gh, log: () => {} }),
+      /release\/0\.12\.0/
+    );
+    assert.strictEqual(gh.calls.length, 0);
+  });
+
+  test('a failed branch push winds everything back and never reaches the pull request', () => {
+    // The reachable half-done state, asserted rather than assumed. The push is
+    // the boundary: before it, the repository is put back exactly as the
+    // preflight found it, which the preflight itself makes safe by proving the
+    // tree was clean.
+    gateOnHead();
+    const mainBefore = inOrigin(['rev-parse', 'main']);
+    const headBefore = inWork(['rev-parse', 'HEAD']);
+    const gh = fakeGh();
+    const git = (args) => {
+      if (args[0] === 'push') throw new Error('remote rejected the branch');
+      return gitAt(work)(args);
+    };
+
+    assert.throws(
+      () => prepareRelease('0.12.0', { root: work, git, gh, log: () => {} }),
+      /remote rejected the branch/
+    );
+
+    assert.strictEqual(gh.calls.length, 0, 'no pull request after a failed push');
+    assert.strictEqual(inWork(['tag', '-l']), '', 'no tag anywhere');
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'no tag on the remote');
+    assert.strictEqual(inOrigin(['rev-parse', 'main']), mainBefore, 'origin/main untouched');
+    assert.strictEqual(inOrigin(['branch', '--list', 'release/0.12.0']), '', 'no branch on the remote');
+    assert.strictEqual(inWork(['symbolic-ref', '--short', 'HEAD']), 'main', 'back on main');
+    assert.strictEqual(inWork(['rev-parse', 'HEAD']), headBefore, 'no commit left behind');
+    assert.strictEqual(inWork(['status', '--porcelain']), '', 'the bump is not left in the working tree');
+    assert.strictEqual(inWork(['branch', '--list', 'release/0.12.0']), '', 'no local branch left behind');
+  });
+
+  test('a failed pull request creation keeps the pushed branch and says so', () => {
+    // Past the push there is nothing safe to wind back: the branch is on the
+    // remote and somebody else may already be looking at it. The failure has to
+    // name that state instead of tidying it away.
+    gateOnHead();
+    const gh = fakeGh(new Error('gh: could not create pull request'));
+
+    assert.throws(
+      () => prepareRelease('0.12.0', { root: work, gh, log: () => {} }),
+      /release\/0\.12\.0/
+    );
+
+    assert.strictEqual(
+      inOrigin(['rev-parse', 'refs/heads/release/0.12.0']),
+      inWork(['rev-parse', 'HEAD']),
+      'the pushed branch is left alone'
+    );
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'still no tag');
+    assert.strictEqual(inOrigin(['rev-parse', 'main']), inWork(['rev-parse', 'main']), 'main still untouched');
+  });
+});

--- a/test/unit/release-prepare-tag.test.js
+++ b/test/unit/release-prepare-tag.test.js
@@ -20,7 +20,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
-const { prepareRelease } = require('../../scripts/release.js');
+const { prepareRelease, tagRelease } = require('../../scripts/release.js');
 const { GATE_FILE_NAME } = require('../../scripts/release-gate.js');
 
 const CHANGELOG = `# Changelog
@@ -282,5 +282,122 @@ describe('release:prepare puts the version bump through a pull request', () => {
     );
     assert.strictEqual(inOrigin(['tag', '-l']), '', 'still no tag');
     assert.strictEqual(inOrigin(['rev-parse', 'main']), inWork(['rev-parse', 'main']), 'main still untouched');
+  });
+});
+
+describe('release:tag tags what actually merged', () => {
+  // What a merged pull request leaves behind: the release commit reachable from
+  // main, pushed, with local main in step with it.
+  function mergeTheReleaseBranch(version) {
+    inWork(['checkout', 'main']);
+    inWork(['merge', '--no-ff', '-m', `Prepare the ${version} release (#42)`, `release/${version}`]);
+    inWork(['push', 'origin', 'main']);
+  }
+
+  function prepared(version = '0.12.0') {
+    gateOnHead();
+    prepareRelease(version, { root: work, gh: fakeGh(), log: () => {} });
+  }
+
+  test('the prepare pull request has not merged yet: refuses, naming both versions', () => {
+    prepared();
+    inWork(['checkout', 'main']);
+
+    assert.throws(
+      () => tagRelease('0.12.0', { root: work, log: () => {} }),
+      /0\.11\.8[\s\S]*0\.12\.0|0\.12\.0[\s\S]*0\.11\.8/
+    );
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'nothing tagged');
+  });
+
+  test('the bump merged but the changelog promotion did not: refuses, naming the changelog', () => {
+    // The version alone is not proof the release commit landed: a tag on this
+    // tree would publish a release whose notes were never promoted.
+    inWork(['checkout', 'main']);
+    fs.writeFileSync(path.join(work, 'package.json'), JSON.stringify({ name: 'rundock', version: '0.12.0' }, null, 2) + '\n');
+    inWork(['commit', '-am', 'bump the version only']);
+    inWork(['push', 'origin', 'main']);
+
+    assert.throws(
+      () => tagRelease('0.12.0', { root: work, log: () => {} }),
+      /CHANGELOG/
+    );
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'nothing tagged');
+  });
+
+  test('after the merge: exactly one tag, on the merged commit, pushed', () => {
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    const merged = inOrigin(['rev-parse', 'main']);
+
+    const result = tagRelease('0.12.0', { root: work, log: () => {} });
+
+    assert.strictEqual(result.tag, 'v0.12.0');
+    assert.strictEqual(inOrigin(['tag', '-l']), 'v0.12.0', 'exactly one tag on the remote');
+    assert.strictEqual(inOrigin(['rev-list', '-n', '1', 'v0.12.0']), merged, 'the tag is on the merged commit');
+  });
+
+  test('the tagged commit is the one carrying the version bump and the notes', () => {
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    tagRelease('0.12.0', { root: work, log: () => {} });
+
+    assert.strictEqual(JSON.parse(inOrigin(['show', 'v0.12.0:package.json'])).version, '0.12.0');
+    assert.match(gitAt(origin)(['show', 'v0.12.0:CHANGELOG.md']), /^## 0\.12\.0: Foundations \(/m);
+  });
+
+  test('no gate record is needed: the gate governs prepare, not the tag', () => {
+    // The tagged commit is always one past the gated one, because the bump
+    // commit sits on top of it. Re-running the gate here would mean gating a
+    // commit that only touches package.json and CHANGELOG.md, so the check
+    // belongs where it already is, in prepare, against the pre-bump commit.
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    fs.rmSync(path.join(work, GATE_FILE_NAME), { force: true });
+
+    assert.doesNotThrow(() => tagRelease('0.12.0', { root: work, log: () => {} }));
+    assert.strictEqual(inOrigin(['tag', '-l']), 'v0.12.0');
+  });
+
+  test('local main carrying an unpushed commit: refuses rather than tagging it', () => {
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    fs.writeFileSync(path.join(work, 'CHANGELOG.md'), `${CHANGELOG}\n<!-- local edit -->\n`);
+    inWork(['commit', '-am', 'a local commit nobody reviewed']);
+
+    assert.throws(() => tagRelease('0.12.0', { root: work, log: () => {} }), /origin\/main/);
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'nothing tagged');
+  });
+
+  test('the tag already exists: refuses', () => {
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    inWork(['tag', 'v0.12.0']);
+
+    assert.throws(() => tagRelease('0.12.0', { root: work, log: () => {} }), /v0\.12\.0/);
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'nothing pushed');
+  });
+
+  test('a dirty tree: refuses', () => {
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    fs.writeFileSync(path.join(work, 'CHANGELOG.md'), `${CHANGELOG}\nstray edit\n`);
+
+    assert.throws(() => tagRelease('0.12.0', { root: work, log: () => {} }), /clean/i);
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'nothing tagged');
+  });
+
+  test('a failed tag push leaves no tag behind, so running it again is not blocked', () => {
+    prepared();
+    mergeTheReleaseBranch('0.12.0');
+    const git = (args) => {
+      if (args[0] === 'push') throw new Error('the remote refused the tag');
+      return gitAt(work)(args);
+    };
+
+    assert.throws(() => tagRelease('0.12.0', { root: work, git, log: () => {} }), /refused the tag/);
+
+    assert.strictEqual(inOrigin(['tag', '-l']), '', 'no tag on the remote');
+    assert.strictEqual(inWork(['tag', '-l']), '', 'no local tag either, so a retry gets past the preflight');
   });
 });

--- a/test/unit/release-prepare-tag.test.js
+++ b/test/unit/release-prepare-tag.test.js
@@ -401,3 +401,49 @@ describe('release:tag tags what actually merged', () => {
     assert.strictEqual(inWork(['tag', '-l']), '', 'no local tag either, so a retry gets past the preflight');
   });
 });
+
+describe('the command line refuses the old one step form', () => {
+  // A release used to be one command, and that command pushed to main. It
+  // cannot work against a protected branch, so the bare form has to say what
+  // replaced it rather than start something that dies halfway. Every case here
+  // is refused before any git or gh call, which is why running the real script
+  // against this checkout is safe.
+  const RELEASE = path.join(__dirname, '..', '..', 'scripts', 'release.js');
+
+  function releaseCli(args) {
+    const res = require('node:child_process').spawnSync(process.execPath, [RELEASE, ...args], { encoding: 'utf8' });
+    return { code: res.status, out: `${res.stdout}${res.stderr}` };
+  }
+
+  test('a bare version names the two commands that replaced it', () => {
+    const { code, out } = releaseCli(['0.12.0']);
+    assert.strictEqual(code, 1);
+    assert.match(out, /prepare/);
+    assert.match(out, /tag/);
+  });
+
+  test('no arguments at all prints the usage', () => {
+    const { code, out } = releaseCli([]);
+    assert.strictEqual(code, 1);
+    assert.match(out, /prepare <version>/);
+    assert.match(out, /tag <version>/);
+    assert.match(out, /publish <version>/);
+  });
+
+  test('an unknown subcommand says which one it did not recognise', () => {
+    const { code, out } = releaseCli(['frobnicate', '0.12.0']);
+    assert.strictEqual(code, 1);
+    assert.match(out, /frobnicate/);
+  });
+
+  test('each subcommand requires a semver version', () => {
+    for (const subcommand of ['prepare', 'tag', 'publish']) {
+      const missing = releaseCli([subcommand]);
+      assert.strictEqual(missing.code, 1, `${subcommand} with no version`);
+      assert.match(missing.out, new RegExp(subcommand));
+
+      const nonsense = releaseCli([subcommand, 'v0.12']);
+      assert.strictEqual(nonsense.code, 1, `${subcommand} with a version that is not semver`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`npm run release -- <version>` used to bump the version, commit, and push directly to `main`. Branch protection on `main` requires 6 passing status checks, so that push is rejected every time — hit for real cutting 0.11.7, worked around manually since.

A release is now two commands, with the human approval point where it already was rather than buried behind a script trying to poll and auto-merge a PR:

```
npm run release:gate                    # the full gauntlet, on the candidate
npm run release -- prepare <version>    # bump, promote the changelog, open a pull request
...review and merge that pull request...
npm run release -- tag <version>        # tag the merged commit, which starts the build
...watch the build, review the draft it publishes...
npm run release -- publish <version>    # unchanged
```

`prepare` runs the existing preflight and gate checks, then commits the bump on `release/<version>` and opens a PR against `main` — no direct push to `main`, no tag. `tag` is run once that PR has merged. It doesn't re-run the gate (the tagged commit is always one past the gated one, since the bump only touches `package.json` and `CHANGELOG.md`); instead it verifies the merge actually landed on `origin/main` — the right version, the promoted changelog heading, local `main` exactly at that commit — before tagging and pushing.

The pre-commit gate's existing exemption for the release commit (previously scoped to a direct commit on `main`) now also covers the exact `release/<version>` branch it's made on, matched by full semver rather than by prefix so the exemption can't be adopted by an arbitrary branch name.

## Test plan

- [x] New: `test/unit/release-prepare-tag.test.js`, 25 tests against a real throwaway git repository (only `gh pr create` stubbed) — refusals, rollback on a failed branch push or failed PR creation, the tag landing on the actual merged commit, the PR text carrying no internal-address language
- [x] Extended: `test/unit/precommit-gate.test.js`, +7 tests for the release-branch exemption
- [x] `npm run precommit` passes
- [x] `npm run red-first` proves the change: 30 tests fail without it and pass with it
