### PR TITLE
Re-capture the stream-truth contract against Claude Code 2.1.246

### DIFF
--- a/scripts/stream-truth/captured-grammar.json
+++ b/scripts/stream-truth/captured-grammar.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "2.1.237",
-  "capturedAt": "2026-08-20T21:04:55.592Z",
+  "runtimeVersion": "2.1.246",
+  "capturedAt": "2026-08-27T08:12:32.227Z",
   "scenarios": {
     "text-turn": {
       "invariants": [


### PR DESCRIPTION
## Summary

The release gate's `stream-truth` step refuses when the installed Claude Code CLI has moved past the captured runtime contract, which is what happened here: the capture was against 2.1.237, the installed CLI is 2.1.246.

Re-captured with `npm run stream:truth -- --capture`, which verifies stream invariants against the real runtime before writing. Both scenarios held. The resulting grammar is byte-identical to the previous capture aside from the version and timestamp fields, meaning no real streaming behaviour changed between these two CLI versions.

## Test plan

- [x] `npm run stream:truth -- --capture` reports invariants hold for text-turn and tool-turn, and the stub matches the new capture
- [x] `npm run precommit` passes