### PR TITLE
Prepare the 0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
-## Unreleased
-
-**Name:** Permissions & Connections
+## 0.13.0: Permissions & Connections (2026-09-06)
 
 Rundock stops asking permission for its own plumbing, and starts showing you what things are connected to.
 


### PR DESCRIPTION
Version bump and changelog promotion for 0.13.0, and nothing else. The commit sits on top of 0124f92b5, which is the commit the release gate passed on.

Promoted changelog heading: 0.13.0: Permissions & Connections (2026-09-06)
Full entry: https://github.com/liamdarmody/rundock/blob/release/0.13.0/CHANGELOG.md

Branch protection requires the checks on this pull request to pass before it can merge, so there is nothing further to run locally. Once it has merged, `npm run release -- tag 0.13.0` tags the merged commit on main, and that tag is what starts the build, sign, notarise and draft publish workflow.
