### PR TITLE
Add package import approval evaluator

### DIFF
--- a/lib/packages/import-evaluate.js
+++ b/lib/packages/import-evaluate.js
@@ -1,0 +1,315 @@
+'use strict';
+
+const APPROVAL_SCHEMA = 'rundock.package-import-approval/v1';
+const ABSENT_DIGEST = 'absent';
+const DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const KINDS = new Set(['agent', 'skill']);
+const DECISIONS = new Set(['add', 'overwrite', 'skip']);
+
+function invalid(path, message) {
+  throw new TypeError(`Invalid package import ${path}: ${message}.`);
+}
+function assertRecord(value, path, fields) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    invalid(path, 'must be an object');
+  }
+  const allowed = new Set(fields);
+  for (const field of Object.keys(value)) {
+    if (!allowed.has(field)) invalid(path, `has unknown field "${field}"`);
+  }
+}
+function assertArray(value, path) {
+  if (!Array.isArray(value)) invalid(path, 'must be an array');
+}
+function assertString(value, path) {
+  if (typeof value !== 'string' || value.length === 0) invalid(path, 'must be a non-empty string');
+}
+function assertBoolean(value, path) {
+  if (typeof value !== 'boolean') invalid(path, 'must be a boolean');
+}
+function assertDigest(value, path, allowAbsent = false) {
+  if (allowAbsent && value === ABSENT_DIGEST) return;
+  if (typeof value !== 'string' || !DIGEST_PATTERN.test(value)) {
+    invalid(path, `must be ${allowAbsent ? '"absent" or ' : ''}a sha256 digest`);
+  }
+}
+function canonicalDestination(kind, slug) {
+  return kind === 'agent'
+    ? `.claude/agents/${slug}.md`
+    : `.claude/skills/${slug}`;
+}
+function validateIdentity(entry, path) {
+  assertString(entry.id, `${path}.id`);
+  if (!KINDS.has(entry.kind)) invalid(`${path}.kind`, 'must be "agent" or "skill"');
+  if (typeof entry.slug !== 'string' || !SLUG_PATTERN.test(entry.slug)) {
+    invalid(`${path}.slug`, 'must contain lower-case letters, numbers and single hyphens');
+  }
+  const expectedId = `${entry.kind}:${entry.slug}`;
+  if (entry.id !== expectedId) invalid(`${path}.id`, `must equal "${expectedId}"`);
+}
+function validateManifest(manifest) {
+  assertArray(manifest, 'approval.manifest');
+  const byId = new Map();
+  let previousId = null;
+  for (const [index, entry] of manifest.entries()) {
+    const path = `approval.manifest[${index}]`;
+    assertRecord(entry, path, ['id', 'kind', 'slug', 'sourceDigest']);
+    validateIdentity(entry, path);
+    assertDigest(entry.sourceDigest, `${path}.sourceDigest`);
+    if (byId.has(entry.id)) invalid('approval.manifest', `contains duplicate manifest id "${entry.id}"`);
+    if (previousId !== null && previousId.localeCompare(entry.id) >= 0) {
+      invalid('approval.manifest', 'must be sorted by id');
+    }
+    byId.set(entry.id, entry);
+    previousId = entry.id;
+  }
+  return byId;
+}
+function validateAgentMetadata(value, path) {
+  assertRecord(value, path, ['plannedDefault', 'approvedDefault']);
+  assertBoolean(value.plannedDefault, `${path}.plannedDefault`);
+  assertBoolean(value.approvedDefault, `${path}.approvedDefault`);
+}
+function validateItem(item, index) {
+  const path = `approval.items[${index}]`;
+  assertRecord(item, path, [
+    'id', 'kind', 'slug', 'destination', 'collision',
+    'decision', 'plannedDigest', 'approvedDigest', 'sourceDigest', 'agent',
+  ]);
+  validateIdentity(item, path);
+  const expectedDestination = canonicalDestination(item.kind, item.slug);
+  if (item.destination !== expectedDestination) {
+    invalid(`${path}.destination`, `must equal "${expectedDestination}"`);
+  }
+  assertBoolean(item.collision, `${path}.collision`);
+  if (!DECISIONS.has(item.decision)) {
+    invalid(`${path}.decision`, 'must be "add", "overwrite" or "skip"');
+  }
+  assertDigest(item.plannedDigest, `${path}.plannedDigest`, true);
+  assertDigest(item.approvedDigest, `${path}.approvedDigest`, item.decision === 'skip');
+  assertDigest(item.sourceDigest, `${path}.sourceDigest`);
+  if (item.collision !== (item.plannedDigest !== ABSENT_DIGEST)) {
+    invalid(`${path}.collision`, 'must match plannedDigest');
+  }
+  if (item.decision === 'add' && item.collision) {
+    invalid(`${path}.decision`, 'add requires an absent planned destination');
+  }
+  if (item.decision === 'overwrite' && !item.collision) {
+    invalid(`${path}.decision`, 'overwrite requires an existing planned destination');
+  }
+  if (item.decision === 'skip' && item.approvedDigest !== item.plannedDigest) {
+    invalid(path, 'skip requires approvedDigest to equal plannedDigest');
+  }
+  if (item.kind === 'agent') {
+    validateAgentMetadata(item.agent, `${path}.agent`);
+    if (item.plannedDigest === ABSENT_DIGEST && item.agent.plannedDefault) {
+      invalid(`${path}.agent.plannedDefault`, 'must be false for an absent destination');
+    }
+    if (item.decision === 'skip'
+      && item.agent.approvedDefault !== item.agent.plannedDefault) {
+      invalid(`${path}.agent`, 'skip requires matching planned and approved default state');
+    }
+    if (item.plannedDigest === item.approvedDigest
+      && item.agent.approvedDefault !== item.agent.plannedDefault) {
+      invalid(`${path}.agent`, 'matching digests require matching default state');
+    }
+  } else if (item.agent !== null) {
+    invalid(`${path}.agent`, 'must be null for a skill');
+  }
+}
+function validateApproval(approval) {
+  assertRecord(approval, 'approval', ['schema', 'source', 'manifest', 'items']);
+  if (approval.schema !== APPROVAL_SCHEMA) {
+    invalid('approval.schema', `must equal "${APPROVAL_SCHEMA}"`);
+  }
+  assertRecord(approval.source, 'approval.source', ['id', 'reference']);
+  assertString(approval.source.id, 'approval.source.id');
+  if (approval.source.reference !== null) {
+    assertString(approval.source.reference, 'approval.source.reference');
+  }
+  const manifestById = validateManifest(approval.manifest);
+  assertArray(approval.items, 'approval.items');
+  const itemsById = new Map();
+  for (const [index, item] of approval.items.entries()) {
+    validateItem(item, index);
+    if (itemsById.has(item.id)) invalid('approval.items', `contains duplicate item id "${item.id}"`);
+    itemsById.set(item.id, item);
+  }
+  const manifestIds = [...manifestById.keys()].sort();
+  const itemIds = [...itemsById.keys()].sort();
+  if (manifestIds.length !== itemIds.length
+    || manifestIds.some((id, index) => id !== itemIds[index])) {
+    invalid('approval', 'manifest and items must contain the same ids');
+  }
+  for (const id of manifestIds) {
+    const manifestEntry = manifestById.get(id);
+    const item = itemsById.get(id);
+    if (manifestEntry.kind !== item.kind
+      || manifestEntry.slug !== item.slug
+      || manifestEntry.sourceDigest !== item.sourceDigest) {
+      invalid(`approval.items[${id}]`, 'must match its manifest entry');
+    }
+  }
+  return [...itemsById.values()];
+}
+function indexFacts(entries, path, key, fields, validate) {
+  assertArray(entries, path);
+  const indexed = new Map();
+  for (const [index, entry] of entries.entries()) {
+    const entryPath = `${path}[${index}]`;
+    assertRecord(entry, entryPath, fields);
+    assertString(entry[key], `${entryPath}.${key}`);
+    validate(entry, entryPath);
+    if (indexed.has(entry[key])) invalid(path, `contains duplicate ${key} "${entry[key]}"`);
+    indexed.set(entry[key], entry);
+  }
+  return indexed;
+}
+function validateCurrent(current, items) {
+  assertRecord(current, 'current', ['destinations', 'sources', 'agents']);
+  const destinations = indexFacts(
+    current.destinations,
+    'current.destinations',
+    'destination',
+    ['destination', 'digest'],
+    (entry, path) => assertDigest(entry.digest, `${path}.digest`, true),
+  );
+  const sources = indexFacts(
+    current.sources,
+    'current.sources',
+    'id',
+    ['id', 'digest'],
+    (entry, path) => assertDigest(entry.digest, `${path}.digest`),
+  );
+  const agents = indexFacts(
+    current.agents,
+    'current.agents',
+    'destination',
+    ['destination', 'digest', 'isDefault'],
+    (entry, path) => {
+      if (!/^\.claude\/agents\/[a-z0-9]+(?:-[a-z0-9]+)*\.md$/.test(entry.destination)) {
+        invalid(`${path}.destination`, 'must be a canonical agent destination');
+      }
+      assertDigest(entry.digest, `${path}.digest`);
+      assertBoolean(entry.isDefault, `${path}.isDefault`);
+    },
+  );
+  for (const item of items) {
+    if (!destinations.has(item.destination)) {
+      invalid('current.destinations', `is missing "${item.destination}"`);
+    }
+    if (item.kind !== 'agent') continue;
+    const currentDigest = destinations.get(item.destination).digest;
+    const currentAgent = agents.get(item.destination);
+    if (currentDigest === ABSENT_DIGEST && currentAgent) {
+      invalid('current.agents', `contains absent destination "${item.destination}"`);
+    }
+    if (currentDigest !== ABSENT_DIGEST
+      && (!currentAgent || currentAgent.digest !== currentDigest)) {
+      invalid('current.agents', `must match destination "${item.destination}"`);
+    }
+    if (currentDigest === item.plannedDigest && currentDigest !== ABSENT_DIGEST
+      && currentAgent.isDefault !== item.agent.plannedDefault) {
+      invalid('current.agents', `has contradictory planned default metadata for "${item.destination}"`);
+    }
+    if (currentDigest === item.approvedDigest
+      && currentAgent.isDefault !== item.agent.approvedDefault) {
+      invalid('current.agents', `has contradictory approved default metadata for "${item.destination}"`);
+    }
+  }
+  return { destinations, sources, agents };
+}
+function basicOutcome(item) {
+  return { id: item.id, kind: item.kind, destination: item.destination };
+}
+function writeOutcome(item) {
+  return {
+    id: item.id,
+    kind: item.kind,
+    destination: item.destination,
+    approvedDigest: item.approvedDigest,
+    sourceDigest: item.sourceDigest,
+  };
+}
+function sortOutcomes(entries) {
+  return entries.sort((left, right) => left.id.localeCompare(right.id));
+}
+function result(status, writes, unchanged, skipped, blocked, stale) {
+  return {
+    status,
+    writes: sortOutcomes(writes),
+    unchanged: sortOutcomes(unchanged),
+    skipped: sortOutcomes(skipped),
+    blocked: sortOutcomes(blocked),
+    stale: sortOutcomes(stale),
+  };
+}
+function evaluateImport(approval, current) {
+  const items = validateApproval(approval);
+  const facts = validateCurrent(current, items);
+  const pending = [];
+  const unchanged = [];
+  const skipped = [];
+  const stale = [];
+
+  for (const item of items) {
+    const currentDigest = facts.destinations.get(item.destination).digest;
+    if (item.decision === 'skip') {
+      if (currentDigest === item.plannedDigest || currentDigest === item.approvedDigest) {
+        skipped.push(basicOutcome(item));
+      } else {
+        stale.push({ ...basicOutcome(item), reason: 'destination-changed' });
+      }
+    } else if (currentDigest === item.approvedDigest) {
+      unchanged.push(basicOutcome(item));
+    } else if (currentDigest === item.plannedDigest) {
+      pending.push(item);
+    } else {
+      stale.push({ ...basicOutcome(item), reason: 'destination-changed' });
+    }
+  }
+
+  if (stale.length) return result('stale', [], unchanged, skipped, [], stale);
+
+  for (const item of pending) {
+    const source = facts.sources.get(item.id);
+    if (!source) {
+      stale.push({ ...basicOutcome(item), reason: 'source-missing' });
+    } else if (source.digest !== item.sourceDigest) {
+      stale.push({ ...basicOutcome(item), reason: 'source-changed' });
+    }
+  }
+  if (stale.length) return result('stale', [], unchanged, skipped, [], stale);
+
+  const projectedAgents = new Map([...facts.agents.values()]
+    .map(agent => [agent.destination, agent.isDefault]));
+  const selectedAgents = items.filter(item => item.kind === 'agent' && item.decision !== 'skip');
+  for (const item of selectedAgents) {
+    projectedAgents.set(item.destination, item.agent.approvedDefault);
+  }
+
+  const blockedIds = new Set();
+  const projectedDefaults = [...projectedAgents.values()].filter(Boolean).length;
+  if (projectedDefaults > 1) {
+    for (const item of selectedAgents) {
+      const currentDefault = facts.agents.get(item.destination)?.isDefault || false;
+      if (currentDefault !== item.agent.approvedDefault) blockedIds.add(item.id);
+    }
+  }
+
+  const blocked = items
+    .filter(item => blockedIds.has(item.id))
+    .map(item => ({ ...basicOutcome(item), reason: 'default-conflict' }));
+  const writes = pending
+    .filter(item => !blockedIds.has(item.id))
+    .map(writeOutcome);
+  const status = blocked.length && writes.length === 0 ? 'decisions-blocked' : 'ready';
+  return result(status, writes, unchanged, skipped, blocked, []);
+}
+
+module.exports = {
+  ABSENT_DIGEST,
+  APPROVAL_SCHEMA,
+  evaluateImport,
+};

