### PR TITLE
Hold the Packages door shut until the room behind it is finished

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -166,7 +166,22 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
           Workspace
         </div>
-        <div class="settings-nav-item" data-settings="packages" onclick="showSettingsSection('packages')">
+        <!-- The Packages door is held shut until the room behind it is
+             finished. The import half is real: a package colliding with
+             nothing plans, confirms, applies and leaves a receipt. A package
+             colliding with anything disables confirm and tells the person
+             each item needs its own decision, and the surface that takes
+             those decisions is not built yet. A door opening onto an
+             instruction the product cannot carry out is worse than no door.
+             HIDDEN, NOT DELETED, and the distinction is load-bearing:
+             packagesSectionVisible() reads dataset.settings off the active
+             nav item, so deleting this element makes that guard permanently
+             false, packagesRenderIfVisible() stops firing, and the flow never
+             redraws past its first paint. The e2e suite reaches the section
+             through showSettingsSection() rather than through this rail, so
+             the foundation keeps being proven while it is out of reach.
+             Remove the style attribute in the Packages release. -->
+        <div class="settings-nav-item" data-settings="packages" style="display:none" onclick="showSettingsSection('packages')">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
           Packages
         </div>


### PR DESCRIPTION
The Packages settings entry is hidden until the feature behind it is whole.

The import half is real and proven by the e2e suite: a package that collides with nothing plans, confirms, applies and leaves a receipt, cancel leaves the workspace byte-identical, and socket loss at either step keeps the flow usable. A package that collides with anything, though, disables confirm and tells the person each item needs its own decision, and the surface that takes those decisions is not built yet. A door that opens onto an instruction the product cannot carry out is worse than no door, so the rail entry goes and the room stays exactly as it is.

Hidden rather than deleted, and the distinction is load-bearing. `packagesSectionVisible()` reads `dataset.settings` off the active nav item, so removing the element makes that guard permanently false, `packagesRenderIfVisible()` stops firing, and the install flow never redraws past its first paint. The first version of this change did delete the element; the e2e specs reach the section through `showSettingsSection()` rather than through the rail, so the opening assertion still passed while every step after it would have hung. The reason is written into the comment beside the attribute so the next reader does not rediscover it the same way.

Nothing else changes. The section, its handlers, its model, its styles and its tests all remain, and the suite keeps exercising them, so the foundation goes on being proven while it is out of reach. The extension host is unaffected: it mounts from the file view, answers unregistered-with-reason when nothing is installed, and renders the file plainly, which is what it already did.

The entry returns alongside the collision decisions and the install-from-a-link flow.
