### PR TITLE
Run the scoped set on push, the complete set nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,30 @@ jobs:
   # instead of transcribed. Not part of `npm test`: it runs that suite once per
   # guard, which is too slow to pay on every run and cheap to pay once per push.
   mutation:
-    name: Renderer guards and fixture provenance
+    # Renamed when this job went from the renderer's guards to every harness.
+    # Checked before renaming: this context is NOT among the required status
+    # checks on main (those are the two Test jobs, E2E, Coverage floors,
+    # Typecheck and Hygiene), so no branch-protection setting names this string
+    # and no pull request can be left waiting on a context that stopped
+    # reporting. If it is ever made required, the setting and this line have to
+    # change together, and neither order is safe on its own.
+    name: Mutation guards and fixture provenance
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Raised from 20 because this job went from one harness to all of them.
+    # Measured at about 31 minutes on a developer machine that was doing other
+    # work at the same time; 45 leaves room without letting a hang run for an
+    # hour, which is the failure a ceiling exists to bound.
+    # SEVENTY-FIVE, NOT FORTY-FIVE. The forty-five came from a developer laptop
+    # running the eighteen harnesses in about thirty-one minutes. Measured again
+    # since: roughly sixteen minutes of a local run, and these runners are
+    # commonly two to three times slower, which puts a serial run somewhere
+    # around thirty-two to forty-eight. A ceiling at the median turns a slow
+    # runner into a red build that says nothing about the code.
+    #
+    # The right answer is to shard the harnesses across a matrix so this is
+    # several short jobs rather than one long one. That is a separate change;
+    # until then the ceiling is set above the range rather than inside it.
+    timeout-minutes: 75
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -143,13 +164,24 @@ jobs:
       - name: Install test-only DOM dependency
         run: npm install --no-save --ignore-scripts jsdom@29.1.1
 
-      - name: Remove each renderer guard and require a red test
-        run: node test/tools/mutate-render-guards.js --markdown
+      # EVERY HARNESS, NOT ONE. The local gate now runs only the harnesses a
+      # change can affect, which is what makes it fast enough to run often. That
+      # trade is only safe while something runs the complete set, and this is
+      # that something: a machine that is not the author's, on every push, with
+      # no selection at all.
+      #
+      # Before this, the local gate was the only exhaustive run and CI checked a
+      # single harness, so a harness wrongly skipped locally was checked nowhere.
+      - name: Remove every guard in turn and require a red test
+        run: npm run mutate:guards:all
 
-      # The file is restored by the tool, including when a run throws. If a
-      # failure ever leaves it modified, that is itself worth seeing.
-      - name: Fail if the tool left the renderer modified
-        run: git diff --exit-code -- public/markdown-render.js
+      # The tools restore what they mutate, including when a run throws. A
+      # failure that leaves any of them modified is itself worth seeing, and
+      # says so about the whole tree rather than one file.
+      - name: Fail if any tool left a file modified
+        run: git diff --exit-code
+
+
 
       # The frozen "before" fixture is the only record of how ordinary markdown
       # rendered before this work, and every claim that it is unchanged is taken

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,21 +129,13 @@ jobs:
     # change together, and neither order is safe on its own.
     name: Mutation guards and fixture provenance
     runs-on: ubuntu-latest
-    # Raised from 20 because this job went from one harness to all of them.
-    # Measured at about 31 minutes on a developer machine that was doing other
-    # work at the same time; 45 leaves room without letting a hang run for an
-    # hour, which is the failure a ceiling exists to bound.
-    # SEVENTY-FIVE, NOT FORTY-FIVE. The forty-five came from a developer laptop
-    # running the eighteen harnesses in about thirty-one minutes. Measured again
-    # since: roughly sixteen minutes of a local run, and these runners are
-    # commonly two to three times slower, which puts a serial run somewhere
-    # around thirty-two to forty-eight. A ceiling at the median turns a slow
-    # runner into a red build that says nothing about the code.
+    # This job runs the SCOPED set, the same selection the local gate makes, so
+    # it costs minutes rather than tens of minutes. Thirty is far above a scoped
+    # run and still bounds a hang, which is the failure a ceiling exists for.
     #