--- a/lib/packages/import-evaluate.js
+++ b/lib/packages/import-evaluate.js
@@ -7,6 +7,10 @@ const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const KINDS = new Set(['agent', 'skill']);
 const DECISIONS = new Set(['add', 'overwrite', 'skip']);
 
+function compareIds(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 function invalid(path, message) {
   throw new TypeError(`Invalid package import ${path}: ${message}.`);
 }
@@ -58,7 +62,7 @@ function validateManifest(manifest) {
     validateIdentity(entry, path);
     assertDigest(entry.sourceDigest, `${path}.sourceDigest`);
     if (byId.has(entry.id)) invalid('approval.manifest', `contains duplicate manifest id "${entry.id}"`);
-    if (previousId !== null && previousId.localeCompare(entry.id) >= 0) {
+    if (previousId !== null && compareIds(previousId, entry.id) >= 0) {
       invalid('approval.manifest', 'must be sorted by id');
     }
     byId.set(entry.id, entry);
@@ -136,8 +140,8 @@ function validateApproval(approval) {
     if (itemsById.has(item.id)) invalid('approval.items', `contains duplicate item id "${item.id}"`);
     itemsById.set(item.id, item);
   }
-  const manifestIds = [...manifestById.keys()].sort();
-  const itemIds = [...itemsById.keys()].sort();
+  const manifestIds = [...manifestById.keys()].sort(compareIds);
+  const itemIds = [...itemsById.keys()].sort(compareIds);
   if (manifestIds.length !== itemIds.length
     || manifestIds.some((id, index) => id !== itemIds[index])) {
     invalid('approval', 'manifest and items must contain the same ids');
@@ -188,7 +192,10 @@ function validateCurrent(current, items) {
     'destination',
     ['destination', 'digest', 'isDefault'],
     (entry, path) => {
-      if (!/^\.claude\/agents\/[a-z0-9]+(?:-[a-z0-9]+)*\.md$/.test(entry.destination)) {
+      const prefix = '.claude/agents/';
+      const slug = entry.destination.startsWith(prefix) && entry.destination.endsWith('.md')
+        ? entry.destination.slice(prefix.length, -3) : '';
+      if (!SLUG_PATTERN.test(slug) || entry.destination !== canonicalDestination('agent', slug)) {
         invalid(`${path}.destination`, 'must be a canonical agent destination');
       }
       assertDigest(entry.digest, `${path}.digest`);
@@ -209,11 +216,12 @@ function validateCurrent(current, items) {
       && (!currentAgent || currentAgent.digest !== currentDigest)) {
       invalid('current.agents', `must match destination "${item.destination}"`);
     }
+    // Default metadata is derived from agent bytes, so matching digests must agree with it.
     if (currentDigest === item.plannedDigest && currentDigest !== ABSENT_DIGEST
       && currentAgent.isDefault !== item.agent.plannedDefault) {
       invalid('current.agents', `has contradictory planned default metadata for "${item.destination}"`);
     }
-    if (currentDigest === item.approvedDigest
+    if (currentDigest === item.approvedDigest && currentDigest !== ABSENT_DIGEST
       && currentAgent.isDefault !== item.agent.approvedDefault) {
       invalid('current.agents', `has contradictory approved default metadata for "${item.destination}"`);
     }
@@ -233,7 +241,7 @@ function writeOutcome(item) {
   };
 }
 function sortOutcomes(entries) {
-  return entries.sort((left, right) => left.id.localeCompare(right.id));
+  return entries.sort((left, right) => compareIds(left.id, right.id));
 }
 function result(status, writes, unchanged, skipped, blocked, stale) {
   return {
@@ -256,7 +264,7 @@ function evaluateImport(approval, current) {
   for (const item of items) {
     const currentDigest = facts.destinations.get(item.destination).digest;
     if (item.decision === 'skip') {
-      if (currentDigest === item.plannedDigest || currentDigest === item.approvedDigest) {
+      if (currentDigest === item.plannedDigest) {
         skipped.push(basicOutcome(item));
       } else {
         stale.push({ ...basicOutcome(item), reason: 'destination-changed' });

--- a/test/unit/package-import-evaluate.test.js
+++ b/test/unit/package-import-evaluate.test.js
@@ -1,0 +1,511 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  ABSENT_DIGEST,
+  APPROVAL_SCHEMA,
+  evaluateImport,
+} = require('../../lib/packages/import-evaluate.js');
+
+const digest = character => `sha256:${character.repeat(64)}`;
+
+function skill(slug = 'notes', overrides = {}) {
+  return {
+    id: `skill:${slug}`,
+    kind: 'skill',
+    slug,
+    destination: `.claude/skills/${slug}`,
+    collision: false,
+    decision: 'add',
+    plannedDigest: ABSENT_DIGEST,
+    approvedDigest: digest('a'),
+    sourceDigest: digest('b'),
+    agent: null,
+    ...overrides,
+  };
+}
+
+function agent(slug, overrides = {}) {
+  return {
+    id: `agent:${slug}`,
+    kind: 'agent',
+    slug,
+    destination: `.claude/agents/${slug}.md`,
+    collision: false,
+    decision: 'add',
+    plannedDigest: ABSENT_DIGEST,
+    approvedDigest: digest('c'),
+    sourceDigest: digest('d'),
+    agent: { plannedDefault: false, approvedDefault: false },
+    ...overrides,
+  };
+}
+
+function approval(items) {
+  return {
+    schema: APPROVAL_SCHEMA,
+    source: { id: 'package:local:test', reference: null },
+    manifest: items
+      .map(item => ({
+        id: item.id,
+        kind: item.kind,
+        slug: item.slug,
+        sourceDigest: item.sourceDigest,
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    items,
+  };
+}
+
+function current(destinations, sources, agents = []) {
+  return {
+    destinations: Object.entries(destinations).map(([destination, value]) => ({
+      destination,
+      digest: value,
+    })),
+    sources: Object.entries(sources).map(([id, value]) => ({ id, digest: value })),
+    agents,
+  };
+}
+
+function currentFor(items, overrides = {}) {
+  const destinations = {};
+  const sources = {};
+  for (const item of items) {
+    destinations[item.destination] = item.plannedDigest;
+    sources[item.id] = item.sourceDigest;
+  }
+  return current(
+    { ...destinations, ...(overrides.destinations || {}) },
+    { ...sources, ...(overrides.sources || {}) },
+    overrides.agents || [],
+  );
+}
+
+function ids(entries) {
+  return entries.map(entry => entry.id);
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+test('exports the versioned approval schema and absent digest', () => {
+  assert.equal(APPROVAL_SCHEMA, 'rundock.package-import-approval/v1');
+  assert.equal(ABSENT_DIGEST, 'absent');
+});
+
+test('rejects missing, extra and malformed approval fields', () => {
+  const item = skill();
+  const valid = approval([item]);
+  assert.throws(
+    () => evaluateImport({ ...valid, schema: undefined }, currentFor([item])),
+    /approval\.schema/,
+  );
+  assert.throws(
+    () => evaluateImport({ ...valid, extra: true }, currentFor([item])),
+    /approval.*unknown field "extra"/,
+  );
+  assert.throws(
+    () => evaluateImport(approval([{ ...item, decision: undefined }]), currentFor([item])),
+    /decision/,
+  );
+  assert.throws(
+    () => evaluateImport(approval([{ ...item, approvedDigest: 'bad' }]), currentFor([item])),
+    /approvedDigest/,
+  );
+});
+
+test('rejects duplicate, missing and unknown approval items', () => {
+  const item = skill();
+  const duplicateManifest = approval([item]);
+  duplicateManifest.manifest.push({ ...duplicateManifest.manifest[0] });
+  assert.throws(
+    () => evaluateImport(duplicateManifest, currentFor([item])),
+    /duplicate manifest id/,
+  );
+  const missingItem = approval([item]);
+  missingItem.items = [];
+  assert.throws(
+    () => evaluateImport(missingItem, currentFor([item])),
+    /manifest and items must contain the same ids/,
+  );
+  const other = skill('other', { approvedDigest: digest('e'), sourceDigest: digest('f') });
+  const unknownItem = approval([item]);
+  unknownItem.items = [item, other];
+  assert.throws(
+    () => evaluateImport(unknownItem, currentFor([item, other])),
+    /manifest and items must contain the same ids/,
+  );
+});
+
+test('rejects non-canonical identities, destinations and decision state', () => {
+  const item = skill();
+  assert.throws(
+    () => evaluateImport(approval([{ ...item, id: 'skill:other' }]), currentFor([item])),
+    /id: must equal/,
+  );
+  assert.throws(
+    () => evaluateImport(
+      approval([{ ...item, destination: '../outside' }]),
+      current({ '../outside': ABSENT_DIGEST }, { [item.id]: item.sourceDigest }),
+    ),
+    /destination: must equal/,
+  );
+  assert.throws(
+    () => evaluateImport(
+      approval([{ ...item, collision: true }]),
+      currentFor([{ ...item, collision: true }]),
+    ),
+    /collision: must match plannedDigest/,
+  );
+  assert.throws(
+    () => evaluateImport(
+      approval([skill('notes', {
+        collision: true,
+        decision: 'skip',
+        plannedDigest: digest('1'),
+        approvedDigest: digest('2'),
+      })]),
+      current({}, {}),
+    ),
+    /skip.*approvedDigest.*plannedDigest/,
+  );
+});
+
+test('rejects agent metadata that contradicts the matching current digest', () => {
+  const item = agent('existing', {
+    collision: true, decision: 'overwrite',
+    plannedDigest: digest('1'), approvedDigest: digest('2'),
+    agent: { plannedDefault: true, approvedDefault: false },
+  });
+  const snapshot = currentFor([item], { agents: [{
+    destination: item.destination, digest: item.plannedDigest, isDefault: false,
+  }] });
+  assert.throws(() => evaluateImport(approval([item]), snapshot), /planned default metadata/);
+});
+
+const overwriteItem = skill('notes', {
+  collision: true, decision: 'overwrite',
+  plannedDigest: digest('1'), approvedDigest: digest('2'),
+});
+const skippedAbsentItem = skill('notes', {
+  decision: 'skip', approvedDigest: ABSENT_DIGEST,
+});
+const skippedExistingItem = skill('notes', {
+  collision: true, decision: 'skip',
+  plannedDigest: digest('1'), approvedDigest: digest('1'),
+});
+
+for (const row of [
+  { name: 'add at P', item: skill(), currentDigest: ABSENT_DIGEST, outcome: 'writes' },
+  { name: 'add at A', item: skill(), currentDigest: digest('a'), outcome: 'unchanged' },
+  { name: 'add at other C', item: skill(), currentDigest: digest('1'), outcome: 'stale' },
+  { name: 'overwrite at P', item: overwriteItem, currentDigest: digest('1'), outcome: 'writes' },
+  { name: 'overwrite at A', item: overwriteItem, currentDigest: digest('2'), outcome: 'unchanged' },
+  { name: 'overwrite at other C', item: overwriteItem, currentDigest: digest('3'), outcome: 'stale' },
+  { name: 'skip absent at P and A', item: skippedAbsentItem, currentDigest: ABSENT_DIGEST, outcome: 'skipped' },
+  { name: 'skip at P and A', item: skippedExistingItem, currentDigest: digest('1'), outcome: 'skipped' },
+  { name: 'skip at other C', item: skippedExistingItem, currentDigest: digest('2'), outcome: 'stale' },
+]) {
+  test(`classifies ${row.name}`, () => {
+    const input = approval([row.item]);
+    const snapshot = current(
+      { [row.item.destination]: row.currentDigest },
+      { [row.item.id]: row.item.sourceDigest },
+      row.item.kind === 'agent' && row.currentDigest !== ABSENT_DIGEST
+        ? [{
+          destination: row.item.destination,
+          digest: row.currentDigest,
+          isDefault: row.item.agent.approvedDefault,
+        }]
+        : [],
+    );
+    const result = evaluateImport(input, snapshot);
+
+    assert.deepEqual(ids(result[row.outcome]), [row.item.id]);
+    if (row.outcome === 'stale') {
+      assert.equal(result.status, 'stale');
+      assert.deepEqual(result.writes, []);
+    } else {
+      assert.equal(result.status, 'ready');
+    }
+  });
+}
+
+test('one stale item suppresses every otherwise eligible write', () => {
+  const stale = skill('stale', { approvedDigest: digest('1'), sourceDigest: digest('2') });
+  const eligible = skill('eligible', { approvedDigest: digest('3'), sourceDigest: digest('4') });
+  const snapshot = currentFor([stale, eligible], {
+    destinations: { [stale.destination]: digest('5') },
+  });
+  const result = evaluateImport(approval([eligible, stale]), snapshot);
+  assert.equal(result.status, 'stale');
+  assert.deepEqual(result.writes, []);
+  assert.deepEqual(ids(result.stale), [stale.id]);
+});
+
+test('changed or missing source bytes make a pending write stale', () => {
+  const item = skill();
+  const changed = evaluateImport(
+    approval([item]),
+    current({ [item.destination]: ABSENT_DIGEST }, { [item.id]: digest('1') }),
+  );
+  assert.equal(changed.status, 'stale');
+  assert.equal(changed.stale[0].reason, 'source-changed');
+  const missing = evaluateImport(
+    approval([item]),
+    current({ [item.destination]: ABSENT_DIGEST }, {}),
+  );
+  assert.equal(missing.status, 'stale');
+  assert.equal(missing.stale[0].reason, 'source-missing');
+});
+
+test('source bytes are not required when approved bytes are already present', () => {
+  const item = skill();
+  const result = evaluateImport(
+    approval([item]),
+    current({ [item.destination]: item.approvedDigest }, { [item.id]: digest('1') }),
+  );
+
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(ids(result.unchanged), [item.id]);
+  assert.deepEqual(result.stale, []);
+});
+
+test('a current source item absent from approval cannot enter writes', () => {
+  const approved = skill();
+  const result = evaluateImport(
+    approval([approved]),
+    current(
+      { [approved.destination]: ABSENT_DIGEST },
+      { [approved.id]: approved.sourceDigest, 'skill:later': digest('1') },
+    ),
+  );
+
+  assert.deepEqual(ids(result.writes), [approved.id]);
+});
+
+test('blocks an added default when the workspace already has one', () => {
+  const incoming = agent('incoming', {
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+  const existing = {
+    destination: '.claude/agents/existing.md',
+    digest: digest('1'),
+    isDefault: true,
+  };
+
+  const result = evaluateImport(
+    approval([incoming]),
+    currentFor([incoming], { agents: [existing] }),
+  );
+  assert.equal(result.status, 'decisions-blocked');
+  assert.deepEqual(result.writes, []);
+  assert.deepEqual(ids(result.blocked), [incoming.id]);
+  assert.equal(result.blocked[0].reason, 'default-conflict');
+});
+
+test('accepts replacing the existing default with another default as one set', () => {
+  const removeDefault = agent('existing', {
+    collision: true,
+    decision: 'overwrite',
+    plannedDigest: digest('1'),
+    approvedDigest: digest('2'),
+    sourceDigest: digest('3'),
+    agent: { plannedDefault: true, approvedDefault: false },
+  });
+  const addDefault = agent('incoming', {
+    approvedDigest: digest('4'),
+    sourceDigest: digest('5'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+
+  const result = evaluateImport(
+    approval([addDefault, removeDefault]),
+    currentFor([addDefault, removeDefault], {
+      agents: [{
+        destination: removeDefault.destination,
+        digest: removeDefault.plannedDigest,
+        isDefault: true,
+      }],
+    }),
+  );
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(ids(result.writes), [removeDefault.id, addDefault.id]);
+  assert.deepEqual(result.blocked, []);
+});
+
+test('blocks two incoming defaults in either input order', () => {
+  const first = agent('first', {
+    approvedDigest: digest('1'),
+    sourceDigest: digest('2'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+  const second = agent('second', {
+    approvedDigest: digest('3'),
+    sourceDigest: digest('4'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+
+  for (const items of [[first, second], [second, first]]) {
+    const result = evaluateImport(approval(items), currentFor(items));
+    assert.equal(result.status, 'decisions-blocked');
+    assert.deepEqual(ids(result.blocked), [first.id, second.id]);
+    assert.deepEqual(result.writes, []);
+  }
+});
+
+test('keeps an unrelated skill eligible when default choices conflict', () => {
+  const first = agent('first', {
+    approvedDigest: digest('1'),
+    sourceDigest: digest('2'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+  const second = agent('second', {
+    approvedDigest: digest('3'),
+    sourceDigest: digest('4'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+  const unrelated = skill('unrelated', {
+    approvedDigest: digest('5'),
+    sourceDigest: digest('6'),
+  });
+  const items = [first, unrelated, second];
+  const result = evaluateImport(approval(items), currentFor(items));
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(ids(result.blocked), [first.id, second.id]);
+  assert.deepEqual(ids(result.writes), [unrelated.id]);
+});
+
+test('keeps a skipped default and writes an unrelated item', () => {
+  const skipped = agent('existing', {
+    collision: true,
+    decision: 'skip',
+    plannedDigest: digest('1'),
+    approvedDigest: digest('1'),
+    sourceDigest: digest('2'),
+    agent: { plannedDefault: true, approvedDefault: true },
+  });
+  const unrelated = skill('unrelated', {
+    approvedDigest: digest('3'),
+    sourceDigest: digest('4'),
+  });
+
+  const result = evaluateImport(
+    approval([unrelated, skipped]),
+    currentFor([unrelated, skipped], {
+      agents: [{
+        destination: skipped.destination,
+        digest: skipped.plannedDigest,
+        isDefault: true,
+      }],
+    }),
+  );
+
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(ids(result.skipped), [skipped.id]);
+  assert.deepEqual(ids(result.writes), [unrelated.id]);
+});
+
+test('a pre-existing multi-default workspace does not block an unrelated item', () => {
+  const unrelated = skill();
+  const result = evaluateImport(
+    approval([unrelated]),
+    currentFor([unrelated], {
+      agents: [
+        { destination: '.claude/agents/one.md', digest: digest('1'), isDefault: true },
+        { destination: '.claude/agents/two.md', digest: digest('2'), isDefault: true },
+      ],
+    }),
+  );
+
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(ids(result.writes), [unrelated.id]);
+  assert.deepEqual(result.blocked, []);
+});
+
+test('permuting every input collection produces the same result', () => {
+  const first = agent('first', {
+    approvedDigest: digest('1'),
+    sourceDigest: digest('2'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+  const second = agent('second', {
+    approvedDigest: digest('3'),
+    sourceDigest: digest('4'),
+    agent: { plannedDefault: false, approvedDefault: true },
+  });
+  const unrelated = skill('unrelated', {
+    approvedDigest: digest('5'),
+    sourceDigest: digest('6'),
+  });
+  const items = [first, second, unrelated];
+  const leftApproval = approval(items);
+  const rightApproval = approval([...items].reverse());
+  const leftCurrent = currentFor(items, {
+    agents: [
+      { destination: '.claude/agents/zulu.md', digest: digest('7'), isDefault: false },
+      { destination: '.claude/agents/alpha.md', digest: digest('8'), isDefault: false },
+    ],
+  });
+  const rightCurrent = {
+    destinations: [...leftCurrent.destinations].reverse(),
+    sources: [...leftCurrent.sources].reverse(),
+    agents: [...leftCurrent.agents].reverse(),
+  };
+
+  assert.deepEqual(
+    evaluateImport(leftApproval, leftCurrent),
+    evaluateImport(rightApproval, rightCurrent),
+  );
+});
+
+test('does not mutate frozen approval or current inputs', () => {
+  const item = skill();
+  const input = deepFreeze(approval([item]));
+  const snapshot = deepFreeze(currentFor([item]));
+  const approvalBefore = JSON.stringify(input);
+  const currentBefore = JSON.stringify(snapshot);
+
+  assert.doesNotThrow(() => evaluateImport(input, snapshot));
+  assert.equal(JSON.stringify(input), approvalBefore);
+  assert.equal(JSON.stringify(snapshot), currentBefore);
+});
+
+test('replaying exact approved destinations produces only unchanged outcomes', () => {
+  const first = skill('first', { approvedDigest: digest('1'), sourceDigest: digest('2') });
+  const second = skill('second', { approvedDigest: digest('3'), sourceDigest: digest('4') });
+  const result = evaluateImport(
+    approval([first, second]),
+    current(
+      {
+        [first.destination]: first.approvedDigest,
+        [second.destination]: second.approvedDigest,
+      },
+      {},
+    ),
+  );
+
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(result.writes, []);
+  assert.deepEqual(ids(result.unchanged), [first.id, second.id]);
+});
+
+test('write outcomes expose only approved adapter fields', () => {
+  const item = skill();
+  const result = evaluateImport(approval([item]), currentFor([item]));
+
+  assert.deepEqual(result.writes, [{
+    id: item.id,
+    kind: item.kind,
+    destination: item.destination,
+    approvedDigest: item.approvedDigest,
+    sourceDigest: item.sourceDigest,
+  }]);
+});

--- a/test/unit/package-import-evaluate.test.js
+++ b/test/unit/package-import-evaluate.test.js
@@ -48,12 +48,7 @@ function approval(items) {
     schema: APPROVAL_SCHEMA,
     source: { id: 'package:local:test', reference: null },
     manifest: items
-      .map(item => ({
-        id: item.id,
-        kind: item.kind,
-        slug: item.slug,
-        sourceDigest: item.sourceDigest,
-      }))
+      .map(item => ({ id: item.id, kind: item.kind, slug: item.slug, sourceDigest: item.sourceDigest }))
       .sort((left, right) => left.id.localeCompare(right.id)),
     items,
   };
@@ -61,10 +56,8 @@ function approval(items) {
 
 function current(destinations, sources, agents = []) {
   return {
-    destinations: Object.entries(destinations).map(([destination, value]) => ({
-      destination,
-      digest: value,
-    })),
+    destinations: Object.entries(destinations)
+      .map(([destination, value]) => ({ destination, digest: value })),
     sources: Object.entries(sources).map(([id, value]) => ({ id, digest: value })),
     agents,
   };
@@ -188,6 +181,32 @@ test('rejects agent metadata that contradicts the matching current digest', () =
     destination: item.destination, digest: item.plannedDigest, isDefault: false,
   }] });
   assert.throws(() => evaluateImport(approval([item]), snapshot), /planned default metadata/);
+
+  const approvedSnapshot = currentFor([item], {
+    destinations: { [item.destination]: item.approvedDigest },
+    agents: [{ destination: item.destination, digest: item.approvedDigest, isDefault: true }],
+  });
+  assert.throws(() => evaluateImport(approval([item]), approvedSnapshot), /approved default metadata/);
+});
+
+test('rejects malformed manifest, item and current fact combinations', () => {
+  const first = skill('first', { approvedDigest: digest('1'), sourceDigest: digest('2') });
+  const second = skill('second', { approvedDigest: digest('3'), sourceDigest: digest('4') });
+  const unsorted = approval([first, second]);
+  unsorted.manifest.reverse();
+  assert.throws(() => evaluateImport(unsorted, currentFor([first, second])), /sorted by id/);
+  const mismatch = approval([first]);
+  mismatch.manifest[0].sourceDigest = digest('5');
+  assert.throws(() => evaluateImport(mismatch, currentFor([first])), /match its manifest entry/);
+  const duplicate = approval([first]);
+  duplicate.items.push({ ...first });
+  assert.throws(() => evaluateImport(duplicate, currentFor([first])), /duplicate item id/);
+  assert.throws(() => evaluateImport(approval([{ ...first, agent: {} }]), currentFor([first])), /must be null for a skill/);
+  assert.throws(() => evaluateImport(approval([first]), current({}, { [first.id]: first.sourceDigest })), /is missing/);
+  const absent = agent('absent');
+  assert.throws(() => evaluateImport(approval([absent]), currentFor([absent], { agents: [{
+    destination: absent.destination, digest: digest('6'), isDefault: false,
+  }] })), /contains absent destination/);
 });
 
 const overwriteItem = skill('notes', {
@@ -210,6 +229,8 @@ for (const row of [
   { name: 'overwrite at A', item: overwriteItem, currentDigest: digest('2'), outcome: 'unchanged' },
   { name: 'overwrite at other C', item: overwriteItem, currentDigest: digest('3'), outcome: 'stale' },
   { name: 'skip absent at P and A', item: skippedAbsentItem, currentDigest: ABSENT_DIGEST, outcome: 'skipped' },
+  { name: 'agent skip absent at P and A', item: agent('skipped', { decision: 'skip', approvedDigest: ABSENT_DIGEST }), currentDigest: ABSENT_DIGEST, outcome: 'skipped' },
+  { name: 'agent add at A', item: agent('present'), currentDigest: digest('c'), outcome: 'unchanged' },
   { name: 'skip at P and A', item: skippedExistingItem, currentDigest: digest('1'), outcome: 'skipped' },
   { name: 'skip at other C', item: skippedExistingItem, currentDigest: digest('2'), outcome: 'stale' },
 ]) {
@@ -227,7 +248,6 @@ for (const row of [
         : [],
     );
     const result = evaluateImport(input, snapshot);
-
     assert.deepEqual(ids(result[row.outcome]), [row.item.id]);
     if (row.outcome === 'stale') {
       assert.equal(result.status, 'stale');
@@ -272,13 +292,12 @@ test('source bytes are not required when approved bytes are already present', ()
     approval([item]),
     current({ [item.destination]: item.approvedDigest }, { [item.id]: digest('1') }),
   );
-
   assert.equal(result.status, 'ready');
   assert.deepEqual(ids(result.unchanged), [item.id]);
   assert.deepEqual(result.stale, []);
 });
 
-test('a current source item absent from approval cannot enter writes', () => {
+test('a current source item absent from approval cannot enter any outcome', () => {
   const approved = skill();
   const result = evaluateImport(
     approval([approved]),
@@ -287,8 +306,11 @@ test('a current source item absent from approval cannot enter writes', () => {
       { [approved.id]: approved.sourceDigest, 'skill:later': digest('1') },
     ),
   );
-
-  assert.deepEqual(ids(result.writes), [approved.id]);
+  assert.equal(result.status, 'ready');
+  assert.deepEqual(
+    ['writes', 'unchanged', 'skipped', 'blocked', 'stale'].flatMap(key => ids(result[key])),
+    [approved.id],
+  );
 });
 
 test('blocks an added default when the workspace already has one', () => {
@@ -300,7 +322,6 @@ test('blocks an added default when the workspace already has one', () => {
     digest: digest('1'),
     isDefault: true,
   };
-
   const result = evaluateImport(
     approval([incoming]),
     currentFor([incoming], { agents: [existing] }),
@@ -376,11 +397,14 @@ test('keeps an unrelated skill eligible when default choices conflict', () => {
     approvedDigest: digest('5'),
     sourceDigest: digest('6'),
   });
-  const items = [first, unrelated, second];
+  const nonDefault = agent('non-default', {
+    approvedDigest: digest('7'), sourceDigest: digest('8'),
+  });
+  const items = [first, unrelated, nonDefault, second];
   const result = evaluateImport(approval(items), currentFor(items));
   assert.equal(result.status, 'ready');
   assert.deepEqual(ids(result.blocked), [first.id, second.id]);
-  assert.deepEqual(ids(result.writes), [unrelated.id]);
+  assert.deepEqual(ids(result.writes), [nonDefault.id, unrelated.id]);
 });
 
 test('keeps a skipped default and writes an unrelated item', () => {
@@ -407,7 +431,6 @@ test('keeps a skipped default and writes an unrelated item', () => {
       }],
     }),
   );
-
   assert.equal(result.status, 'ready');
   assert.deepEqual(ids(result.skipped), [skipped.id]);
   assert.deepEqual(ids(result.writes), [unrelated.id]);
@@ -455,8 +478,7 @@ test('permuting every input collection produces the same result', () => {
     ],
   });
   const rightCurrent = {
-    destinations: [...leftCurrent.destinations].reverse(),
-    sources: [...leftCurrent.sources].reverse(),
+    destinations: [...leftCurrent.destinations].reverse(), sources: [...leftCurrent.sources].reverse(),
     agents: [...leftCurrent.agents].reverse(),
   };
 
@@ -484,10 +506,7 @@ test('replaying exact approved destinations produces only unchanged outcomes', (
   const result = evaluateImport(
     approval([first, second]),
     current(
-      {
-        [first.destination]: first.approvedDigest,
-        [second.destination]: second.approvedDigest,
-      },
+      { [first.destination]: first.approvedDigest, [second.destination]: second.approvedDigest },
       {},
     ),
   );
@@ -501,11 +520,7 @@ test('write outcomes expose only approved adapter fields', () => {
   const item = skill();
   const result = evaluateImport(approval([item]), currentFor([item]));
 
-  assert.deepEqual(result.writes, [{
-    id: item.id,
-    kind: item.kind,
-    destination: item.destination,
-    approvedDigest: item.approvedDigest,
-    sourceDigest: item.sourceDigest,
-  }]);
+  assert.deepEqual(result.writes, [{ id: item.id, kind: item.kind,
+    destination: item.destination, approvedDigest: item.approvedDigest,
+    sourceDigest: item.sourceDigest }]);
 });


### PR DESCRIPTION
## Summary
- validate versioned package import approvals and current state snapshots
- classify pending, unchanged, skipped and stale items without filesystem access
- calculate default-agent conflicts as a complete set while preserving unrelated writes

## Testing
- node --test test/unit/package-import-evaluate.test.js
- npm run precommit
- npm run red-first