### PR TITLE
A sentence is not a value, and the value style truncates on purpose

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -186,7 +186,11 @@
           Packages
         </div>
         <div class="settings-nav-item" data-settings="connectors" onclick="showSettingsSection('connectors')">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 7v4a3 3 0 0 0 6 0V7"/><line x1="9" y1="2" x2="9" y2="7"/><line x1="15" y1="2" x2="15" y2="7"/><path d="M12 14v3a4 4 0 0 1-4 4H7"/></svg>
+          <!-- A plug, drawn symmetrically. The previous one carried its cord
+               off to one side, which at this size reads as a stethoscope
+               rather than a connector. Two prongs, a body, and a lead
+               straight down: the shape people already know. -->
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><line x1="9" y1="2" x2="9" y2="8"/><line x1="15" y1="2" x2="15" y2="8"/><path d="M7 8h10v3a5 5 0 0 1-10 0z"/><line x1="12" y1="16" x2="12" y2="22"/></svg>
           Connectors
         </div>
         <div class="settings-nav-item" data-settings="appearance" onclick="showSettingsSection('appearance')">

--- a/public/styles/views/settings.css
+++ b/public/styles/views/settings.css
@@ -13,6 +13,17 @@
 .settings-row + .settings-row { border-top: 1px solid var(--border); }
 .settings-label { font-size: var(--body); font-weight: 500; color: var(--text-1); }
 .settings-value { font-size: var(--caption); color: var(--text-2); font-family: 'SF Mono','Fira Code','Consolas',monospace; max-width: 320px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* A SENTENCE IS NOT A VALUE, AND THE VALUE STYLE TRUNCATES ON PURPOSE.
+   .settings-value clips to one 320px monospace line with an ellipsis, which
+   is right for a path or a command that would otherwise push a row wide, and
+   wrong for anything written to be read: a paragraph loses its second half
+   silently, and a line of feedback vanishes into the ellipsis, which reads
+   as a control that did nothing. So sentences get their own class: the body
+   face rather than monospace, wrapping, no width cap, and a line height that
+   makes more than one line comfortable. Values keep the clip, and keep their
+   title attribute so the full text is still reachable. */
+.settings-prose { font-size: var(--caption); color: var(--text-2); line-height: 1.5; white-space: normal; overflow: visible; }
+.settings-prose code { font-family: 'SF Mono','Fira Code','Consolas',monospace; }
 .settings-btn { padding: 6px 14px; font-size: var(--caption); font-weight: 600; border-radius: var(--radius-md); background: var(--card); color: var(--text-1); border: 1px solid var(--border); transition: all var(--duration-base) ease; cursor: pointer; }
 .settings-btn:hover { border-color: var(--accent); color: var(--accent); }
 .settings-btn-primary { padding: 6px 14px; font-size: var(--caption); font-weight: 600; border-radius: var(--radius-md); background: var(--accent); color: white; border: none; transition: all var(--duration-base) ease; cursor: pointer; }

--- a/public/views/settings.js
+++ b/public/views/settings.js
@@ -364,21 +364,21 @@ function connectorsSectionHtml(state) {
   // list to misread as empty, and no Add form, because a write built on text
   // we never saw is the overwrite this whole state exists to prevent.
   if (state.error && state.readFailed) {
-    return `<div class="settings-section-title">Connectors</div><div class="settings-card"><div class="settings-row"><span class="settings-value">${connectorsEsc(state.error)}</span></div></div>`;
+    return `<div class="settings-section-title">Connectors</div><div class="settings-card"><div class="settings-row"><span class="settings-prose">${connectorsEsc(state.error)}</span></div></div>`;
   }
   let body;
   if (state.error) {
-    body = `<div class="settings-card"><div class="settings-row"><span class="settings-value">${connectorsEsc(state.error)}</span></div></div>`;
+    body = `<div class="settings-card"><div class="settings-row"><span class="settings-prose">${connectorsEsc(state.error)}</span></div></div>`;
   } else if (state.missing || state.servers.length === 0) {
     body = `<div class="settings-card"><div class="settings-row" style="flex-direction:column;align-items:stretch;gap:6px">
-      <span class="settings-value">No connectors configured in this workspace yet.</span>
-      <span class="settings-value">Workspace connectors live in <code>.mcp.json</code> at the workspace root and travel with the folder, so everyone opening this workspace gets them. Connectors added at claude.ai or in Claude Code's own settings are the operator's personal reach and are managed there, not here.</span>
+      <span class="settings-prose">No connectors configured in this workspace yet.</span>
+      <span class="settings-prose">Workspace connectors live in <code>.mcp.json</code> at the workspace root and travel with the folder, so everyone opening this workspace gets them. Connectors added at claude.ai or in Claude Code's own settings are the operator's personal reach and are managed there, not here.</span>
     </div></div>`;
   } else {
     const rows = state.servers.map(srv => `<div class="settings-row" data-connector="${connectorsEscAttr(srv.name)}" style="flex-direction:column;align-items:stretch;gap:2px">
-      <span class="settings-label">${connectorsEsc(srv.name)} <span class="settings-value" style="opacity:.7">Workspace connector: travels with this folder</span></span>
+      <span class="settings-label">${connectorsEsc(srv.name)} <span class="settings-prose" style="opacity:.7">Workspace connector: travels with this folder</span></span>
       <span class="settings-value" title="${connectorsEscAttr(srv.target)}">${connectorsEsc(srv.transport === 'url' ? 'Talks to ' + srv.target : 'Starts ' + srv.target)}</span>
-      ${srv.envKeys.length ? `<span class="settings-value" style="opacity:.7">Credential keys (values kept out of this file): ${connectorsEsc(srv.envKeys.join(', '))}</span>` : ''}
+      ${srv.envKeys.length ? `<span class="settings-prose" style="opacity:.7">Credential keys (values kept out of this file): ${connectorsEsc(srv.envKeys.join(', '))}</span>` : ''}
     </div>`).join('');
     body = `<div class="settings-card">${rows}</div>`;
   }
@@ -387,10 +387,10 @@ function connectorsSectionHtml(state) {
       <span class="settings-label">Add a connector</span>
       <input class="settings-input" id="connector-name" placeholder="Name (for example: notion)">
       <input class="settings-input" id="connector-target" placeholder="Command to start it, or its URL">
-      <div class="settings-value" id="connector-add-note" style="min-height:1em"></div>
+      <div class="settings-prose" id="connector-add-note" style="min-height:1em"></div>
       <button class="settings-btn" onclick="connectorsAdd()">Add to .mcp.json</button>
     </div></div>
-    <div class="settings-row"><span class="settings-value">Edits land in <code>.mcp.json</code>, the same file agents read their connectors from on their next start.</span></div>`;
+    <div class="settings-row"><span class="settings-prose">Edits land in <code>.mcp.json</code>, the same file agents read their connectors from on their next start.</span></div>`;
 }
 
 // Three states, kept apart because conflating them destroys a file. `null`

--- a/test/tools/mutate-approve-once-guards.js
+++ b/test/tools/mutate-approve-once-guards.js
@@ -89,7 +89,7 @@ const MUTATIONS = [
   // Render a read-failed state as the empty state and the next Add writes over
   // a file we merely could not read.
   [SETTINGS, 'a read that failed draws its error, never the empty state',
-    "  if (state.error && state.readFailed) {\n    return `<div class=\"settings-section-title\">Connectors</div><div class=\"settings-card\"><div class=\"settings-row\"><span class=\"settings-value\">${connectorsEsc(state.error)}</span></div></div>`;\n  }",
+    "  if (state.error && state.readFailed) {\n    return `<div class=\"settings-section-title\">Connectors</div><div class=\"settings-card\"><div class=\"settings-row\"><span class=\"settings-prose\">${connectorsEsc(state.error)}</span></div></div>`;\n  }",
     ''],
   // Let connectorsAdd proceed after a failed read and it merges from null,
   // dropping the real file's servers.

--- a/test/unit/approve-once.test.js
+++ b/test/unit/approve-once.test.js
@@ -464,6 +464,40 @@ describe('the connectors tab edits the file the runtime reads', () => {
       'and it is never rendered as an empty state a person would trust');
   });
 
+  // A SENTENCE RENDERED IN THE VALUE STYLE IS A SENTENCE THE READER LOSES.
+  // That style clips to one line with an ellipsis, which is right for a
+  // command or a URL and silently eats the second half of a paragraph. It ate
+  // the empty state's explanation, and it ate the line of feedback the add
+  // button writes, which is why the button was reported as doing nothing: it
+  // worked, and its answer was clipped to invisibility. Pinned by counting,
+  // because the failure is silent in a browser and looks like clean markup
+  // in a diff.
+  test('the sentences render in the prose style, and only real values keep the clipping one', () => {
+    const rendered = [
+      settings.connectorsSectionHtml(settings.connectorsParse(null)),
+      settings.connectorsSectionHtml(settings.connectorsParse('{ not json')),
+      settings.connectorsSectionHtml(settings.connectorsParse(MCP)),
+    ].join('\n');
+    for (const sentence of [
+      'No connectors configured',
+      'Workspace connectors live in',
+      'Edits land in',
+      'could not be read',
+    ]) {
+      const at = rendered.indexOf(sentence);
+      assert.ok(at !== -1, `the rendered markup carries "${sentence}"`);
+      const opensAt = rendered.lastIndexOf('<', at);
+      assert.ok(rendered.slice(opensAt, at).includes('settings-prose'),
+        `"${sentence}" is a sentence, so it wraps rather than being clipped to one line`);
+    }
+    assert.ok(rendered.includes('id="connector-add-note" class="settings-prose"')
+      || /class="settings-prose"[^>]*id="connector-add-note"/.test(rendered),
+      'the line the add button writes its answer into wraps, or the answer is clipped to nothing '
+      + 'and the button reads as broken');
+    assert.match(rendered, /class="settings-value" title=/,
+      'a command or URL keeps the clipping style, with its full text still reachable by title');
+  });
+
   test('an added connector round-trips through the same file the runtime reads', () => {
     const merged = settings.connectorsMerge(MCP, 'calendar', { url: 'https://mcp.example.com/cal' });
     assert.strictEqual(merged.reason, null);


### PR DESCRIPTION
The connectors page rendered its prose in the style meant for values, which clips to one 320px monospace line with an ellipsis. That is right for a command or a URL that would otherwise push a row wide, and wrong for anything written to be read: the empty state lost the second half of every sentence, mid-word.

The same style sat on the element the Add button writes its answer into, which is why that button was reported as doing nothing. It was working. Pressed with the fields empty it says "Say what it starts or where it lives", and that answer was being clipped into the ellipsis. A control whose feedback is invisible is indistinguishable from one that is broken, and the person pressing it has no way to tell which they have.

Sentences now use a prose style: the body face rather than monospace, wrapping, no width cap. Values keep the clipping and keep their title attribute, so the full text of a long command is still reachable. The distinction is pinned by a test that reads the rendered markup and was checked against a deliberate regression, because this failure is silent in a browser and looks like clean markup in a diff.

The tab's icon is redrawn symmetrically. The previous plug carried its cord off to one side, which at that size read as a stethoscope.