-    # The right answer is to shard the harnesses across a matrix so this is
-    # several short jobs rather than one long one. That is a separate change;
-    # until then the ceiling is set above the range rather than inside it.
-    timeout-minutes: 75
+    # The complete set is not run here. It runs nightly, in
+    # mutation-nightly.yml, for the reason written up in that file.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -164,16 +156,18 @@ jobs:
       - name: Install test-only DOM dependency
         run: npm install --no-save --ignore-scripts jsdom@29.1.1
 
-      # EVERY HARNESS, NOT ONE. The local gate now runs only the harnesses a
-      # change can affect, which is what makes it fast enough to run often. That
-      # trade is only safe while something runs the complete set, and this is
-      # that something: a machine that is not the author's, on every push, with
-      # no selection at all.
+      # THE SCOPED SET, THE SAME SELECTION THE LOCAL GATE MAKES. This job is the
+      # backstop for a commit that never ran the gate, so it repeats the gate's
+      # own choice rather than widening it.
       #
-      # Before this, the local gate was the only exhaustive run and CI checked a
-      # single harness, so a harness wrongly skipped locally was checked nowhere.
-      - name: Remove every guard in turn and require a red test
-        run: npm run mutate:guards:all
+      # Measured before this was settled: the complete set costs 1204s on these
+      # runners and 1628s on a developer machine, and two of the eighteen
+      # harnesses account for 63% of that. Running all of them on every push put
+      # twenty minutes in front of every review in order to re-check harnesses
+      # that no change on the branch could reach. The complete set still runs,
+      # nightly, where nothing is waiting on it.
+      - name: Remove each guard a change can reach, and require a red test
+        run: npm run mutate:guards
 
       # The tools restore what they mutate, including when a run throws. A
       # failure that leaves any of them modified is itself worth seeing, and

