### PR TITLE
Callouts render their content, and still round-trip byte for byte

### DIFF
--- a/public/editor/nodes/callout.js
+++ b/public/editor/nodes/callout.js
@@ -51,6 +51,9 @@ function bodyLineToRaw(line) {
 // renderHTML describes, so display and editing share one structure.
 function specToDom(doc, spec) {
   if (typeof spec === 'string') return doc.createTextNode(spec);
+  // A rendered run arrives as a real element rather than a spec, because the
+  // markdown pipeline produces markup and a spec cannot carry it.
+  if (spec && typeof spec === 'object' && spec.nodeType) return spec;
   const [tag, attrs, ...children] = spec;
   const el = doc.createElement(tag);
   let rest = children;
@@ -215,24 +218,90 @@ export function parseCalloutBody(body) {
 // expand/collapse works with no script; plain callouts render as divs.
 // Nested callouts in the body render as real nested boxes, never literal
 // `> [!type]` text.
-function calloutChildrenSpec({ type, fold, title, body }) {
-  const headerChildren = [['span', { class: 'callout-tag' }, type]];
-  if (title) headerChildren.push(['span', { class: 'callout-title' }, title]);
+/**
+ * The document's own markdown renderer, or null where it is not loaded.
+ *
+ * THE SAME ENTRY POINT ORDINARY BODY TEXT USES, deliberately, rather than a
+ * second renderer for callouts. The most expensive defect of a recent release
+ * was two layers that both parsed the same thing and learned different rules,
+ * each internally correct. A callout that rendered its own way would be that
+ * again, with the escaping surface the wikilink node exists to avoid.
+ *
+ * `callouts: false` because a callout's body is parsed for callouts here, by
+ * parseCalloutBody, which produces real nested boxes. Letting the pipeline
+ * re-enter would render the same nesting twice.
+ */
+function markdownRenderer() {
+  const root = (typeof globalThis !== 'undefined' && globalThis) || null;
+  const fn = root && (root.renderMarkdown
+    || (root.RundockRenderer && root.RundockRenderer.renderMarkdown));
+  return typeof fn === 'function' ? (text) => fn(text, { callouts: false }) : null;
+}
 
+/**
+ * One run of body lines, rendered.
+ *
+ * Returns a spec when the pipeline is absent so the callout still shows its
+ * text: a document that renders as source is a defect, and a document that
+ * renders as nothing is a worse one.
+ */
+function renderedRun(doc, render, text) {
+  if (!render || !doc) return ['div', { class: 'callout-line' }, text];
+  const holder = doc.createElement('div');
+  holder.className = 'callout-md';
+  holder.innerHTML = render(text);
+  return holder;
+}
+
+/**
+ * A title renders its INLINE markup only.
+ *
+ * The pipeline returns block html, so a title would arrive wrapped in a
+ * paragraph and break the header's layout. The lone wrapper is unwrapped rather
+ * than the renderer being asked for something it does not offer, which would be
+ * a second rendering path by another name.
+ */
+function renderedTitle(doc, render, text) {
+  if (!render || !doc) return ['span', { class: 'callout-title' }, text];
+  const holder = doc.createElement('span');
+  holder.className = 'callout-title';
+  holder.innerHTML = render(text);
+  const only = holder.children.length === 1 ? holder.children[0] : null;
+  if (only && only.tagName === 'P') holder.innerHTML = only.innerHTML;
+  return holder;
+}
+
+function calloutChildrenSpec({ type, fold, title, body }, doc = null) {
+  const render = markdownRenderer();
+  const headerChildren = [['span', { class: 'callout-tag' }, type]];
+  if (title) headerChildren.push(renderedTitle(doc, render, title));
+
+  // RUNS, NOT LINES. Markdown is a block language: a list, or a paragraph
+  // spanning two lines, only parses when its lines are handed over together.
+  // Rendering line by line was why a list inside a callout showed its hyphens.
   const bodyChildren = [];
+  let run = [];
+  const flushRun = () => {
+    if (!run.length) return;
+    bodyChildren.push(renderedRun(doc, render, run.join('\n')));
+    run = [];
+  };
   for (const seg of parseCalloutBody(body)) {
     if (seg.kind === 'callout') {
+      flushRun();
       bodyChildren.push([
         'div',
         { class: `callout callout-${seg.type} callout-nested` },
-        ...calloutChildrenSpec(seg),
+        ...calloutChildrenSpec(seg, doc),
       ]);
     } else if (seg.text.trim().length === 0) {
+      flushRun();
       bodyChildren.push(['div', { class: 'callout-line empty' }, ' ']);
     } else {
-      bodyChildren.push(['div', { class: 'callout-line' }, seg.text]);
+      run.push(seg.text);
     }
   }
+  flushRun();
   const hasBody = body.length > 0;
 
   if (fold) {
@@ -301,6 +370,10 @@ export const Callout = Node.create({
         'data-callout-body':  encodeURIComponent(body),
         'data-callout-head':  encodeURIComponent(head),
       },
+      // NO DOCUMENT HERE, so this returns specs and the runs stay as plain
+      // lines. ProseMirror builds this form itself, and the node view repaints
+      // the same callout with a document a moment later, which is where the
+      // rendering happens. The two agree because both call this one function.
       ...calloutChildrenSpec({ type, fold, title, body }),
     ];
   },
@@ -321,7 +394,7 @@ export const Callout = Node.create({
         dom.className = `callout callout-${type} callout-editable`;
         dom.setAttribute('data-callout-type', type);
         dom.innerHTML = '';
-        for (const spec of calloutChildrenSpec({ type, fold, title, body })) {
+        for (const spec of calloutChildrenSpec({ type, fold, title, body }, document)) {
           dom.appendChild(specToDom(document, spec));
         }
         const header = dom.querySelector('.callout-header');

--- a/public/styles/views/editor.css
+++ b/public/styles/views/editor.css
@@ -191,6 +191,17 @@ textarea.editor-content { resize: none; border: none; background: transparent; w
 .tiptap-editor .ProseMirror .callout-tag { display: inline-block; padding: 2px 10px; background: var(--callout-color); color: #fff; border-radius: var(--radius-pill); font-size: var(--label); font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
 .tiptap-editor .ProseMirror .callout-title { font-size: var(--body); font-weight: 600; color: var(--text-1); }
 .tiptap-editor .ProseMirror .callout-body { font-size: var(--body); color: var(--text-1); line-height: 1.55; }
+/* A run of body lines, rendered through the document's own markdown pipeline.
+   Paragraphs inside a callout carry no outer margin: the callout body already
+   provides the spacing, and a paragraph margin would double it on the first and
+   last line only, which reads as a callout that is not vertically centred. */
+.tiptap-editor .ProseMirror .callout-md > :first-child { margin-top: 0; }
+.tiptap-editor .ProseMirror .callout-md > :last-child { margin-bottom: 0; }
+.tiptap-editor .ProseMirror .callout-md p { margin: 0 0 0.5em; }
+.tiptap-editor .ProseMirror .callout-md ul,
+.tiptap-editor .ProseMirror .callout-md ol { margin: 0 0 0.5em; padding-left: 1.4em; }
+/* Still reachable: a blank body line, and the path where the markdown pipeline
+   is not loaded, which renders the text rather than nothing. */
 .tiptap-editor .ProseMirror .callout-line { min-height: 1.55em; }
 .tiptap-editor .ProseMirror .callout-line.empty { color: transparent; }
 /* Foldable callouts (+ open, - closed): native details/summary, disclosure caret on the header. */

--- a/test/e2e/fixture.js
+++ b/test/e2e/fixture.js
@@ -340,7 +340,10 @@ function buildFixture() {
     '---',
     '',
     '> [!abstract]+ Today at a glance',
-    '> Two meetings, one deadline.',
+    // Inline markup inside the callout body, because the defect this fixture
+    // now covers is that it rendered as literal source. The daily briefing
+    // this is modelled on is written exactly like this.
+    '> **Two meetings**, one deadline.',
     '',
     '> [!warning]- Blocked items',
     '> The vendor reply is overdue.',

--- a/test/e2e/viewers.spec.js
+++ b/test/e2e/viewers.spec.js
@@ -487,9 +487,29 @@ test('clicking a callout does not show the inline formatting toolbar', async ({ 
   await expect(callout).toBeVisible();
   // Clicking a callout selects the atom node; the inline toolbar cannot format
   // it, so it must stay hidden (editing is via the callout's own editor).
-  await callout.locator('.callout-line').first().click();
+  // The body, whatever shape it takes. A non-blank body renders through the
+  // document's markdown pipeline into `.callout-md`; `.callout-line` survives
+  // only for blank lines and the no-pipeline fallback, so selecting it here
+  // would tie this test to a shape the renderer no longer produces.
+  await callout.locator('.callout-body').first().click();
   await page.waitForTimeout(200);
   await expect(page.locator('#tiptap-toolbar')).not.toHaveClass(/\bvisible\b/);
+});
+
+test('a callout renders its markdown in a real browser, not as source', async ({ page }) => {
+  // THE PROOF THAT WAS MISSING. An earlier attempt at this fix was rejected for
+  // having jsdom evidence only: what a reader actually sees is the rendered
+  // surface in a browser, and that is where the defect was reported from.
+  await boot(page);
+  await openFromTree(page, 'briefing.md');
+  const callout = page.locator('.callout.callout-abstract').first();
+  await expect(callout).toBeVisible();
+  const body = callout.locator('.callout-body');
+  // Formatting is rendered as elements rather than shown as punctuation.
+  await expect(body.locator('strong').first()).toBeVisible();
+  await expect(body).not.toContainText('**');
+  // And the title, which the earlier attempt left as plain text.
+  await expect(callout.locator('.callout-title')).toBeVisible();
 });
 
 test('a callout edits in place and saves byte-honestly', async ({ page }) => {

--- a/test/helpers/editor-harness.js
+++ b/test/helpers/editor-harness.js
@@ -78,6 +78,21 @@ export async function bootEditorEnv() {
       // at module-evaluation time.
       const mod = await import('../../public/editor/index.js');
       const pipeline = await import('../../public/editor/markdown/pipeline.js');
+      // THE DOCUMENT'S OWN RENDERER, loaded into the same globals the browser
+      // gives it. A callout renders its body through this rather than through a
+      // renderer of its own, so a harness without it would exercise the
+      // fallback and prove nothing about what a reader actually sees.
+      const markdown = await import('../../public/markdown-render.js');
+      // The renderer wants the marked NAMESPACE (it constructs marked.Marked),
+      // which is what the browser's global `marked` is, not the parse function.
+      const markedNs = await import('marked');
+      // UMD module: under ESM import the CommonJS exports arrive as `default`.
+      const factory = markdown.createMarkdownRenderer || markdown.default.createMarkdownRenderer;
+      const renderer = factory({ marked: markedNs.default || markedNs });
+      window.RundockRenderer = renderer;
+      window.renderMarkdown = (t, o) => renderer.renderMarkdown(t, o);
+      globalThis.RundockRenderer = renderer;
+      globalThis.renderMarkdown = window.renderMarkdown;
       return { ...mod, pipeline, window };
     })();
   }

--- a/test/tools/innerhtml-sites.js
+++ b/test/tools/innerhtml-sites.js
@@ -96,6 +96,12 @@ const TABLE = {
     ['a', 'cleared', 'the callout title bar, emptied before rebuild'],
     ['a', 'iconConst', 'the edit button glyph'],
     ['a', 'cleared', 'the callout title bar, emptied on the plain path'],
+    ['b', 'attr-escaper', 'a run of callout body lines, rendered through the document\'s own markdown '
+      + 'pipeline (renderMarkdown), which is the same entry point ordinary body text uses and escapes '
+      + 'the same way. The source is the callout body, which is a person\'s own document text'],
+    ['b', 'attr-escaper', 'a callout title, rendered through the same pipeline'],
+    ['a', 'cleared', 'the title\'s block wrapper unwrapped: markup this file just produced, re-read '
+      + 'from the element it was put in, never new input'],
   ],
   'editor/nodes/source-markers.js': [
     ['a', 'closedWithReason', 'the fenced-block newline trim, a read-modify-write of markup'],

--- a/test/unit/callouts-and-properties.test.js
+++ b/test/unit/callouts-and-properties.test.js
@@ -5,7 +5,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import { JSDOM } from 'jsdom';
-import { bootEditorEnv } from '../helpers/editor-harness.js';
+import { bootEditorEnv, roundTrip } from '../helpers/editor-harness.js';
 import { parseCalloutBody } from '../../public/editor/nodes/callout.js';
 import { renderProperties, parsePropWikilink, dateString } from '../../public/editor/panels/properties.js';
 import { extractFrontmatter } from '../../public/editor/markdown/frontmatter.js';
@@ -18,6 +18,87 @@ async function renderedHtml(src) {
   env.destroyEditor(editor);
   return html;
 }
+
+// ── Markdown inside callouts ────────────────────────────────────────────
+// Text inside a callout rendered as literal source: `**bold**` showed its
+// asterisks and `[[wikilinks]]` their brackets, while the same markup worked
+// everywhere else. One cause, not three bugs: every body line was built as a
+// DOM text node, and a text node cannot contain markup.
+//
+// The body remains the SOURCE OF TRUTH and is rendered through the document's
+// own pipeline. Holding real inline content instead was costed and rejected: it
+// replaces "store the source, re-emit the source" with "parse and serialise
+// back", which cannot be byte-exact for arbitrary markdown, so files nobody
+// edited would change on save.
+//
+// READ FROM THE PAINTED DOM. The node view repaints each callout with a real
+// document a moment after ProseMirror builds it, and rendering needs a document:
+// without one there is nothing to put markup into. Snapshotting innerHTML before
+// that paint sees the unrendered form and would report this as unfixed while a
+// reader sees it fixed.
+async function paintedCallout(src) {
+  return new JSDOM(await renderedHtml(src)).window.document;
+}
+
+describe('a callout renders its own content', () => {
+  test('bold, italics and inline code render as formatting, not as source', async () => {
+    const doc = await paintedCallout('> [!abstract]+ Briefing\n> **Goal pulse** and *emphasis* and `code`.');
+    const body = doc.querySelector('.callout-body');
+    assert.ok(body, `the callout has a body; got: ${doc.body.innerHTML.slice(0, 300)}`);
+    assert.ok(body.querySelector('strong'), 'bold is rendered');
+    assert.ok(body.querySelector('em'), 'italics are rendered');
+    assert.ok(body.querySelector('code'), 'inline code is rendered');
+    assert.ok(!body.textContent.includes('**'), 'and no asterisks survive into the text');
+  });
+
+  test('a list inside a callout is a list, which is why lines render as runs', async () => {
+    // Markdown is a block language: a list only parses when its lines are handed
+    // over together. Rendering line by line was why hyphens showed.
+    const doc = await paintedCallout('> [!note] Team\n> - **Penn:** drafting\n> - **Des:** mocks');
+    const items = doc.querySelectorAll('.callout-body li');
+    assert.equal(items.length, 2, 'both lines became list items');
+    assert.ok(items[0].querySelector('strong'), 'and inline markup inside them renders too');
+  });
+
+  test('the TITLE renders its markup, and stays a single line', async () => {
+    const doc = await paintedCallout('> [!abstract]+ *Briefing* for **today**\n> Body.');
+    const title = doc.querySelector('.callout-title');
+    assert.ok(title.querySelector('em'), 'italics in the title render');
+    assert.ok(title.querySelector('strong'), 'and bold');
+    assert.equal(title.querySelector('p'), null,
+      'and the block wrapper is unwrapped, or the header layout breaks');
+  });
+
+  test('a NESTED callout renders its markup too, because it is one cause', async () => {
+    const doc = await paintedCallout('> [!note] Outer\n> > [!warning] Inner\n> > **inside** the nested one');
+    const nested = doc.querySelector('.callout-nested');
+    assert.ok(nested.querySelector('strong'), 'the nested body renders its markup');
+  });
+
+  test('a script tag in a callout is text, not markup', async () => {
+    // The escaping surface the wikilink node exists to avoid. The pipeline is the
+    // document's own, so this is the same guarantee ordinary body text has;
+    // asserted here because the callout is where a shortcut would be tempting.
+    const doc = await paintedCallout('> [!note] Careful\n> <script>alert(1)</script> and "quoted"');
+    const body = doc.querySelector('.callout-body');
+    assert.equal(body.querySelector('script'), null, 'no script element is created');
+    assert.match(body.textContent, /alert\(1\)/, 'and the text is still shown');
+  });
+
+  test('an untouched callout still round-trips byte for byte', async () => {
+    // THE GUARANTEE THIS ROUTE WAS CHOSEN TO PROTECT. The body is stored as its
+    // source and re-emitted verbatim, so a document opened and saved without
+    // editing is unchanged to the byte, including spacing and fold markers.
+    for (const src of [
+      '> [!abstract]+ Briefing\n> **Goal pulse** and *emphasis*.\n> - a list item',
+      '> [!note] Outer\n> Outer body.\n> > [!warning]- Nested\n> > Nested body.',
+      '> [!tip]\n> No title, one line.',
+      '> [!note] Spacing\n>\n> after a blank line',
+    ]) {
+      assert.equal(await roundTrip(src), src, `round-trip changed this callout:\n${src}`);
+    }
+  });
+});
 
 describe('callout rendering', () => {
   test('foldable callouts render as details/summary with the right default state', async () => {

--- a/test/unit/innerhtml-inventory.test.js
+++ b/test/unit/innerhtml-inventory.test.js
@@ -44,9 +44,9 @@ describe('the innerHTML inventory', () => {
 
   test('the counts the audit quotes are the counts the tree has', () => {
     const t = totals(classify().rows);
-    assert.strictEqual(t.total, 111, 'first-party assignments under public/');
-    assert.strictEqual(t.byGroup.a, 79, 'group (a): closed with a stated reason');
-    assert.strictEqual(t.byGroup.b, 32, 'group (b): fixed');
+    assert.strictEqual(t.total, 114, 'first-party assignments under public/');
+    assert.strictEqual(t.byGroup.a, 80, 'group (a): closed with a stated reason');
+    assert.strictEqual(t.byGroup.b, 34, 'group (b): fixed');
     assert.strictEqual(t.byGroup.a + t.byGroup.b, t.total, 'every site is in exactly one group');
   });
 


### PR DESCRIPTION
Text inside a callout rendered as literal source: `**bold**` showed its asterisks, `*emphasis*` showed its asterisks, and a list showed its hyphens, while the same markup worked everywhere else in the document. One cause rather than three bugs: every body line was built as a DOM text node, and a text node cannot contain markup. The title had the same problem, and nested callouts inherited it.

It is the surface read most often. A daily briefing is written into the vault as an `[!abstract]+` callout, so every briefing was affected, every day.

## The route, costed before implementation

The body is held as a string attribute and the serialiser re-emits that string verbatim, which is what makes an untouched callout round-trip byte for byte.

Holding real inline content instead would let marks and the wikilink node work natively, and is the cleaner answer architecturally. It was costed first and rejected: it replaces "store the source, re-emit the source" with "parse to nodes, serialise back", which cannot be byte-exact for arbitrary markdown. Spacing, escaping and link-syntax variants normalise on the way out, so the guarantee would quietly weaken from byte-exact to semantically equivalent, and files nobody edited would change on save. That is a worse regression than the defect being fixed.

So the body stays the source of truth and is rendered through **the document's own pipeline**, the same entry point ordinary body text uses, never a second renderer: two layers that both parse the same thing and learn different rules was the most expensive defect of a recent release. Lines are gathered into runs before rendering, because markdown is a block language and a list only parses when its lines are handed over together.

## What the earlier attempt was rejected for

Three things, all addressed here. The **title** renders its markup too, with the block wrapper unwrapped so the header layout holds. The **end-to-end test** no longer selects `.callout-line`, which a non-blank body no longer produces. And the **proof is at the rendered surface in a real browser**, not under jsdom alone.

## The guarantee, pinned

Four callout shapes, including nested and blank-line spacing, open and save byte-for-byte unchanged. That is the property this route was chosen to protect, so it is asserted rather than assumed.