### PR TITLE
Name the release: Working Folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ## Unreleased
 
+**Name:** Working Folders
+
 ### Added
 
 - **Tell Rundock which folders your agents work in, and stop approving them one at a time:** if your workspace holds your team and your actual work lives elsewhere, every project you own counted as outside it, and no approval ever caught up: a build is almost all terminal commands, and those are approved for that one request only, never remembered. Settings under Workspace now takes a list of the folders your agents work in besides the workspace itself. Name a parent such as `~/Projects` and everything beneath it is covered, including projects you start next month, so this is something you set once rather than revisit. Naming a folder stops the approval cards that check paths, for everything beneath it, and changes nothing else. Two limits, both stated where you name the folder: in Knowledge mode on macOS a terminal write outside your workspace is still refused by the operating system and the retry still raises a card, so Code mode is where those end; and agents running on Codex are not affected by this setting at all. Claude Code's own folder is never included either, so your Claude account credentials still ask on every single access, whatever you name. Removing a folder takes effect for the next agent that starts, with no restart. A folder that has gone is shown as missing rather than quietly dropped, and starts covering again if it comes back. Approval cards for a path outside your workspace now point at this setting, so the way to stop being asked is named where you are being asked.


### PR DESCRIPTION
The release gate requires every release to carry a name, and the Unreleased section had none, so `release:gate` refuses before it reaches anything else.

Named for the thing it ships and for the words the interface already uses, so the release name, the Settings heading and the answer to how someone stops the approval storm are all the same phrase.