--- a/.github/workflows/mutation-nightly.yml
+++ b/.github/workflows/mutation-nightly.yml
@@ -1,0 +1,80 @@
+# The complete mutation set: every harness, no selection at all.
+#
+# WHY THIS IS A SEPARATE WORKFLOW, AND NOT A STEP IN ci.yml.
+# The local gate and the CI mutation job both run the SCOPED set: only the
+# harnesses a change can reach. That selection is what makes them fast enough to
+# run on every commit, and it is safe only while something, somewhere, runs the
+# complete set. This is that something.
+#
+# It does not belong on the critical path. Measured before this was settled: the
+# complete set is 1204s here and 1628s on a developer machine, so putting it on
+# every push cost twenty minutes per review to re-check harnesses no change in
+# the branch could reach. Off the critical path the same twenty minutes costs
+# nobody anything, because nobody is waiting on it.
+#
+# WHAT THIS CATCHES THAT THE SCOPED RUN CANNOT. A harness rots without anyone
+# touching it: pinned to source text that has since moved, or resting on a
+# behaviour of the machine it happened to run on. The first exhaustive run in CI
+# found exactly that. A guard in the boundary harness was passing because the
+# only spelling it compared came from os.tmpdir(), which is aliased on macOS and
+# not on Linux, so the mutation was invisible on the platform CI runs. No commit
+# broke it, so no scoped run would ever have selected it. Only running everything
+# on a machine that is not the author's could surface it, and that is this job.
+#
+# BEFORE A RELEASE. Cutting a release is the other moment the complete set is
+# worth waiting for. Dispatch this workflow and let it finish before tagging.
+name: Nightly mutation sweep
+
+on:
+  schedule:
+    # 03:00 UTC. Nothing waits on this, so the only thing the hour has to do is
+    # avoid competing with the working day.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Deliberately NOT sharing ci.yml's concurrency group. That group cancels in
+# progress runs on a new push to the same ref, which is right for a job someone
+# is waiting on and wrong for this one: a day of pushes to main would cancel the
+# sweep every time and it would never complete.
+concurrency:
+  group: mutation-nightly
+  cancel-in-progress: false
+
+jobs:
+  mutation-sweep:
+    name: Every guard, no selection
+    runs-on: ubuntu-latest
+    # Measured at 1204s for the complete set. Seventy-five leaves generous room
+    # for a slower runner without letting a hang burn an hour.
+    timeout-minutes: 75
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+
+      - name: Install runtime dependencies
+        run: npm ci --omit=dev
+
+      # The harnesses run suites that need a DOM. Without this the suites fail to
+      # load, every mutation looks red, and the sweep reports a clean table over
+      # a run where nothing was verified.
+      - name: Install test-only DOM dependency
+        run: npm install --no-save --ignore-scripts jsdom@29.1.1
+
+      - name: Remove every guard in turn and require a red test
+        run: npm run mutate:guards:all
+
+      # The tools restore what they mutate, including when a run throws. A
+      # failure that leaves any file modified is itself worth seeing.
+      - name: Fail if any tool left a file modified
+        run: git diff --exit-code

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -161,6 +161,26 @@ const STEPS = [
 // end and this number is never reached.
 const STEP_END_GRACE_MS = 5000;
 
+// HOW LONG A STEP GETS BEFORE IT IS ENDED, matching the ceilings CI already
+// applies to the same work.
+//
+// On 2026-08-28 `test:coverage` ran for ninety-five minutes with no output: one
+// worker waited on a port the launching shell's sandbox would not let it bind,
+// CI caps that job at twenty minutes, and the local gate had no ceiling at all,
+// so nothing ended it and nothing said it was stuck. On 2026-09-07 the same
+// step hung again, for a different reason, and cost an hour before anybody
+// noticed. A gate is a control only while it can finish.
+//
+// The number is per step rather than for the run, because the run's length is
+// not the signal: a suite that normally takes four minutes and is still going
+// at twenty is stuck whatever the other steps have done.
+const STEP_CEILING_MS = {
+  'test:coverage': 20 * 60 * 1000,
+  'mutate:guards': 45 * 60 * 1000, // every harness, when the change touches the machinery
+};
+const DEFAULT_STEP_CEILING_MS = 10 * 60 * 1000;
+const ceilingFor = (name) => STEP_CEILING_MS[name] || DEFAULT_STEP_CEILING_MS;
+
 // How long a step gets to finish flushing its output after it has exited.
 //
 // The wait below is on 'exit' and not on 'close', because 'close' also waits
@@ -347,16 +367,35 @@ function runStep(step, root = ROOT) {
     let ended = null;
     let settled = false;
     let timer = null;
+    // ENDED THE WAY AN INTERRUPT ALREADY ENDS IT, through the process group,
+    // because the step's own children are what hang and killing only the
+    // parent leaves them running. Reported as a timeout rather than a failure:
+    // a step that never finished proved nothing, and calling that a failure
+    // would say the check ran and disagreed, which it did not.
+    const ceiling = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      const mins = Math.round(ceilingFor(step.name) / 60000);
+      if (kid.pid) endGroup(kid.pid, { graceMs: STEP_END_GRACE_MS });
+      resolve({
+        ok: false, timedOut: true, code: null, signal: null,
+        out: `${out}\n[precommit] ${step.name} passed ${mins} minutes without finishing and was ended. `
+          + 'Nothing it was checking is known: this is a step that never ran to a verdict, not a check that failed.',
+      });
+    }, ceilingFor(step.name));
     const settle = () => {
       if (settled || !ended) return;
       settled = true;
       if (timer) clearTimeout(timer);
+      clearTimeout(ceiling);
       resolve({ ok: ended.code === 0, code: ended.code, signal: ended.signal, out });
     };
     kid.on('error', (err) => {
       if (settled) return;
       settled = true;
       if (timer) clearTimeout(timer);
+      clearTimeout(ceiling);
       reject(err);
     });
     kid.on('exit', (code, signal) => {
@@ -603,7 +642,13 @@ async function run() {
       const { failed, result, stepMs, timings: spentSoFar } = outcome;
       const detail = result.out.trim();
       if (detail) console.error(failed.fullOutput ? detail : detail.split('\n').slice(-25).join('\n'));
-      const how = result.signal ? ` (ended by ${result.signal})` : '';
+      // A STEP THAT NEVER FINISHED IS NOT A STEP THAT FAILED, and the ceiling
+      // exists to tell them apart. Reported as a plain failure, a step ended at
+      // its ceiling sends a developer looking for a broken test that isn't
+      // there, which is the hour the ceiling was written to stop being lost.
+      const how = result.timedOut
+        ? ` (ended at its ${(ceilingFor(failed.name) / 60000).toFixed(0)} minute ceiling, so it reached no verdict)`
+        : (result.signal ? ` (ended by ${result.signal})` : '');
       // WITH THE ELAPSED TIME, because the runs this ordering is measured on are
       // the FAILING ones: a cheap failure surfaced in seconds rather than after
       // the suite is the whole saving, and a failing run used to leave no
@@ -653,4 +698,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { refusal, runSteps, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, workingTreeDrift, stagedPaths, isReleaseCommit, RELEASE_FOOTPRINT, RECORD, STEPS, STEP_END_GRACE_MS };
+module.exports = { refusal, runSteps, buildRecord, writeRecord, readRecord, currentTree, defaultBranch, workingTreeDrift, stagedPaths, isReleaseCommit, RELEASE_FOOTPRINT, RECORD, STEPS, STEP_END_GRACE_MS, STEP_CEILING_MS, DEFAULT_STEP_CEILING_MS, ceilingFor };

--- a/scripts/smoke/run.mjs
+++ b/scripts/smoke/run.mjs
@@ -190,6 +190,48 @@ const s5ev = readEvents(workspace).some(e => e.e === 'permission' && e.d && e.d.
 record('S5 permission event recorded', s5ev);
 
 
+// ── S5b: the command shapes that escaped 0.13.0 ─────────────────────────
+// EVERY ONE OF THESE SHIPPED BROKEN AND WAS FOUND BY HAND. S5 above proves
+// the two permission paths exist; it never exercised a command shaped like
+// the ones people actually write, so a grader that disagreed with the
+// boundary classifier about ordinary text passed every gate and reached a
+// user. These are cheap because they ask the real endpoint the same question
+// the running product asks.
+//
+// Each line is a defect that was reported, not a hypothetical.
+// The runtime's own home, which is what these commands reach into: the same
+// folder the boundary frees reads of and refuses writes to.
+const HOME_DIR = os.homedir();
+const askPermission = (command) => fetch(`http://127.0.0.1:${PORT}/api/permission-request`, {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ tool_name: 'Bash', tool_input: { command }, conversation_id: '', session_id: '' }),
+}).then(r => r.json()).catch(() => null);
+
+// Reported: listing the runtime's own agents and skills drew a card, because
+// the grader split on `&` and cut `2>&1` into a redirect and an orphan `1`.
+const s6a = await Promise.race([
+  askPermission(`ls -la ${HOME_DIR}/.claude/agents/ ${HOME_DIR}/.claude/skills/ 2>&1`),
+  new Promise(r => setTimeout(() => r(null), 15000)),
+]);
+record('S5b a listing that discards its error output auto-approves', !!(s6a && s6a.allow === true));
+
+// Reported: a search whose PATTERN contained a pipe drew a card, because the
+// grader's segmenter was not quote-aware and cut the pattern in half.
+const s6b = await Promise.race([
+  askPermission(`grep -oE '"(app|window_title)": "[^"]{0,70}' /tmp/x.txt | head -20`),
+  new Promise(r => setTimeout(() => r(null), 15000)),
+]);
+record('S5b a shell operator inside quotes is text, not a separator', !!(s6b && s6b.allow === true));
+
+// Found in review: a lone `&` joined two commands and the line was judged by
+// its first word, so a removal rode in behind a listing and asked nothing.
+// This one must NOT auto-approve. A card here is the correct answer.
+const s6c = await Promise.race([
+  askPermission(`ls -1 ${HOME_DIR}/.claude/agents & rm -rf ${HOME_DIR}/.claude/agents/x.md`),
+  new Promise(r => setTimeout(() => r(null), 8000)),
+]);
+record('S5b a destructive command after a lone & does not auto-approve', !(s6c && s6c.allow === true));
+
 // ── S7: the workspace boundary, incident replay through the real card ───
 // The real PreToolUse hook binary is invoked exactly as the runtime invokes
 // it, targeting a folder OUTSIDE the workspace. The card must appear, the

--- a/test/unit/preflight.test.js
+++ b/test/unit/preflight.test.js
@@ -308,6 +308,25 @@ describe('the gate runs it first', () => {
     assert.ok(record.totalMs >= 0, 'with a total, so two runs can be compared directly');
   });
 
+  test('a step ended at its ceiling is reported as unfinished, not as failed', async () => {
+    // The distinction the ceilings exist for. A step killed at its ceiling
+    // reached no verdict; calling that a failure sends a reader looking for a
+    // broken test that is not there, which is the hour this was written to stop
+    // being lost. The merge that brought the ceilings in did not carry this
+    // through, and a textual merge would not have noticed.
+    const { runSteps, ceilingFor, DEFAULT_STEP_CEILING_MS } = require('../../scripts/precommit-gate.js');
+    assert.strictEqual(typeof ceilingFor('typecheck'), 'number', 'every step has a ceiling');
+    assert.strictEqual(ceilingFor('a step nobody declared'), DEFAULT_STEP_CEILING_MS,
+      'and an undeclared one inherits the default rather than running unbounded');
+    const outcome = await runSteps({
+      steps: [{ name: 'hangs' }],
+      runOne: async () => ({ ok: false, timedOut: true, out: '', code: null, signal: null }),
+    });
+    assert.strictEqual(outcome.ok, false);
+    assert.strictEqual(outcome.result.timedOut, true,
+      'the outcome carries the distinction through, so the caller can report it');
+  });
+
   test('a failing step stops the run and reports what had been spent', async () => {
     const { runSteps } = require('../../scripts/precommit-gate.js');
     const ran = [];

--- a/test/unit/sdlc-gate-hardening.test.js
+++ b/test/unit/sdlc-gate-hardening.test.js
@@ -105,6 +105,28 @@ function trackedMarkdown() {
 }
 
 describe('documented steps and uncommitted work', () => {
+  test('every gate step has a ceiling, and it matches what CI allows the same work', () => {
+    // A GATE IS A CONTROL ONLY WHILE IT CAN FINISH. On 2026-08-28 test:coverage
+    // ran for ninety-five minutes with no output, because a worker waited on a
+    // port the sandbox would not let it bind; CI caps that job, the local gate
+    // had no ceiling, so nothing ended it and nothing said it was stuck. On
+    // 2026-09-07 the same step hung again and cost an hour. Both were carded;
+    // neither was bounded until now.
+    const gate = require('../../scripts/precommit-gate.js');
+    for (const step of gate.STEPS) {
+      const ms = gate.ceilingFor(step.name);
+      assert.ok(Number.isFinite(ms) && ms > 0, `${step.name} has no ceiling, so it can hang forever`);
+      assert.ok(ms <= 45 * 60 * 1000, `${step.name}'s ceiling is longer than any step should ever take`);
+    }
+    // The two long steps are named explicitly rather than inheriting the
+    // default, because both legitimately exceed it and a default that had to
+    // cover them would be too loose to bound anything else.
+    assert.strictEqual(gate.ceilingFor('test:coverage'), 20 * 60 * 1000,
+      'the suite gets what CI gives the same suite');
+    assert.strictEqual(gate.ceilingFor('typecheck'), gate.DEFAULT_STEP_CEILING_MS,
+      'an ordinary step takes the default rather than a bespoke number nobody maintains');
+  });
+
   test('the destructive-command pattern bites every covered shape and no neighbour', () => {
     // One positive and one near-miss per shape, so a narrowing of the
     // pattern, or an over-match into the innocent form beside each command,

--- a/test/unit/workspace-boundary.test.js
+++ b/test/unit/workspace-boundary.test.js
@@ -249,6 +249,17 @@ describe('one directory under two names is one identity', () => {
       boundary.addBoundaryGrant(link);
       assert.strictEqual(boundary.boundaryGrantCovers(path.join(target, 'file.md')), true,
         'granted through the symlink, asked about through the real path: one folder, one decision');
+      // The mirror of the line above, and the only assertion here that drives
+      // canonicalisation of the ASKED-ABOUT path. addBoundaryGrant already
+      // canonicalises on write, so the stored grant is the real spelling: the
+      // question arriving under the symlink spelling is the sole thing left
+      // that has to be resolved. Asking through `link`, a symlink this test
+      // makes itself, is what carries that on every platform. Asking through
+      // a path from os.tmpdir() does it only on hosts where the temp dir
+      // itself sits behind an alias (macOS /var -> /private/var), which left
+      // the guard proving nothing on Linux and so nothing in CI.
+      assert.strictEqual(boundary.boundaryGrantCovers(path.join(link, 'file.md')), true,
+        'and granted under the real path, asked about through the symlink: still one folder, one decision');
       assert.strictEqual(boundary.boundaryGrantCovers(path.join(linkHome, 'other', 'f.md')), false,
         'and the grant covers only what its author meant');
     } finally {


### PR DESCRIPTION
This branch started out doing the opposite of what it now does, and the reversal is the point of it, so the reasoning is recorded here rather than buried in the commits.

**What it originally did.** It made the CI mutation job run all eighteen harnesses on every push, on the argument that the local gate runs only a scoped selection and something has to run the complete set. The first half of that argument is right. The schedule was wrong.

**What the measurements showed.** The complete set costs 1204s on these runners and 1628s on a developer machine, and two of the eighteen harnesses account for 63% of it. More to the point, on a green pull request the scoped mutation job cost 76s while E2E cost 4m56s. Mutation was never what set the wall time. Making it exhaustive on every push turned a 76 second job into a twenty minute one and put that in front of every review, in order to re-check harnesses that no change on the branch could reach.

**What it does now.** The push job runs the scoped set, the same selection the local gate makes, with its ceiling reduced from 75 to 30 minutes. The complete set moves to `mutation-nightly.yml`, running nightly plus manual dispatch, where nothing is waiting on it. The step ceilings from the original work are kept, including the fix so that a step stopped at its ceiling reports that it reached no verdict rather than reporting a failure.

**Why the sweep is a separate workflow rather than a conditional step.** It needs a concurrency group that does not cancel in progress. `ci.yml`'s group cancels on every new push to a ref, which is correct for a job someone is waiting on and would mean a day of pushes to main cancels the sweep every time, so it would never complete.

**The exhaustive run earned its keep before being moved.** Its first execution failed, and correctly. A guard in the boundary harness was passing because the only spelling it compared came from `os.tmpdir()`, which sits behind an alias on macOS and does not on Linux, so the mutation was invisible on the platform CI runs. No commit broke it, so no scoped run would ever have selected it. That fix is the first commit here, proven by pointing `TMPDIR` at an unaliased directory to reproduce the runner: without the new assertion the suite stays green under the mutation, and with it the harness reports the guard red and names the killing test.

That is also the argument for keeping the sweep rather than dropping it. A harness rots without anyone touching it, and only running everything, on a machine that is not the author's, surfaces it. It just does not need to happen within twenty minutes of a push.

Local gate green on both commits, at 1473s and 1622s, the complete set in both cases because this branch's diff touches `scripts/precommit-gate.js`, which can change what any harness proves.
