### PR TITLE
Pin the macOS runner, because the signing job is where latest costs most

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,21 @@ jobs:
   macos:
     name: Build macOS (arm64 + x64)
     needs: [test, e2e, smoke, create-release]
-    runs-on: macos-latest
+    # PINNED, NOT LATEST, AND THE SIGNING JOB IS EXACTLY WHERE THAT MATTERS.
+    # `macos-latest` is a moving label. It rolled onto macOS 26 (image dated
+    # 2026-08-31) four days after the last release signed successfully on the
+    # image before it, and the signing broke: the keychain call electron-builder
+    # makes to authorise the imported certificate fails there, reported as
+    # "the user name or passphrase you entered is not correct", which sends
+    # whoever reads it hunting through credentials that were never wrong. The
+    # secrets had not been touched in a fortnight.
+    #
+    # A release build that quietly changes operating system between runs is
+    # not reproducible, and reproducibility is the property this job needs
+    # most: it is the one that signs the software other people install. So the
+    # version is stated here, and moving it is a deliberate edit with a build
+    # to prove it, rather than something that happens to us on a Tuesday.
+    runs-on: macos-15
     # Declares the protected release environment, which is where the signing
     # secrets now live. They were repository secrets, readable by ANY workflow
     # in this repo including one added on a pull request branch. The

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,7 +17,12 @@ on:
 jobs:
   smoke:
     name: Boot the packaged app
-    runs-on: macos-latest
+    # The same pin as the signing job in release.yml, and for a reason of its
+    # own: this test exists to prove the packaged app boots on the platform we
+    # ship. Run it on a different macOS from the one the release is built and
+    # signed on and it stops answering that question, while still reporting
+    # green. The two must move together or the check is decorative.
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
The last release signed successfully on 27 August. The `macos-latest` label rolled onto macOS 26 four days later, and the next signing attempt failed on a keychain call reported as `the user name or passphrase you entered is not correct`.

The credentials were never wrong. The signing secrets are environment secrets on `release`, last updated 20 August, and they are the same ones that signed 0.12.0 on 27 August. The Developer ID certificate is valid until April 2031. The operating system changed underneath them.

An error that names the wrong cause is worse than one that names none, because it sends the reader somewhere else entirely: the obvious response to that message is to go and re-export a certificate that was never the problem. The reasoning is written beside the pin so the next person to meet it finds the explanation rather than rediscovering it.

A build that signs software other people install should not change operating system between runs without anyone deciding it should. The version is now stated rather than inherited, and moving it takes a deliberate edit with a build to prove it.

The packaged smoke test is pinned to the same image for its own reason: it exists to prove the packaged app boots on the platform we ship, so running it on a different macOS from the one the release is signed on leaves it reporting green while answering a question nobody asked. The two move together or the check is decorative.

The durable follow-up, once this release is out, is upgrading electron-builder to a version that handles macOS 26 keychains and then moving the pin forward deliberately.