### PR TITLE
Verify the draft release is what its tag should have produced

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,9 +230,13 @@ jobs:
   # the API with the same changelog-derived name and notes. The releaseInfo
   # flags stay until this step has proven itself at a real tag, then they can
   # go, so there is one mechanism rather than two.
+  #
+  # The last step of this job then reads the draft back and asserts it is what
+  # the tag should have produced. Until it existed, a green release workflow
+  # proved only that no step had thrown: the draft itself was never checked.
   # ---------------------------------------------------------------------------
   finalize:
-    name: Name and fill the draft release
+    name: Name, fill, and verify the draft release
     needs: [macos, windows]
     runs-on: ubuntu-latest
     steps:
@@ -267,6 +271,22 @@ jobs:
             -f name="$(cat release-info/release-name.txt)" \
             -f body="$(cat release-info/release-notes.md)" > /dev/null
           echo "Draft release ${RELEASE_ID} named and filled from the changelog."
+
+      - name: Verify the draft release
+        # Deliberately after the patch above rather than merely after the
+        # builds. The tag binding drops on any edit that omits tag_name, and
+        # the patch is itself such an edit, so a check that ran before it
+        # would attest to a state nobody publishes. Cutting 0.11.7 produced a
+        # draft with the right name, the right notes and all nine artefacts,
+        # bound to an untagged- placeholder rather than the tag.
+        #
+        # The script re-fetches the release list itself. It does not reuse
+        # RELEASE_ID above, and could not: each run block is a fresh shell.
+        # That is the behaviour wanted anyway, since the question is what
+        # actually landed, not what the patch was aimed at.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/verify-release-draft.js --info-dir release-info
 
   # ---------------------------------------------------------------------------
   # SCAFFOLDED, INACTIVE. Reserved for future Linux support.

