### PR TITLE
One wikilink delegate, both spellings of the target

### DIFF
--- a/public/editor/index.js
+++ b/public/editor/index.js
@@ -28,14 +28,24 @@ const _editorHandles = new WeakMap();
 
 // Wires a click delegate on the host element that routes wikilink clicks to
 // the host's onWikilinkClick callback. Returns an unbind function.
-function wireWikilinkClicks(hostElement, onWikilinkClick) {
+export function wireWikilinkClicks(hostElement, onWikilinkClick) {
   if (!hostElement || typeof onWikilinkClick !== 'function') return () => {};
   const handler = (event) => {
     const anchor = event.target && event.target.closest && event.target.closest('a.wikilink');
     if (!anchor) return;
     event.preventDefault();
     event.stopPropagation();
-    const target = anchor.getAttribute('data-target') || '';
+    // TWO SPELLINGS OF THE SAME IDEA, and this delegate knew one of them.
+    // The editor's own wikilink node writes `data-target`; the markdown renderer
+    // writes `data-wikilink`, and a callout's body is rendered through that
+    // renderer. This handler matches `a.wikilink`, which both produce, and then
+    // stopped propagation before reading an attribute only one of them has: the
+    // click was consumed and dropped, so a wikilink inside a callout looked
+    // right and went nowhere while the same link outside one worked. Reading
+    // both is what makes one delegate serve both, rather than adding a second.
+    const target = anchor.getAttribute('data-target')
+      || anchor.getAttribute('data-wikilink')
+      || '';
     const alias  = anchor.getAttribute('data-alias') || null;
     if (target) onWikilinkClick(target, alias);
   };

--- a/test/unit/wikilink-delegate.test.js
+++ b/test/unit/wikilink-delegate.test.js
@@ -1,0 +1,69 @@
+'use strict';
+// The editor's wikilink click delegate, and the two spellings it has to serve.
+//
+// THE DEFECT THIS EXISTS FOR, found by clicking a link in a real briefing after
+// the callout rendering had shipped. The delegate matches `a.wikilink`, which is
+// what BOTH producers emit, then stops propagation, then read only
+// `data-target`. The editor's own wikilink node writes that attribute; the
+// markdown renderer, which a callout's body is rendered through, writes
+// `data-wikilink`. So a wikilink inside a callout was matched, its propagation
+// stopped, its attribute missed, and the click dropped in silence: the link
+// looked right and went nowhere, while the identical link outside a callout
+// worked.
+//
+// It is the seam failure the criteria keep warning about: two layers, each
+// internally correct, disagreeing about one name. The fix is one delegate that
+// reads both, never a second delegate.
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { wireWikilinkClicks } from '../../public/editor/index.js';
+
+function host(html) {
+  const dom = new JSDOM(`<div id="host">${html}</div>`);
+  const el = dom.window.document.getElementById('host');
+  const seen = [];
+  const unbind = wireWikilinkClicks(el, (target, alias) => seen.push({ target, alias }));
+  return { dom, el, seen, unbind };
+}
+
+describe('the wikilink delegate serves both spellings', () => {
+  test('an anchor written by the editor\'s own node is dispatched', () => {
+    const { el, seen } = host('<a class="wikilink" data-target="Roadmap-2026" data-alias="plan">plan</a>');
+    el.querySelector('a').click();
+    assert.deepStrictEqual(seen, [{ target: 'Roadmap-2026', alias: 'plan' }]);
+  });
+
+  test('an anchor written by the MARKDOWN renderer is dispatched too', () => {
+    // The half that was missing. A callout body goes through this renderer, so
+    // this is the shape a link in a briefing actually has.
+    const { el, seen } = host('<a class="wikilink" data-wikilink="digest-2026-09-04">digest</a>');
+    el.querySelector('a').click();
+    assert.strictEqual(seen.length, 1, 'the click must reach the callback, not be dropped');
+    assert.strictEqual(seen[0].target, 'digest-2026-09-04');
+  });
+
+  test('a wikilink with NEITHER attribute is not dispatched, and says nothing', () => {
+    // The guard that turned a missed attribute into silence. Kept, because an
+    // anchor with no target has nowhere to go; what changed is that the shape
+    // the renderer produces is no longer in this category.
+    const { el, seen } = host('<a class="wikilink">nothing</a>');
+    el.querySelector('a').click();
+    assert.deepStrictEqual(seen, []);
+  });
+
+  test('an ordinary link and an email address are left alone entirely', () => {
+    // The delegate claims only wikilinks. Anything else must keep its default
+    // behaviour, or a callout would swallow every hyperlink in it.
+    const { el, seen } = host('<a href="https://example.com">web</a><a href="mailto:a@b.c">mail</a>');
+    for (const a of el.querySelectorAll('a')) a.click();
+    assert.deepStrictEqual(seen, [], 'neither is claimed by the wikilink delegate');
+  });
+
+  test('unbinding stops the delegate, so a torn-down editor claims nothing', () => {
+    const { el, seen, unbind } = host('<a class="wikilink" data-wikilink="x">x</a>');
+    unbind();
+    el.querySelector('a').click();
+    assert.deepStrictEqual(seen, []);
+  });
+});


### PR DESCRIPTION
Found by clicking a link in a real briefing, in Chrome, after the rendering half had shipped and after four tests said it worked.

## The defect

The editor delegates wikilink clicks on its host element. It matches `a.wikilink`, which is what **both** producers emit, stops propagation, and then read only `data-target`. The editor's own wikilink node writes that attribute; the markdown renderer, which a callout's body is rendered through, writes `data-wikilink`.

So a wikilink inside a callout was matched, its propagation stopped, its attribute missed, and the click dropped in silence. The link looked correct and went nowhere, while the identical link outside a callout worked.

Two layers, each internally correct, disagreeing about one name. The delegate reads both now, because the answer to a seam like this is one place that knows both spellings, never a second delegate beside it.

## Why it survived every check

Worth recording, because it matters more than the fix.

The criterion said wikilinks render as links **and open on click**. Rendering was asserted; opening was not.

The card skipped independent review, which is the step that had caught exactly that shape of half-proof three times on other cards.

And when a browser test of the **outcome** kept failing, it was weakened into a test of the **mechanism**, with a considered comment explaining why that was the better seam to assert. It was not. The failing test was right and the reasoning was wrong.

## The regression test

Drives the delegate with both anchor shapes, proves an anchor with neither attribute stays silent, and proves ordinary and `mailto:` links are never claimed by it. It fails with this change reverted, checked by hand.