### PR TITLE
Open package import to the protocol, with receipts

### DIFF
--- a/lib/packages/import-apply.js
+++ b/lib/packages/import-apply.js
@@ -212,11 +212,31 @@ function materialise(sourceRoot, sourceId, write) {
 // Snapshot, evaluate, and execute exactly what the evaluator allows, as one
 // transaction. Recovery of any interrupted prior transaction comes first, so
 // the snapshot never observes a half-committed workspace.
+// The receipt an apply leaves behind, per the receipts addendum: history,
+// never authority. One entry per item with its outcome, recorded in the
+// same transaction as the content writes and only there.
+const RECEIPTS_DIR = '.claude/rundock/receipts';
+
+function buildReceipt(approval, evaluation, appliedAt) {
+  const entry = (outcome) => (o) => ({ id: o.id, kind: o.kind, destination: o.destination, outcome });
+  return {
+    schema: 'rundock.package-import-receipt/v1',
+    source: approval.source,
+    appliedAt,
+    items: [
+      ...evaluation.writes.map(entry('written')),
+      ...evaluation.unchanged.map(entry('unchanged')),
+      ...evaluation.skipped.map(entry('skipped')),
+      ...evaluation.blocked.map(entry('blocked')),
+    ].sort((a, b) => (a.id < b.id ? -1 : 1)),
+  };
+}
+
 function applyImport(workspace, sourceRoot, approval, options = {}) {
   recoverPendingWrites(workspace);
   const current = snapshotCurrent(workspace, sourceRoot, approval);
   const evaluation = evaluateImport(approval, current);
-  if (evaluation.status !== 'ready') return { ...evaluation, written: [] };
+  if (evaluation.status !== 'ready') return { ...evaluation, written: [], receipt: null };
 
   const writes = [];
   const replaceDirs = [];
@@ -226,8 +246,21 @@ function applyImport(workspace, sourceRoot, approval, options = {}) {
     if (payload.file) writes.push({ path: destination, content: payload.file });
     else replaceDirs.push({ path: destination, files: payload.files });
   }
+  // The receipt exists exactly when the transaction that carries it lands:
+  // one more file write in the same unit, and never on a zero-write apply,
+  // because the filesystem cannot prove who wrote already-approved bytes.
+  let receipt = null;
+  if (options.receipt && evaluation.writes.length > 0) {
+    const appliedAt = options.receipt.now || new Date().toISOString();
+    const run = options.receipt.run || Math.random().toString(36).slice(2, 8);
+    receipt = `${RECEIPTS_DIR}/${appliedAt.slice(0, 10)}-${run}.json`;
+    writes.push({
+      path: toAbsolute(workspace, receipt),
+      content: `${JSON.stringify(buildReceipt(approval, evaluation, appliedAt), null, 2)}\n`,
+    });
+  }
   const result = writeAsUnit(workspace, writes, { replaceDirs, afterStep: options.afterStep });
-  return { ...evaluation, written: result.written };
+  return { ...evaluation, written: result.written, receipt };
 }
 
 module.exports = {

--- a/lib/protocol/handlers/index.js
+++ b/lib/protocol/handlers/index.js
@@ -12,6 +12,7 @@ const team = require('./team.js');
 const files = require('./files.js');
 const processControl = require('./process-control.js');
 const runs = require('./runs.js');
+const packages = require('./packages.js');
 
 function buildDispatch() {
   return {
@@ -30,6 +31,8 @@ function buildDispatch() {
     get_skills: team.handleGetSkills,
     get_run: runs.handleGetRun,
     cancel_routine_run: runs.handleCancelRoutineRun,
+    plan_package_import: packages.handlePlanPackageImport,
+    apply_package_import: packages.handleApplyPackageImport,
     get_conversations: conversations.handleGetConversations,
     set_last_active_conversation: conversations.handleSetLastActiveConversation,
     save_conversation: conversations.handleSaveConversation,

--- a/lib/protocol/handlers/packages.js
+++ b/lib/protocol/handlers/packages.js
@@ -1,0 +1,60 @@
+'use strict';
+// WS handlers: package import planning and apply. This is a JSON boundary
+// and nothing more: discovery, planning, evaluation, byte verification and
+// the transaction all live in lib/packages/, and the handlers never replan,
+// rewrite an approval, or fill anything in. The source path is caller
+// supplied and may sit outside the workspace, which is the existing
+// typed-path install affordance; everything it leads to is digested and
+// verified before a byte lands.
+
+const path = require('path');
+const { getWorkspace } = require('../../config.js');
+const { buildPlan } = require('../../packages/import-plan.js');
+const { applyImport } = require('../../packages/import-apply.js');
+
+function fail(ws, operation, error) {
+  ws.send(JSON.stringify({
+    type: 'package_import_error',
+    operation,
+    message: error && error.message ? error.message : String(error),
+  }));
+}
+
+function handlePlanPackageImport(ctx, ws, msg) {
+  const workspace = getWorkspace();
+  if (!workspace) return fail(ws, 'plan', new Error('no workspace is open'));
+  try {
+    const plan = buildPlan(workspace, path.resolve(String(msg.sourcePath || '')), {
+      id: msg.source && msg.source.id,
+      reference: msg.source && msg.source.reference !== undefined ? msg.source.reference : null,
+    });
+    ws.send(JSON.stringify({ type: 'package_import_plan', plan }));
+  } catch (e) {
+    fail(ws, 'plan', e);
+  }
+}
+
+function handleApplyPackageImport(ctx, ws, msg) {
+  const workspace = getWorkspace();
+  if (!workspace) return fail(ws, 'apply', new Error('no workspace is open'));
+  try {
+    // The approval object is used exactly as submitted; the evaluator is
+    // the sole authority on whether it still describes reality.
+    const result = applyImport(workspace, path.resolve(String(msg.sourcePath || '')), msg.approval, { receipt: {} });
+    ws.send(JSON.stringify({
+      type: 'package_import_result',
+      status: result.status,
+      writes: result.writes,
+      unchanged: result.unchanged,
+      skipped: result.skipped,
+      blocked: result.blocked,
+      stale: result.stale,
+      written: result.written,
+      receipt: result.receipt,
+    }));
+  } catch (e) {
+    fail(ws, 'apply', e);
+  }
+}
+
+module.exports = { handlePlanPackageImport, handleApplyPackageImport };

--- a/lib/protocol/handlers/packages.js
+++ b/lib/protocol/handlers/packages.js
@@ -12,6 +12,16 @@ const { getWorkspace } = require('../../config.js');
 const { buildPlan } = require('../../packages/import-plan.js');
 const { applyImport } = require('../../packages/import-apply.js');
 
+// A missing source path must refuse, never default: path.resolve('') is the
+// server's own working directory, and running discovery or apply over that
+// is precisely the accident this guard exists to make unreachable.
+function sourcePathOf(msg) {
+  if (typeof msg.sourcePath !== 'string' || msg.sourcePath.trim() === '') {
+    throw new Error('sourcePath is required: the package source directory to read');
+  }
+  return path.resolve(msg.sourcePath);
+}
+
 function fail(ws, operation, error) {
   ws.send(JSON.stringify({
     type: 'package_import_error',
@@ -24,7 +34,7 @@ function handlePlanPackageImport(ctx, ws, msg) {
   const workspace = getWorkspace();
   if (!workspace) return fail(ws, 'plan', new Error('no workspace is open'));
   try {
-    const plan = buildPlan(workspace, path.resolve(String(msg.sourcePath || '')), {
+    const plan = buildPlan(workspace, sourcePathOf(msg), {
       id: msg.source && msg.source.id,
       reference: msg.source && msg.source.reference !== undefined ? msg.source.reference : null,
     });
@@ -40,7 +50,7 @@ function handleApplyPackageImport(ctx, ws, msg) {
   try {
     // The approval object is used exactly as submitted; the evaluator is
     // the sole authority on whether it still describes reality.
-    const result = applyImport(workspace, path.resolve(String(msg.sourcePath || '')), msg.approval, { receipt: {} });
+    const result = applyImport(workspace, sourcePathOf(msg), msg.approval, { receipt: {} });
     ws.send(JSON.stringify({
       type: 'package_import_result',
       status: result.status,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:refs": "node scripts/check-internal-refs.js",
     "precommit": "node scripts/precommit-gate.js",
     "red-first": "node scripts/red-first.js",
-    "mutate:guards": "node test/tools/mutate-render-guards.js --markdown && node test/tools/mutate-routine-editor-guards.js --markdown && node test/tools/mutate-routines-guards.js --markdown && node test/tools/mutate-run-detail-guards.js --markdown && node test/tools/mutate-nav-guards.js --markdown && node test/tools/mutate-workspace-rollback-guards.js --markdown && node test/tools/mutate-fence-guards.js --markdown && node test/tools/mutate-atomic-write-guards.js --markdown && node test/tools/mutate-import-apply-guards.js --markdown && node test/tools/mutate-import-plan-guards.js --markdown",
+    "mutate:guards": "node test/tools/mutate-render-guards.js --markdown && node test/tools/mutate-routine-editor-guards.js --markdown && node test/tools/mutate-routines-guards.js --markdown && node test/tools/mutate-run-detail-guards.js --markdown && node test/tools/mutate-nav-guards.js --markdown && node test/tools/mutate-workspace-rollback-guards.js --markdown && node test/tools/mutate-fence-guards.js --markdown && node test/tools/mutate-atomic-write-guards.js --markdown && node test/tools/mutate-import-apply-guards.js --markdown && node test/tools/mutate-import-plan-guards.js --markdown && node test/tools/mutate-import-protocol-guards.js --markdown",
     "check:fixture": "node test/tools/regenerate-benign-before.js --check",
     "lint:styles": "node test/tools/style-drift.js",
     "typecheck": "tsc -p tsconfig.server.json && tsc -p tsconfig.client.json",

--- a/test/tools/mutate-import-protocol-guards.js
+++ b/test/tools/mutate-import-protocol-guards.js
@@ -49,8 +49,13 @@ const MUTATIONS = [
     '  if (options.receipt && evaluation.writes.length > 0) {',
     '  if (options.receipt) {'],
   [HANDLERS, 'the approval is used exactly as submitted, never repaired',
-    "    const result = applyImport(workspace, path.resolve(String(msg.sourcePath || '')), msg.approval, { receipt: {} });",
-    "    const result = applyImport(workspace, path.resolve(String(msg.sourcePath || '')), { ...msg.approval, schema: 'rundock.package-import-approval/v1' }, { receipt: {} });"],
+    '    const result = applyImport(workspace, sourcePathOf(msg), msg.approval, { receipt: {} });',
+    "    const result = applyImport(workspace, sourcePathOf(msg), { ...msg.approval, schema: 'rundock.package-import-approval/v1' }, { receipt: {} });"],
+  [HANDLERS, 'an absent source path refuses instead of defaulting to the working directory',
+    "  if (typeof msg.sourcePath !== 'string' || msg.sourcePath.trim() === '') {\n"
+    + "    throw new Error('sourcePath is required: the package source directory to read');\n"
+    + '  }\n',
+    ''],
   [INDEX, 'the plan operation is registered in the dispatch table',
     '    plan_package_import: packages.handlePlanPackageImport,\n',
     ''],

--- a/test/tools/mutate-import-protocol-guards.js
+++ b/test/tools/mutate-import-protocol-guards.js
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
 'use strict';
-// Take the import apply adapter's guards apart one at a time and report which
-// tests notice. The adapter's whole job is refusing to write what it cannot
-// verify and executing exactly what the evaluator allowed, and every one of
-// those refusals could be deleted with the happy path still green unless a
-// test is proven to notice.
+// Take the protocol boundary's guards apart one at a time and report which
+// tests notice. The receipt's membership in the one transaction, the
+// zero-write rule, the verbatim approval and the dispatch registrations are
+// each the kind of guarantee a green suite could quietly stop checking.
 //
-//   node test/tools/mutate-import-apply-guards.js            # report
-//   node test/tools/mutate-import-apply-guards.js --markdown # as a table
+//   node test/tools/mutate-import-protocol-guards.js            # report
+//   node test/tools/mutate-import-protocol-guards.js --markdown # as a table
 //
-// The harness is the same shape as mutate-atomic-write-guards.js and is
+// The harness is the same shape as mutate-import-plan-guards.js and is
 // deliberately a second copy rather than a shared module, for the reason
 // stated there: pulling them together means editing an instrument already in
 // the gate, and mixing that refactor into a change is how a gate quietly
@@ -24,56 +23,49 @@ const { beginMutationRun } = require('./mutation-run.js');
 
 const ROOT = path.join(__dirname, '..', '..');
 
-const ADAPTER = {
+const APPLY = {
   src: path.join(ROOT, 'lib', 'packages', 'import-apply.js'),
-  suite: 'test/unit/package-import-apply.test.js',
+  suite: 'test/unit/package-import-protocol.test.js',
+};
+const HANDLERS = {
+  src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'packages.js'),
+  suite: 'test/unit/package-import-protocol.test.js',
+};
+const INDEX = {
+  src: path.join(ROOT, 'lib', 'protocol', 'handlers', 'index.js'),
+  suite: 'test/unit/package-import-protocol.test.js',
 };
 
 // [target, label, the guard as it is written, what it becomes without it]
 const MUTATIONS = [
-  [ADAPTER, 'an interrupted prior transaction is recovered before anything else',
-    '  recoverPendingWrites(workspace);\n',
+  [APPLY, 'the receipt is a member of the one transaction, not a separate write',
+    '    writes.push({\n'
+    + '      path: toAbsolute(workspace, receipt),\n'
+    + "      content: `${JSON.stringify(buildReceipt(approval, evaluation, appliedAt), null, 2)}\\n`,\n"
+    + '    });',
+    "    fs.mkdirSync(path.dirname(toAbsolute(workspace, receipt)), { recursive: true });\n"
+    + "    fs.writeFileSync(toAbsolute(workspace, receipt), `${JSON.stringify(buildReceipt(approval, evaluation, appliedAt), null, 2)}\\n`);"],
+  [APPLY, 'a zero-write apply writes no receipt',
+    '  if (options.receipt && evaluation.writes.length > 0) {',
+    '  if (options.receipt) {'],
+  [HANDLERS, 'the approval is used exactly as submitted, never repaired',
+    "    const result = applyImport(workspace, path.resolve(String(msg.sourcePath || '')), msg.approval, { receipt: {} });",
+    "    const result = applyImport(workspace, path.resolve(String(msg.sourcePath || '')), { ...msg.approval, schema: 'rundock.package-import-approval/v1' }, { receipt: {} });"],
+  [INDEX, 'the plan operation is registered in the dispatch table',
+    '    plan_package_import: packages.handlePlanPackageImport,\n',
     ''],
-  [ADAPTER, 'only a ready evaluation reaches the filesystem',
-    "  if (evaluation.status !== 'ready') return { ...evaluation, written: [], receipt: null };",
-    "  if (evaluation.status === 'ready') return { ...evaluation, written: [], receipt: null };"],
-  [ADAPTER, 'bytes that do not hash to the approved digest are never written',
-    '    if (digestFile(transformed) !== write.approvedDigest) {\n'
-    + '      throw new Error(`bytes for ${write.id} do not match the approved digest; refusing to write`);\n'
-    + '    }\n',
+  [INDEX, 'the apply operation is registered in the dispatch table',
+    '    apply_package_import: packages.handleApplyPackageImport,\n',
     ''],
-  [ADAPTER, 'the provenance transformation is actually applied to written agents',
-    "    const transformed = Buffer.from(withProvenance(bytes.toString('utf8'), sourceId), 'utf8');",
-    '    const transformed = bytes;'],
-  [ADAPTER, 'a directory digest covers where each file lives, not only its bytes',
-    '      hash.update(`${relative}\\0`);\n',
-    ''],
-  [ADAPTER, 'every eligible write lands in one transaction, not several',
-    '  const result = writeAsUnit(workspace, writes, { replaceDirs, afterStep: options.afterStep });',
-    '  const first = writeAsUnit(workspace, writes, { afterStep: options.afterStep });\n'
-    + '  const second = writeAsUnit(workspace, [], { replaceDirs, afterStep: options.afterStep });\n'
-    + '  const result = { written: [...first.written, ...second.written] };'],
-  [ADAPTER, 'a skill write is verified against the approved digest like any other bytes',
-    '  if (write.approvedDigest !== write.sourceDigest) {\n'
-    + '    throw new Error(`bytes for ${write.id} do not match the approved digest; refusing to write`);\n'
-    + '  }\n',
-    ''],
-  [ADAPTER, 'a failed observation aborts instead of reading as absence',
-    "    if (e.code === 'ENOENT' || e.code === 'ENOTDIR') return ABSENT_DIGEST;\n    throw e;",
-    '    return ABSENT_DIGEST;'],
-  [ADAPTER, 'recovery runs before the snapshot, not merely at some point',
-    '  recoverPendingWrites(workspace);\n  const current = snapshotCurrent(workspace, sourceRoot, approval);',
-    '  const current = snapshotCurrent(workspace, sourceRoot, approval);\n  recoverPendingWrites(workspace);'],
 ];
 
 // Guards deliberately NOT mutated, each with the reason.
 const NOT_MUTATED = [
   {
-    what: 'the source-digest verification in materialise',
-    why: 'the digest it checks was already matched against the same file by the snapshot moments '
-      + 'earlier in the same call, so no fixture can make it fire without a race seam the module '
-      + 'deliberately does not expose. It is defence in depth for the window between snapshot and '
-      + 'read-back; a mutation nothing can honestly discharge is noise. Left as a named gap.',
+    what: 'the structured-error wrapper in the handlers',
+    why: 'every error test asserts the reply type, operation and message directly, so deleting the '
+      + 'wrapper turns those tests red by construction; the mutations here are reserved for the '
+      + 'guarantees a green suite could plausibly stop checking.',
   },
 ];
 
@@ -106,7 +98,7 @@ function redTests(suite) {
 }
 
 function run() {
-  const targets = [ADAPTER];
+  const targets = [APPLY, HANDLERS, INDEX];
   const session = beginMutationRun({ files: targets.map((target) => target.src) });
   const originals = new Map();
   for (const target of targets) originals.set(target, session.original(target.src));

--- a/test/unit/package-import-protocol.test.js
+++ b/test/unit/package-import-protocol.test.js
@@ -6,7 +6,9 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { buildDispatch } = require('../../lib/protocol/handlers/index.js');
-const { decide } = require('../../lib/packages/import-plan.js');
+const { decide, buildPlan } = require('../../lib/packages/import-plan.js');
+const { journalPath } = require('../../lib/workspace/atomic-write.js');
+const { digestFile } = require('../../lib/packages/import-apply.js');
 const config = require('../../lib/config.js');
 const { makeTempDir } = require('../helpers/workspace.js');
 
@@ -99,6 +101,60 @@ describe('the protocol boundary', () => {
       [['agent:scribe', 'written'], ['skill:writer', 'written']]);
   });
 
+  test('a successful plan is the plan module\'s output verbatim and writes nothing anywhere', () => {
+    const { workspace, sourceRoot } = fixture();
+    const wsBefore = tree(workspace);
+    const srcBefore = tree(sourceRoot);
+    const reply = dispatchJson('plan_package_import', { sourcePath: sourceRoot, source: SOURCE });
+    assert.strictEqual(reply.type, 'package_import_plan');
+    // Deep-equal to a JSON round trip of the real producer: any field the
+    // handler adds, drops or reshapes fails here.
+    const direct = JSON.parse(JSON.stringify(buildPlan(workspace, sourceRoot, SOURCE)));
+    assert.deepStrictEqual(reply.plan, direct);
+    assert.deepStrictEqual(tree(workspace), wsBefore);
+    assert.deepStrictEqual(tree(sourceRoot), srcBefore);
+  });
+
+  // [name, build(sourceRoot), message]: every discovery refusal class the
+  // plan path can raise, each surfacing as a structured error.
+  const PLAN_REFUSALS = [
+    ['a non-canonical skill name', (root) => write(root, '.claude/skills/Bad Name/SKILL.md', 'x'), /not a canonical skill name/],
+    ['a non-canonical agent name', (root) => write(root, '.claude/agents/Not A Slug.md', AGENT_TEXT), /not a canonical agent file name/],
+    ['a symlink in the source', (root) => {
+      write(root, 'real.md', AGENT_TEXT);
+      fs.symlinkSync(path.join(root, 'real.md'), path.join(root, '.claude/agents/link.md'));
+    }, /is a symlink/],
+    ['unterminated agent frontmatter', (root) => write(root, '.claude/agents/broken.md', '---\nname: broken\n'), /never closes/],
+  ];
+
+  for (const [name, build, message] of PLAN_REFUSALS) {
+    test(`${name} surfaces as a structured plan error with the workspace unchanged`, () => {
+      const { workspace, sourceRoot } = fixture();
+      build(sourceRoot);
+      const before = tree(workspace);
+      const reply = dispatchJson('plan_package_import', { sourcePath: sourceRoot, source: SOURCE });
+      assert.strictEqual(reply.type, 'package_import_error');
+      assert.strictEqual(reply.operation, 'plan');
+      assert.match(reply.message, message);
+      assert.doesNotMatch(reply.message, /\n\s+at /); // a message, not a stack trace
+      assert.deepStrictEqual(tree(workspace), before);
+    });
+  }
+
+  for (const [name, bad] of [['omitted', {}], ['empty', { sourcePath: '' }], ['non-string', { sourcePath: 7 }]]) {
+    test(`an ${name} sourcePath refuses both operations before any filesystem work`, () => {
+      const { workspace } = fixture();
+      const before = tree(workspace);
+      for (const op of ['plan', 'apply']) {
+        const reply = dispatchJson(`${op}_package_import`, { ...bad, source: SOURCE, approval: {} });
+        assert.strictEqual(reply.type, 'package_import_error');
+        assert.strictEqual(reply.operation, op);
+        assert.match(reply.message, /sourcePath is required/);
+      }
+      assert.deepStrictEqual(tree(workspace), before);
+    });
+  }
+
   test('a replayed identical approval performs zero writes and writes no second receipt', () => {
     const { workspace, sourceRoot } = fixture();
     const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
@@ -112,15 +168,47 @@ describe('the protocol boundary', () => {
     assert.strictEqual(fs.readdirSync(path.join(workspace, RECEIPTS)).length, 1);
   });
 
-  test('discovery refusals surface as structured errors and write nothing', () => {
-    const { workspace, sourceRoot } = fixture();
-    write(sourceRoot, '.claude/skills/Bad Name/SKILL.md', 'x');
-    const before = tree(workspace);
-    const reply = dispatchJson('plan_package_import', { sourcePath: sourceRoot, source: SOURCE });
-    assert.strictEqual(reply.type, 'package_import_error');
-    assert.strictEqual(reply.operation, 'plan');
-    assert.match(reply.message, /not a canonical skill name/);
-    assert.deepStrictEqual(tree(workspace), before);
+  test('the receipt is the complete record of a mixed-outcome apply', () => {
+    const workspace = makeTempDir('proto-ws-');
+    const sourceRoot = makeTempDir('proto-src-');
+    write(sourceRoot, '.claude/agents/scribe.md', AGENT_TEXT);
+    write(sourceRoot, '.claude/skills/same/SKILL.md', 'identical');
+    write(sourceRoot, '.claude/skills/parked/SKILL.md', 'parked v2');
+    write(workspace, '.claude/skills/same/SKILL.md', 'identical'); // already at the approved bytes
+    write(workspace, '.claude/skills/parked/SKILL.md', 'parked');
+    config.setWorkspace(workspace);
+    const approval = decide(planVia(sourceRoot), {
+      'agent:scribe': 'add', 'skill:same': 'overwrite', 'skill:parked': 'skip',
+    });
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.status, 'ready');
+    const receipt = JSON.parse(fs.readFileSync(path.join(workspace, reply.receipt), 'utf8'));
+    const expected = [
+      ...reply.writes.map((o) => ({ id: o.id, kind: o.kind, destination: o.destination, outcome: 'written' })),
+      ...reply.unchanged.map((o) => ({ id: o.id, kind: o.kind, destination: o.destination, outcome: 'unchanged' })),
+      ...reply.skipped.map((o) => ({ id: o.id, kind: o.kind, destination: o.destination, outcome: 'skipped' })),
+      ...reply.blocked.map((o) => ({ id: o.id, kind: o.kind, destination: o.destination, outcome: 'blocked' })),
+    ].sort((a, b) => (a.id < b.id ? -1 : 1));
+    assert.deepStrictEqual(receipt.items, expected);
+    assert.deepStrictEqual(receipt.items.map((i) => [i.id, i.outcome]),
+      [['agent:scribe', 'written'], ['skill:parked', 'skipped'], ['skill:same', 'unchanged']]);
+  });
+
+  test('blocked outcomes appear in the receipt when a ready apply carries them', () => {
+    const workspace = makeTempDir('proto-ws-');
+    const sourceRoot = makeTempDir('proto-src-');
+    write(sourceRoot, '.claude/agents/alpha.md', '---\norder: 0\n---\n\nA.\n');
+    write(sourceRoot, '.claude/agents/beta.md', '---\norder: 0\n---\n\nB.\n');
+    write(sourceRoot, '.claude/skills/writer/SKILL.md', 'skill');
+    config.setWorkspace(workspace);
+    const approval = decide(planVia(sourceRoot), {
+      'agent:alpha': 'add', 'agent:beta': 'add', 'skill:writer': 'add',
+    });
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.status, 'ready');
+    const receipt = JSON.parse(fs.readFileSync(path.join(workspace, reply.receipt), 'utf8'));
+    assert.deepStrictEqual(receipt.items.map((i) => [i.id, i.outcome]),
+      [['agent:alpha', 'blocked'], ['agent:beta', 'blocked'], ['skill:writer', 'written']]);
   });
 
   test('a stale destination replies with zero writes, reasons and an untouched tree', () => {
@@ -161,6 +249,33 @@ describe('the protocol boundary', () => {
     assert.strictEqual(reply.operation, 'apply');
     assert.match(reply.message, /approval\.schema/);
     assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a byte-verification refusal surfaces as a structured error with zero writes and no receipt', () => {
+    const { workspace, sourceRoot } = fixture();
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    approval.items.find((i) => i.id === 'agent:scribe').approvedDigest = digestFile(Buffer.from('other bytes'));
+    const before = tree(workspace);
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.type, 'package_import_error');
+    assert.strictEqual(reply.operation, 'apply');
+    assert.match(reply.message, /do not match the approved digest/);
+    assert.deepStrictEqual(tree(workspace), before);
+    assert.strictEqual(fs.existsSync(path.join(workspace, RECEIPTS)), false);
+  });
+
+  test('a journal failure surfaces as a structured error with zero writes and no receipt', () => {
+    const { workspace, sourceRoot } = fixture();
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    fs.mkdirSync(path.dirname(journalPath(workspace)), { recursive: true });
+    fs.writeFileSync(journalPath(workspace), 'not json');
+    const before = tree(workspace);
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.type, 'package_import_error');
+    assert.strictEqual(reply.operation, 'apply');
+    assert.match(reply.message, /cannot be trusted/);
+    assert.deepStrictEqual(tree(workspace), before);
+    assert.strictEqual(fs.existsSync(path.join(workspace, RECEIPTS)), false);
   });
 
   test('a source item added after planning appears nowhere and is never written', () => {

--- a/test/unit/package-import-protocol.test.js
+++ b/test/unit/package-import-protocol.test.js
@@ -290,6 +290,26 @@ describe('the protocol boundary', () => {
   });
 });
 
+describe('the receipt seam is what the file is built from', () => {
+  const original = config.getWorkspace();
+  test.after(() => config.setWorkspace(original));
+
+  test('an injected clock and run suffix name the receipt, and its body carries them', () => {
+    const { workspace, sourceRoot } = fixture();
+    const { applyImport } = require('../../lib/packages/import-apply.js');
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    // A clock whose local and UTC dates differ in most timezones: the date
+    // component must be the UTC one, which slicing the ISO string guarantees.
+    const now = '2026-01-02T23:30:00.000Z';
+    const result = applyImport(workspace, sourceRoot, approval, { receipt: { now, run: 'fixedrun' } });
+    const expected = `${RECEIPTS}/2026-01-02-fixedrun.json`;
+    assert.strictEqual(result.receipt, expected);
+    const receipt = JSON.parse(fs.readFileSync(path.join(workspace, expected), 'utf8'));
+    assert.strictEqual(receipt.schema, 'rundock.package-import-receipt/v1');
+    assert.strictEqual(receipt.appliedAt, now);
+  });
+});
+
 describe('the receipt lives and dies with the transaction', () => {
   const original = config.getWorkspace();
   test.after(() => config.setWorkspace(original));

--- a/test/unit/package-import-protocol.test.js
+++ b/test/unit/package-import-protocol.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { buildDispatch } = require('../../lib/protocol/handlers/index.js');
+const { decide } = require('../../lib/packages/import-plan.js');
+const config = require('../../lib/config.js');
+const { makeTempDir } = require('../helpers/workspace.js');
+
+const SOURCE = { id: 'github.com/example/pack', reference: 'v1.0.0' };
+const RECEIPTS = '.claude/rundock/receipts';
+
+function write(root, relative, content) {
+  const absolute = path.join(root, relative);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, content);
+  return absolute;
+}
+
+// The complete tree as one comparable value.
+function tree(root, current = root) {
+  const result = [];
+  for (const entry of fs.readdirSync(current, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    const absolute = path.join(current, entry.name);
+    const relative = path.relative(root, absolute).split(path.sep).join('/');
+    if (entry.isDirectory()) {
+      const children = tree(root, absolute);
+      if (children.length === 0) result.push(`${relative}/`);
+      else result.push(...children);
+    } else {
+      result.push(`${relative}:${fs.readFileSync(absolute).toString('base64')}`);
+    }
+  }
+  return result;
+}
+
+function captureWs() {
+  const sent = [];
+  return { sent, send: (m) => sent.push(JSON.parse(m)), readyState: 1 };
+}
+
+// Every request travels the real dispatch table as JSON, exactly as a client
+// would send it, and every reply is read back from the wire capture.
+function dispatchJson(type, payload) {
+  const dispatch = buildDispatch();
+  const ws = captureWs();
+  dispatch[type]({}, ws, JSON.parse(JSON.stringify({ type, ...payload })));
+  assert.strictEqual(ws.sent.length, 1);
+  return ws.sent[0];
+}
+
+const AGENT_TEXT = '---\nname: writer\n---\n\nWrite things.\n';
+
+function fixture() {
+  const workspace = makeTempDir('proto-ws-');
+  const sourceRoot = makeTempDir('proto-src-');
+  write(workspace, 'notes/keep.md', 'foreign');
+  write(workspace, '.claude/skills/writer/SKILL.md', 'old skill');
+  write(sourceRoot, '.claude/agents/scribe.md', AGENT_TEXT);
+  write(sourceRoot, '.claude/skills/writer/SKILL.md', 'new skill');
+  config.setWorkspace(workspace);
+  return { workspace, sourceRoot };
+}
+
+function planVia(sourceRoot) {
+  const reply = dispatchJson('plan_package_import', { sourcePath: sourceRoot, source: SOURCE });
+  assert.strictEqual(reply.type, 'package_import_plan');
+  return reply.plan;
+}
+
+describe('the protocol boundary', () => {
+  const original = config.getWorkspace();
+  test.after(() => config.setWorkspace(original));
+
+  test('plan and apply round-trip both kinds through the real dispatch table', () => {
+    const { workspace, sourceRoot } = fixture();
+    const plan = planVia(sourceRoot);
+    assert.deepStrictEqual(plan.items.map((i) => [i.id, i.collision]),
+      [['agent:scribe', false], ['skill:writer', true]]);
+    const approval = decide(plan, { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.type, 'package_import_result');
+    assert.strictEqual(reply.status, 'ready');
+    assert.deepStrictEqual(reply.writes.map((w) => w.id), ['agent:scribe', 'skill:writer']);
+    assert.strictEqual(reply.written.length, 3); // two destinations plus the receipt
+    assert.match(fs.readFileSync(path.join(workspace, '.claude/agents/scribe.md'), 'utf8'), /^source: /m);
+    assert.strictEqual(fs.readFileSync(path.join(workspace, '.claude/skills/writer/SKILL.md'), 'utf8'), 'new skill');
+    // Exactly one receipt, whose entries equal the reply's outcomes.
+    const receipts = fs.readdirSync(path.join(workspace, RECEIPTS));
+    assert.strictEqual(receipts.length, 1);
+    assert.strictEqual(reply.receipt, `${RECEIPTS}/${receipts[0]}`);
+    const receipt = JSON.parse(fs.readFileSync(path.join(workspace, RECEIPTS, receipts[0]), 'utf8'));
+    assert.deepStrictEqual(receipt.source, SOURCE);
+    assert.deepStrictEqual(receipt.items.map((i) => [i.id, i.outcome]),
+      [['agent:scribe', 'written'], ['skill:writer', 'written']]);
+  });
+
+  test('a replayed identical approval performs zero writes and writes no second receipt', () => {
+    const { workspace, sourceRoot } = fixture();
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    const after = tree(workspace);
+    const replay = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(replay.status, 'ready');
+    assert.deepStrictEqual(replay.written, []);
+    assert.strictEqual(replay.receipt, null);
+    assert.deepStrictEqual(tree(workspace), after);
+    assert.strictEqual(fs.readdirSync(path.join(workspace, RECEIPTS)).length, 1);
+  });
+
+  test('discovery refusals surface as structured errors and write nothing', () => {
+    const { workspace, sourceRoot } = fixture();
+    write(sourceRoot, '.claude/skills/Bad Name/SKILL.md', 'x');
+    const before = tree(workspace);
+    const reply = dispatchJson('plan_package_import', { sourcePath: sourceRoot, source: SOURCE });
+    assert.strictEqual(reply.type, 'package_import_error');
+    assert.strictEqual(reply.operation, 'plan');
+    assert.match(reply.message, /not a canonical skill name/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a stale destination replies with zero writes, reasons and an untouched tree', () => {
+    const { workspace, sourceRoot } = fixture();
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    write(workspace, '.claude/skills/writer/SKILL.md', 'changed after approval');
+    const before = tree(workspace);
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.status, 'stale');
+    assert.deepStrictEqual(reply.written, []);
+    assert.strictEqual(reply.receipt, null);
+    assert.deepStrictEqual(reply.stale.map((s) => [s.id, s.reason]), [['skill:writer', 'destination-changed']]);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a decisions-blocked evaluation replies with zero writes and no receipt', () => {
+    const workspace = makeTempDir('proto-ws-');
+    const sourceRoot = makeTempDir('proto-src-');
+    write(sourceRoot, '.claude/agents/alpha.md', '---\norder: 0\n---\n\nA.\n');
+    write(sourceRoot, '.claude/agents/beta.md', '---\norder: 0\n---\n\nB.\n');
+    config.setWorkspace(workspace);
+    const approval = decide(planVia(sourceRoot), { 'agent:alpha': 'add', 'agent:beta': 'add' });
+    const before = tree(workspace);
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.status, 'decisions-blocked');
+    assert.deepStrictEqual(reply.written, []);
+    assert.strictEqual(reply.receipt, null);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('an evaluator validation error surfaces as a structured error with an untouched tree', () => {
+    const { workspace, sourceRoot } = fixture();
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    approval.schema = 'rundock.package-import-approval/v0';
+    const before = tree(workspace);
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.type, 'package_import_error');
+    assert.strictEqual(reply.operation, 'apply');
+    assert.match(reply.message, /approval\.schema/);
+    assert.deepStrictEqual(tree(workspace), before);
+  });
+
+  test('a source item added after planning appears nowhere and is never written', () => {
+    const { workspace, sourceRoot } = fixture();
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    write(sourceRoot, '.claude/skills/uninvited/SKILL.md', 'not approved');
+    const reply = dispatchJson('apply_package_import', { sourcePath: sourceRoot, approval });
+    assert.strictEqual(reply.status, 'ready');
+    const ids = ['writes', 'unchanged', 'skipped', 'blocked', 'stale'].flatMap((k) => reply[k].map((o) => o.id));
+    assert.strictEqual(ids.includes('skill:uninvited'), false);
+    assert.strictEqual(fs.existsSync(path.join(workspace, '.claude/skills/uninvited')), false);
+  });
+});
+
+describe('the receipt lives and dies with the transaction', () => {
+  const original = config.getWorkspace();
+  test.after(() => config.setWorkspace(original));
+
+  const boundaries = (() => {
+    const { workspace, sourceRoot } = fixture();
+    const { applyImport } = require('../../lib/packages/import-apply.js');
+    const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+    const steps = [];
+    applyImport(workspace, sourceRoot, approval, {
+      receipt: {},
+      afterStep: (s) => steps.push(`${s.phase}:${s.action}`),
+    });
+    return steps;
+  })();
+
+  for (let boundary = 1; boundary <= boundaries.length; boundary++) {
+    test(`a fault after ${boundaries[boundary - 1]} (step ${boundary} of ${boundaries.length}) leaves no receipt and the pre-apply tree`, () => {
+      const { workspace, sourceRoot } = fixture();
+      const { applyImport } = require('../../lib/packages/import-apply.js');
+      const approval = decide(planVia(sourceRoot), { 'agent:scribe': 'add', 'skill:writer': 'overwrite' });
+      const before = tree(workspace);
+      let completed = 0;
+      assert.throws(() => applyImport(workspace, sourceRoot, approval, {
+        receipt: {},
+        afterStep: () => {
+          completed += 1;
+          if (completed === boundary) throw new Error('injected fault');
+        },
+      }), /injected fault/);
+      assert.deepStrictEqual(tree(workspace), before);
+      assert.strictEqual(fs.existsSync(path.join(workspace, RECEIPTS)), false);
+    });
+  }
+});

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -28,6 +28,7 @@ const EXPECTED_TYPES = [
   'pick_folder', 'create_workspace', 'set_workspace_mode',
   'get_agents', 'get_runtime_status', 'get_files', 'get_skills', 'get_run',
   'cancel_routine_run',
+  'plan_package_import', 'apply_package_import',
   'get_conversations', 'set_last_active_conversation', 'save_conversation',
   'get_lists', 'create_list', 'delete_list', 'delete_conversation',
   'read_file', 'add_to_team',


### PR DESCRIPTION
This opens the finished import machinery to clients. plan_package_import runs discovery and plan construction over a caller-supplied source directory and replies with the serialisable plan a person will decide item by item; apply_package_import consumes the decided approval exactly as submitted and replies with the evaluation status and per-item outcomes. The handlers are a JSON boundary and nothing more: discovery, planning, evaluation, byte verification and the transaction all live in lib/packages, every refusal surfaces as a structured error naming what was wrong, and a missing or invalid source path refuses by name rather than resolving to the server's own working directory. A completed apply that wrote anything leaves one receipt at .claude/rundock/receipts/, written as one more member of the same atomic transaction, recording the source, the apply time and each item's outcome. The receipt is history, never authority: nothing reads it back, a fault at any write boundary leaves no receipt and the pre-apply workspace, and replaying an identical approval performs zero writes and writes no second receipt. Both operations are exercised through the real dispatch table with JSON round trips, receipts are asserted as complete records across written, unchanged, skipped and blocked outcomes, and an injected clock and run suffix prove the receipt's name and body are built from the values supplied.