### PR TITLE
Apply approved package imports through the atomic write primitive

### DIFF
--- a/lib/agents/discovery.js
+++ b/lib/agents/discovery.js
@@ -47,6 +47,14 @@ const GUIDE_RESERVED_ICON = '⬡';
 // next time somebody extends this.
 const AUTO_ASSIGNED_ICONS = ['★', '✎', '◎', '▦', '◇', '✦', '△'];
 
+// THE one definition of default-agent membership, from parsed frontmatter.
+// Exported so the package-import snapshot judges defaults with exactly the
+// rule the running product uses; a private copy elsewhere is how an import
+// quietly creates a second default.
+function agentIsDefault(meta) {
+  return meta.isDefault === 'true' || meta.isDefault === true || Boolean(meta.order && parseInt(meta.order) === 0);
+}
+
 function discoverAgents() {
   // No workspace selected yet: nothing to discover. Guards path.join(null,…),
   // which otherwise throws and crashes GET /api/agents before a workspace is
@@ -71,7 +79,7 @@ function discoverAgents() {
         const fmText = extractFrontmatterText(content);
         const meta = parseAgentFrontmatter(content);
         const id = file.replace('.md', '');
-        const isDefault = meta.isDefault === 'true' || meta.isDefault === true || (meta.order && parseInt(meta.order) === 0);
+        const isDefault = agentIsDefault(meta);
 
         const fmName = meta.name || id;
         const displayName = meta.displayName || meta.name || titleCase(id);
@@ -393,7 +401,7 @@ function parseSkills(fmText) {
 }
 
 module.exports = {
-  discoverAgents, invalidateAgentCache,
+  discoverAgents, invalidateAgentCache, agentIsDefault,
   readNormalisedFile, extractFrontmatterText, titleCase,
   parseAgentFrontmatter, parseCapabilities, parseRoutines, parsePrompts, parseSkills,
   AGENT_CACHE_TTL, AGENT_INSTRUCTIONS_MAX,

--- a/lib/packages/import-apply.js
+++ b/lib/packages/import-apply.js
@@ -16,7 +16,7 @@ const path = require('node:path');
 
 const { evaluateImport, ABSENT_DIGEST } = require('./import-evaluate.js');
 const { writeAsUnit, recoverPendingWrites } = require('../workspace/atomic-write.js');
-const { readNormalisedFile, parseAgentFrontmatter } = require('../agents/discovery.js');
+const { readNormalisedFile, parseAgentFrontmatter, agentIsDefault } = require('../agents/discovery.js');
 
 const DIGEST_VERSION = 'rundock-content-v1';
 const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -102,20 +102,18 @@ function toAbsolute(root, relative) {
 // is never overwritten, and the transformation is deterministic so the plan
 // side derives the approved digest from exactly these bytes.
 function withProvenance(text, sourceId) {
-  if (text.startsWith('---\n')) {
-    const end = text.indexOf('\n---', 4);
-    if (end !== -1) {
-      if (/^source:/m.test(text.slice(4, end))) return text;
-      return `${text.slice(0, end)}\nsource: ${sourceId}${text.slice(end)}`;
-    }
-  }
-  return `---\nsource: ${sourceId}\n---\n\n${text}`;
-}
-
-// The same default-agent reading discovery applies, so the snapshot and the
-// running product cannot disagree about who the default is.
-function isDefaultAgent(meta) {
-  return meta.isDefault === 'true' || meta.isDefault === true || Boolean(meta.order && parseInt(meta.order, 10) === 0);
+  // A leading byte-order mark is dropped in every branch: the product's
+  // frontmatter reader does not tolerate one, and an imported agent must be
+  // readable by the product that imported it.
+  const rest = text.startsWith('\ufeff') ? text.slice(1) : text;
+  const open = /^---\r?\n/.exec(rest);
+  if (!open) return `---\nsource: ${sourceId}\n---\n\n${rest}`;
+  const eol = open[0].slice(3); // the file's own line ending
+  const close = /\r?\n---(\r?\n|$)/.exec(rest.slice(open[0].length));
+  if (!close) throw new Error('agent frontmatter opens but never closes; refusing to transform');
+  const closeIndex = open[0].length + close.index;
+  if (/^source:/m.test(rest.slice(open[0].length, closeIndex))) return rest;
+  return `${rest.slice(0, closeIndex)}${eol}source: ${sourceId}${rest.slice(closeIndex)}`;
 }
 
 // The exact `current` snapshot shape the evaluator validates: one digest per
@@ -165,7 +163,7 @@ function snapshotCurrent(workspace, sourceRoot, approval) {
       throw e;
     }
     if (!stat.isFile()) throw new TypeError(`unsupported filesystem entry type at ${absolute}`);
-    const isDefault = isDefaultAgent(parseAgentFrontmatter(readNormalisedFile(absolute)));
+    const isDefault = agentIsDefault(parseAgentFrontmatter(readNormalisedFile(absolute)));
     if (!SLUG.test(name.slice(0, -3))) {
       if (isDefault) {
         throw new TypeError(`agent file ${name} declares default membership but is outside canonical naming, so default validity cannot be evaluated`);

--- a/lib/packages/import-apply.js
+++ b/lib/packages/import-apply.js
@@ -1,0 +1,214 @@
+'use strict';
+// The filesystem adapter between the pure import evaluator and the atomic
+// write primitive. It owns three things and nothing else: reading the real
+// workspace and package source into the exact snapshot shape the evaluator
+// validates, refusing to write bytes it cannot verify against the approval,
+// and handing the evaluator's complete eligible write set to writeAsUnit as
+// one transaction. It never reinterprets, filters or reorders a decision.
+//
+// The canonical content digests are defined HERE and exported, so the future
+// plan module computes approval digests with the same functions this adapter
+// uses to observe the filesystem. A digest never covers timestamps, inode
+// identity or traversal order.
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { evaluateImport, ABSENT_DIGEST } = require('./import-evaluate.js');
+const { writeAsUnit, recoverPendingWrites } = require('../workspace/atomic-write.js');
+const { readNormalisedFile, parseAgentFrontmatter } = require('../agents/discovery.js');
+
+const DIGEST_VERSION = 'rundock-content-v1';
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function sha256(update) {
+  const hash = crypto.createHash('sha256');
+  update(hash);
+  return `sha256:${hash.digest('hex')}`;
+}
+
+// A file digest covers its exact bytes plus the canonical file marker, so a
+// file and a directory with coinciding content can never share a digest.
+function digestFile(bytes) {
+  return sha256((hash) => {
+    hash.update(`${DIGEST_VERSION}:file\0`);
+    hash.update(bytes);
+  });
+}
+
+// A directory digest covers the sorted relative path and exact bytes of
+// every regular file. Empty directories are not represented: the write
+// primitive replaces a directory with exactly the files it is given, so an
+// empty directory cannot survive an import and must not influence identity.
+// Symlinks, devices and other entry types are refused, never followed.
+function walkDirectory(root) {
+  const files = [];
+  const stack = [''];
+  while (stack.length) {
+    const relative = stack.pop();
+    const absolute = path.join(root, relative.split('/').join(path.sep));
+    for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+      const childRelative = relative ? `${relative}/${entry.name}` : entry.name;
+      if (entry.isSymbolicLink()) throw new TypeError(`unsupported symlink at ${root}/${childRelative}`);
+      if (entry.isDirectory()) stack.push(childRelative);
+      else if (entry.isFile()) files.push(childRelative);
+      else throw new TypeError(`unsupported filesystem entry type at ${root}/${childRelative}`);
+    }
+  }
+  return files.sort();
+}
+
+function digestDirectory(root) {
+  const files = walkDirectory(root);
+  return sha256((hash) => {
+    hash.update(`${DIGEST_VERSION}:dir\0`);
+    for (const relative of files) {
+      hash.update(`${relative}\0`);
+      hash.update(digestFile(fs.readFileSync(path.join(root, relative.split('/').join(path.sep)))));
+      hash.update('\n');
+    }
+  });
+}
+
+// What is at a path right now, as a digest: the absent sentinel, a file
+// digest, or a directory digest. A symlink or special file is refused.
+function digestAt(absolute) {
+  let stat;
+  try {
+    stat = fs.lstatSync(absolute);
+  } catch {
+    return ABSENT_DIGEST;
+  }
+  if (stat.isFile()) return digestFile(fs.readFileSync(absolute));
+  if (stat.isDirectory()) return digestDirectory(absolute);
+  throw new TypeError(`unsupported filesystem entry type at ${absolute}`);
+}
+
+function itemRelativePath(kind, slug) {
+  return kind === 'agent' ? `.claude/agents/${slug}.md` : `.claude/skills/${slug}`;
+}
+
+function toAbsolute(root, relative) {
+  return path.join(root, relative.split('/').join(path.sep));
+}
+
+// The provenance transformation an imported agent receives: a `source:` line
+// recording where it came from, informational only. An existing source value
+// is never overwritten, and the transformation is deterministic so the plan
+// side derives the approved digest from exactly these bytes.
+function withProvenance(text, sourceId) {
+  if (text.startsWith('---\n')) {
+    const end = text.indexOf('\n---', 4);
+    if (end !== -1) {
+      if (/^source:/m.test(text.slice(4, end))) return text;
+      return `${text.slice(0, end)}\nsource: ${sourceId}${text.slice(end)}`;
+    }
+  }
+  return `---\nsource: ${sourceId}\n---\n\n${text}`;
+}
+
+// The same default-agent reading discovery applies, so the snapshot and the
+// running product cannot disagree about who the default is.
+function isDefaultAgent(meta) {
+  return meta.isDefault === 'true' || meta.isDefault === true || Boolean(meta.order && parseInt(meta.order, 10) === 0);
+}
+
+// The exact `current` snapshot shape the evaluator validates: one digest per
+// approval destination, one digest per present source item, and every
+// canonically-named agent in the workspace with its default membership.
+// Agents whose filename is not a valid slug are outside the evaluator's
+// contract (it admits only canonical destinations) and are not represented.
+function snapshotCurrent(workspace, sourceRoot, approval) {
+  if (!approval || !Array.isArray(approval.items) || !Array.isArray(approval.manifest)) {
+    throw new TypeError('approval must carry items and manifest arrays');
+  }
+  const destinations = [];
+  const seen = new Set();
+  for (const item of approval.items) {
+    if (!item || typeof item.destination !== 'string' || seen.has(item.destination)) continue;
+    seen.add(item.destination);
+    destinations.push({ destination: item.destination, digest: digestAt(toAbsolute(workspace, item.destination)) });
+  }
+  const sources = [];
+  for (const entry of approval.manifest) {
+    if (!entry || typeof entry.id !== 'string') continue;
+    const absolute = toAbsolute(sourceRoot, itemRelativePath(entry.kind, entry.slug));
+    const digest = digestAt(absolute);
+    if (digest !== ABSENT_DIGEST) sources.push({ id: entry.id, digest });
+  }
+  const agents = [];
+  const agentsDir = path.join(workspace, '.claude', 'agents');
+  let names = [];
+  try { names = fs.readdirSync(agentsDir); } catch { /* no agents directory */ }
+  for (const name of names.sort()) {
+    if (!name.endsWith('.md') || !SLUG.test(name.slice(0, -3))) continue;
+    const absolute = path.join(agentsDir, name);
+    if (!fs.lstatSync(absolute).isFile()) continue;
+    agents.push({
+      destination: `.claude/agents/${name.slice(0, -3)}`.concat('.md'),
+      digest: digestFile(fs.readFileSync(absolute)),
+      isDefault: isDefaultAgent(parseAgentFrontmatter(readNormalisedFile(absolute))),
+    });
+  }
+  return { destinations, sources, agents };
+}
+
+// One eligible write, turned into verified bytes. The digests recorded at
+// approval time are the authority: bytes that do not hash to them are never
+// written, whatever the reason for the difference.
+function materialise(sourceRoot, sourceId, write) {
+  const absolute = toAbsolute(sourceRoot, write.destination);
+  if (write.kind === 'agent') {
+    const bytes = fs.readFileSync(absolute);
+    if (digestFile(bytes) !== write.sourceDigest) {
+      throw new Error(`source for ${write.id} changed after approval; refusing to write`);
+    }
+    const transformed = Buffer.from(withProvenance(bytes.toString('utf8'), sourceId), 'utf8');
+    if (digestFile(transformed) !== write.approvedDigest) {
+      throw new Error(`bytes for ${write.id} do not match the approved digest; refusing to write`);
+    }
+    return { file: transformed };
+  }
+  if (digestDirectory(absolute) !== write.sourceDigest) {
+    throw new Error(`source for ${write.id} changed after approval; refusing to write`);
+  }
+  if (write.approvedDigest !== write.sourceDigest) {
+    throw new Error(`bytes for ${write.id} do not match the approved digest; refusing to write`);
+  }
+  return {
+    files: walkDirectory(absolute).map((relative) => ({
+      rel: relative.split('/').join(path.sep),
+      content: fs.readFileSync(path.join(absolute, relative.split('/').join(path.sep))),
+    })),
+  };
+}
+
+// Snapshot, evaluate, and execute exactly what the evaluator allows, as one
+// transaction. Recovery of any interrupted prior transaction comes first, so
+// the snapshot never observes a half-committed workspace.
+function applyImport(workspace, sourceRoot, approval, options = {}) {
+  recoverPendingWrites(workspace);
+  const current = snapshotCurrent(workspace, sourceRoot, approval);
+  const evaluation = evaluateImport(approval, current);
+  if (evaluation.status !== 'ready') return { ...evaluation, written: [] };
+
+  const writes = [];
+  const replaceDirs = [];
+  for (const write of evaluation.writes) {
+    const payload = materialise(sourceRoot, approval.source.id, write);
+    const destination = toAbsolute(workspace, write.destination);
+    if (payload.file) writes.push({ path: destination, content: payload.file });
+    else replaceDirs.push({ path: destination, files: payload.files });
+  }
+  const result = writeAsUnit(workspace, writes, { replaceDirs, afterStep: options.afterStep });
+  return { ...evaluation, written: result.written };
+}
+
+module.exports = {
+  applyImport,
+  snapshotCurrent,
+  digestFile,
+  digestDirectory,
+  withProvenance,
+};

--- a/lib/packages/import-apply.js
+++ b/lib/packages/import-apply.js
@@ -117,8 +117,11 @@ function isDefaultAgent(meta) {
 // The exact `current` snapshot shape the evaluator validates: one digest per
 // approval destination, one digest per present source item, and every
 // canonically-named agent in the workspace with its default membership.
-// Agents whose filename is not a valid slug are outside the evaluator's
-// contract (it admits only canonical destinations) and are not represented.
+// The evaluator's contract admits only canonical slug destinations, so a
+// non-slug agent file cannot be represented. Omitting one is provably
+// harmless while it is not a default (the projection only counts defaults),
+// and a refusal when it IS one, so an unrepresentable default can never let
+// an import create a second default.
 function snapshotCurrent(workspace, sourceRoot, approval) {
   if (!approval || !Array.isArray(approval.items) || !Array.isArray(approval.manifest)) {
     throw new TypeError('approval must carry items and manifest arrays');
@@ -142,13 +145,27 @@ function snapshotCurrent(workspace, sourceRoot, approval) {
   let names = [];
   try { names = fs.readdirSync(agentsDir); } catch { /* no agents directory */ }
   for (const name of names.sort()) {
-    if (!name.endsWith('.md') || !SLUG.test(name.slice(0, -3))) continue;
+    if (!name.endsWith('.md')) continue;
     const absolute = path.join(agentsDir, name);
-    if (!fs.lstatSync(absolute).isFile()) continue;
+    let stat;
+    try {
+      stat = fs.lstatSync(absolute);
+    } catch (e) {
+      if (e.code === 'ENOENT') continue; // removed since the readdir: absent
+      throw e;
+    }
+    if (!stat.isFile()) throw new TypeError(`unsupported filesystem entry type at ${absolute}`);
+    const isDefault = isDefaultAgent(parseAgentFrontmatter(readNormalisedFile(absolute)));
+    if (!SLUG.test(name.slice(0, -3))) {
+      if (isDefault) {
+        throw new TypeError(`agent file ${name} declares default membership but is outside canonical naming, so default validity cannot be evaluated`);
+      }
+      continue;
+    }
     agents.push({
-      destination: `.claude/agents/${name.slice(0, -3)}`.concat('.md'),
+      destination: `.claude/agents/${name}`,
       digest: digestFile(fs.readFileSync(absolute)),
-      isDefault: isDefaultAgent(parseAgentFrontmatter(readNormalisedFile(absolute))),
+      isDefault,
     });
   }
   return { destinations, sources, agents };

--- a/lib/packages/import-apply.js
+++ b/lib/packages/import-apply.js
@@ -1,10 +1,9 @@
 'use strict';
 // The filesystem adapter between the pure import evaluator and the atomic
-// write primitive. It owns three things and nothing else: reading the real
-// workspace and package source into the exact snapshot shape the evaluator
-// validates, refusing to write bytes it cannot verify against the approval,
-// and handing the evaluator's complete eligible write set to writeAsUnit as
-// one transaction. It never reinterprets, filters or reorders a decision.
+// write primitive: it reads the real workspace and package source into the
+// exact snapshot shape the evaluator validates, refuses bytes it cannot
+// verify against the approval, and hands the complete eligible write set to
+// writeAsUnit as one transaction. It never reinterprets a decision.
 //
 // The canonical content digests are defined HERE and exported, so the future
 // plan module computes approval digests with the same functions this adapter
@@ -78,10 +77,10 @@ function digestAt(absolute) {
   try {
     stat = fs.lstatSync(absolute);
   } catch (e) {
-    // ENOENT is absence, and ENOTDIR means a parent that should be a
-    // directory is a file, below which nothing can exist. Every other
-    // failure is a failed observation, not a fact: reporting it as absence
-    // is what turns a collision into an unreviewed overwrite, so it aborts.
+    // ENOENT is absence; ENOTDIR is a file where a parent dir belongs, below
+    // which nothing can exist. Every other failure is a failed observation,
+    // not a fact, and reporting it as absence turns a collision into an
+    // unreviewed overwrite: it aborts instead.
     if (e.code === 'ENOENT' || e.code === 'ENOTDIR') return ABSENT_DIGEST;
     throw e;
   }
@@ -151,9 +150,8 @@ function snapshotCurrent(workspace, sourceRoot, approval) {
   try {
     names = fs.readdirSync(agentsDir);
   } catch (e) {
-    // Only a missing directory means no agents. An unreadable directory or
-    // a file at this path is a failed observation: an empty agent set here
-    // could hide an existing default from the projection.
+    // Only a missing directory means no agents: an empty set from a failed
+    // read could hide an existing default from the projection.
     if (e.code !== 'ENOENT') throw e;
   }
   for (const name of names.sort()) {

--- a/lib/packages/import-apply.js
+++ b/lib/packages/import-apply.js
@@ -77,8 +77,13 @@ function digestAt(absolute) {
   let stat;
   try {
     stat = fs.lstatSync(absolute);
-  } catch {
-    return ABSENT_DIGEST;
+  } catch (e) {
+    // ENOENT is absence, and ENOTDIR means a parent that should be a
+    // directory is a file, below which nothing can exist. Every other
+    // failure is a failed observation, not a fact: reporting it as absence
+    // is what turns a collision into an unreviewed overwrite, so it aborts.
+    if (e.code === 'ENOENT' || e.code === 'ENOTDIR') return ABSENT_DIGEST;
+    throw e;
   }
   if (stat.isFile()) return digestFile(fs.readFileSync(absolute));
   if (stat.isDirectory()) return digestDirectory(absolute);
@@ -143,7 +148,14 @@ function snapshotCurrent(workspace, sourceRoot, approval) {
   const agents = [];
   const agentsDir = path.join(workspace, '.claude', 'agents');
   let names = [];
-  try { names = fs.readdirSync(agentsDir); } catch { /* no agents directory */ }
+  try {
+    names = fs.readdirSync(agentsDir);
+  } catch (e) {
+    // Only a missing directory means no agents. An unreadable directory or
+    // a file at this path is a failed observation: an empty agent set here
+    // could hide an existing default from the projection.
+    if (e.code !== 'ENOENT') throw e;
+  }
   for (const name of names.sort()) {
     if (!name.endsWith('.md')) continue;
     const absolute = path.join(agentsDir, name);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:refs": "node scripts/check-internal-refs.js",
     "precommit": "node scripts/precommit-gate.js",
     "red-first": "node scripts/red-first.js",
-    "mutate:guards": "node test/tools/mutate-render-guards.js --markdown && node test/tools/mutate-routine-editor-guards.js --markdown && node test/tools/mutate-routines-guards.js --markdown && node test/tools/mutate-run-detail-guards.js --markdown && node test/tools/mutate-nav-guards.js --markdown && node test/tools/mutate-workspace-rollback-guards.js --markdown && node test/tools/mutate-fence-guards.js --markdown && node test/tools/mutate-atomic-write-guards.js --markdown",
+    "mutate:guards": "node test/tools/mutate-render-guards.js --markdown && node test/tools/mutate-routine-editor-guards.js --markdown && node test/tools/mutate-routines-guards.js --markdown && node test/tools/mutate-run-detail-guards.js --markdown && node test/tools/mutate-nav-guards.js --markdown && node test/tools/mutate-workspace-rollback-guards.js --markdown && node test/tools/mutate-fence-guards.js --markdown && node test/tools/mutate-atomic-write-guards.js --markdown && node test/tools/mutate-import-apply-guards.js --markdown",
     "check:fixture": "node test/tools/regenerate-benign-before.js --check",
     "lint:styles": "node test/tools/style-drift.js",
     "typecheck": "tsc -p tsconfig.server.json && tsc -p tsconfig.client.json",

--- a/test/tools/mutate-import-apply-guards.js
+++ b/test/tools/mutate-import-apply-guards.js
@@ -48,6 +48,14 @@ const MUTATIONS = [
   [ADAPTER, 'a directory digest covers where each file lives, not only its bytes',
     '      hash.update(`${relative}\\0`);\n',
     ''],
+  [ADAPTER, 'every eligible write lands in one transaction, not several',
+    '  const result = writeAsUnit(workspace, writes, { replaceDirs, afterStep: options.afterStep });',
+    '  const first = writeAsUnit(workspace, writes, { afterStep: options.afterStep });\n'
+    + '  const second = writeAsUnit(workspace, [], { replaceDirs, afterStep: options.afterStep });\n'
+    + '  const result = { written: [...first.written, ...second.written] };'],
+  [ADAPTER, 'recovery runs before the snapshot, not merely at some point',
+    '  recoverPendingWrites(workspace);\n  const current = snapshotCurrent(workspace, sourceRoot, approval);',
+    '  const current = snapshotCurrent(workspace, sourceRoot, approval);\n  recoverPendingWrites(workspace);'],
 ];
 
 // Guards deliberately NOT mutated, each with the reason.

--- a/test/tools/mutate-import-apply-guards.js
+++ b/test/tools/mutate-import-apply-guards.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+'use strict';
+// Take the import apply adapter's guards apart one at a time and report which
+// tests notice. The adapter's whole job is refusing to write what it cannot
+// verify and executing exactly what the evaluator allowed, and every one of
+// those refusals could be deleted with the happy path still green unless a
+// test is proven to notice.
+//
+//   node test/tools/mutate-import-apply-guards.js            # report
+//   node test/tools/mutate-import-apply-guards.js --markdown # as a table
+//
+// The harness is the same shape as mutate-atomic-write-guards.js and is
+// deliberately a second copy rather than a shared module, for the reason
+// stated there: pulling them together means editing an instrument already in
+// the gate, and mixing that refactor into a change is how a gate quietly
+// stops checking what it used to.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const os = require('node:os');
+const { preflight } = require('../helpers/temp-root.js');
+const { beginMutationRun } = require('./mutation-run.js');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+const ADAPTER = {
+  src: path.join(ROOT, 'lib', 'packages', 'import-apply.js'),
+  suite: 'test/unit/package-import-apply.test.js',
+};
+
+// [target, label, the guard as it is written, what it becomes without it]
+const MUTATIONS = [
+  [ADAPTER, 'an interrupted prior transaction is recovered before anything else',
+    '  recoverPendingWrites(workspace);\n',
+    ''],
+  [ADAPTER, 'only a ready evaluation reaches the filesystem',
+    "  if (evaluation.status !== 'ready') return { ...evaluation, written: [] };",
+    "  if (evaluation.status === 'ready') return { ...evaluation, written: [] };"],
+  [ADAPTER, 'bytes that do not hash to the approved digest are never written',
+    '    if (digestFile(transformed) !== write.approvedDigest) {\n'
+    + '      throw new Error(`bytes for ${write.id} do not match the approved digest; refusing to write`);\n'
+    + '    }\n',
+    ''],
+  [ADAPTER, 'the provenance transformation is actually applied to written agents',
+    "    const transformed = Buffer.from(withProvenance(bytes.toString('utf8'), sourceId), 'utf8');",
+    '    const transformed = bytes;'],
+  [ADAPTER, 'a directory digest covers where each file lives, not only its bytes',
+    '      hash.update(`${relative}\\0`);\n',
+    ''],
+];
+
+// Guards deliberately NOT mutated, each with the reason.
+const NOT_MUTATED = [
+  {
+    what: 'the source-digest verification in materialise',
+    why: 'the digest it checks was already matched against the same file by the snapshot moments '
+      + 'earlier in the same call, so no fixture can make it fire without a race seam the module '
+      + 'deliberately does not expose. It is defence in depth for the window between snapshot and '
+      + 'read-back; a mutation nothing can honestly discharge is noise. Left as a named gap.',
+  },
+];
+
+const REPORTER = ['--test-reporter=spec', '--test-reporter-destination=stdout'];
+
+function redTests(suite) {
+  let out = '';
+  let failed = false;
+  try {
+    out = execFileSync('node', ['--test', ...REPORTER, suite],
+      { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (e) {
+    failed = true;
+    out = (e.stdout || '') + (e.stderr || '');
+  }
+  const marker = out.indexOf('failing tests:');
+  if (marker === -1) {
+    if (!failed) return [];
+    throw new Error(
+      'the suite failed but its output carries no "failing tests:" summary, so no '
+      + 'test names could be read. The spec reporter\'s format is what this parses; '
+      + 'if it changed, fix this parser rather than trusting the empty result.');
+  }
+  const names = [];
+  for (const line of out.slice(marker).split('\n')) {
+    const m = /^✖ (.+?) \(\d/.exec(line.trim());
+    if (m && !names.includes(m[1])) names.push(m[1]);
+  }
+  return names;
+}
+
+function run() {
+  const targets = [ADAPTER];
+  const session = beginMutationRun({ files: targets.map((target) => target.src) });
+  const originals = new Map();
+  for (const target of targets) originals.set(target, session.original(target.src));
+  const results = [];
+  try {
+    for (const [target, label, guard, without] of MUTATIONS) {
+      const original = originals.get(target);
+      const matches = original.split(guard).length - 1;
+      if (matches === 0) {
+        results.push({ label, applied: false, red: [] });
+        continue;
+      }
+      // A guard that matches more than once is refused rather than taking the
+      // first, for the reason set out in the sibling harnesses.
+      if (matches > 1) {
+        results.push({ label, applied: false, ambiguous: matches, red: [] });
+        continue;
+      }
+      fs.writeFileSync(target.src, original.replace(guard, without));
+      results.push({ label, applied: true, matches, red: redTests(target.suite) });
+      fs.writeFileSync(target.src, original);
+    }
+  } finally {
+    session.finish();
+  }
+  return results;
+}
+
+function report(results, markdown) {
+  let failed = 0;
+  const lines = [];
+  for (const { label, applied, red, ambiguous, matches } of results) {
+    if (ambiguous) {
+      failed++;
+      const why = `the guard text matches ${ambiguous} places, so it would break whichever came first`;
+      lines.push(markdown ? `| ${label} | ${ambiguous} | **${why}** | |` : `${label}\n  AMBIGUOUS: ${why}`);
+      continue;
+    }
+    if (!applied) {
+      failed++;
+      lines.push(markdown
+        ? `| ${label} | 0 | **the guard text was not found, so nothing was mutated** | |`
+        : `${label}\n  THE GUARD TEXT WAS NOT FOUND, so nothing was mutated`);
+      continue;
+    }
+    if (red.length === 0) {
+      failed++;
+      lines.push(markdown ? `| ${label} | ${matches} | **nothing turned red** | |` : `${label}\n  NOTHING TURNED RED`);
+      continue;
+    }
+    lines.push(markdown
+      ? `| ${label} | ${matches} | ${red.length} | ${red.map((n) => `\`${n}\``).join('<br>')} |`
+      : `${label}\n  found in ${matches} place\n  ${red.length} red\n${red.map((n) => `    - ${n}`).join('\n')}`);
+  }
+  if (markdown) {
+    console.log('| Guard broken | Places found | Tests red | Which |');
+    console.log('|---|---|---|---|');
+    for (const line of lines) console.log(line);
+  } else {
+    for (const line of lines) console.log(`\n${line}`);
+  }
+  return failed;
+}
+
+function requireSaneTempRoot() {
+  const verdict = preflight(os.tmpdir());
+  if (verdict.ok) return;
+  console.error(verdict.message);
+  process.exit(2);
+}
+
+if (require.main === module) {
+  requireSaneTempRoot();
+  if (process.argv.includes('--preflight-only')) process.exit(0);
+  const failed = report(run(), process.argv.includes('--markdown'));
+  if (failed) {
+    console.error(`\n${failed} mutation(s) proved nothing. A guard no test notices is not guarded,`
+      + ' and a mutation that could break more than one place proves nothing about either.');
+    process.exit(1);
+  }
+}
+
+module.exports = { MUTATIONS, NOT_MUTATED, run };

--- a/test/tools/mutate-import-apply-guards.js
+++ b/test/tools/mutate-import-apply-guards.js
@@ -53,6 +53,14 @@ const MUTATIONS = [
     '  const first = writeAsUnit(workspace, writes, { afterStep: options.afterStep });\n'
     + '  const second = writeAsUnit(workspace, [], { replaceDirs, afterStep: options.afterStep });\n'
     + '  const result = { written: [...first.written, ...second.written] };'],
+  [ADAPTER, 'a skill write is verified against the approved digest like any other bytes',
+    '  if (write.approvedDigest !== write.sourceDigest) {\n'
+    + '    throw new Error(`bytes for ${write.id} do not match the approved digest; refusing to write`);\n'
+    + '  }\n',
+    ''],
+  [ADAPTER, 'a failed observation aborts instead of reading as absence',
+    "    if (e.code === 'ENOENT' || e.code === 'ENOTDIR') return ABSENT_DIGEST;\n    throw e;",
+    '    return ABSENT_DIGEST;'],
   [ADAPTER, 'recovery runs before the snapshot, not merely at some point',
     '  recoverPendingWrites(workspace);\n  const current = snapshotCurrent(workspace, sourceRoot, approval);',
     '  const current = snapshotCurrent(workspace, sourceRoot, approval);\n  recoverPendingWrites(workspace);'],

--- a/test/unit/package-import-apply.test.js
+++ b/test/unit/package-import-apply.test.js
@@ -60,9 +60,8 @@ function declaresDefault(text) {
   return end !== -1 && /^order:\s*0\s*$/m.test(text.slice(4, end));
 }
 
-// Build a valid approval from a source tree and the current workspace, using
-// the module's own exported digest and provenance functions, which is exactly
-// what the future plan module will do.
+// Build a valid approval from a source tree and the current workspace with
+// the module's own exported helpers, as the future plan module will.
 function buildApproval(workspace, sourceRoot, decisions) {
   const entries = [];
   for (const [id, decision] of Object.entries(decisions)) {
@@ -104,8 +103,7 @@ const AGENT_TEXT = '---\nname: writer\n---\n\nWrite things.\n';
 const DEFAULT_AGENT_A = '---\nname: alpha\norder: 0\n---\n\nLead.\n';
 const DEFAULT_AGENT_B = '---\nname: beta\norder: 0\n---\n\nAlso lead.\n';
 
-// The standard fixture: an agent to add, a skill to overwrite, a skill to
-// skip, and a foreign workspace file nothing may touch.
+// An agent to add, a skill to overwrite, a skill to skip, a foreign file.
 function fixture() {
   const workspace = makeTempDir('import-apply-ws-');
   const sourceRoot = makeTempDir('import-apply-src-');
@@ -159,21 +157,12 @@ describe('canonical digests', () => {
 
 describe('withProvenance', () => {
   test('inserts the source line inside existing frontmatter, pinned byte-for-byte', () => {
-    assert.strictEqual(
-      withProvenance('---\nname: writer\n---\n\nBody.\n', 'a/b'),
-      '---\nname: writer\nsource: a/b\n---\n\nBody.\n',
-    );
-    assert.strictEqual(
-      withProvenance('---\nsource: kept/value\n---\n\nBody.\n', 'a/b'),
-      '---\nsource: kept/value\n---\n\nBody.\n',
-    );
+    assert.strictEqual(withProvenance('---\nname: writer\n---\n\nBody.\n', 'a/b'), '---\nname: writer\nsource: a/b\n---\n\nBody.\n');
+    assert.strictEqual(withProvenance('---\nsource: kept/value\n---\n\nBody.\n', 'a/b'), '---\nsource: kept/value\n---\n\nBody.\n');
   });
 
   test('creates frontmatter when the agent has none, pinned byte-for-byte', () => {
-    assert.strictEqual(
-      withProvenance('Just a body.\n', 'a/b'),
-      '---\nsource: a/b\n---\n\nJust a body.\n',
-    );
+    assert.strictEqual(withProvenance('Just a body.\n', 'a/b'), '---\nsource: a/b\n---\n\nJust a body.\n');
   });
 });
 
@@ -327,8 +316,7 @@ describe('applyImport', () => {
     // introduced nothing beyond them.
     assert.strictEqual(read(workspace, '.claude/agents/scribe.md'), approvedText);
     assert.strictEqual(read(workspace, '.claude/agents/scribe.md').match(/^source:/gm).length, 1);
-    // The product's own frontmatter reader must see the value, so a source
-    // line landing outside the frontmatter block fails here.
+    // The product's own frontmatter reader must see the value.
     const meta = parseAgentFrontmatter(readNormalisedFile(path.join(workspace, '.claude/agents/scribe.md')));
     assert.strictEqual(meta.source, SOURCE_ID);
     assert.strictEqual(read(workspace, 'notes/keep.md'), 'foreign');

--- a/test/unit/package-import-apply.test.js
+++ b/test/unit/package-import-apply.test.js
@@ -12,8 +12,8 @@ const {
   digestDirectory,
   withProvenance,
 } = require('../../lib/packages/import-apply.js');
-const { journalPath, IMPORT_SUBDIR } = require('../../lib/workspace/atomic-write.js');
-const { readNormalisedFile, parseAgentFrontmatter } = require('../../lib/agents/discovery.js');
+const { journalPath, writeAsUnit, IMPORT_SUBDIR } = require('../../lib/workspace/atomic-write.js');
+const { readNormalisedFile, parseAgentFrontmatter, agentIsDefault } = require('../../lib/agents/discovery.js');
 const { makeTempDir } = require('../helpers/workspace.js');
 
 const SOURCE_ID = 'github.com/example/pack';
@@ -54,10 +54,10 @@ function digestPath(absolute) {
     : digestFile(fs.readFileSync(absolute));
 }
 
+// Normalise the way readNormalisedFile does, then apply the product's own
+// default rule, so this helper cannot encode a competing definition.
 function declaresDefault(text) {
-  if (!text.startsWith('---\n')) return false;
-  const end = text.indexOf('\n---', 4);
-  return end !== -1 && /^order:\s*0\s*$/m.test(text.slice(4, end));
+  return agentIsDefault(parseAgentFrontmatter(text.replace(/^\ufeff/, '').replace(/\r\n/g, '\n')));
 }
 
 // Build a valid approval from a source tree and the current workspace with
@@ -96,6 +96,25 @@ function buildApproval(workspace, sourceRoot, decisions) {
     source: { id: SOURCE_ID, reference: 'v1.0.0' },
     manifest: entries.map(({ id, kind, slug, sourceDigest }) => ({ id, kind, slug, sourceDigest })),
     items: entries,
+  };
+}
+
+// A minimal single-item approval whose approvedDigest is supplied raw, for
+// cases where deriving it through the transformation is the thing under test.
+function buildApprovalWithRawApproved(workspace, sourceRoot, id, approvedDigest) {
+  const [kind, slug] = id.split(':');
+  const destination = `.claude/agents/${slug}.md`;
+  const sourceDigest = digestPath(path.join(sourceRoot, destination));
+  const item = {
+    id, kind, slug, destination, collision: false, decision: 'add',
+    plannedDigest: 'absent', approvedDigest, sourceDigest,
+    agent: { plannedDefault: false, approvedDefault: false },
+  };
+  return {
+    schema: 'rundock.package-import-approval/v1',
+    source: { id: SOURCE_ID, reference: 'v1.0.0' },
+    manifest: [{ id, kind, slug, sourceDigest }],
+    items: [item],
   };
 }
 
@@ -322,6 +341,40 @@ describe('applyImport', () => {
     assert.strictEqual(read(workspace, 'notes/keep.md'), 'foreign');
   });
 
+  test('a CRLF agent keeps its frontmatter, its keys and its own line endings', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    write(sourceRoot, '.claude/agents/crlf.md', '---\r\nname: crlf\r\norder: 5\r\n---\r\n\r\nBody.\r\n');
+    applyImport(workspace, sourceRoot, buildApproval(workspace, sourceRoot, { 'agent:crlf': 'add' }));
+    assert.strictEqual(read(workspace, '.claude/agents/crlf.md'),
+      '---\r\nname: crlf\r\norder: 5\r\nsource: github.com/example/pack\r\n---\r\n\r\nBody.\r\n');
+    const meta = parseAgentFrontmatter(readNormalisedFile(path.join(workspace, '.claude/agents/crlf.md')));
+    assert.strictEqual(meta.name, 'crlf');
+    assert.strictEqual(meta.order, '5');
+    assert.strictEqual(meta.source, SOURCE_ID);
+  });
+
+  test('a BOM-prefixed agent lands readable by the product parser, with one frontmatter block', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    write(sourceRoot, '.claude/agents/bom.md', '\ufeff---\nname: bom\n---\n\nB.\n');
+    applyImport(workspace, sourceRoot, buildApproval(workspace, sourceRoot, { 'agent:bom': 'add' }));
+    assert.strictEqual(read(workspace, '.claude/agents/bom.md'), '---\nname: bom\nsource: github.com/example/pack\n---\n\nB.\n');
+    const meta = parseAgentFrontmatter(readNormalisedFile(path.join(workspace, '.claude/agents/bom.md')));
+    assert.strictEqual(meta.name, 'bom');
+    assert.strictEqual(meta.source, SOURCE_ID);
+  });
+
+  test('frontmatter that opens but never closes is refused with nothing written', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    const bad = write(sourceRoot, '.claude/agents/broken.md', '---\nname: broken\n');
+    const approval = buildApprovalWithRawApproved(workspace, sourceRoot, 'agent:broken', digestFile(fs.readFileSync(bad)));
+    const before = tree(workspace);
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /never closes/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
   test('a decisions-blocked evaluation performs zero destination writes', () => {
     const workspace = makeTempDir('import-apply-ws-');
     const sourceRoot = makeTempDir('import-apply-src-');
@@ -400,6 +453,27 @@ describe('applyImport', () => {
   });
 });
 
+// Run the real primitive over a directory destination on a scratch tree and
+// read its journal off disk at the first commit boundary.
+function captureRealCommittingJournal() {
+  const scratch = makeTempDir('journal-capture-');
+  write(scratch, '.claude/skills/parked/SKILL.md', 'parked');
+  let captured = null;
+  try {
+    writeAsUnit(scratch, [], {
+      replaceDirs: [{ path: path.join(scratch, '.claude/skills/parked'), files: [{ rel: 'SKILL.md', content: 'v2' }] }],
+      afterStep: (step) => {
+        if (step.phase === 'commit' && step.action === 'remove') {
+          captured = JSON.parse(fs.readFileSync(journalPath(scratch), 'utf8'));
+          throw new Error('captured');
+        }
+      },
+    });
+  } catch { /* the abort is the point; the primitive rolls the scratch back */ }
+  assert.ok(captured, 'no committing journal was captured');
+  return captured;
+}
+
 describe('recovery comes before everything', () => {
   test('an interrupted prior transaction is recovered before the snapshot', () => {
     const { workspace, sourceRoot, approval } = fixture();
@@ -410,14 +484,23 @@ describe('recovery comes before everything', () => {
     // run after the snapshot, this same apply reports the skill as stale.
     write(workspace, '.claude/skills/parked/SKILL.md', 'half-committed bytes');
     write(workspace, path.join(IMPORT_SUBDIR, 'run', 'backup', '0', 'SKILL.md'), 'parked');
-    fs.writeFileSync(journalPath(workspace), JSON.stringify({
+    const planted = {
       version: 1,
       runId: 'stale',
       createdState: [],
       phase: 'committing',
       entries: [{ slot: 0, type: 'dir', priorType: 'dir', destination: '.claude/skills/parked' }],
       createdDirs: [],
-    }));
+    };
+    // The literal must be shaped exactly like a journal the real primitive
+    // leaves mid-commit, so lane A format drift turns this test red instead
+    // of leaving it proving recovery of a state nothing produces.
+    const real = captureRealCommittingJournal();
+    assert.deepStrictEqual(Object.keys(planted).sort(), Object.keys(real).sort());
+    assert.strictEqual(planted.phase, real.phase);
+    assert.deepStrictEqual(Object.keys(planted.entries[0]).sort(), Object.keys(real.entries[0]).sort());
+    assert.strictEqual(planted.entries[0].type, real.entries[0].type);
+    fs.writeFileSync(journalPath(workspace), JSON.stringify(planted));
     const result = applyImport(workspace, sourceRoot, approval);
     assert.strictEqual(result.status, 'ready');
     assert.strictEqual(result.written.length, 2);
@@ -436,15 +519,21 @@ describe('recovery comes before everything', () => {
 });
 
 describe('a fault at any write boundary leaves the pre-apply workspace after recovery', () => {
-  const boundaries = (() => {
+  const recorded = (() => {
     const { workspace, sourceRoot, approval } = fixture();
     const steps = [];
-    applyImport(workspace, sourceRoot, approval, { afterStep: (s) => steps.push(`${s.phase}:${s.action}`) });
+    applyImport(workspace, sourceRoot, approval, {
+      afterStep: (s) => steps.push({ label: `${s.phase}:${s.action}`, destination: s.destination || null }),
+    });
     return steps;
   })();
+  const boundaries = recorded.map((s) => s.label);
 
-  test('the fixture crosses write boundaries for both a file and a directory destination', () => {
-    assert.ok(boundaries.length >= 6, boundaries.join(','));
+  test('both the agent file and the skill directory contribute write boundaries', () => {
+    const touched = new Set(recorded.filter((s) => s.destination)
+      .map((s) => s.destination.split(path.sep).slice(-2).join('/')));
+    assert.ok(touched.has('agents/scribe.md'), [...touched].join(','));
+    assert.ok(touched.has('skills/writer'), [...touched].join(','));
     assert.ok(boundaries.includes('commit:rename'));
     assert.ok(boundaries.includes('prepare:backup'));
   });

--- a/test/unit/package-import-apply.test.js
+++ b/test/unit/package-import-apply.test.js
@@ -177,12 +177,33 @@ describe('snapshotCurrent', () => {
     const { workspace, sourceRoot, approval } = fixture();
     write(workspace, '.claude/agents/alpha.md', DEFAULT_AGENT_A);
     write(workspace, '.claude/agents/plain.md', AGENT_TEXT);
-    write(workspace, '.claude/agents/Not A Slug.md', DEFAULT_AGENT_B);
+    write(workspace, '.claude/agents/Not A Slug.md', AGENT_TEXT);
     const current = snapshotCurrent(workspace, sourceRoot, approval);
     assert.deepStrictEqual(current.agents.map((a) => [a.destination, a.isDefault]), [
       ['.claude/agents/alpha.md', true],
       ['.claude/agents/plain.md', false],
     ]);
+  });
+});
+
+describe('the snapshot refuses what it cannot represent', () => {
+  test('a symlink at a canonical agent path aborts the snapshot and the apply', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    write(workspace, 'real.md', DEFAULT_AGENT_A);
+    fs.mkdirSync(path.join(workspace, '.claude/agents'), { recursive: true });
+    fs.symlinkSync(path.join(workspace, 'real.md'), path.join(workspace, '.claude/agents/lead.md'));
+    const before = tree(workspace);
+    assert.throws(() => snapshotCurrent(workspace, sourceRoot, approval), /unsupported filesystem entry type/);
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /unsupported filesystem entry type/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a default agent outside canonical naming refuses the import rather than hiding the default', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    write(workspace, '.claude/agents/Not A Slug.md', DEFAULT_AGENT_B);
+    const before = tree(workspace);
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /outside canonical naming/);
+    assert.deepStrictEqual(tree(workspace), before);
   });
 });
 
@@ -226,6 +247,43 @@ describe('applyImport', () => {
     const written = read(workspace, '.claude/agents/scribe.md');
     assert.match(written, /^source: somewhere\/else$/m);
     assert.strictEqual(written.match(/^source:/gm).length, 1);
+  });
+
+  test('overwriting an agent that already carries a source lands exactly the approved bytes', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    write(workspace, '.claude/agents/scribe.md', '---\nname: scribe\nsource: previous/place\n---\n\nOld body.\n');
+    write(workspace, 'notes/keep.md', 'foreign');
+    write(sourceRoot, '.claude/agents/scribe.md', AGENT_TEXT);
+    const approval = buildApproval(workspace, sourceRoot, { 'agent:scribe': 'overwrite' });
+    const approvedText = withProvenance(AGENT_TEXT, SOURCE_ID);
+    applyImport(workspace, sourceRoot, approval);
+    // Byte-for-byte the approved post-state: the prior source value is gone
+    // because the approved bytes replaced the file, and apply logic itself
+    // introduced nothing beyond them.
+    assert.strictEqual(read(workspace, '.claude/agents/scribe.md'), approvedText);
+    assert.strictEqual(read(workspace, '.claude/agents/scribe.md').match(/^source:/gm).length, 1);
+    assert.strictEqual(read(workspace, 'notes/keep.md'), 'foreign');
+  });
+
+  test('a decisions-blocked evaluation performs zero destination writes', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    write(sourceRoot, '.claude/agents/alpha.md', DEFAULT_AGENT_A);
+    write(sourceRoot, '.claude/agents/beta.md', DEFAULT_AGENT_B);
+    const approval = buildApproval(workspace, sourceRoot, { 'agent:alpha': 'add', 'agent:beta': 'add' });
+    const before = tree(workspace);
+    const result = applyImport(workspace, sourceRoot, approval);
+    assert.strictEqual(result.status, 'decisions-blocked');
+    assert.deepStrictEqual(result.written, []);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('an evaluator validation error propagates with zero destination writes', () => {
+    const { workspace, sourceRoot, approval, before } = fixture();
+    approval.schema = 'rundock.package-import-approval/v0';
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /Invalid package import approval\.schema/);
+    assert.deepStrictEqual(tree(workspace), before);
   });
 
   test('bytes that do not hash to the approved digest are refused with nothing written', () => {
@@ -281,13 +339,25 @@ describe('applyImport', () => {
 describe('recovery comes before everything', () => {
   test('an interrupted prior transaction is recovered before the snapshot', () => {
     const { workspace, sourceRoot, approval } = fixture();
-    fs.mkdirSync(path.join(workspace, IMPORT_SUBDIR, 'run', 'staging'), { recursive: true });
+    // A genuinely half-committed prior transaction over the skipped skill:
+    // the destination holds replaced bytes, and the pre-transaction bytes the
+    // approval was planned against live only in the journal's backup. The
+    // snapshot can therefore match the approval ONLY if recovery ran first;
+    // run after the snapshot, this same apply reports the skill as stale.
+    write(workspace, '.claude/skills/parked/SKILL.md', 'half-committed bytes');
+    write(workspace, path.join(IMPORT_SUBDIR, 'run', 'backup', '0', 'SKILL.md'), 'parked');
     fs.writeFileSync(journalPath(workspace), JSON.stringify({
-      version: 1, runId: 'stale', createdState: [], phase: 'preparing', entries: [], createdDirs: [],
+      version: 1,
+      runId: 'stale',
+      createdState: [],
+      phase: 'committing',
+      entries: [{ slot: 0, type: 'dir', priorType: 'dir', destination: '.claude/skills/parked' }],
+      createdDirs: [],
     }));
     const result = applyImport(workspace, sourceRoot, approval);
     assert.strictEqual(result.status, 'ready');
     assert.strictEqual(result.written.length, 2);
+    assert.strictEqual(read(workspace, '.claude/skills/parked/SKILL.md'), 'parked');
     assert.strictEqual(fs.existsSync(journalPath(workspace)), false);
   });
 

--- a/test/unit/package-import-apply.test.js
+++ b/test/unit/package-import-apply.test.js
@@ -1,0 +1,331 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  applyImport,
+  snapshotCurrent,
+  digestFile,
+  digestDirectory,
+  withProvenance,
+} = require('../../lib/packages/import-apply.js');
+const { journalPath, IMPORT_SUBDIR } = require('../../lib/workspace/atomic-write.js');
+const { makeTempDir } = require('../helpers/workspace.js');
+
+const SOURCE_ID = 'github.com/example/pack';
+
+function write(root, relative, content) {
+  const absolute = path.join(root, relative);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, content);
+  return absolute;
+}
+
+function read(root, relative) {
+  return fs.readFileSync(path.join(root, relative), 'utf8');
+}
+
+// The complete workspace as one comparable value.
+function tree(root, current = root) {
+  const result = [];
+  for (const entry of fs.readdirSync(current, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    const absolute = path.join(current, entry.name);
+    const relative = path.relative(root, absolute).split(path.sep).join('/');
+    if (entry.isDirectory()) {
+      const children = tree(root, absolute);
+      if (children.length === 0) result.push(`${relative}/`);
+      else result.push(...children);
+    } else {
+      result.push(`${relative}:${fs.readFileSync(absolute).toString('base64')}`);
+    }
+  }
+  return result;
+}
+
+function digestPath(absolute) {
+  if (!fs.existsSync(absolute)) return 'absent';
+  return fs.statSync(absolute).isDirectory()
+    ? digestDirectory(absolute)
+    : digestFile(fs.readFileSync(absolute));
+}
+
+function declaresDefault(text) {
+  if (!text.startsWith('---\n')) return false;
+  const end = text.indexOf('\n---', 4);
+  return end !== -1 && /^order:\s*0\s*$/m.test(text.slice(4, end));
+}
+
+// Build a valid approval from a source tree and the current workspace, using
+// the module's own exported digest and provenance functions, which is exactly
+// what the future plan module will do.
+function buildApproval(workspace, sourceRoot, decisions) {
+  const entries = [];
+  for (const [id, decision] of Object.entries(decisions)) {
+    const [kind, slug] = id.split(':');
+    const destination = kind === 'agent' ? `.claude/agents/${slug}.md` : `.claude/skills/${slug}`;
+    const sourceAbsolute = path.join(sourceRoot, destination);
+    const sourceDigest = digestPath(sourceAbsolute);
+    const destAbsolute = path.join(workspace, destination);
+    const plannedDigest = digestPath(destAbsolute);
+    const collision = plannedDigest !== 'absent';
+    let approvedDigest;
+    let approvedText = null;
+    if (decision === 'skip') {
+      approvedDigest = plannedDigest;
+    } else if (kind === 'agent') {
+      approvedText = withProvenance(fs.readFileSync(sourceAbsolute, 'utf8'), SOURCE_ID);
+      approvedDigest = digestFile(Buffer.from(approvedText, 'utf8'));
+    } else {
+      approvedDigest = sourceDigest;
+    }
+    let agent = null;
+    if (kind === 'agent') {
+      const plannedDefault = collision ? declaresDefault(fs.readFileSync(destAbsolute, 'utf8')) : false;
+      const approvedDefault = decision === 'skip' ? plannedDefault : declaresDefault(approvedText);
+      agent = { plannedDefault, approvedDefault };
+    }
+    entries.push({ id, kind, slug, destination, collision, decision, plannedDigest, approvedDigest, sourceDigest, agent });
+  }
+  entries.sort((a, b) => (a.id < b.id ? -1 : 1));
+  return {
+    schema: 'rundock.package-import-approval/v1',
+    source: { id: SOURCE_ID, reference: 'v1.0.0' },
+    manifest: entries.map(({ id, kind, slug, sourceDigest }) => ({ id, kind, slug, sourceDigest })),
+    items: entries,
+  };
+}
+
+const AGENT_TEXT = '---\nname: writer\n---\n\nWrite things.\n';
+const DEFAULT_AGENT_A = '---\nname: alpha\norder: 0\n---\n\nLead.\n';
+const DEFAULT_AGENT_B = '---\nname: beta\norder: 0\n---\n\nAlso lead.\n';
+
+// The standard fixture: an agent to add, a skill to overwrite, a skill to
+// skip, and a foreign workspace file nothing may touch.
+function fixture() {
+  const workspace = makeTempDir('import-apply-ws-');
+  const sourceRoot = makeTempDir('import-apply-src-');
+  write(workspace, 'notes/keep.md', 'foreign');
+  write(workspace, '.claude/skills/writer/SKILL.md', 'old skill');
+  write(workspace, '.claude/skills/writer/stale.md', 'stale file');
+  write(workspace, '.claude/skills/parked/SKILL.md', 'parked');
+  write(sourceRoot, '.claude/agents/scribe.md', AGENT_TEXT);
+  write(sourceRoot, '.claude/skills/writer/SKILL.md', 'new skill');
+  write(sourceRoot, '.claude/skills/writer/refs/a.md', 'ref');
+  write(sourceRoot, '.claude/skills/parked/SKILL.md', 'parked v2');
+  const approval = buildApproval(workspace, sourceRoot, {
+    'agent:scribe': 'add',
+    'skill:writer': 'overwrite',
+    'skill:parked': 'skip',
+  });
+  return { workspace, sourceRoot, approval, before: tree(workspace) };
+}
+
+describe('canonical digests', () => {
+  test('a file digest covers exact bytes and never collides with a directory digest', () => {
+    const root = makeTempDir('digest-');
+    write(root, 'dir/a.md', 'x');
+    assert.notStrictEqual(digestFile(Buffer.from('x')), digestFile(Buffer.from('y')));
+    assert.notStrictEqual(digestFile(Buffer.from('x')), digestDirectory(path.join(root, 'dir')));
+  });
+
+  test('a directory digest covers the relative path of every file, not only its bytes', () => {
+    const a = makeTempDir('digest-a-');
+    const b = makeTempDir('digest-b-');
+    write(a, 'SKILL.md', 'same bytes');
+    write(b, 'RENAMED.md', 'same bytes');
+    assert.notStrictEqual(digestDirectory(a), digestDirectory(b));
+  });
+
+  test('a directory digest is identical for identical trees built in different orders', () => {
+    const a = makeTempDir('digest-a-');
+    const b = makeTempDir('digest-b-');
+    write(a, 'one.md', '1'); write(a, 'sub/two.md', '2');
+    write(b, 'sub/two.md', '2'); write(b, 'one.md', '1');
+    assert.strictEqual(digestDirectory(a), digestDirectory(b));
+  });
+
+  test('a symlink inside a directory is refused, never followed', () => {
+    const root = makeTempDir('digest-');
+    write(root, 'dir/a.md', 'x');
+    fs.symlinkSync(path.join(root, 'dir', 'a.md'), path.join(root, 'dir', 'link.md'));
+    assert.throws(() => digestDirectory(path.join(root, 'dir')), /unsupported symlink/);
+  });
+});
+
+describe('snapshotCurrent', () => {
+  test('reports destination digests for file, directory and absent destinations', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    const current = snapshotCurrent(workspace, sourceRoot, approval);
+    const byDest = new Map(current.destinations.map((d) => [d.destination, d.digest]));
+    assert.strictEqual(byDest.get('.claude/agents/scribe.md'), 'absent');
+    assert.strictEqual(byDest.get('.claude/skills/writer'), digestDirectory(path.join(workspace, '.claude/skills/writer')));
+    assert.strictEqual(byDest.get('.claude/skills/parked'), digestDirectory(path.join(workspace, '.claude/skills/parked')));
+  });
+
+  test('omits missing sources so the evaluator can classify them as source-missing', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    fs.rmSync(path.join(sourceRoot, '.claude/agents/scribe.md'));
+    const current = snapshotCurrent(workspace, sourceRoot, approval);
+    assert.deepStrictEqual(current.sources.map((s) => s.id).sort(), ['skill:parked', 'skill:writer']);
+  });
+
+  test('reports every canonically named agent with its default membership, and only those', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    write(workspace, '.claude/agents/alpha.md', DEFAULT_AGENT_A);
+    write(workspace, '.claude/agents/plain.md', AGENT_TEXT);
+    write(workspace, '.claude/agents/Not A Slug.md', DEFAULT_AGENT_B);
+    const current = snapshotCurrent(workspace, sourceRoot, approval);
+    assert.deepStrictEqual(current.agents.map((a) => [a.destination, a.isDefault]), [
+      ['.claude/agents/alpha.md', true],
+      ['.claude/agents/plain.md', false],
+    ]);
+  });
+});
+
+describe('applyImport', () => {
+  test('applies add, overwrite and skip as one transaction with verified bytes', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    const result = applyImport(workspace, sourceRoot, approval);
+    assert.strictEqual(result.status, 'ready');
+    assert.deepStrictEqual(result.writes.map((w) => w.id), ['agent:scribe', 'skill:writer']);
+    assert.deepStrictEqual(result.skipped.map((w) => w.id), ['skill:parked']);
+    assert.strictEqual(result.written.length, 2);
+    // The added agent carries provenance; the skill tree is replaced exactly.
+    assert.match(read(workspace, '.claude/agents/scribe.md'), /^source: github\.com\/example\/pack$/m);
+    assert.strictEqual(read(workspace, '.claude/skills/writer/SKILL.md'), 'new skill');
+    assert.strictEqual(read(workspace, '.claude/skills/writer/refs/a.md'), 'ref');
+    assert.strictEqual(fs.existsSync(path.join(workspace, '.claude/skills/writer/stale.md')), false);
+    assert.strictEqual(read(workspace, '.claude/skills/parked/SKILL.md'), 'parked');
+    assert.strictEqual(read(workspace, 'notes/keep.md'), 'foreign');
+    assert.strictEqual(fs.existsSync(journalPath(workspace)), false);
+  });
+
+  test('replaying the exact JSON approval performs zero destination writes', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    applyImport(workspace, sourceRoot, approval);
+    const after = tree(workspace);
+    const replay = applyImport(workspace, sourceRoot, JSON.parse(JSON.stringify(approval)));
+    assert.strictEqual(replay.status, 'ready');
+    assert.deepStrictEqual(replay.writes, []);
+    assert.deepStrictEqual(replay.written, []);
+    assert.deepStrictEqual(replay.unchanged.map((w) => w.id), ['agent:scribe', 'skill:writer']);
+    assert.deepStrictEqual(tree(workspace), after);
+  });
+
+  test('an agent that already declares a source keeps it', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    const text = '---\nname: scribe\nsource: somewhere/else\n---\n\nBody.\n';
+    write(sourceRoot, '.claude/agents/scribe.md', text);
+    const approval = buildApproval(workspace, sourceRoot, { 'agent:scribe': 'add' });
+    applyImport(workspace, sourceRoot, approval);
+    const written = read(workspace, '.claude/agents/scribe.md');
+    assert.match(written, /^source: somewhere\/else$/m);
+    assert.strictEqual(written.match(/^source:/gm).length, 1);
+  });
+
+  test('bytes that do not hash to the approved digest are refused with nothing written', () => {
+    const { workspace, sourceRoot, approval, before } = fixture();
+    const item = approval.items.find((i) => i.id === 'agent:scribe');
+    item.approvedDigest = digestFile(Buffer.from('something else'));
+    item.agent.approvedDefault = false;
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /do not match the approved digest/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a stale destination aborts with zero writes', () => {
+    const { workspace, sourceRoot, approval, before } = fixture();
+    write(workspace, '.claude/skills/writer/SKILL.md', 'changed after approval');
+    const result = applyImport(workspace, sourceRoot, approval);
+    assert.strictEqual(result.status, 'stale');
+    assert.deepStrictEqual(result.written, []);
+    assert.deepStrictEqual(result.stale.map((s) => [s.id, s.reason]), [['skill:writer', 'destination-changed']]);
+    const expected = before.map((line) => (line.startsWith('.claude/skills/writer/SKILL.md:')
+      ? '.claude/skills/writer/SKILL.md:' + Buffer.from('changed after approval').toString('base64') : line));
+    assert.deepStrictEqual(tree(workspace), expected.sort());
+  });
+
+  test('a default conflict blocks the conflicting agents while unrelated writes land', () => {
+    const workspace = makeTempDir('import-apply-ws-');
+    const sourceRoot = makeTempDir('import-apply-src-');
+    write(sourceRoot, '.claude/agents/alpha.md', DEFAULT_AGENT_A);
+    write(sourceRoot, '.claude/agents/beta.md', DEFAULT_AGENT_B);
+    write(sourceRoot, '.claude/skills/writer/SKILL.md', 'skill');
+    const approval = buildApproval(workspace, sourceRoot, {
+      'agent:alpha': 'add', 'agent:beta': 'add', 'skill:writer': 'add',
+    });
+    const result = applyImport(workspace, sourceRoot, approval);
+    assert.strictEqual(result.status, 'ready');
+    assert.deepStrictEqual(result.blocked.map((b) => [b.id, b.reason]),
+      [['agent:alpha', 'default-conflict'], ['agent:beta', 'default-conflict']]);
+    assert.deepStrictEqual(result.written, [path.join(workspace, '.claude/skills/writer')]);
+    assert.strictEqual(fs.existsSync(path.join(workspace, '.claude/agents')), false);
+    assert.strictEqual(read(workspace, '.claude/skills/writer/SKILL.md'), 'skill');
+  });
+
+  test('a filesystem item absent from the approval never enters the result or the writes', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    write(sourceRoot, '.claude/skills/uninvited/SKILL.md', 'not approved');
+    const result = applyImport(workspace, sourceRoot, approval);
+    const ids = ['writes', 'unchanged', 'skipped', 'blocked', 'stale']
+      .flatMap((key) => result[key].map((o) => o.id));
+    assert.strictEqual(ids.includes('skill:uninvited'), false);
+    assert.strictEqual(fs.existsSync(path.join(workspace, '.claude/skills/uninvited')), false);
+  });
+});
+
+describe('recovery comes before everything', () => {
+  test('an interrupted prior transaction is recovered before the snapshot', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    fs.mkdirSync(path.join(workspace, IMPORT_SUBDIR, 'run', 'staging'), { recursive: true });
+    fs.writeFileSync(journalPath(workspace), JSON.stringify({
+      version: 1, runId: 'stale', createdState: [], phase: 'preparing', entries: [], createdDirs: [],
+    }));
+    const result = applyImport(workspace, sourceRoot, approval);
+    assert.strictEqual(result.status, 'ready');
+    assert.strictEqual(result.written.length, 2);
+    assert.strictEqual(fs.existsSync(journalPath(workspace)), false);
+  });
+
+  test('a journal that cannot be trusted blocks apply with zero writes', () => {
+    const { workspace, sourceRoot, approval, before } = fixture();
+    fs.mkdirSync(path.dirname(journalPath(workspace)), { recursive: true });
+    fs.writeFileSync(journalPath(workspace), 'not json');
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), (e) => e.code === 'ERR_ATOMIC_JOURNAL');
+    const kept = tree(workspace).filter((line) => !line.startsWith('.rundock/'));
+    assert.deepStrictEqual(kept, before);
+  });
+});
+
+describe('a fault at any write boundary leaves the pre-apply workspace after recovery', () => {
+  const boundaries = (() => {
+    const { workspace, sourceRoot, approval } = fixture();
+    const steps = [];
+    applyImport(workspace, sourceRoot, approval, { afterStep: (s) => steps.push(`${s.phase}:${s.action}`) });
+    return steps;
+  })();
+
+  test('the fixture crosses write boundaries for both a file and a directory destination', () => {
+    assert.ok(boundaries.length >= 6, boundaries.join(','));
+    assert.ok(boundaries.includes('commit:rename'));
+    assert.ok(boundaries.includes('prepare:backup'));
+  });
+
+  for (let boundary = 1; boundary <= boundaries.length; boundary++) {
+    test(`failure after ${boundaries[boundary - 1]} (step ${boundary} of ${boundaries.length})`, () => {
+      const { workspace, sourceRoot, approval, before } = fixture();
+      let completed = 0;
+      assert.throws(() => applyImport(workspace, sourceRoot, approval, {
+        afterStep: () => {
+          completed += 1;
+          if (completed === boundary) throw new Error('injected fault');
+        },
+      }), /injected fault/);
+      assert.deepStrictEqual(tree(workspace), before);
+    });
+  }
+});

--- a/test/unit/package-import-apply.test.js
+++ b/test/unit/package-import-apply.test.js
@@ -13,6 +13,7 @@ const {
   withProvenance,
 } = require('../../lib/packages/import-apply.js');
 const { journalPath, IMPORT_SUBDIR } = require('../../lib/workspace/atomic-write.js');
+const { readNormalisedFile, parseAgentFrontmatter } = require('../../lib/agents/discovery.js');
 const { makeTempDir } = require('../helpers/workspace.js');
 
 const SOURCE_ID = 'github.com/example/pack';
@@ -156,6 +157,26 @@ describe('canonical digests', () => {
   });
 });
 
+describe('withProvenance', () => {
+  test('inserts the source line inside existing frontmatter, pinned byte-for-byte', () => {
+    assert.strictEqual(
+      withProvenance('---\nname: writer\n---\n\nBody.\n', 'a/b'),
+      '---\nname: writer\nsource: a/b\n---\n\nBody.\n',
+    );
+    assert.strictEqual(
+      withProvenance('---\nsource: kept/value\n---\n\nBody.\n', 'a/b'),
+      '---\nsource: kept/value\n---\n\nBody.\n',
+    );
+  });
+
+  test('creates frontmatter when the agent has none, pinned byte-for-byte', () => {
+    assert.strictEqual(
+      withProvenance('Just a body.\n', 'a/b'),
+      '---\nsource: a/b\n---\n\nJust a body.\n',
+    );
+  });
+});
+
 describe('snapshotCurrent', () => {
   test('reports destination digests for file, directory and absent destinations', () => {
     const { workspace, sourceRoot, approval } = fixture();
@@ -187,6 +208,49 @@ describe('snapshotCurrent', () => {
 });
 
 describe('the snapshot refuses what it cannot represent', () => {
+  test('every default declaration form discovery accepts is seen as a default', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    write(workspace, '.claude/agents/bybool.md', '---\nisDefault: true\n---\n\nA.\n');
+    write(workspace, '.claude/agents/bystring.md', '---\nisDefault: "true"\n---\n\nB.\n');
+    write(workspace, '.claude/agents/byorder.md', '---\norder: 0\n---\n\nC.\n');
+    write(workspace, '.claude/agents/plain.md', AGENT_TEXT);
+    const current = snapshotCurrent(workspace, sourceRoot, approval);
+    assert.deepStrictEqual(current.agents.map((a) => [a.destination, a.isDefault]), [
+      ['.claude/agents/bybool.md', true],
+      ['.claude/agents/byorder.md', true],
+      ['.claude/agents/bystring.md', true],
+      ['.claude/agents/plain.md', false],
+    ]);
+  });
+
+  test('a non-canonical default declared via isDefault refuses the import too', () => {
+    const { workspace, sourceRoot, approval } = fixture();
+    write(workspace, '.claude/agents/Not A Slug Two.md', '---\nisDefault: true\n---\n\nD.\n');
+    const before = tree(workspace);
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /outside canonical naming/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a destination that cannot be observed aborts rather than reading as absent', (t) => {
+    if (process.getuid && process.getuid() === 0) { t.skip('root ignores modes'); return; }
+    const { workspace, sourceRoot, approval, before } = fixture();
+    const skills = path.join(workspace, '.claude', 'skills');
+    fs.chmodSync(skills, 0o000);
+    try {
+      assert.throws(() => applyImport(workspace, sourceRoot, approval), /EACCES|EPERM/);
+    } finally {
+      fs.chmodSync(skills, 0o755);
+    }
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a file standing where the agents directory belongs aborts the snapshot', () => {
+    const { workspace, sourceRoot, approval, before } = fixture();
+    write(workspace, '.claude/agents', 'not a directory');
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /ENOTDIR/);
+    assert.deepStrictEqual(tree(workspace), [...before, '.claude/agents:' + Buffer.from('not a directory').toString('base64')].sort());
+  });
+
   test('a symlink at a canonical agent path aborts the snapshot and the apply', () => {
     const { workspace, sourceRoot, approval } = fixture();
     write(workspace, 'real.md', DEFAULT_AGENT_A);
@@ -263,6 +327,10 @@ describe('applyImport', () => {
     // introduced nothing beyond them.
     assert.strictEqual(read(workspace, '.claude/agents/scribe.md'), approvedText);
     assert.strictEqual(read(workspace, '.claude/agents/scribe.md').match(/^source:/gm).length, 1);
+    // The product's own frontmatter reader must see the value, so a source
+    // line landing outside the frontmatter block fails here.
+    const meta = parseAgentFrontmatter(readNormalisedFile(path.join(workspace, '.claude/agents/scribe.md')));
+    assert.strictEqual(meta.source, SOURCE_ID);
     assert.strictEqual(read(workspace, 'notes/keep.md'), 'foreign');
   });
 
@@ -291,6 +359,14 @@ describe('applyImport', () => {
     const item = approval.items.find((i) => i.id === 'agent:scribe');
     item.approvedDigest = digestFile(Buffer.from('something else'));
     item.agent.approvedDefault = false;
+    assert.throws(() => applyImport(workspace, sourceRoot, approval), /do not match the approved digest/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a skill whose approved digest disagrees with its source is refused with nothing written', () => {
+    const { workspace, sourceRoot, approval, before } = fixture();
+    const item = approval.items.find((i) => i.id === 'skill:writer');
+    item.approvedDigest = digestFile(Buffer.from('some other tree'));
     assert.throws(() => applyImport(workspace, sourceRoot, approval), /do not match the approved digest/);
     assert.deepStrictEqual(tree(workspace), before);
   });


### PR DESCRIPTION
This joins the two halves of package import that already live on main: the pure evaluator that classifies an approval against the current workspace, and the journaled atomic write primitive that lands multi-file changes as one transaction. The adapter snapshots the real workspace and package source into exactly the shape the evaluator validates, executes only a ready evaluation, and hands the complete eligible write set to a single transaction, so an approved import of agents and skills either lands whole or not at all. Bytes are never trusted on the way through: source bytes must hash to the digest recorded at approval time, and written bytes must hash to the approved digest, so any disagreement refuses with nothing written rather than writing something nobody reviewed. An imported agent gains an informational source line through a transformation that honours the file's own line endings, keeps existing frontmatter keys byte-intact, drops a leading byte-order mark so the result stays readable by the agent parser, and refuses frontmatter that opens without closing. Default-agent membership is now decided by one exported rule that discovery itself uses, so the import's default-conflict check and the running product can never disagree about who the default is; a workspace agent that declares default membership from outside canonical naming refuses the import rather than being silently ignored. A failed filesystem observation aborts instead of being read as absence, because absence is exactly the fact that turns a collision into an unreviewed overwrite. Evidence includes an injected fault at every write boundary with complete tree comparison, recovery of a genuinely half-committed prior transaction proven to run before the snapshot, byte-identical replay of the same approval, and pinned byte-for-byte provenance results for LF, CRLF and BOM inputs. The canonical content digest functions are defined and exported here so the plan construction that follows computes approval digests with the same code that observes the filesystem.