### PR TITLE
A mutation run proves its environment before it reports anything

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "smoke": "node scripts/smoke/run.mjs",
     "smoke:personas": "node scripts/smoke/personas.mjs",
     "stream:truth": "node scripts/stream-truth/run.mjs",
-    "transcript:truth": "node scripts/transcript-truth/run.mjs"
+    "transcript:truth": "node scripts/transcript-truth/run.mjs",
+    "verdicts:pin": "node scripts/verdicts-pin.js"
   },
   "dependencies": {
     "electron-updater": "^6.8.9",

--- a/scripts/precommit-gate.js
+++ b/scripts/precommit-gate.js
@@ -128,6 +128,11 @@ const STEPS = [
   { name: 'typecheck', args: ['run', 'typecheck'] },
   { name: 'lint:styles', args: ['run', 'lint:styles'] },
   { name: 'check:refs', args: ['run', 'check:refs'] },
+  // Runs a real adopted mutation harness and requires its verdicts to match
+  // what it reported before the baseline check existed. Cheap, and it belongs
+  // here rather than in the suite: a harness rewrites source on disk, so it
+  // cannot run alongside tests that read those same files.
+  { name: 'verdicts:pin', args: ['run', 'verdicts:pin'] },
   { name: 'test:coverage', args: ['run', 'test:coverage'] },
   // Removes each of the renderer's escaping guards in turn and requires a test
   // to go red for it. Slower than the rest because it runs a suite per guard,

--- a/scripts/verdicts-pin.js
+++ b/scripts/verdicts-pin.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+'use strict';
+// The verdicts an adopted harness reports, pinned to what it reported before the
+// baseline check existed.
+//
+// WHY THIS IS NOT A UNIT TEST. A mutation harness rewrites source files on disk
+// and puts them back. Run inside `npm test`, it corrupts whatever sibling suite
+// happens to be reading those files at the time, which is why the harnesses are
+// deliberately not part of the ordinary suite. An earlier version of this check
+// lived in test/unit and did exactly that: it turned the very suite the
+// install-flow harness mutates red, mid-run.
+//
+// WHY IT EXISTS AT ALL. Adding a baseline pass in front of every harness is a
+// change to shared machinery, and the claim that it leaves the verdicts alone is
+// worth more than an assurance. The generic mechanism is covered by
+// test/unit/mutation-baseline.test.js against a throwaway harness. This covers
+// the other half: that a REAL harness still concludes exactly what it concluded
+// before. A regression in ordering, timing or environment around the new check
+// would leave the generic tests green while quietly changing what is reported.
+//
+// A row moving here is either a deliberate behaviour change, in which case this
+// list is updated in the same commit, or this machinery breaking a promise.
+//
+//   node scripts/verdicts-pin.js
+
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..');
+
+const PINNED = {
+  tool: 'test/tools/mutate-install-flow-guards.js',
+  rows: [
+    ['a colliding plan can never produce an apply message', '1', '1'],
+    ['cancel sends nothing at all', '1', '1'],
+    ['the approval comes through the shared decide module, not a local copy', '1', '1'],
+    ['every item is decided add before the shared decide runs', '1', '1'],
+    ['the nothing-usable state is classified by its code, never by prose', '1', '1'],
+    ['blocked items are rendered, not dropped', '1', '1'],
+  ],
+};
+
+function main() {
+  // SCRUBBED. A nested `node --test` inherits NODE_TEST_CONTEXT from whatever
+  // spawned it and misreports its own results, so a harness invoked from inside
+  // a runner draws the wrong conclusions. Same reason preflight scrubs it.
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  delete env.NODE_OPTIONS;
+
+  const r = spawnSync(process.execPath, [path.join(ROOT, PINNED.tool), '--markdown'],
+    { cwd: ROOT, encoding: 'utf8', env });
+  if (r.status !== 0) {
+    console.error(`verdicts-pin: ${PINNED.tool} did not complete, so its verdicts could not be read.\n`
+      + `${(r.stderr || '').trim().slice(0, 800)}`);
+    process.exit(1);
+  }
+
+  const rows = r.stdout.split('\n')
+    .filter((l) => l.startsWith('| ') && !l.startsWith('| Guard broken') && !l.startsWith('|---'))
+    .map((l) => l.split('|').slice(1, 4).map((c) => c.trim()));
+
+  const actual = JSON.stringify(rows, null, 1);
+  const expected = JSON.stringify(PINNED.rows, null, 1);
+  if (actual !== expected) {
+    console.error(`verdicts-pin: ${PINNED.tool} no longer reports what it reported before the\n`
+      + 'baseline check was added. Either a guard genuinely changed, in which case update the\n'
+      + 'pinned list in this file in the same commit, or the machinery around it altered a\n'
+      + 'verdict without anyone deciding to.\n\n'
+      + `expected:\n${expected}\n\nactual:\n${actual}`);
+    process.exit(1);
+  }
+  console.log(`verdicts-pin: ${rows.length} verdicts unchanged in ${PINNED.tool}`);
+}
+
+main();

--- a/test/tools/mutate-install-flow-guards.js
+++ b/test/tools/mutate-install-flow-guards.js
@@ -93,7 +93,14 @@ function redTests(suite) {
 
 function run() {
   const targets = [MODEL];
-  const session = beginMutationRun({ files: targets.map((target) => target.src) });
+  // The suites are declared so the envelope can run them ONCE, unmutated, before
+  // anything is touched. A suite that cannot pass before the experiment starts
+  // makes every verdict after it meaningless, and a table printed over that is
+  // indistinguishable from a real one.
+  const session = beginMutationRun({
+    files: targets.map((target) => target.src),
+    suites: targets.map((target) => target.suite),
+  });
   const originals = new Map();
   for (const target of targets) originals.set(target, session.original(target.src));
   const results = [];

--- a/test/tools/mutation-run.js
+++ b/test/tools/mutation-run.js
@@ -324,7 +324,45 @@ function inspect({ root = ROOT, files = [] } = {}) {
  * the temp-root preflight each harness already runs, and it means a harness
  * cannot forget to act on the verdict.
  */
-function beginMutationRun({ root = ROOT, files: declared = [] } = {}) {
+/**
+ * Run each suite once, unmutated, and require it to pass.
+ *
+ * WITHOUT THIS, A DEAD HARNESS AND A CLEAN ONE READ THE SAME. The report says,
+ * for each guard removed, which tests went red. If a suite cannot load at all,
+ * every mutation "turns tests red" for reasons that have nothing to do with the
+ * mutation, and the run reports a full table over machinery that never ran.
+ *
+ * Measured on 2026-09-09: the eighteen harnesses were timed in a worktree with no
+ * node_modules. Every suite needing a dependency exited immediately, all
+ * eighteen ran to completion, and the reported total was 88 seconds against a
+ * real cost of 1628. That number was believed, acted on, and produced a wrong
+ * decision about where mutation should run.
+ *
+ * The env is scrubbed for the same reason preflight scrubs it: a nested
+ * `node --test` inherits NODE_TEST_CONTEXT from the runner that spawned it and
+ * misreports its own results.
+ */
+function baselineGreen(root, suites) {
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  delete env.NODE_OPTIONS;
+  for (const suite of suites) {
+    const r = spawnSync(process.execPath, ['--test', suite], { cwd: root, encoding: 'utf8', env });
+    if (r.status !== 0) {
+      // EXIT BEFORE ANY MUTATION, AND BEFORE ANY TABLE. A failed baseline must
+      // never reach the report: a table printed after this point would be read
+      // as verdicts, which is the exact confusion this exists to end.
+      console.error(
+        `mutation run REFUSED: ${suite} does not pass before anything is mutated, so no verdict `
+        + 'from this harness would mean anything. NO MUTATION WAS APPLIED and no results are '
+        + 'reported.\nFix the suite, or the environment it needs, and run again.\n'
+        + `Check it:  node --test ${suite}`);
+      process.exit(3);
+    }
+  }
+}
+
+function beginMutationRun({ root = ROOT, files: declared = [], suites: declaredSuites = [] } = {}) {
   // Deduplicated, because a harness names one target per guard and several
   // guards of the same file are ordinary. Left in, the same path would be read
   // twice, restored twice, and listed twice in a refusal that is supposed to be
@@ -343,6 +381,12 @@ function beginMutationRun({ root = ROOT, files: declared = [] } = {}) {
     console.error(`A previous mutation run (pid ${s2.pid}) never finished. Its files have been put `
       + `back from the index:\n${list(s2.files)}`);
   }
+
+  // BEFORE THE ORIGINALS ARE READ, and so before any mutation can be written.
+  // Deduplicated: a harness names one suite per target and several targets
+  // sharing a suite is ordinary, so the cost is bounded by the number of
+  // DISTINCT suites rather than by the number of guards.
+  if (declaredSuites.length) baselineGreen(root, [...new Set(declaredSuites)]);
 
   const originals = new Map();
   for (const file of files) originals.set(file, fs.readFileSync(file, 'utf8'));
@@ -427,4 +471,4 @@ function beginMutationRun({ root = ROOT, files: declared = [] } = {}) {
   return session;
 }
 
-module.exports = { beginMutationRun, inspect, markerPath, markerDir, readMarkers, recoverAbandoned, MARKER, MARKER_DIR, ROOT };
+module.exports = { beginMutationRun, baselineGreen, inspect, markerPath, markerDir, readMarkers, recoverAbandoned, MARKER, MARKER_DIR, ROOT };

--- a/test/unit/mutation-baseline.test.js
+++ b/test/unit/mutation-baseline.test.js
@@ -1,0 +1,154 @@
+'use strict';
+// A mutation run proves its environment before it reports anything.
+//
+// THE FAILURE THIS CLOSES. The report says, for each guard removed, which tests
+// went red. If a suite cannot load at all, every mutation "turns tests red" for
+// reasons unrelated to the mutation, and the run prints a full table over
+// machinery that never ran. A green result and a result from a dead harness are
+// indistinguishable, so nothing forces the question.
+//
+// Measured on 2026-09-09: the eighteen harnesses were timed in a worktree with
+// no node_modules, every dependent suite exited immediately, all eighteen ran to
+// completion, and the reported total was 88 seconds against a real cost of 1628.
+// The number was believed and acted on.
+//
+// Driven through a REAL harness process rather than by calling the function,
+// because the property under test is what the process does on its way out: exit
+// code, what it prints, and above all what it does NOT print.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..', '..');
+const made = [];
+
+function tmp(prefix) {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  made.push(d);
+  return d;
+}
+
+process.on('exit', () => {
+  for (const d of made) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* going anyway */ } }
+});
+
+/**
+ * A throwaway harness that declares one target file and the suites named here,
+ * then prints a table. The table is the thing that must not appear when a
+ * baseline suite fails.
+ */
+function harness(dir, suites, targetRel) {
+  const file = path.join(dir, 'harness.js');
+  fs.writeFileSync(file, `
+    const { beginMutationRun } = require(${JSON.stringify(path.join(ROOT, 'test', 'tools', 'mutation-run.js'))});
+    const session = beginMutationRun({
+      root: ${JSON.stringify(dir)},
+      files: [${JSON.stringify(path.join(dir, targetRel))}],
+      suites: ${JSON.stringify(suites)},
+    });
+    console.log('| Guard removed | Tests red |');
+    console.log('MUTATION-APPLIED');
+    session.finish();
+  `);
+  return file;
+}
+
+function workspace() {
+  const dir = tmp('mut-baseline-');
+  fs.mkdirSync(path.join(dir, 'suites'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'target.js'), 'module.exports = 1;\n');
+  return dir;
+}
+
+function writeSuite(dir, name, passes) {
+  const rel = path.join('suites', name);
+  fs.writeFileSync(path.join(dir, rel), `
+    const { test } = require('node:test');
+    const assert = require('node:assert');
+    test('${name}', () => { assert.strictEqual(${passes ? 1 : 2}, 1); });
+  `);
+  return rel;
+}
+
+function run(file, dir) {
+  return spawnSync(process.execPath, [file], { cwd: dir, encoding: 'utf8' });
+}
+
+describe('a mutation run proves its environment before it reports', () => {
+  test('a failing baseline suite ends the run before any mutation, and reports no verdicts', () => {
+    const dir = workspace();
+    const bad = writeSuite(dir, 'bad.test.js', false);
+    const r = run(harness(dir, [bad], 'target.js'), dir);
+
+    // NOTHING WAS MUTATED. The harness prints this marker only after
+    // beginMutationRun returns, so its absence is the proof.
+    assert.ok(!r.stdout.includes('MUTATION-APPLIED'),
+      'the run ended before the harness could mutate anything');
+    // A run that proved nothing must not look like success to a caller.
+    assert.notStrictEqual(r.status, 0, 'a run that proved nothing must not exit 0');
+    // NO RESULTS TABLE. A table printed after a failed baseline would be read
+    // as verdicts, which is the confusion this exists to end.
+    assert.ok(!r.stdout.includes('| Guard removed |'),
+      'no results table is printed, so a failed baseline cannot be read as a set of verdicts');
+    // The message has to name the suite and say plainly that nothing was mutated,
+    // or the reader cannot tell this from an ordinary test failure.
+    assert.ok(r.stderr.includes(bad), `the message names the failing suite (got: ${r.stderr.slice(0, 200)})`);
+    assert.ok(/NO MUTATION WAS APPLIED/i.test(r.stderr),
+      'and says plainly that no mutation was applied');
+  });
+
+  test('a suite that cannot even load is caught, which is the shape that was actually missed', () => {
+    // The measured incident was not a failing assertion. It was a suite whose
+    // dependency was absent, so it exited before running anything. A baseline
+    // that only caught assertion failures would have missed the real case.
+    const dir = workspace();
+    const rel = path.join('suites', 'unloadable.test.js');
+    fs.writeFileSync(path.join(dir, rel), "require('a-dependency-that-is-not-installed');\n");
+    const r = run(harness(dir, [rel], 'target.js'), dir);
+    assert.notStrictEqual(r.status, 0);
+    assert.ok(!r.stdout.includes('MUTATION-APPLIED'), 'nothing was mutated');
+    assert.ok(r.stderr.includes(rel), 'and the unloadable suite is named');
+  });
+
+  test('when every baseline suite passes, the run proceeds unchanged', () => {
+    const dir = workspace();
+    const a = writeSuite(dir, 'a.test.js', true);
+    const b = writeSuite(dir, 'b.test.js', true);
+    const r = run(harness(dir, [a, b], 'target.js'), dir);
+    assert.strictEqual(r.status, 0, `a green baseline lets the run continue (stderr: ${r.stderr.slice(0, 300)})`);
+    assert.ok(r.stdout.includes('MUTATION-APPLIED'), 'the harness reached its own work');
+    assert.ok(r.stdout.includes('| Guard removed |'), 'and printed its table as it does today');
+  });
+
+  test('each distinct suite is run once, however many guards name it', () => {
+    // The cost added is bounded by the number of DISTINCT suites, not by the
+    // number of guards, or a baseline would cost as much as the run it guards.
+    // A harness naming one suite per target repeats them heavily.
+    const dir = workspace();
+    const counter = path.join(dir, 'runs.log');
+    const rel = path.join('suites', 'counted.test.js');
+    fs.writeFileSync(path.join(dir, rel), `
+      const fs = require('node:fs');
+      const { test } = require('node:test');
+      fs.appendFileSync(${JSON.stringify(counter)}, 'x');
+      test('counted', () => {});
+    `);
+    const r = run(harness(dir, [rel, rel, rel, rel], 'target.js'), dir);
+    assert.strictEqual(r.status, 0, 'the run completed');
+    assert.strictEqual(fs.readFileSync(counter, 'utf8').length, 1,
+      'the suite ran exactly once despite being named four times');
+  });
+
+  test('a harness that declares no suites is unaffected, so adoption can be incremental', () => {
+    // The eighteen harnesses adopt this one at a time. Until a harness passes
+    // its suites, it behaves exactly as it does today rather than failing.
+    const dir = workspace();
+    const r = run(harness(dir, [], 'target.js'), dir);
+    assert.strictEqual(r.status, 0);
+    assert.ok(r.stdout.includes('MUTATION-APPLIED'), 'it runs as before');
+  });
+});

--- a/test/unit/mutation-baseline.test.js
+++ b/test/unit/mutation-baseline.test.js
@@ -12,6 +12,10 @@
 // completion, and the reported total was 88 seconds against a real cost of 1628.
 // The number was believed and acted on.
 //
+// The verdicts of a REAL adopted harness are pinned separately, by
+// scripts/verdicts-pin.js, because running a mutation harness rewrites source
+// files on disk and cannot share a process with the ordinary suite.
+//
 // Driven through a REAL harness process rather than by calling the function,
 // because the property under test is what the process does on its way out: exit
 // code, what it prints, and above all what it does NOT print.

--- a/test/unit/preflight.test.js
+++ b/test/unit/preflight.test.js
@@ -283,6 +283,12 @@ describe('the gate runs it first', () => {
     const { STEPS } = require('../../scripts/precommit-gate.js');
     assert.deepStrictEqual(STEPS.map(s2 => s2.name), [
       'preflight', 'typecheck', 'lint:styles', 'check:refs',
+      // Runs a real adopted mutation harness and requires its verdicts to be the
+      // ones it reported before a baseline pass was added in front of every
+      // harness. Placed with the cheap checks, at about three seconds, and
+      // deliberately not in the suite: a harness rewrites source files on disk,
+      // so it cannot run beside tests reading those same files.
+      'verdicts:pin',
       'test:coverage', 'mutate:guards', 'check:fixture',
     ], 'every check that ran before still runs; changing this set is a deliberate edit');
   });


### PR DESCRIPTION
The report says, for each guard removed, which tests went red. If a suite cannot load at all, every mutation turns tests red for reasons that have nothing to do with the mutation, and the run prints a full table over machinery that never ran. A green result and a result from a dead harness read the same, so nothing forces the question.

**Measured, rather than imagined.** On 2026-09-09 the eighteen harnesses were timed in a git worktree with no `node_modules`. Every suite needing a dependency exited immediately, all eighteen ran to completion, and the reported total was 88 seconds against a real cost of 1628. That number was believed and acted on. It produced a wrong conclusion about where mutation should run, which was then retracted twice, and it cost more time than any real bug found that day.

**What changes.** `beginMutationRun` now takes the suites a harness will run. Each is run once, unmutated, before anything is touched. A suite that does not pass ends the run with a non-zero exit BEFORE any mutation is written and before any table is printed, so a failed baseline can never be read as a set of verdicts. The message names the failing suite and says plainly that nothing was mutated, so it cannot be mistaken for an ordinary test failure.

Suites are deduplicated, so the cost added is bounded by the number of distinct suites rather than the number of guards. A harness names one suite per target and repeats them heavily, so this matters.

The environment is scrubbed of `NODE_TEST_CONTEXT` for the same reason preflight scrubs it: a nested `node --test` inherits it from the runner that spawned it and misreports its own results. That has already caused one bug on the trunk.

**Adoption is incremental by design.** A harness that declares no suites behaves exactly as it does today, so the remaining seventeen move over one at a time rather than in a single change touching eighteen files. Making it mandatory, so a harness cannot silently opt out, is a separate change that should land once they have all adopted it. `install-flow` adopts it here as proof the seam works end to end.

**On the evidence.** One test covers a suite that cannot LOAD rather than one that fails an assertion, because that was the actual incident. A baseline catching only assertion failures would have missed the real case entirely. The tests drive a real harness process rather than calling the function, because the property under test is what the process does on its way out: its exit code, what it prints, and above all what it does not print.

Verified red-first: with the baseline call removed, three of the five checks fail. The two that pass are control cases that must behave identically either way, and their passing is the point.

Local gate green at 1254s.