### PR TITLE
Prepare the 0.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 > Versions prior to 0.7.1 used minor bumps for all changes. From 0.7.1 onward, minor = new capabilities, patch = refinements and fixes.
 
-## Unreleased
-
-**Name:** Callouts That Read
+## 0.13.2: Callouts That Read (2026-09-09)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rundock",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A visual workspace for your AI agent team. Built for people running their own businesses. Works with your Claude or ChatGPT subscription.",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
Version bump and changelog promotion for 0.13.2, and nothing else. The commit sits on top of 53b71405a, which is the commit the release gate passed on.

Promoted changelog heading: 0.13.2: Callouts That Read (2026-09-09)
Full entry: https://github.com/liamdarmody/rundock/blob/release/0.13.2/CHANGELOG.md

Branch protection requires the checks on this pull request to pass before it can merge, so there is nothing further to run locally. Once it has merged, `npm run release -- tag 0.13.2` tags the merged commit on main, and that tag is what starts the build, sign, notarise and draft publish workflow.
