### PR TITLE
doc-claims: bound the current-entry slice by heading, not a literal version

### DIFF
--- a/test/unit/doc-claims.test.js
+++ b/test/unit/doc-claims.test.js
@@ -41,9 +41,17 @@ const changelog = fs.readFileSync(path.join(ROOT, 'CHANGELOG.md'), 'utf-8');
 // pin below passed while the current entry named five of the six exempt
 // directories, because a 0.9 entry about PATH detection happened to mention
 // the sixth.
+//
+// Bounded by heading structure, not by a literal version string: the release
+// script renames "## Unreleased" to "## <version>: ..." the moment a release
+// branch is prepared, so a pin naming today's version number would go blind
+// (empty slice, every assertion failing) on the very next release. The
+// topmost "## " heading is always the entry being shipped, whatever it is
+// named; the second bounds it.
+const changelogHeadings = [...changelog.matchAll(/^## .*$/gm)];
 const unreleased = changelog.slice(
-  changelog.indexOf('## Unreleased'),
-  changelog.indexOf('## 0.11.8'),
+  changelogHeadings[0].index,
+  changelogHeadings[1]?.index ?? changelog.length,
 );
 const architecture = fs.readFileSync(path.join(ROOT, 'ARCHITECTURE.md'), 'utf-8');
 const skillsDoc = fs.readFileSync(path.join(ROOT, 'docs', 'SKILLS.md'), 'utf-8');


### PR DESCRIPTION
## Summary
- \`test/unit/doc-claims.test.js\` sliced the changelog between the literal strings \`## Unreleased\` and \`## 0.11.8\` to isolate the entry being shipped
- \`release.js prepare\` renames \`## Unreleased\` to the new version heading, so on a release branch \`indexOf\` returns -1, the slice collapses to empty, and every pinned assertion fails
- Broke PR #232 (the 0.12.0 release branch) this way; would break every future release the same way
- Fix: bound the slice by heading structure (topmost \`## \` line to the next one) instead of a literal version string, so it works whether the top section is still \`## Unreleased\` or has already been promoted

## Test plan
- [x] All 34 doc-claims tests pass against the current \`## Unreleased\` changelog on main
- [x] All 34 doc-claims tests pass against the promoted \`## 0.12.0: ...\` changelog pulled from the release branch (verified manually before committing)
- [x] Full precommit gate passes (test:coverage, typecheck, lint:styles, check:refs, mutate:guards, check:fixture)