### PR TITLE
A grant is for a folder, not for a spelling of one

### DIFF
--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -224,7 +224,17 @@ record('S5 permission event recorded', s5ev);
   record('S7 folder approval resolves the hook with allow',
     !!(outsideOut && outsideOut.hookSpecificOutput && outsideOut.hookSpecificOutput.permissionDecision === 'allow'));
   const grantsFile = path.join(workspace, '.rundock', 'permissions.json');
-  const granted = fs.existsSync(grantsFile) && JSON.parse(fs.readFileSync(grantsFile, 'utf8')).allowedDirs.includes(outsideDir);
+  // A GRANT IS FOR A FOLDER, NOT FOR A SPELLING OF ONE. Grants are stored
+  // canonicalised, so on macOS a temp directory handed out as /var/folders/…
+  // is recorded as its real /private/var/folders/… path. Comparing the raw
+  // string would fail here while the grant works perfectly, which is exactly
+  // the confusion between a path and the directory it names that produced
+  // the card storm this release fixes. So the question asked is the real
+  // one: does some stored grant name this same directory?
+  const realOutside = fs.realpathSync(outsideDir);
+  const granted = fs.existsSync(grantsFile)
+    && JSON.parse(fs.readFileSync(grantsFile, 'utf8')).allowedDirs
+      .some(d => { try { return fs.realpathSync(d) === realOutside; } catch { return d === realOutside; } });
   record('S7 grant persisted into the workspace, folder-level', granted);
   const secondOut = await runHook({ file_path: path.join(outsideDir, 'export-two.md'), content: 'y' });
   record('S7 granted folder allows silently on the next access',


### PR DESCRIPTION
The boundary smoke check asked whether the stored grants contained the temp directory's path as a string. Grants are stored canonicalised now, so on this platform a directory handed out as `/var/folders/...` is recorded under its real `/private/var/folders/...` path, and that comparison failed while the grant itself worked perfectly: the very next check, that the granted folder then allows silently, passed throughout.

That is the same confusion between a path and the directory it names that produced the approval-card storm this release fixes, turning up in our own test. The check now asks the question that matters, whether some stored grant names this same directory, and resolves both sides before comparing them.

Twenty of twenty smoke checks pass.