--- a/scripts/verify-release-draft.js
+++ b/scripts/verify-release-draft.js
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Verify the draft GitHub release a tag build produced, before it is publishable.
+ *
+ * Why: the product has a nine-step gate in front of every commit, and the
+ * machinery that turns a gated commit into a downloadable release had no
+ * verification at all. Cutting 0.11.7 hit three faults in that machinery and
+ * none in application code. The dangerous one was a draft carrying the right
+ * name, the right notes and all nine artefacts, bound to
+ * `untagged-084fdf02808ef05fdba4` instead of `v0.11.7`. Publishing it would
+ * have created a release under a meaningless tag with the auto-update feed
+ * pointing at it. It looked entirely correct in the GitHub interface, and was
+ * caught only because the tag was read back and compared rather than glanced
+ * at.
+ *
+ * That binding comes loose on any edit that omits `tag_name`, including edits
+ * made in the GitHub interface, which is exactly where a release gets renamed
+ * before publishing. So this runs as the last step of the release workflow's
+ * `finalize` job, after that job's own PATCH, and re-fetches the release list
+ * from the API rather than trusting an id or a field read earlier in the run.
+ *
+ * A passing release workflow used to mean nothing had been checked. The point
+ * here is that it means something, so this prints what it verified on success
+ * and names every problem individually on failure.
+ *
+ * Usage:
+ *   node scripts/verify-release-draft.js [--info-dir <dir>]
+ *
+ * Reads GITHUB_REPOSITORY and GITHUB_REF_NAME from the environment, and the
+ * expected name and notes from <dir>/release-name.txt and
+ * <dir>/release-notes.md (default `release-info`, as written by
+ * scripts/release-notes.js). Needs `gh` authenticated, as GH_TOKEN in CI.
+ * Exits non-zero if the draft is not exactly what the tag should have made.
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Expectations and checks (pure, unit-tested)
+// ---------------------------------------------------------------------------
+
+// Every artefact a tag build attaches, grouped by the job that produces it.
+// These names are copied from the asset lists of real published releases
+// (v0.11.7 and v0.11.8 each carry exactly these nine), not inferred from the
+// electron-builder config: the config says which targets run, not what
+// electron-builder names their output. macOS builds universal dmg + zip,
+// Windows builds an NSIS installer + a portable exe, each platform publishes
+// its own update feed, and the differential-update blockmaps ride along.
+function expectedAssets(version) {
+  return {
+    macOS: [
+      `Rundock-${version}-universal.dmg`,
+      `Rundock-${version}-universal.dmg.blockmap`,
+      `Rundock-${version}-universal-mac.zip`,
+      `Rundock-${version}-universal-mac.zip.blockmap`,
+      'latest-mac.yml',
+    ],
+    Windows: [
+      `Rundock-Setup-${version}.exe`,
+      `Rundock-Setup-${version}.exe.blockmap`,
+      `Rundock-${version}.exe`,
+      'latest.yml',
+    ],
+  };
+}
+
+function allExpectedAssets(version) {
+  const groups = expectedAssets(version);
+  return Object.keys(groups).reduce((names, platform) => names.concat(groups[platform]), []);
+}
+
+// GitHub stores a release body verbatim, but the value being compared against
+// it came off disk with a trailing newline and may have travelled through a
+// Windows runner, so compare on line endings and edge whitespace normalised.
+function normaliseText(value) {
+  return String(value == null ? '' : value).replace(/\r\n/g, '\n').trim();
+}
+
+// Locate the release this tag build produced.
+//
+// Matching on `tag_name` is the primary lookup and is also the assertion: a
+// draft whose tag has been reset is not found by it. Rather than report the
+// unhelpful "no release found", fall back to finding the release by the
+// artefacts it carries, because a draft bound to an `untagged-` placeholder
+// still holds this version's files. That fallback is what turns the 0.11.7
+// failure from a mystery into a one-line diagnosis.
+function findReleaseForTag(releases, tag) {
+  const version = String(tag).replace(/^v/, '');
+  const list = Array.isArray(releases) ? releases : [];
+
+  const byTag = list.filter((r) => r && r.tag_name === tag);
+  if (byTag.length === 1) return { release: byTag[0], matchedBy: 'tag', candidates: byTag };
+  if (byTag.length > 1) return { release: null, matchedBy: 'ambiguous-tag', candidates: byTag };
+
+  const versioned = new Set(allExpectedAssets(version).filter((name) => name.includes(version)));
+  const byAssets = list.filter((r) => {
+    const assets = r && Array.isArray(r.assets) ? r.assets : [];
+    return assets.some((a) => a && versioned.has(a.name));
+  });
+  if (byAssets.length === 1) return { release: byAssets[0], matchedBy: 'assets', candidates: byAssets };
+  if (byAssets.length > 1) return { release: null, matchedBy: 'ambiguous-assets', candidates: byAssets };
+
+  return { release: null, matchedBy: null, candidates: [] };
+}
+
+function describeTags(releases) {
+  return releases.map((r) => `${r && r.tag_name} (id ${r && r.id})`).join(', ');
+}
+
+// Returns every problem found rather than the first: a release cut is
+// expensive to repeat, so a run should report the whole picture at once.
+function verifyReleaseDraft({ releases, tag, expectedName, expectedNotes }) {
+  const failures = [];
+  const warnings = [];
+  const version = String(tag).replace(/^v/, '');
+  const found = findReleaseForTag(releases, tag);
+  const release = found.release;
+
+  if (!release) {
+    if (found.matchedBy === 'ambiguous-tag') {
+      failures.push(
+        `${found.candidates.length} releases carry the tag ${tag}: ${describeTags(found.candidates)}. ` +
+        'One of them is a leftover; delete it before publishing, or the wrong one gets promoted.'
+      );
+    } else if (found.matchedBy === 'ambiguous-assets') {
+      failures.push(
+        `No release carries the tag ${tag}, and ${found.candidates.length} releases carry ${version} artefacts: ` +
+        `${describeTags(found.candidates)}. The build's artefacts are split across releases, none of them tagged ${tag}.`
+      );
+    } else {
+      failures.push(
+        `No release carries the tag ${tag}, and no release carries any ${version} artefact. ` +
+        'The build should have created a draft and attached files to it; there is nothing here to publish.'
+      );
+    }
+    return { failures, warnings, release: null, matchedBy: found.matchedBy, assets: null };
+  }
+
+  // 1. The tag binding. Reaching the release through its artefacts rather than
+  //    its tag IS the failure, so it is reported from how it was found.
+  if (found.matchedBy === 'assets') {
+    failures.push(
+      `tag_name is "${release.tag_name}", expected "${tag}". The release holding the ${version} artefacts is bound ` +
+      'to the wrong tag: publishing it would ship under that tag with the auto-update feed pointing at it. Repoint ' +
+      'it with a PATCH that sets tag_name, and re-check afterwards, since any later edit that omits tag_name resets it.'
+    );
+  }
+
+  // 2. The artefacts, by name and by count, per platform. A platform whose
+  //    build broke leaves a draft that still looks complete at a glance.
+  const groups = expectedAssets(version);
+  const expectedNames = allExpectedAssets(version);
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+  const byName = new Map(assets.filter((a) => a && a.name).map((a) => [a.name, a]));
+  let present = 0;
+
+  Object.keys(groups).forEach((platform) => {
+    const names = groups[platform];
+    const missing = names.filter((name) => !byName.has(name));
+    present += names.length - missing.length;
+    if (missing.length) {
+      failures.push(
+        `${platform} artefacts missing from the draft, ${names.length - missing.length} of ${names.length} present. ` +
+        `Missing: ${missing.join(', ')}.`
+      );
+    }
+    names.forEach((name) => {
+      const asset = byName.get(name);
+      if (!asset) return;
+      // An asset stuck at "starting" is an upload that never finished. It is
+      // listed on the release and downloads as nothing.
+      if (asset.state !== 'uploaded') {
+        failures.push(`Asset ${name} is in state "${asset.state}", not "uploaded": its upload did not complete.`);
+      } else if (!(Number(asset.size) > 0)) {
+        failures.push(`Asset ${name} is ${asset.size} bytes.`);
+      }
+    });
+  });
+
+  assets.forEach((asset) => {
+    const name = asset && asset.name;
+    if (!name || expectedNames.includes(name)) return;
+    if (/^Rundock-/.test(name)) {
+      // Every Rundock artefact this build produces is accounted for by name,
+      // so an extra one belongs to another version or another target. A stale
+      // artefact on a draft downloads as if it were this release.
+      failures.push(`The draft carries an unexpected artefact: ${name}. It is not part of the ${version} build.`);
+    } else {
+      warnings.push(`Unrecognised extra asset on the draft: ${name}.`);
+    }
+  });
+
+  // 3. The name, against the changelog heading this version's notes came from.
+  const wantName = normaliseText(expectedName);
+  const haveName = normaliseText(release.name);
+  if (!wantName) {
+    failures.push('No expected release name was supplied: release-name.txt is empty, so the name cannot be verified.');
+  } else if (!haveName) {
+    failures.push(`The draft has no name. It should carry the changelog heading for ${version}: "${wantName}".`);
+  } else if (haveName !== wantName) {
+    failures.push(`The draft is named "${haveName}", expected the changelog heading "${wantName}".`);
+  }
+
+  // 4. The notes. A draft release with blank notes must never be published,
+  //    and a body that no longer matches the changelog means an edit or a
+  //    partial patch replaced them after they were written.
+  const wantNotes = normaliseText(expectedNotes);
+  const haveNotes = normaliseText(release.body);
+  if (!wantNotes) {
+    failures.push('No expected release notes were supplied: release-notes.md is empty, so the body cannot be verified.');
+  } else if (!haveNotes) {
+    failures.push(
+      'The draft body is empty. The patch that fills it from the changelog either did not apply or was overwritten.'
+    );
+  } else if (haveNotes !== wantNotes) {
+    failures.push(
+      `The draft body does not match the changelog notes for ${version} ` +
+      `(draft ${haveNotes.length} chars, changelog ${wantNotes.length} chars).`
+    );
+  }
+
+  return {
+    failures,
+    warnings,
+    release,
+    matchedBy: found.matchedBy,
+    assets: { total: assets.length, expected: expectedNames.length, present },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+// One page of 100 covers every release this project has, and the API returns
+// newest first, so the release just built is always on it. Deliberately not
+// `--paginate`: combined with `--jq` it emits one result per page, which is
+// not parseable as a single document, and this needs structured output.
+function fetchReleases(repo) {
+  const out = execFileSync('gh', ['api', `repos/${repo}/releases?per_page=100`], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const parsed = JSON.parse(out);
+  if (!Array.isArray(parsed)) {
+    throw new Error('the releases endpoint did not return a list');
+  }
+  return parsed;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const dirFlag = args.indexOf('--info-dir');
+  const infoDir = dirFlag !== -1 ? args[dirFlag + 1] : 'release-info';
+
+  const repo = process.env.GITHUB_REPOSITORY;
+  const tag = process.env.GITHUB_REF_NAME;
+  if (!repo || !tag) {
+    console.error('verify-release-draft: GITHUB_REPOSITORY and GITHUB_REF_NAME must both be set.');
+    process.exit(1);
+  }
+
+  let expectedName;
+  let expectedNotes;
+  try {
+    expectedName = fs.readFileSync(path.join(infoDir, 'release-name.txt'), 'utf8');
+    expectedNotes = fs.readFileSync(path.join(infoDir, 'release-notes.md'), 'utf8');
+  } catch (err) {
+    console.error(
+      `verify-release-draft: could not read the changelog-derived name and notes from ${infoDir} (${err.message}). ` +
+      'Run scripts/release-notes.js first.'
+    );
+    process.exit(1);
+  }
+
+  let releases;
+  try {
+    releases = fetchReleases(repo);
+  } catch (err) {
+    console.error(`verify-release-draft: could not list the releases of ${repo} (${err.message}).`);
+    process.exit(1);
+  }
+
+  const result = verifyReleaseDraft({ releases, tag, expectedName, expectedNotes });
+  result.warnings.forEach((warning) => console.log(`verify-release-draft: warning: ${warning}`));
+
+  if (result.failures.length) {
+    console.error(`\nverify-release-draft: the draft for ${tag} is NOT publishable. ${result.failures.length} problem(s):\n`);
+    result.failures.forEach((failure, i) => console.error(`  ${i + 1}. ${failure}`));
+    console.error('\nNothing has been published: the release is still a draft. Fix it, then re-run this job.');
+    process.exit(1);
+  }
+
+  const release = result.release;
+  console.log(`verify-release-draft: release ${release.id} verified for ${tag}.`);
+  console.log(`  tag_name    ${release.tag_name}`);
+  console.log(`  name        ${normaliseText(release.name)}`);
+  console.log(`  notes       ${normaliseText(release.body).length} chars, matching the changelog entry`);
+  console.log(
+    `  artefacts   ${result.assets.present} of ${result.assets.expected} expected present, ` +
+    `${result.assets.total} assets on the release`
+  );
+}
+
+if (require.main === module) main();
+
+module.exports = { expectedAssets, allExpectedAssets, findReleaseForTag, verifyReleaseDraft };

--- a/test/unit/verify-release-draft.test.js
+++ b/test/unit/verify-release-draft.test.js
@@ -1,0 +1,307 @@
+// Tests for the draft-release verification that runs at the end of a tag
+// build (scripts/verify-release-draft.js).
+//
+// The release pipeline ships the product and was itself unchecked: a workflow
+// that went green proved only that no step had thrown. Cutting 0.11.7 produced
+// a draft that looked completely correct, right name, right notes, all nine
+// artefacts, and was bound to `untagged-084fdf02808ef05fdba4` rather than
+// `v0.11.7`. Publishing it would have released under a meaningless tag with
+// the auto-update feed pointing at it.
+//
+// So the case that matters most below is not a hypothetical: it is that exact
+// release object, and the check must reject it while every other assertion
+// about it passes.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const {
+  expectedAssets,
+  allExpectedAssets,
+  findReleaseForTag,
+  verifyReleaseDraft,
+} = require('../../scripts/verify-release-draft.js');
+
+// Copied verbatim from the assets of the published v0.11.7 release. Every
+// release from v0.9.0 onward carries this same nine, with the version swapped.
+const PUBLISHED_0_11_7_ASSET_NAMES = [
+  'latest-mac.yml',
+  'latest.yml',
+  'Rundock-0.11.7-universal-mac.zip',
+  'Rundock-0.11.7-universal-mac.zip.blockmap',
+  'Rundock-0.11.7-universal.dmg',
+  'Rundock-0.11.7-universal.dmg.blockmap',
+  'Rundock-0.11.7.exe',
+  'Rundock-Setup-0.11.7.exe',
+  'Rundock-Setup-0.11.7.exe.blockmap',
+];
+
+const NAME = '0.11.7: Foundations & File Tree Stability';
+const NOTES = '### Fixed\n\n- **The file tree stopped losing its place:** it no longer collapses on refresh.\n';
+
+function assets(names = PUBLISHED_0_11_7_ASSET_NAMES) {
+  return names.map((name) => ({ name, state: 'uploaded', size: 1024 }));
+}
+
+function release(overrides = {}) {
+  return {
+    id: 1001,
+    tag_name: 'v0.11.7',
+    name: NAME,
+    body: NOTES,
+    draft: true,
+    assets: assets(),
+    ...overrides,
+  };
+}
+
+function verify(releases, tag = 'v0.11.7') {
+  return verifyReleaseDraft({ releases, tag, expectedName: NAME + '\n', expectedNotes: NOTES });
+}
+
+describe('expectedAssets', () => {
+  test('expects exactly the nine assets a real release carries', () => {
+    assert.deepStrictEqual(
+      allExpectedAssets('0.11.7').slice().sort(),
+      PUBLISHED_0_11_7_ASSET_NAMES.slice().sort()
+    );
+  });
+
+  test('splits them by the job that produces them', () => {
+    const groups = expectedAssets('0.11.7');
+    assert.strictEqual(groups.macOS.length, 5);
+    assert.strictEqual(groups.Windows.length, 4);
+    assert.ok(groups.macOS.includes('Rundock-0.11.7-universal.dmg'));
+    assert.ok(groups.Windows.includes('Rundock-Setup-0.11.7.exe'));
+  });
+});
+
+describe('a draft that is what the tag should have produced', () => {
+  test('passes with no failures and no warnings', () => {
+    const result = verify([release()]);
+    assert.deepStrictEqual(result.failures, []);
+    assert.deepStrictEqual(result.warnings, []);
+    assert.strictEqual(result.matchedBy, 'tag');
+  });
+
+  test('reports the artefact count it verified', () => {
+    const result = verify([release()]);
+    assert.deepStrictEqual(result.assets, { total: 9, expected: 9, present: 9 });
+  });
+
+  test('is found among other releases rather than by position', () => {
+    const older = release({ id: 900, tag_name: 'v0.11.6', draft: false, assets: [] });
+    const result = verify([older, release()]);
+    assert.deepStrictEqual(result.failures, []);
+    assert.strictEqual(result.release.id, 1001);
+  });
+});
+
+describe('the 0.11.7 tag reset', () => {
+  // The real one. Name, notes and all nine artefacts correct; tag_name reset
+  // to the placeholder the API handed back.
+  const resetDraft = release({ tag_name: 'untagged-084fdf02808ef05fdba4' });
+
+  test('is rejected', () => {
+    const result = verify([resetDraft]);
+    assert.strictEqual(result.failures.length, 1);
+  });
+
+  test('the failure names the tag it has and the tag it should have', () => {
+    const [failure] = verify([resetDraft]).failures;
+    assert.match(failure, /untagged-084fdf02808ef05fdba4/);
+    assert.match(failure, /v0\.11\.7/);
+  });
+
+  test('nothing else about the draft is flagged, which is why it passed by eye', () => {
+    // Every other assertion holds. Anything looking at name, notes or
+    // artefacts alone would have called this draft ready to publish.
+    const result = verify([resetDraft]);
+    assert.strictEqual(result.matchedBy, 'assets');
+    assert.deepStrictEqual(result.assets, { total: 9, expected: 9, present: 9 });
+  });
+
+  test('a tag reset by a later edit is caught the same way', () => {
+    // The binding drops on any edit that omits tag_name, including a rename
+    // in the GitHub interface, so the value differs from run to run.
+    const result = verify([release({ tag_name: 'untagged-9f2c1de4a7b30516' })]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /untagged-9f2c1de4a7b30516/);
+  });
+
+  test('a draft bound to a different real tag is caught too', () => {
+    const result = verify([release({ tag_name: 'v0.11.6' })]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /v0\.11\.6/);
+  });
+});
+
+describe('locating the release', () => {
+  test('an empty release list fails rather than passing vacuously', () => {
+    const result = verify([]);
+    assert.strictEqual(result.release, null);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /No release carries the tag v0\.11\.7/);
+  });
+
+  test('a release with no artefacts at all fails', () => {
+    const result = verify([release({ tag_name: 'untagged-abc123', assets: [] })]);
+    assert.match(result.failures[0], /no release carries any 0\.11\.7 artefact/);
+  });
+
+  test('two releases on the same tag fail rather than one being picked', () => {
+    const result = verify([release(), release({ id: 1002 })]);
+    assert.strictEqual(result.release, null);
+    assert.match(result.failures[0], /2 releases carry the tag v0\.11\.7/);
+  });
+
+  test('artefacts split across two untagged releases fail', () => {
+    const macOnly = release({ id: 1, tag_name: 'untagged-aaa', assets: assets(expectedAssets('0.11.7').macOS) });
+    const winOnly = release({ id: 2, tag_name: 'untagged-bbb', assets: assets(expectedAssets('0.11.7').Windows) });
+    const result = verify([macOnly, winOnly]);
+    assert.strictEqual(result.release, null);
+    assert.match(result.failures[0], /2 releases carry 0\.11\.7 artefacts/);
+  });
+
+  test('findReleaseForTag prefers the tag over the artefacts', () => {
+    const tagged = release({ id: 7 });
+    const orphan = release({ id: 8, tag_name: 'untagged-ccc' });
+    assert.strictEqual(findReleaseForTag([orphan, tagged], 'v0.11.7').release.id, 7);
+  });
+});
+
+describe('artefacts', () => {
+  test('a silently broken Windows build fails, naming what is missing', () => {
+    const macOnly = release({ assets: assets(expectedAssets('0.11.7').macOS) });
+    const result = verify([macOnly]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /Windows artefacts missing/);
+    assert.match(result.failures[0], /Rundock-Setup-0\.11\.7\.exe/);
+    assert.match(result.failures[0], /latest\.yml/);
+  });
+
+  test('a missing update feed fails even when the installers are all there', () => {
+    const noFeed = PUBLISHED_0_11_7_ASSET_NAMES.filter((name) => name !== 'latest-mac.yml');
+    const result = verify([release({ assets: assets(noFeed) })]);
+    assert.match(result.failures[0], /macOS artefacts missing from the draft, 4 of 5 present/);
+  });
+
+  test('an upload that never finished fails', () => {
+    const partial = assets();
+    partial[4].state = 'starting';
+    const result = verify([release({ assets: partial })]);
+    assert.match(result.failures[0], /Rundock-0\.11\.7-universal\.dmg is in state "starting"/);
+  });
+
+  test('a zero-byte artefact fails', () => {
+    const empty = assets();
+    empty[4].size = 0;
+    const result = verify([release({ assets: empty })]);
+    assert.match(result.failures[0], /Rundock-0\.11\.7-universal\.dmg is 0 bytes/);
+  });
+
+  test('an artefact left over from another version fails', () => {
+    const stale = assets().concat(assets(['Rundock-0.11.6-universal.dmg']));
+    const result = verify([release({ assets: stale })]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /unexpected artefact: Rundock-0\.11\.6-universal\.dmg/);
+  });
+
+  test('an unrelated file attached to the draft warns rather than failing', () => {
+    // Someone attaching a supplementary file to a draft is not a broken
+    // release, but it should not go unmentioned either.
+    const extra = assets().concat(assets(['checksums.txt']));
+    const result = verify([release({ assets: extra })]);
+    assert.deepStrictEqual(result.failures, []);
+    assert.strictEqual(result.warnings.length, 1);
+    assert.match(result.warnings[0], /checksums\.txt/);
+  });
+});
+
+describe('name and notes', () => {
+  test('a name that is not the changelog heading fails, quoting both', () => {
+    const result = verify([release({ name: '0.11.7' })]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /named "0\.11\.7", expected the changelog heading "0\.11\.7: Foundations & File Tree Stability"/);
+  });
+
+  test('an unnamed draft fails', () => {
+    const result = verify([release({ name: '' })]);
+    assert.match(result.failures[0], /has no name/);
+  });
+
+  test('the trailing newline release-name.txt carries is not a mismatch', () => {
+    const result = verifyReleaseDraft({
+      releases: [release()],
+      tag: 'v0.11.7',
+      expectedName: NAME + '\n',
+      expectedNotes: NOTES + '\n\n',
+    });
+    assert.deepStrictEqual(result.failures, []);
+  });
+
+  test('notes that survived a Windows runner are not a mismatch', () => {
+    const result = verifyReleaseDraft({
+      releases: [release({ body: NOTES.replace(/\n/g, '\r\n') })],
+      tag: 'v0.11.7',
+      expectedName: NAME,
+      expectedNotes: NOTES,
+    });
+    assert.deepStrictEqual(result.failures, []);
+  });
+
+  test('a blank body fails: a draft with blank notes must never be published', () => {
+    const result = verify([release({ body: '' })]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /body is empty/);
+  });
+
+  test('a null body fails rather than reading as a match', () => {
+    const result = verify([release({ body: null })]);
+    assert.match(result.failures[0], /body is empty/);
+  });
+
+  test('notes replaced by a later edit fail', () => {
+    const result = verify([release({ body: 'Notes to follow.' })]);
+    assert.strictEqual(result.failures.length, 1);
+    assert.match(result.failures[0], /body does not match the changelog notes for 0\.11\.7/);
+  });
+
+  test('an empty expected name fails rather than verifying nothing', () => {
+    // release-name.txt coming back empty would otherwise make the name check
+    // pass against an equally empty draft name.
+    const result = verifyReleaseDraft({
+      releases: [release({ name: '' })],
+      tag: 'v0.11.7',
+      expectedName: '',
+      expectedNotes: NOTES,
+    });
+    assert.match(result.failures[0], /No expected release name was supplied/);
+  });
+
+  test('empty expected notes fail rather than verifying nothing', () => {
+    const result = verifyReleaseDraft({
+      releases: [release({ body: '' })],
+      tag: 'v0.11.7',
+      expectedName: NAME,
+      expectedNotes: '   \n',
+    });
+    assert.match(result.failures[0], /No expected release notes were supplied/);
+  });
+});
+
+describe('reporting', () => {
+  test('every problem is reported, not just the first', () => {
+    const broken = release({
+      tag_name: 'untagged-084fdf02808ef05fdba4',
+      name: 'Untitled',
+      body: '',
+      assets: assets(expectedAssets('0.11.7').macOS),
+    });
+    const result = verify([broken]);
+    assert.strictEqual(result.failures.length, 4);
+    assert.match(result.failures.join('\n'), /untagged-084fdf02808ef05fdba4/);
+    assert.match(result.failures.join('\n'), /Windows artefacts missing/);
+    assert.match(result.failures.join('\n'), /named "Untitled"/);
+    assert.match(result.failures.join('\n'), /body is empty/);
+  });
+});


### PR DESCRIPTION
## Summary

The release workflow's `finalize` job builds macOS and Windows, publishes artifacts to a draft release, then patches the draft's name and notes from the changelog. Nothing verified the result. Cutting 0.11.7 hit a real, dangerous version of that gap: a draft with the right name, the right notes, and all nine artifacts, bound to `untagged-084fdf02808ef05fdba4` instead of `v0.11.7`. Publishing it would have shipped under a meaningless tag with the auto-update feed pointing at it. Caught only because the tag was read back and compared by hand.

Adds a verification step, run last in `finalize` (after its own patch, since that patch is itself an edit that can reset the tag binding), that checks:

- the draft's `tag_name` matches the tag that triggered the build, falling back to a lookup by the version's own artifacts when the tag lookup fails, so a reset reads as a diagnosis rather than "no release found"
- all 9 expected artifacts (5 macOS, 4 Windows) are present by exact name, uploaded, and non-zero bytes, with no unexpected `Rundock-*` artifact left over from another version
- the draft's name matches the changelog heading
- the draft's notes match the changelog entry exactly, not merely non-empty

Any failure fails the workflow with every problem named at once, rather than leaving a plausible-looking draft.

## Verification

This is a workflow change; there's no way to run a GitHub Actions release job locally against a real signed build, so it can't be end-to-end tested the way application code can. What's actually proven:

- 31 unit tests against the pure verification logic, including the real v0.11.7 asset list and the real bad tag value from that incident
- Run for real, read-only, against this repository's actual release history: `GITHUB_REF_NAME=v0.11.8` passes with an exact body match against the regenerated changelog notes and all 9 artifacts confirmed present
- `npm run precommit` passes; `npm run red-first` proves the change

The workflow YAML's placement and behaviour at runtime is sound by inspection; the first real tagged build is the first time it runs for real.
