### PR TITLE
release: resend tag_name on every PATCH to the draft, or it un-binds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,6 +310,14 @@ jobs:
       - name: Patch the draft release with the name and notes
         # Draft releases are not addressable via /releases/tags/<tag>, so list
         # and match on tag_name instead.
+        #
+        # tag_name is resent here even though it is not changing. GitHub's
+        # release PATCH endpoint drops the tag binding to a generated
+        # "untagged-<hash>" placeholder on any edit that omits it: cutting
+        # 0.11.7 produced a draft with the right name, the right notes and
+        # all nine artefacts, bound to that placeholder rather than the tag,
+        # and 0.12.0 hit the same thing when this step patched name and body
+        # without it. Every future PATCH to this release must carry it.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -320,17 +328,20 @@ jobs:
             exit 1
           fi
           gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+            -f tag_name="${GITHUB_REF_NAME}" \
             -f name="$(cat release-info/release-name.txt)" \
             -f body="$(cat release-info/release-notes.md)" > /dev/null
           echo "Draft release ${RELEASE_ID} named and filled from the changelog."
 
       - name: Verify the draft release
         # Deliberately after the patch above rather than merely after the
-        # builds. The tag binding drops on any edit that omits tag_name, and
-        # the patch is itself such an edit, so a check that ran before it
-        # would attest to a state nobody publishes. Cutting 0.11.7 produced a
-        # draft with the right name, the right notes and all nine artefacts,
-        # bound to an untagged- placeholder rather than the tag.
+        # builds: the patch is the step most likely to disturb the tag
+        # binding (see its comment), so a check that ran before it would
+        # attest to a state nobody publishes. Kept as a second, independent
+        # line of defence even with tag_name now resent above: this is
+        # exactly the class of defect (an omitted field silently resetting
+        # state) that recurs when someone next edits this step without
+        # reading why the field is there.
         #
         # The script re-fetches the release list itself. It does not reuse
         # RELEASE_ID above, and could not: each run block is a fresh shell.


### PR DESCRIPTION
## Summary
- The \`finalize\` job's PATCH step sets \`name\` and \`body\` on the draft release but never resends \`tag_name\`
- GitHub's release PATCH endpoint drops the tag binding to a generated \`untagged-<hash>\` placeholder on any edit that omits it
- This exact failure was already documented in the job's own comment (happened at v0.11.7, fixed by hand at the time) and recurred on the 0.12.0 cut for the same reason: the comment recorded the risk, nothing in the code resent the field
- \`verify-release-draft.js\` (built earlier this session) caught it as designed, so 0.12.0 did not ship broken, but the release needed a manual API re-patch to unblock
- Fix: resend \`tag_name\` on every PATCH. The verify step stays as a second, independent line of defence

## Test plan
- [x] YAML validated
- [x] Full precommit gate passes (test:coverage, typecheck, lint:styles, check:refs, mutate:guards, check:fixture)
- [x] Verified live against the actual 0.12.0 draft release (manually re-patched with tag_name, then re-ran verify-release-draft.js locally against it — passed)