### PR TITLE
A spec that moves the shared server must hand it back even when it fails

### DIFF
--- a/test/e2e/packages-install.spec.js
+++ b/test/e2e/packages-install.spec.js
@@ -25,8 +25,23 @@ async function boot(page) {
   await expect(page.locator('.convo-item').first()).toBeVisible();
 }
 
+// ASKING ONCE IS NOT ENOUGH RIGHT AFTER A WORKSPACE SWITCH. The switch
+// announces itself to every window, and that announcement redraws the shell.
+// A single showView() racing that redraw can be undone by it, leaving the
+// field present in the page but not on screen, which is what a plain
+// toBeVisible then waits seven seconds to discover. Asking again each time
+// the poll runs costs nothing when the view is already right and removes the
+// race when it is not.
 async function openPackages(page) {
-  await page.evaluate(() => { showView('settings'); showSettingsSection('packages'); });
+  await expect.poll(
+    () => page.evaluate(() => {
+      showView('settings');
+      showSettingsSection('packages');
+      const el = document.getElementById('packages-source-path');
+      return !!(el && el.offsetParent !== null);
+    }),
+    { message: 'the packages field is on screen after asking for it' },
+  ).toBe(true);
   await expect(page.locator('#packages-source-path')).toBeVisible();
 }
 
@@ -133,15 +148,23 @@ test('switching workspace returns the flow to idle, discarding the previous plan
   const original = await page.evaluate(() => currentWorkspacePath);
   const other = original + '-b';
   fs.mkdirSync(other, { recursive: true });
-  await page.evaluate((dir) => ws.send(JSON.stringify({ type: 'set_workspace', path: dir })), other);
-  await expect.poll(() => page.evaluate(() => currentWorkspacePath)).toBe(other);
-  await openPackages(page);
-  await expect(page.locator('#packages-source-path')).toBeVisible();
-  await expect(page.locator('#packages-source-path')).toHaveValue('');
-  await expect(page.locator('.packages-confirm-card')).toHaveCount(0);
-  // Hand the server back to the original workspace for the tests that follow.
-  await page.evaluate((dir) => ws.send(JSON.stringify({ type: 'set_workspace', path: dir })), original);
-  await expect.poll(() => page.evaluate(() => currentWorkspacePath)).toBe(original);
+  // THE SERVER IS SHARED, SO THE HANDBACK CANNOT BE AN ORDINARY LAST LINE.
+  // This moves the one server every spec in this run talks to. If an
+  // assertion below fails before the handback, every later spec boots into
+  // the empty second workspace, finds no conversations, and fails waiting for
+  // a row that will never render: one flake reported as a hundred, with the
+  // real one buried at the top. The handback belongs in a finally, so a
+  // failure here stays a failure here.
+  try {
+    await page.evaluate((dir) => ws.send(JSON.stringify({ type: 'set_workspace', path: dir })), other);
+    await expect.poll(() => page.evaluate(() => currentWorkspacePath)).toBe(other);
+    await openPackages(page);
+    await expect(page.locator('#packages-source-path')).toHaveValue('');
+    await expect(page.locator('.packages-confirm-card')).toHaveCount(0);
+  } finally {
+    await page.evaluate((dir) => ws.send(JSON.stringify({ type: 'set_workspace', path: dir })), original);
+    await expect.poll(() => page.evaluate(() => currentWorkspacePath)).toBe(original);
+  }
 });
 
 test('a connection lost mid-wait ends the wait and re-enables the flow', async ({ page }) => {


### PR DESCRIPTION
The workspace-switch spec points the one server every spec in the run talks to at a second, empty workspace, then hands it back on its last line. When an assertion in between failed, that line never ran, so every later spec booted into the empty workspace, found no conversations, and failed waiting for a row that would never render.

One flake was therefore reported as a hundred and eight failures with the real one buried at the top, which is why it was read as infrastructure trouble on two separate runs before anyone looked at where it started. All three occurrences began at the same spec, which is not what infrastructure trouble looks like. The handback now sits in a finally, so a failure there stays a failure there.

The flake itself is a race with the redraw the workspace switch announces to every window: a single showView racing that redraw can be undone by it, leaving the field present in the page but not on screen, which a plain visibility assertion then spends seven seconds discovering. Asking again on each poll costs nothing when the view is already right and removes the race when it is not.

Eight of eight pass locally.