### PR TITLE
Re-capture the stream grammar against the runtime that is actually installed

### DIFF
--- a/scripts/stream-truth/captured-grammar.json
+++ b/scripts/stream-truth/captured-grammar.json
@@ -1,6 +1,6 @@
 {
-  "runtimeVersion": "2.1.246",
-  "capturedAt": "2026-08-27T08:12:32.227Z",
+  "runtimeVersion": "2.1.260",
+  "capturedAt": "2026-09-05T13:27:13.011Z",
   "scenarios": {
     "text-turn": {
       "invariants": [


### PR DESCRIPTION
The committed capture was taken from CLI 2.1.246 and the installed runtime is now 2.1.260, so the check refused. That refusal is the design: a runtime change invalidates the capture, because a stub modelling last month's stream is not evidence about this month's.

Re-captured live against 2.1.260 across both scenarios, the plain text turn and the tool-use turn whose multi-message shape killed the first 0.11.6 draft. The invariants held during capture and the stub matches the new capture in both, so the runtime moved and nothing about the way this server reads its output needs to change.

That is the answer the gate exists to produce, and it is worth having before a release rather than discovering it after one.