### PR TITLE
A delegation in flight survives the app quitting

### DIFF
--- a/lib/delegation/engine.js
+++ b/lib/delegation/engine.js
@@ -414,24 +414,28 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
  * the orchestrator came back and asked a specialist for work already delivered.
  * A handback is an event, and the only party that observes it is this one.
  */
-function markDelegationReturned(convoId) {
+function setDelegationReturned(convoId, returned) {
   try {
     const convos = readConversations();
     const convo = convos.find((c) => c.id === convoId);
-    // Already marked, or nothing to mark: write nothing. A load that changes
-    // nothing must not rewrite the file.
-    if (!convo || convo.delegationReturned) return;
-    convo.delegationReturned = true;
+    // Already in this state, or nothing to record: write nothing. A change that
+    // changes nothing must not rewrite the file. Compared as booleans, because
+    // a record written before this field existed carries no value at all, and
+    // absent means the same as false.
+    if (!convo) return;
+    const want = returned === true;
+    if ((convo.delegationReturned === true) === want) return;
+    convo.delegationReturned = want;
     writeConversations(convos);
   } catch (e) {
     // A handback that cannot be recorded must not take the handback down with
     // it. The cost of failing here is the old behaviour, not a broken return.
-    console.warn(`[ScopeReturn] convo=${convoId} could not record the handback: ${e.message}`);
+    console.warn(`[Delegate] convo=${convoId} could not record the handback state: ${e.message}`);
   }
 }
 
 function handleScopeReturn(specialistEntry, convoId, wasPipelineComplete = false) {
-  markDelegationReturned(convoId);
+  setDelegationReturned(convoId, true);
   const agentList = discoverAgents();
   const orchestrator = agentList.find(a => a.type === 'orchestrator');
 
@@ -802,6 +806,13 @@ function handleDelegation(msg, processes) {
   }));
   processes.set(convoId, delegateEntry);
 
+  // A NEW DELEGATION STARTS UNRETURNED. The flag answers "did the delegation
+  // that is running now hand back", and without this it would answer "has this
+  // conversation ever had a handback": true forever after the first one. Every
+  // later delegation would then be reconciled away on a relaunch, which is the
+  // reported bug returning for every delegation after the first.
+  setDelegationReturned(convoId, false);
+
   // Notify client of agent switch
   safeSend(JSON.stringify({
     type: 'system', subtype: 'agent_switch', _conversationId: convoId, _processId: delegateProcessId,
@@ -1009,7 +1020,7 @@ function handleDelegation(msg, processes) {
 
         // A live orchestrator taken back off idle: control has returned to the
         // parent, so the handback is recorded here as on every other such path.
-        markDelegationReturned(convoId);
+        setDelegationReturned(convoId, true);
         safeSend(JSON.stringify({
           type: 'system', subtype: 'agent_switch', _conversationId: convoId,
           fromAgent: delegateEntry.agentId, toAgent: orchestratorAgentId
@@ -1063,7 +1074,7 @@ function handleDelegation(msg, processes) {
       // scope-return marker. A normal single-level delegation never reaches it,
       // so the flag stayed false for the common case and a finished delegation
       // was never reconciled at all.
-      markDelegationReturned(convoId);
+      setDelegationReturned(convoId, true);
       const parentAgentId = delegateEntry.delegation.originalAgentId;
       const parentSessionId = delegateEntry.delegation.parentSessionId;
       console.log(`[AgentIntercept] convo=${convoId} delegate done, restarting parent ${parentAgentId} (session=${parentSessionId}) marker=${returnMarkerSeen || 'none'}`);
@@ -1217,7 +1228,7 @@ function handleDelegation(msg, processes) {
     } else if (orig && !orig.exited) {
       // The other way control returns to a parent: its process is still alive
       // and is simply restored. A handback either way, and recorded either way.
-      markDelegationReturned(convoId);
+      setDelegationReturned(convoId, true);
       orig.idle = true; orig.idleSince = Date.now();
       orig.delegation = null;
       orig.handbackAt = Date.now(); // stale end_delegation guard
@@ -1312,7 +1323,7 @@ function handleEndDelegation(msg, processes) {
   }
 }
 
-// markDelegationReturned is exported for its own test: it is the one writer of
+// setDelegationReturned is exported for its own test: it is the one writer of
 // the signal the conversation loader reads, and a signal nothing writes is a
 // dead condition that silently disables the reset it guards.
-module.exports = { createDelegationEngine, DEP_NAMES, markDelegationReturned };
+module.exports = { createDelegationEngine, DEP_NAMES, setDelegationReturned };

--- a/lib/delegation/engine.js
+++ b/lib/delegation/engine.js
@@ -414,43 +414,58 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
  * the orchestrator came back and asked a specialist for work already delivered.
  * A handback is an event, and the only party that observes it is this one.
  */
-function recordControlReturnedTo(convoId, agentId) {
-  // WHICH AGENT, NOT WHETHER. Delegation nests: an orchestrator delegates to a
-  // specialist that has its own reports, and that specialist delegates again.
-  // When the sub-delegate returns, control goes back to the MID-LEVEL parent,
-  // and the orchestrator's own delegation is still in flight. A bare "returned"
-  // boolean cannot say that, and setting it there told the loader the whole
-  // conversation had come home when it had not.
-  //
-  // So the question asked here is whether control reached the conversation's
-  // base agent. Anything short of that is still delegated.
-  // No try/catch here on purpose. readConversations answers with an empty list
-  // rather than throwing, and the write below carries its own guard, so a
-  // wrapper here would be a branch nothing can reach: dead defensive code that
-  // reads as caution and is only noise.
-  const convo = readConversations().find((c) => c.id === convoId);
-  if (!convo) return;
-  setDelegationReturned(convoId, agentId === convo.agentId);
-}
-
-function setDelegationReturned(convoId, returned) {
+/**
+ * Write the handback record, when it actually changes.
+ *
+ * ONE WRITER. Two entry points ask different questions, "did control reach the
+ * base agent" and "is a new delegation starting", and both come here so the
+ * store is read once, compared once, and written once.
+ */
+function writeDelegationReturned(convoId, convos, convo, want) {
+  // Absent and false mean the same: a record written before this field existed
+  // carries no value. A change that changes nothing must not rewrite the file.
+  if ((convo.delegationReturned === true) === want) return;
+  convo.delegationReturned = want;
   try {
-    const convos = readConversations();
-    const convo = convos.find((c) => c.id === convoId);
-    // Already in this state, or nothing to record: write nothing. A change that
-    // changes nothing must not rewrite the file. Compared as booleans, because
-    // a record written before this field existed carries no value at all, and
-    // absent means the same as false.
-    if (!convo) return;
-    const want = returned === true;
-    if ((convo.delegationReturned === true) === want) return;
-    convo.delegationReturned = want;
     writeConversations(convos);
   } catch (e) {
-    // A handback that cannot be recorded must not take the handback down with
-    // it. The cost of failing here is the old behaviour, not a broken return.
+    // The caller is mid-return. Failing to record this must not abandon the
+    // return itself: the cost is the old behaviour, not a broken handback.
     console.warn(`[Delegate] convo=${convoId} could not record the handback state: ${e.message}`);
   }
+}
+
+/** The conversation, or null when there is nothing to record against. */
+function conversationFor(convoId) {
+  // readConversations answers with an empty list rather than throwing, so there
+  // is no guard here to write: a try/catch would be a branch nothing reaches.
+  const convos = readConversations();
+  const convo = convos.find((c) => c.id === convoId);
+  return convo ? { convos, convo } : null;
+}
+
+/**
+ * Record WHICH agent control returned to.
+ *
+ * Delegation nests: an orchestrator delegates to a specialist that has its own
+ * reports, and that specialist delegates again. When the sub-delegate returns,
+ * control goes back to the MID-LEVEL parent and the orchestrator's own
+ * delegation is still in flight. A bare "returned" boolean cannot say that, and
+ * setting it there told the loader the conversation had come home when it had
+ * not. So the question asked is whether control reached the conversation's base
+ * agent; anything short of that is still delegated.
+ */
+function recordControlReturnedTo(convoId, agentId) {
+  const found = conversationFor(convoId);
+  if (!found) return;
+  writeDelegationReturned(convoId, found.convos, found.convo, agentId === found.convo.agentId);
+}
+
+/** A new delegation starting: whatever the last one did, this one has not returned. */
+function setDelegationReturned(convoId, returned) {
+  const found = conversationFor(convoId);
+  if (!found) return;
+  writeDelegationReturned(convoId, found.convos, found.convo, returned === true);
 }
 
 function handleScopeReturn(specialistEntry, convoId, wasPipelineComplete = false) {

--- a/lib/delegation/engine.js
+++ b/lib/delegation/engine.js
@@ -414,6 +414,25 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
  * the orchestrator came back and asked a specialist for work already delivered.
  * A handback is an event, and the only party that observes it is this one.
  */
+function recordControlReturnedTo(convoId, agentId) {
+  // WHICH AGENT, NOT WHETHER. Delegation nests: an orchestrator delegates to a
+  // specialist that has its own reports, and that specialist delegates again.
+  // When the sub-delegate returns, control goes back to the MID-LEVEL parent,
+  // and the orchestrator's own delegation is still in flight. A bare "returned"
+  // boolean cannot say that, and setting it there told the loader the whole
+  // conversation had come home when it had not.
+  //
+  // So the question asked here is whether control reached the conversation's
+  // base agent. Anything short of that is still delegated.
+  // No try/catch here on purpose. readConversations answers with an empty list
+  // rather than throwing, and the write below carries its own guard, so a
+  // wrapper here would be a branch nothing can reach: dead defensive code that
+  // reads as caution and is only noise.
+  const convo = readConversations().find((c) => c.id === convoId);
+  if (!convo) return;
+  setDelegationReturned(convoId, agentId === convo.agentId);
+}
+
 function setDelegationReturned(convoId, returned) {
   try {
     const convos = readConversations();
@@ -435,9 +454,12 @@ function setDelegationReturned(convoId, returned) {
 }
 
 function handleScopeReturn(specialistEntry, convoId, wasPipelineComplete = false) {
-  setDelegationReturned(convoId, true);
   const agentList = discoverAgents();
   const orchestrator = agentList.find(a => a.type === 'orchestrator');
+  // Control is going back to the orchestrator this conversation was started
+  // under, if it is that conversation's base agent. Recorded the same way as
+  // every other return path, and by the same rule.
+  if (orchestrator) recordControlReturnedTo(convoId, orchestrator.id);
 
   if (!orchestrator || !orchestrator.fileName) {
     console.warn(`[ScopeReturn] convo=${convoId} no orchestrator found, cannot route`);
@@ -1018,9 +1040,9 @@ function handleDelegation(msg, processes) {
         orchestratorEntry.handbackAt = Date.now(); // stale end_delegation guard
         processes.set(convoId, orchestratorEntry);
 
-        // A live orchestrator taken back off idle: control has returned to the
-        // parent, so the handback is recorded here as on every other such path.
-        setDelegationReturned(convoId, true);
+        // A live orchestrator taken back off idle. Recorded as where control
+        // went, because in a nested chain this parent may not be the base agent.
+        recordControlReturnedTo(convoId, orchestratorAgentId);
         safeSend(JSON.stringify({
           type: 'system', subtype: 'agent_switch', _conversationId: convoId,
           fromAgent: delegateEntry.agentId, toAgent: orchestratorAgentId
@@ -1068,14 +1090,15 @@ function handleDelegation(msg, processes) {
 
       // Intercepted return: restart mid-level parent with --resume
       //
-      // RECORDED HERE BECAUSE THIS IS WHERE THE ORDINARY HANDBACK HAPPENS. The
-      // first version of this marked only inside handleScopeReturn, which fires
-      // for a second-level event: a resumed parent later emitting its own
-      // scope-return marker. A normal single-level delegation never reaches it,
-      // so the flag stayed false for the common case and a finished delegation
-      // was never reconciled at all.
-      setDelegationReturned(convoId, true);
+      // RECORDED HERE BECAUSE THIS IS WHERE THE ORDINARY HANDBACK HAPPENS. A
+      // normal single-level delegation returns through this path and never
+      // reaches handleScopeReturn, which fires only for a second-level event.
+      //
+      // The parent may itself be a delegate in a nested chain, so what is
+      // recorded is WHERE control went, and only reaching the base agent counts
+      // as the conversation having come back.
       const parentAgentId = delegateEntry.delegation.originalAgentId;
+      recordControlReturnedTo(convoId, parentAgentId);
       const parentSessionId = delegateEntry.delegation.parentSessionId;
       console.log(`[AgentIntercept] convo=${convoId} delegate done, restarting parent ${parentAgentId} (session=${parentSessionId}) marker=${returnMarkerSeen || 'none'}`);
 
@@ -1227,8 +1250,9 @@ function handleDelegation(msg, processes) {
 
     } else if (orig && !orig.exited) {
       // The other way control returns to a parent: its process is still alive
-      // and is simply restored. A handback either way, and recorded either way.
-      setDelegationReturned(convoId, true);
+      // and is simply restored. Recorded as where control went, for the same
+      // nesting reason as the branches above.
+      recordControlReturnedTo(convoId, delegateEntry.delegation.originalAgentId);
       orig.idle = true; orig.idleSince = Date.now();
       orig.delegation = null;
       orig.handbackAt = Date.now(); // stale end_delegation guard
@@ -1323,7 +1347,9 @@ function handleEndDelegation(msg, processes) {
   }
 }
 
-// setDelegationReturned is exported for its own test: it is the one writer of
-// the signal the conversation loader reads, and a signal nothing writes is a
-// dead condition that silently disables the reset it guards.
-module.exports = { createDelegationEngine, DEP_NAMES, setDelegationReturned };
+// recordControlReturnedTo is exported for its own tests: it is the one writer
+// of the signal the conversation loader reads, and a signal nothing writes is a
+// dead condition that silently disables the reset it guards. The raw boolean
+// setter stays internal, because callers should say WHERE control went and let
+// one place decide what that means.
+module.exports = { createDelegationEngine, DEP_NAMES, recordControlReturnedTo };

--- a/lib/delegation/engine.js
+++ b/lib/delegation/engine.js
@@ -404,17 +404,6 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
 //     next message is a fresh request and the orchestrator must be free to route it anywhere,
 //     including back to the same specialist. Do not tag scopeReturnSource.
 /**
- * Record that a delegate handed back, so a later load can tell that apart from
- * an app that quit.
- *
- * WRITTEN WHEN IT HAPPENS, NOT INFERRED LATER. The conversation loader used to
- * decide a delegation had finished whenever no live process was found. The
- * process map is in memory and dies with the server, so after a relaunch that
- * absence means nothing, and every in-flight delegation was recorded as done:
- * the orchestrator came back and asked a specialist for work already delivered.
- * A handback is an event, and the only party that observes it is this one.
- */
-/**
  * Write the handback record, when it actually changes.
  *
  * ONE WRITER. Two entry points ask different questions, "did control reach the
@@ -435,10 +424,19 @@ function writeDelegationReturned(convoId, convos, convo, want) {
   }
 }
 
-/** The conversation, or null when there is nothing to record against. */
+/**
+ * The conversation, or null when there is nothing to record against.
+ *
+ * NO GUARD HERE, AND THE GUARANTEE IS CHECKED RATHER THAN ASSUMED.
+ * readConversations in lib/store/persistence.js ends with `catch (e) { return
+ * []; }`, so it answers with an empty list on any failure and cannot throw. A
+ * try/catch here would be a branch nothing can reach.
+ *
+ * It matters because the callers are mid-handback: an exception escaping this
+ * would abort the return itself, which is the one thing the surrounding code
+ * says must survive a store it cannot use.
+ */
 function conversationFor(convoId) {
-  // readConversations answers with an empty list rather than throwing, so there
-  // is no guard here to write: a try/catch would be a branch nothing reaches.
   const convos = readConversations();
   const convo = convos.find((c) => c.id === convoId);
   return convo ? { convos, convo } : null;

--- a/lib/delegation/engine.js
+++ b/lib/delegation/engine.js
@@ -1007,6 +1007,9 @@ function handleDelegation(msg, processes) {
         orchestratorEntry.handbackAt = Date.now(); // stale end_delegation guard
         processes.set(convoId, orchestratorEntry);
 
+        // A live orchestrator taken back off idle: control has returned to the
+        // parent, so the handback is recorded here as on every other such path.
+        markDelegationReturned(convoId);
         safeSend(JSON.stringify({
           type: 'system', subtype: 'agent_switch', _conversationId: convoId,
           fromAgent: delegateEntry.agentId, toAgent: orchestratorAgentId
@@ -1053,6 +1056,14 @@ function handleDelegation(msg, processes) {
       }
 
       // Intercepted return: restart mid-level parent with --resume
+      //
+      // RECORDED HERE BECAUSE THIS IS WHERE THE ORDINARY HANDBACK HAPPENS. The
+      // first version of this marked only inside handleScopeReturn, which fires
+      // for a second-level event: a resumed parent later emitting its own
+      // scope-return marker. A normal single-level delegation never reaches it,
+      // so the flag stayed false for the common case and a finished delegation
+      // was never reconciled at all.
+      markDelegationReturned(convoId);
       const parentAgentId = delegateEntry.delegation.originalAgentId;
       const parentSessionId = delegateEntry.delegation.parentSessionId;
       console.log(`[AgentIntercept] convo=${convoId} delegate done, restarting parent ${parentAgentId} (session=${parentSessionId}) marker=${returnMarkerSeen || 'none'}`);
@@ -1204,6 +1215,9 @@ function handleDelegation(msg, processes) {
       });
 
     } else if (orig && !orig.exited) {
+      // The other way control returns to a parent: its process is still alive
+      // and is simply restored. A handback either way, and recorded either way.
+      markDelegationReturned(convoId);
       orig.idle = true; orig.idleSince = Date.now();
       orig.delegation = null;
       orig.handbackAt = Date.now(); // stale end_delegation guard

--- a/lib/delegation/engine.js
+++ b/lib/delegation/engine.js
@@ -17,7 +17,7 @@ const { createDelegationRecord, attachDelegationRecord } = require('./state.js')
 const { discoverAgents } = require('../agents/discovery.js');
 const { buildSystemPrompt, buildTeamRoster, findDirectReportMatch, findOffRosterWorkspaceMatch } = require('../agents/prompt.js');
 const { buildToolSummary } = require('../store/transcripts.js');
-const { readConversations } = require('../store/persistence.js');
+const { readConversations, writeConversations } = require('../store/persistence.js');
 const { recordEvent, bumpSkillUsage } = require('../signals.js');
 const { spawnClaude, getSpawnEnv, getBareArgs, modelArgs, killProcessTree } = require('../runtime/claude.js');
 const { startCodexTurn, wireCodexDelegate, readAgentInstructions } = require('../runtime/codex-glue.js');
@@ -403,7 +403,35 @@ function wireProcessHandlers(entry, convoId, ws, options = {}) {
 //     work cleanly and is handing back control with nothing outstanding. In that case the user's
 //     next message is a fresh request and the orchestrator must be free to route it anywhere,
 //     including back to the same specialist. Do not tag scopeReturnSource.
+/**
+ * Record that a delegate handed back, so a later load can tell that apart from
+ * an app that quit.
+ *
+ * WRITTEN WHEN IT HAPPENS, NOT INFERRED LATER. The conversation loader used to
+ * decide a delegation had finished whenever no live process was found. The
+ * process map is in memory and dies with the server, so after a relaunch that
+ * absence means nothing, and every in-flight delegation was recorded as done:
+ * the orchestrator came back and asked a specialist for work already delivered.
+ * A handback is an event, and the only party that observes it is this one.
+ */
+function markDelegationReturned(convoId) {
+  try {
+    const convos = readConversations();
+    const convo = convos.find((c) => c.id === convoId);
+    // Already marked, or nothing to mark: write nothing. A load that changes
+    // nothing must not rewrite the file.
+    if (!convo || convo.delegationReturned) return;
+    convo.delegationReturned = true;
+    writeConversations(convos);
+  } catch (e) {
+    // A handback that cannot be recorded must not take the handback down with
+    // it. The cost of failing here is the old behaviour, not a broken return.
+    console.warn(`[ScopeReturn] convo=${convoId} could not record the handback: ${e.message}`);
+  }
+}
+
 function handleScopeReturn(specialistEntry, convoId, wasPipelineComplete = false) {
+  markDelegationReturned(convoId);
   const agentList = discoverAgents();
   const orchestrator = agentList.find(a => a.type === 'orchestrator');
 
@@ -1270,4 +1298,7 @@ function handleEndDelegation(msg, processes) {
   }
 }
 
-module.exports = { createDelegationEngine, DEP_NAMES };
+// markDelegationReturned is exported for its own test: it is the one writer of
+// the signal the conversation loader reads, and a signal nothing writes is a
+// dead condition that silently disables the reset it guards.
+module.exports = { createDelegationEngine, DEP_NAMES, markDelegationReturned };

--- a/lib/protocol/handlers/conversations.js
+++ b/lib/protocol/handlers/conversations.js
@@ -19,13 +19,23 @@ function handleGetConversations(ctx, ws, msg) {
   const fiveMinAgo = Date.now() - 5 * 60 * 1000;
   const cleaned = convos.filter(c => c.sessionId || new Date(c.lastActiveAt || c.createdAt).getTime() > fiveMinAgo);
   let convosChanged = cleaned.length < convos.length;
-  // Reconcile activeAgentId on load. A pointer to a delegatee is stale
-  // ONLY when there is no live process: the orchestrator resumes after a
-  // delegate returns or the conversation goes idle. Skip any conversation
-  // with a live process, whose activeAgentId (a live delegate) is
-  // legitimate and must not be clobbered mid-delegation.
+  // Reconcile activeAgentId on load, on an OBSERVED HANDBACK rather than on the
+  // absence of a process.
+  //
+  // WHY ABSENCE IS NOT EVIDENCE. The process map is in memory and dies with the
+  // server. After a page reload the delegate is still parked and reported idle,
+  // so "no process" did mean "the delegate finished". After a RELAUNCH it means
+  // nothing at all, and reading it as a finished delegation recorded every
+  // in-flight one as done, wrote that to disk, and sent the orchestrator back to
+  // ask a specialist for work it had already delivered. Reported by a daily user.
+  //
+  // `delegationReturned` is written when a handback is actually seen, so the two
+  // cases the old rule could not tell apart are now distinct: a delegate that
+  // handed back, and an app that quit. A live process is still skipped, because
+  // a running delegate's pointer is legitimate whatever the flag says.
   for (const c of cleaned) {
-    if (c.activeAgentId && c.activeAgentId !== c.agentId && !ctx.processes.has(c.id)) {
+    if (c.activeAgentId && c.activeAgentId !== c.agentId
+        && c.delegationReturned && !ctx.processes.has(c.id)) {
       c.activeAgentId = c.agentId;
       convosChanged = true;
     }

--- a/lib/protocol/handlers/conversations.js
+++ b/lib/protocol/handlers/conversations.js
@@ -10,6 +10,13 @@ const {
   readState, writeState,
 } = require('../../store/persistence.js');
 const { loadTranscript } = require('../../store/transcripts.js');
+// ONE IMPLEMENTATION OF THE RESTORE RULE, used by the server here and by the
+// view in the browser. It was written twice before, and the two copies
+// disagreed: the server preserved the specialist on disk while the client sent
+// the next message to the orchestrator. Requiring a public/ module from lib is
+// the shape this repository already uses for a rule both sides need, as in
+// lib/packages/import-plan.js.
+const { restoredActiveAgentId } = require('../../../public/delegation-restore.js');
 
 function handleGetConversations(ctx, ws, msg) {
   if (!getWorkspace()) return;
@@ -34,9 +41,12 @@ function handleGetConversations(ctx, ws, msg) {
   // handed back, and an app that quit. A live process is still skipped, because
   // a running delegate's pointer is legitimate whatever the flag says.
   for (const c of cleaned) {
-    if (c.activeAgentId && c.activeAgentId !== c.agentId
-        && c.delegationReturned && !ctx.processes.has(c.id)) {
-      c.activeAgentId = c.agentId;
+    // A live delegate's pointer is legitimate whatever the record says, so a
+    // conversation with a running process is left alone entirely.
+    if (ctx.processes.has(c.id)) continue;
+    const restored = restoredActiveAgentId(c);
+    if (c.activeAgentId && c.activeAgentId !== restored) {
+      c.activeAgentId = restored;
       convosChanged = true;
     }
   }

--- a/lib/protocol/handlers/conversations.js
+++ b/lib/protocol/handlers/conversations.js
@@ -106,10 +106,24 @@ function handleSaveConversation(ctx, ws, msg) {
   if (!getWorkspace() || !msg.conversation || !msg.conversation.id) return;
   const convos = readConversations();
   const idx = convos.findIndex(c => c.id === msg.conversation.id);
+  // SERVER-OWNED, AND CARRIED FORWARD RATHER THAN ACCEPTED FROM THE CLIENT.
+  //
+  // This rebuilds the record from a whitelist and replaces the whole entry, so a
+  // field the whitelist forgets is silently dropped. delegationReturned is
+  // written by the engine when it observes a handback, and the client sends
+  // save_conversation after essentially every turn: left out, a rename, a pin or
+  // an ordinary finished turn would wipe the one signal that says a delegation
+  // ended, and the conversation would stay pointed at a specialist that had
+  // already handed back.
+  //
+  // Taken from the STORED record, never from the message. The client has no
+  // business asserting that a handback happened; only the engine observes one.
+  const stored = idx >= 0 ? convos[idx] : null;
   // Only persist metadata, never message content
   const entry = {
     id: msg.conversation.id,
     agentId: msg.conversation.agentId,
+    delegationReturned: stored ? stored.delegationReturned === true : false,
     activeAgentId: msg.conversation.activeAgentId || null,
     sessionId: msg.conversation.sessionId || null,
     sessionIds: msg.conversation.sessionIds || [],

--- a/public/delegation-restore.js
+++ b/public/delegation-restore.js
@@ -1,0 +1,42 @@
+'use strict';
+// Which agent a conversation is pointed at when it is opened with no live process.
+//
+// WHY THIS IS ITS OWN MODULE. The rule lives on both sides of the wire: the
+// server decides what to persist on load, and the client decides what to route
+// the next message to. Written twice it drifts, and while it was written twice
+// the two halves disagreed: the server preserved the specialist on disk and the
+// client still sent the next message to the orchestrator, so the reported bug
+// survived a fix that looked complete on the server.
+//
+// It is also here because the view module it came from needs a DOM to load, and
+// a rule nothing can test without a browser is a rule nobody tests.
+//
+// THE RULE. A conversation with no live process is in one of two states, and
+// they are not distinguishable by the absence itself:
+//
+//   the delegate handed back      -> the orchestrator owns the conversation
+//   the app quit mid-delegation   -> the specialist still owns it
+//
+// Only an observed handback tells them apart, and `delegationReturned` is
+// written at the moment the engine sees one. Absence of a process says nothing:
+// the process map lives in memory and dies with the server.
+
+/**
+ * @param {{agentId: string, activeAgentId?: string|null, delegationReturned?: boolean}} convo
+ * @returns {string} the agent this conversation is pointed at
+ */
+function restoredActiveAgentId(convo) {
+  if (!convo || !convo.agentId) return '';
+  if (convo.delegationReturned === true) return convo.agentId;
+  return convo.activeAgentId || convo.agentId;
+}
+
+// Node-requireable for its tests, window-attached for the view that uses it.
+// The view reaches it through the global lexical environment, the same way it
+// reaches its other classic-script helpers.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { restoredActiveAgentId };
+} else if (typeof self !== 'undefined') {
+  self.restoredActiveAgentId = restoredActiveAgentId;
+  self.RundockDelegationRestore = { restoredActiveAgentId };
+}

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,7 @@
 <script src="/conversation-state.js"></script>
 <script src="/agent-colour.js"></script>
 <script src="/chat-markup.js"></script>
+<script src="/delegation-restore.js"></script>
 <script src="/markdown-render.js"></script>
 <script src="/file-tree-diff.js"></script>
 <script src="/routine-editor-model.js"></script>

--- a/public/views/chat.js
+++ b/public/views/chat.js
@@ -514,9 +514,22 @@ function renderSessionHistory(d) {
   // running; after a relaunch it does not mean the delegate FINISHED, because
   // the process map died with the server. Only an observed handback says that,
   // and `delegationReturned` is written at the moment one is seen.
+  // THE SAME RULE THE SERVER APPLIES, and it has to be the same or either one
+  // alone reproduces the bug. A missing process means the delegate is not
+  // running; after a relaunch it does not mean the delegate FINISHED, because
+  // the process map died with the server. Only an observed handback says that,
+  // and `delegationReturned` is written at the moment one is seen.
+  //
+  // BOTH DIRECTIONS ARE WRITTEN, which the first version of this got wrong. It
+  // narrowed the reset and stopped there, so for the restored case nothing ever
+  // seeded this runtime state at all. `state` is a per-session object that does
+  // not inherit convo.activeAgentId on its own, and dispatchMessage resolves
+  // `state.activeAgentId || convo.agentId`, so a message after a relaunch still
+  // went to the orchestrator: the reported bug, unfixed, behind a server-side
+  // fix that looked right.
   const state = getConvoState(convo.id);
-  if (!state.activeProcessId && convo.delegationReturned) {
-    state.activeAgentId = convo.agentId;
+  if (!state.activeProcessId) {
+    state.activeAgentId = restoredActiveAgentId(convo);
   }
   if (activeConversation?.id === convo.id) {
     const displayId = state.activeAgentId || convo.agentId;

--- a/public/views/chat.js
+++ b/public/views/chat.js
@@ -514,11 +514,6 @@ function renderSessionHistory(d) {
   // running; after a relaunch it does not mean the delegate FINISHED, because
   // the process map died with the server. Only an observed handback says that,
   // and `delegationReturned` is written at the moment one is seen.
-  // THE SAME RULE THE SERVER APPLIES, and it has to be the same or either one
-  // alone reproduces the bug. A missing process means the delegate is not
-  // running; after a relaunch it does not mean the delegate FINISHED, because
-  // the process map died with the server. Only an observed handback says that,
-  // and `delegationReturned` is written at the moment one is seen.
   //
   // BOTH DIRECTIONS ARE WRITTEN, which the first version of this got wrong. It
   // narrowed the reset and stopped there, so for the restored case nothing ever

--- a/public/views/chat.js
+++ b/public/views/chat.js
@@ -509,8 +509,13 @@ function renderSessionHistory(d) {
   // a live process, handleActiveProcesses already set the correct activeAgentId
   // and activeProcessId; overriding it here would desync the header/placeholder
   // from actual message routing.
+  // THE SAME RULE THE SERVER APPLIES, and it has to be the same or either one
+  // alone reproduces the bug. A missing process means the delegate is not
+  // running; after a relaunch it does not mean the delegate FINISHED, because
+  // the process map died with the server. Only an observed handback says that,
+  // and `delegationReturned` is written at the moment one is seen.
   const state = getConvoState(convo.id);
-  if (!state.activeProcessId) {
+  if (!state.activeProcessId && convo.delegationReturned) {
     state.activeAgentId = convo.agentId;
   }
   if (activeConversation?.id === convo.id) {

--- a/test/integration/conversation-metadata.test.js
+++ b/test/integration/conversation-metadata.test.js
@@ -47,18 +47,37 @@ describe('get_conversations: load pipeline', () => {
     fs.writeFileSync(convosFile, JSON.stringify([
       // Never got a sessionId and is older than the 5-minute grace: dropped.
       { id: 'stale-empty', agentId: 'chief-of-staff', title: 'Abandoned', lastActiveAt: oldStamp },
-      // Points at a delegatee with no live process: reset to the owner.
-      { id: 'reconcile-1', agentId: 'chief-of-staff', activeAgentId: 'penn', sessionId: 's-r1', title: 'Reconciled', lastActiveAt: oldStamp },
+      // Points at a delegatee that HANDED BACK: reset to the owner.
+      //
+      // This case used to carry no handback record and still expected the reset,
+      // because the rule was "no live process means the delegation finished".
+      // That inference is sound after a page reload, where the delegate is
+      // parked and reported idle, and unsound after a RELAUNCH, where the
+      // process map died with the server and absence means nothing. Reported by
+      // a daily user: every in-flight delegation came back marked finished, and
+      // the orchestrator re-asked for work already delivered.
+      //
+      // So the two cases the old fixture conflated are now separate, and both
+      // are checked below.
+      { id: 'reconcile-1', agentId: 'chief-of-staff', activeAgentId: 'penn', sessionId: 's-r1', title: 'Reconciled', lastActiveAt: oldStamp, delegationReturned: true },
+      // In flight when the app quit: no handback was ever seen, so the pointer
+      // stands. This is the case the user reported.
+      { id: 'in-flight', agentId: 'chief-of-staff', activeAgentId: 'penn', sessionId: 's-if', title: 'Still working', lastActiveAt: oldStamp },
     ]));
 
     const res = await getConversations();
     assert.ok(!res.conversations.some(c => c.id === 'stale-empty'), 'stale empty conversation dropped');
     const reconciled = res.conversations.find(c => c.id === 'reconcile-1');
-    assert.strictEqual(reconciled.activeAgentId, 'chief-of-staff', 'stale delegatee pointer reset to the owner');
+    assert.strictEqual(reconciled.activeAgentId, 'chief-of-staff', 'a delegatee that handed back is reset to the owner');
+    const inFlight = res.conversations.find(c => c.id === 'in-flight');
+    assert.strictEqual(inFlight.activeAgentId, 'penn',
+      'a delegation with no observed handback keeps its specialist across a restart');
 
     const persisted = JSON.parse(fs.readFileSync(convosFile, 'utf-8'));
     assert.ok(!persisted.some(c => c.id === 'stale-empty'), 'cleanup persisted to disk');
     assert.strictEqual(persisted.find(c => c.id === 'reconcile-1').activeAgentId, 'chief-of-staff');
+    assert.strictEqual(persisted.find(c => c.id === 'in-flight').activeAgentId, 'penn',
+      'and the in-flight pointer is not rewritten on disk either');
   });
 
   test('enriches each conversation with messageCount and a stripped last-message preview', async () => {

--- a/test/integration/delegation-handback-record.test.js
+++ b/test/integration/delegation-handback-record.test.js
@@ -104,3 +104,64 @@ describe('the record a real handback leaves behind', () => {
     }
   });
 });
+
+describe('the other paths control can return through', () => {
+  test('a sub-delegate returning to its lead leaves the conversation delegated', async () => {
+    // NESTED. The orchestrator delegates to a lead, the lead delegates to its
+    // own report, and that report finishes. Control goes back to the LEAD, not
+    // to the orchestrator, so the conversation has not come home and its record
+    // must not say it has. A bare boolean could not express this, which is what
+    // an earlier version of this fix got wrong.
+    const convoId = h.freshConvoId('nested');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'nested please' },
+        turn: [{ agentTool: { subagent_type: 'content-lead', prompt: 'lead brief' } }],
+      },
+      {
+        match: { agent: 'content-lead', promptIncludes: 'lead brief' },
+        turn: [{ agentTool: { subagent_type: 'content-analyst', prompt: 'analyst brief' } }],
+      },
+      {
+        match: { agent: 'content-analyst', promptIncludes: 'analyst brief' },
+        turn: [{ text: 'ANALYST-DONE. <!-- RUNDOCK:COMPLETE -->' }],
+      },
+      {
+        // The lead takes the analyst's output and finishes too, so control
+        // carries on up to the orchestrator. That second leg is what makes the
+        // first assertion mean something: without it, "not returned" would hold
+        // just as well over a conversation where nothing was ever recorded.
+        match: { agent: 'content-lead', promptIncludes: '[SYSTEM: pipeline-complete]' },
+        turn: [{ text: 'LEAD-DONE. <!-- RUNDOCK:COMPLETE -->' }],
+      },
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'LEAD-DONE' },
+        turn: [{ text: '<silent>' }],
+      },
+    ]);
+
+    client.send({ type: 'save_conversation', conversation: { id: convoId, agentId: 'chief-of-staff', title: 'Nested' } });
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'nested please' });
+
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'content-analyst', { label: 'down to the analyst' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'content-lead', { label: 'back up to the lead' });
+
+    const midChain = storedConversation(convoId);
+    assert.ok(midChain, 'the conversation was persisted');
+    assert.notStrictEqual(midChain.delegationReturned, true,
+      'control reached the lead, not the base agent, so this conversation is still delegated');
+
+    // And when the lead finishes too, control does reach the base agent.
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'home to the orchestrator' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const home = storedConversation(convoId);
+    assert.strictEqual(home.delegationReturned, true,
+      'the same conversation records the return once control actually reaches its base agent, '
+      + 'which is what makes the mid-chain assertion above discriminating rather than vacuous');
+  });
+});

--- a/test/integration/delegation-handback-record.test.js
+++ b/test/integration/delegation-handback-record.test.js
@@ -236,3 +236,46 @@ describe('a delegation whose parent stayed alive', () => {
       'restoring the live parent recorded that control reached the base agent');
   });
 });
+
+describe('control skipping a mid-level parent to reach the orchestrator', () => {
+  test('a report handing back past its lead records reaching the base agent', async () => {
+    // THE FOURTH CALL SITE, and the one an earlier claim of completeness had
+    // wrong. It needs a shape none of the tests above build: a non-intercepted
+    // `delegate` to a lead, so the ORCHESTRATOR's process is parked alive and
+    // the lead carries a live originalEntry; then the lead intercepts an
+    // Agent-tool call to one of its own reports; then that report finishes.
+    // Control skips the lead and goes straight back to the parked orchestrator,
+    // which is its own branch.
+    const convoId = h.freshConvoId('skiplevel');
+    h.clearInvocations();
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'open it' }, turn: [{ text: 'ready' }] },
+      {
+        match: { agent: 'content-lead', promptIncludes: 'lead brief' },
+        turn: [{ agentTool: { subagent_type: 'content-analyst', prompt: 'analyst brief' } }],
+      },
+      {
+        match: { agent: 'content-analyst', promptIncludes: 'analyst brief' },
+        turn: [{ text: 'ANALYST-DONE. <!-- RUNDOCK:COMPLETE -->' }],
+      },
+      { match: { agent: 'chief-of-staff' }, turn: [{ text: '<silent>' }] },
+      { match: { agent: 'content-lead' }, turn: [{ text: '<silent>' }] },
+    ]);
+
+    client.send({ type: 'save_conversation', conversation: { id: convoId, agentId: 'chief-of-staff', title: 'Skip level' } });
+    // A live orchestrator to park, which is what makes this path different.
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'open it' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'orchestrator is live' });
+
+    client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'content-lead', context: 'lead brief' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'content-analyst', { label: 'down to the report' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'straight back to the orchestrator' });
+
+    const stored = storedConversation(convoId);
+    assert.ok(stored, 'the conversation was persisted');
+    assert.strictEqual(stored.delegationReturned, true,
+      'control skipped the lead and reached the base agent, so the record says so');
+  });
+});

--- a/test/integration/delegation-handback-record.test.js
+++ b/test/integration/delegation-handback-record.test.js
@@ -165,3 +165,74 @@ describe('the other paths control can return through', () => {
       + 'which is what makes the mid-chain assertion above discriminating rather than vacuous');
   });
 });
+
+describe('a specialist returning scope on its own', () => {
+  test('a direct specialist that returns scope records where control went', async () => {
+    // THE PATH A SOURCE SCAN COULD NOT PROVE. This one does not go through the
+    // Agent-tool interception at all: the person is talking to the specialist,
+    // the specialist decides the request is outside its scope, emits a RETURN
+    // marker, and its process closes carrying that. Control goes back to the
+    // orchestrator through handleScopeReturn, which is a different branch from
+    // every other test here.
+    const convoId = h.freshConvoId('scopereturn');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'content-lead', promptIncludes: 'not my area' },
+        turn: [{ text: 'That is outside what I handle. <!-- RUNDOCK:RETURN -->' }],
+      },
+      {
+        match: { agent: 'chief-of-staff' },
+        turn: [{ text: 'I will take it from here.' }],
+      },
+    ]);
+
+    // The conversation belongs to the orchestrator; the specialist is who is
+    // being spoken to right now.
+    client.send({ type: 'save_conversation', conversation: { id: convoId, agentId: 'chief-of-staff', activeAgentId: 'content-lead', title: 'Scope return' } });
+    client.send({ type: 'chat', conversationId: convoId, agent: 'content-lead', content: 'not my area' });
+
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'scope return to the orchestrator' });
+
+    const stored = storedConversation(convoId);
+    assert.ok(stored, 'the conversation was persisted');
+    assert.strictEqual(stored.delegationReturned, true,
+      'a scope return that reaches the base agent is recorded, so a restart reconciles it');
+  });
+});
+
+describe('a delegation whose parent stayed alive', () => {
+  test('restoring a live parent records where control went', async () => {
+    // THE LAST PATH A SOURCE SCAN COULD NOT PROVE. A `delegate` request is not
+    // an Agent-tool interception: the parent process is parked rather than
+    // replaced, so when the delegate finishes the parent is simply restored.
+    // That is its own branch, and nothing here had ever executed it.
+    const convoId = h.freshConvoId('liveparent');
+    h.clearInvocations();
+    h.writeScenario([
+      { match: { agent: 'chief-of-staff', promptIncludes: 'open the thread' }, turn: [{ text: 'ready' }] },
+      {
+        match: { agent: 'content-lead', promptIncludes: 'live-parent brief' },
+        turn: [{ text: 'DELIVERED. <!-- RUNDOCK:COMPLETE -->' }],
+      },
+      { match: { agent: 'chief-of-staff' }, turn: [{ text: 'noted' }] },
+    ]);
+
+    client.send({ type: 'save_conversation', conversation: { id: convoId, agentId: 'chief-of-staff', title: 'Live parent' } });
+    // A live parent to park: the delegation below is refused without one.
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'open the thread' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId, { label: 'parent is live' });
+
+    client.send({ type: 'delegate', conversationId: convoId, targetAgent: 'content-lead', context: 'live-parent brief' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'content-lead', { label: 'out to the delegate' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'parent restored' });
+
+    const stored = storedConversation(convoId);
+    assert.ok(stored, 'the conversation was persisted');
+    assert.strictEqual(stored.delegationReturned, true,
+      'restoring the live parent recorded that control reached the base agent');
+  });
+});

--- a/test/integration/delegation-handback-record.test.js
+++ b/test/integration/delegation-handback-record.test.js
@@ -1,0 +1,106 @@
+'use strict';
+// Integration: the handback record is written by a REAL delegation handing back.
+//
+// WHY THIS EXISTS RATHER THAN A SOURCE SCAN. The claim this card rests on is
+// that the engine records where control returned at the moment it observes a
+// handback. That was verified by matching `recordControlReturnedTo(convoId`
+// within a few lines of an agent_switch announcement, which is text proximity,
+// not execution. A regex passes on a call site that is unreachable, guarded by
+// a condition never true, or holding a shadowed identifier.
+//
+// It is not a hypothetical gap. An earlier version of this fix wired the call
+// into one branch only, the ordinary single-level delegation never reached it,
+// and nothing failed: the unit test passed, because the unit worked. Only
+// running a delegation to a real handback and reading what landed on disk can
+// tell the difference.
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const h = require('../helpers/harness.js');
+const { standardTeam } = require('../helpers/workspace.js');
+
+let client;
+
+before(async () => {
+  await h.boot({ agents: standardTeam() });
+  client = await h.connect();
+});
+after(async () => h.shutdown());
+
+function storedConversation(convoId) {
+  const file = path.join(h.workspaceDir, '.rundock', 'conversations.json');
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, 'utf-8')).find((c) => c.id === convoId) || null;
+}
+
+describe('the record a real handback leaves behind', () => {
+  test('a delegation that hands back records that control reached the base agent', async () => {
+    const convoId = h.freshConvoId('handback');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'delegate please' },
+        turn: [{ agentTool: { subagent_type: 'content-lead', prompt: 'the brief' } }],
+      },
+      {
+        match: { agent: 'content-lead', promptIncludes: 'the brief' },
+        turn: [{ text: 'DELIVERED-PAYLOAD. <!-- RUNDOCK:COMPLETE -->' }],
+      },
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: '[SYSTEM: pipeline-complete]' },
+        turn: [{ text: '<silent>' }],
+      },
+    ]);
+
+    // The browser persists a conversation as soon as it is used, so the record
+    // the engine writes into exists by the time a handback happens. Doing the
+    // same here rather than assuming it.
+    client.send({ type: 'save_conversation', conversation: { id: convoId, agentId: 'chief-of-staff', title: 'Handback' } });
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'delegate please' });
+
+    // Control goes out to the specialist, then comes back to the orchestrator.
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'content-lead', { label: 'out to the specialist' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'chief-of-staff', { label: 'back to the orchestrator' });
+    await client.waitForEvent('system', 'done', convoId);
+
+    const stored = storedConversation(convoId);
+    assert.ok(stored, 'the conversation was persisted');
+    assert.strictEqual(stored.delegationReturned, true,
+      'a real handback wrote the record, so a restart will reconcile this conversation');
+  });
+
+  test('a delegation still in flight leaves no such record', async () => {
+    // The other direction, and the one the reported bug is about. The delegate
+    // never emits a marker and never finishes, so nothing observes a handback
+    // and nothing may claim one.
+    const convoId = h.freshConvoId('inflight');
+    h.clearInvocations();
+    h.writeScenario([
+      {
+        match: { agent: 'chief-of-staff', promptIncludes: 'start work' },
+        turn: [{ agentTool: { subagent_type: 'content-lead', prompt: 'long brief' } }],
+      },
+      {
+        match: { agent: 'content-lead', promptIncludes: 'long brief' },
+        turn: [{ text: 'still working on it' }],
+      },
+    ]);
+
+    client.send({ type: 'save_conversation', conversation: { id: convoId, agentId: 'chief-of-staff', title: 'In flight' } });
+    client.send({ type: 'chat', conversationId: convoId, agent: 'chief-of-staff', content: 'start work' });
+    await client.waitFor(m => m.type === 'system' && m.subtype === 'agent_switch'
+      && m._conversationId === convoId && m.toAgent === 'content-lead', { label: 'out to the specialist' });
+    await client.waitFor(m => m.type === 'result' && m._conversationId === convoId
+      && m._agent === 'content-lead', { label: 'specialist spoke' });
+
+    const stored = storedConversation(convoId);
+    if (stored) {
+      assert.notStrictEqual(stored.delegationReturned, true,
+        'no handback was observed, so the conversation is still delegated');
+    }
+  });
+});

--- a/test/unit/delegation-dispatch.test.js
+++ b/test/unit/delegation-dispatch.test.js
@@ -34,6 +34,13 @@ const dom = new JSDOM('<!doctype html><html><body>'
   + '</body></html>');
 global.document = dom.window.document;
 global.window = dom.window;
+// jsdom does not implement scrolling, and the view scrolls.
+dom.window.Element.prototype.scrollIntoView = function () {};
+
+// The view reaches this by name, exactly as it does in the browser where
+// delegation-restore.js attaches it to the window. Requiring it in the test is
+// not enough: the module resolves it from the global environment at call time.
+global.restoredActiveAgentId = restoredActiveAgentId;
 
 // The collaborators chat.js reaches by name. Installed before it is required,
 // because the module captures nothing at load time and resolves each at call
@@ -62,7 +69,7 @@ global.startProcessing = () => {};
 global.renderConvoList = () => {};
 global.persistConversation = () => {};
 
-const { dispatchMessage } = require(path.join(ROOT, 'public', 'views', 'chat.js'));
+const { dispatchMessage, renderSessionHistory } = require(path.join(ROOT, 'public', 'views', 'chat.js'));
 
 function restoredConversation(extra) {
   return {
@@ -79,11 +86,22 @@ function restoredConversation(extra) {
   };
 }
 
-/** What opening a conversation with no live process does to the runtime state. */
+/**
+ * Open the conversation through the REAL view code that opens one.
+ *
+ * An earlier version of this file hand-wrote the two lines renderSessionHistory
+ * runs, and every assertion below then ran against that stand-in. It proved
+ * dispatchMessage routes correctly GIVEN correct state, and proved nothing
+ * about the state ever being set. The double was never checked against the
+ * function it stood in for, which is the failure this whole card is about.
+ */
 function openWithNoLiveProcess(convo) {
+  global.conversations = [convo];
   const state = global.getConvoState(convo.id);
   state.activeProcessId = null;
-  state.activeAgentId = restoredActiveAgentId(convo);
+  // The shape the server sends for get_session_history. No messages, because
+  // what is under test is the pointer, not the rendering.
+  renderSessionHistory({ conversationId: convo.id, messages: [], hasMore: false });
   return state;
 }
 

--- a/test/unit/delegation-dispatch.test.js
+++ b/test/unit/delegation-dispatch.test.js
@@ -1,0 +1,160 @@
+'use strict';
+// The message a restored conversation actually sends.
+//
+// WHY THIS EXISTS SEPARATELY FROM THE RULE'S OWN TESTS. The rule module says
+// which agent a restored conversation is pointed at. That is a claim about a
+// pure function, and an earlier round of this work proved exactly that and
+// nothing more, while the product still sent the next message to the
+// orchestrator: the runtime state the send reads was never seeded from the rule.
+// A helper returning the right answer is not the same as the right answer
+// reaching the wire.
+//
+// So this drives the REAL dispatchMessage from public/views/chat.js and reads
+// the payload it puts on the socket. The module is UMD and Node-requireable; it
+// reaches its collaborators through the global lexical environment, which is
+// what the stubs below provide.
+
+const { test, describe, beforeEach, afterEach, after } = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const { JSDOM } = require('jsdom');
+const { restoredActiveAgentId } = require(path.join(ROOT, 'public', 'delegation-restore.js'));
+
+const sent = [];
+const convoState = {};
+
+// A DOM, because chat.js defines its own startProcessing and that one paints.
+// Only the elements the send path reaches are needed; the rest resolve to null
+// and the code already guards for that.
+const dom = new JSDOM('<!doctype html><html><body>'
+  + '<div id="messages"></div><div id="chat-messages"></div><div id="chat-convo-status"></div>'
+  + '<input id="msg-input"><button id="send-btn"></button>'
+  + '</body></html>');
+global.document = dom.window.document;
+global.window = dom.window;
+
+// The collaborators chat.js reaches by name. Installed before it is required,
+// because the module captures nothing at load time and resolves each at call
+// time, which is what makes this drivable at all.
+global.WebSocket = { OPEN: 1 };
+global.workingConvos = new Set();
+global.conversations = [];
+global.activeConversation = null;
+global.userScrolledUp = false;
+global.unread = {};
+global.agentLastActivity = {};
+global.RundockConversationState = { watchdogVerdict: () => ({ action: 'stop' }) };
+global.RundockChatMarkup = require(path.join(ROOT, 'public', 'chat-markup.js'));
+global.esc = (t) => String(t);
+global.formatMd = (t) => String(t);
+global.formatTimeAgo = () => '';
+global.stripRundockMarkers = (t) => String(t);
+global.updateUnreadBadge = () => {};
+global.updateWorkingBadge = () => {};
+global.tryMessageAnchor = () => {};
+global.scrollBottom = () => {};
+global.ws = { readyState: 1, send: (m) => sent.push(JSON.parse(m)) };
+global.getConvoState = (id) => (convoState[id] = convoState[id] || {});
+global.addUserMsg = () => {};
+global.startProcessing = () => {};
+global.renderConvoList = () => {};
+global.persistConversation = () => {};
+
+const { dispatchMessage } = require(path.join(ROOT, 'public', 'views', 'chat.js'));
+
+function restoredConversation(extra) {
+  return {
+    id: 'c1',
+    agentId: 'chief-of-staff',
+    activeAgentId: 'lead-developer',
+    sessionId: 's-orchestrator',
+    sessionIds: [
+      { agentId: 'chief-of-staff', sessionId: 's-orchestrator' },
+      { agentId: 'lead-developer', sessionId: 's-specialist' },
+    ],
+    messages: [],
+    ...extra,
+  };
+}
+
+/** What opening a conversation with no live process does to the runtime state. */
+function openWithNoLiveProcess(convo) {
+  const state = global.getConvoState(convo.id);
+  state.activeProcessId = null;
+  state.activeAgentId = restoredActiveAgentId(convo);
+  return state;
+}
+
+describe('a restored conversation sends to the agent that owns it', () => {
+  beforeEach(() => { sent.length = 0; for (const k of Object.keys(convoState)) delete convoState[k]; });
+  // The real startProcessing installs a watchdog interval. Left running it
+  // holds the event loop open long after the assertion is done, and the suite
+  // never exits.
+  afterEach(() => {
+    for (const st of Object.values(convoState)) {
+      if (st && st.processingTimeout) { clearInterval(st.processingTimeout); st.processingTimeout = null; }
+    }
+  });
+  after(() => { dom.window.close(); });
+
+  test('in flight when the app quit: the message goes to the specialist', () => {
+    // The reported bug, at the point it bites. Before this, the server kept the
+    // pointer on disk and the client still addressed the orchestrator, so the
+    // orchestrator re-asked for work already delivered.
+    const convo = restoredConversation();
+    openWithNoLiveProcess(convo);
+    dispatchMessage(convo, 'carry on');
+    assert.strictEqual(sent.length, 1, 'one chat message went to the socket');
+    assert.strictEqual(sent[0].agent, 'lead-developer',
+      `the message is addressed to the specialist (got ${sent[0].agent})`);
+  });
+
+  test('and it resumes the specialist session, not the orchestrator one', () => {
+    // Addressing the right agent with the wrong session resumes the wrong
+    // context, which looks the same to the user as the bug being fixed.
+    const convo = restoredConversation();
+    openWithNoLiveProcess(convo);
+    dispatchMessage(convo, 'carry on');
+    assert.strictEqual(sent[0].sessionId, 's-specialist',
+      `the specialist's own session is resumed (got ${sent[0].sessionId})`);
+  });
+
+  test('after an observed handback: the message goes to the orchestrator', () => {
+    const convo = restoredConversation({ delegationReturned: true });
+    openWithNoLiveProcess(convo);
+    dispatchMessage(convo, 'what did they say');
+    assert.strictEqual(sent[0].agent, 'chief-of-staff',
+      'a finished delegation hands the conversation back to its owner');
+    assert.strictEqual(sent[0].sessionId, 's-orchestrator');
+  });
+
+  test('a conversation that was never delegated sends to its own agent', () => {
+    const convo = restoredConversation({ activeAgentId: null });
+    openWithNoLiveProcess(convo);
+    dispatchMessage(convo, 'hello');
+    assert.strictEqual(sent[0].agent, 'chief-of-staff');
+  });
+});
+
+describe('the view seeds that state from the shared rule', () => {
+  // Bound rather than driven: renderSessionHistory needs a document, and what
+  // has to hold is narrower than a DOM. If the seeding is removed or replaced
+  // with a local copy of the rule, the dispatch tests above keep passing,
+  // because they seed the state themselves. This is the line that says the
+  // product does what those tests assume.
+  const fs = require('node:fs');
+  const src = fs.readFileSync(path.join(ROOT, 'public', 'views', 'chat.js'), 'utf8');
+
+  test('renderSessionHistory sets the active agent from restoredActiveAgentId', () => {
+    const at = src.indexOf('function renderSessionHistory');
+    assert.ok(at > -1, 'the view still has the function that opens a conversation');
+    // Bounded by the function, not by a byte count: this one is long, and a
+    // fixed window silently stops covering it the moment it grows.
+    const next = src.indexOf('\nfunction ', at + 1);
+    const body = src.slice(at, next > -1 ? next : src.length);
+    assert.match(body, /state\.activeAgentId = restoredActiveAgentId\(convo\)/,
+      'the runtime state a send reads is seeded from the one shared rule, not from a second copy');
+  });
+});

--- a/test/unit/delegation-engine-lib.test.js
+++ b/test/unit/delegation-engine-lib.test.js
@@ -53,14 +53,14 @@ function stubDeps() {
 
 describe('engine module shape', () => {
   test('exports exactly the factory and its frozen deps list', () => {
-    // markDelegationReturned is exported deliberately, and the reason is worth
+    // setDelegationReturned is exported deliberately, and the reason is worth
     // the widened surface. It is the ONLY writer of the signal the conversation
     // loader reads to decide a delegation has finished, and a signal nothing
     // writes is a dead condition that silently disables the reset it guards.
     // Exported so that writer can be driven directly and proven to persist,
     // rather than asserted about from the outside.
     assert.deepStrictEqual(Object.keys(engineLib).sort(),
-      ['DEP_NAMES', 'createDelegationEngine', 'markDelegationReturned']);
+      ['DEP_NAMES', 'createDelegationEngine', 'setDelegationReturned']);
     assert.deepStrictEqual([...engineLib.DEP_NAMES].sort(), [...EXPECTED_DEPS].sort(),
       'the deps surface is frozen; growing it is a deliberate seam change');
     assert.deepStrictEqual(engineLib.DEP_NAMES, EXPECTED_DEPS,

--- a/test/unit/delegation-engine-lib.test.js
+++ b/test/unit/delegation-engine-lib.test.js
@@ -55,11 +55,10 @@ describe('engine module shape', () => {
   test('exports exactly the factory and its frozen deps list', () => {
     // markDelegationReturned is exported deliberately, and the reason is worth
     // the widened surface. It is the ONLY writer of the signal the conversation
-    // loader reads to decide a delegation finished. A signal nothing writes is a
-    // dead condition that silently disables the reset it guards, which is what
-    // the first draft of that fix shipped: every test green, over a flag no code
-    // ever set. Exported so that writer can be driven directly and proven to
-    // persist, rather than asserted about from the outside.
+    // loader reads to decide a delegation has finished, and a signal nothing
+    // writes is a dead condition that silently disables the reset it guards.
+    // Exported so that writer can be driven directly and proven to persist,
+    // rather than asserted about from the outside.
     assert.deepStrictEqual(Object.keys(engineLib).sort(),
       ['DEP_NAMES', 'createDelegationEngine', 'markDelegationReturned']);
     assert.deepStrictEqual([...engineLib.DEP_NAMES].sort(), [...EXPECTED_DEPS].sort(),

--- a/test/unit/delegation-engine-lib.test.js
+++ b/test/unit/delegation-engine-lib.test.js
@@ -53,14 +53,14 @@ function stubDeps() {
 
 describe('engine module shape', () => {
   test('exports exactly the factory and its frozen deps list', () => {
-    // setDelegationReturned is exported deliberately, and the reason is worth
+    // recordControlReturnedTo is exported deliberately, and the reason is worth
     // the widened surface. It is the ONLY writer of the signal the conversation
     // loader reads to decide a delegation has finished, and a signal nothing
     // writes is a dead condition that silently disables the reset it guards.
     // Exported so that writer can be driven directly and proven to persist,
     // rather than asserted about from the outside.
     assert.deepStrictEqual(Object.keys(engineLib).sort(),
-      ['DEP_NAMES', 'createDelegationEngine', 'setDelegationReturned']);
+      ['DEP_NAMES', 'createDelegationEngine', 'recordControlReturnedTo']);
     assert.deepStrictEqual([...engineLib.DEP_NAMES].sort(), [...EXPECTED_DEPS].sort(),
       'the deps surface is frozen; growing it is a deliberate seam change');
     assert.deepStrictEqual(engineLib.DEP_NAMES, EXPECTED_DEPS,

--- a/test/unit/delegation-engine-lib.test.js
+++ b/test/unit/delegation-engine-lib.test.js
@@ -53,7 +53,15 @@ function stubDeps() {
 
 describe('engine module shape', () => {
   test('exports exactly the factory and its frozen deps list', () => {
-    assert.deepStrictEqual(Object.keys(engineLib).sort(), ['DEP_NAMES', 'createDelegationEngine']);
+    // markDelegationReturned is exported deliberately, and the reason is worth
+    // the widened surface. It is the ONLY writer of the signal the conversation
+    // loader reads to decide a delegation finished. A signal nothing writes is a
+    // dead condition that silently disables the reset it guards, which is what
+    // the first draft of that fix shipped: every test green, over a flag no code
+    // ever set. Exported so that writer can be driven directly and proven to
+    // persist, rather than asserted about from the outside.
+    assert.deepStrictEqual(Object.keys(engineLib).sort(),
+      ['DEP_NAMES', 'createDelegationEngine', 'markDelegationReturned']);
     assert.deepStrictEqual([...engineLib.DEP_NAMES].sort(), [...EXPECTED_DEPS].sort(),
       'the deps surface is frozen; growing it is a deliberate seam change');
     assert.deepStrictEqual(engineLib.DEP_NAMES, EXPECTED_DEPS,

--- a/test/unit/delegation-relaunch.test.js
+++ b/test/unit/delegation-relaunch.test.js
@@ -269,13 +269,10 @@ describe('every path that returns control to a parent records the handback', () 
   // tested through all of it: wherever control goes back to a parent, the
   // handback is recorded.
   //
-  // The first version of this fix marked in ONE place, handleScopeReturn, which
-  // fires only for a second-level event. Ordinary single-level delegations
-  // return through finishDelegateClose and never touched it, so the flag stayed
-  // false for the common case and a finished delegation was never reconciled.
-  // Nothing failed: the unit test passed, because the unit worked.
-  //
-  // The invariant below is what that test could not see. `agent_switch` carrying
+  // A unit test of the writer cannot see whether the engine calls it. This
+  // invariant covers that gap in the cheap direction; the behavioural proof
+  // that a real handback writes the record lives in
+  // test/integration/delegation-handback-record.test.js. `agent_switch` carrying
   // a `toAgent` is the engine saying control moved back to a parent, and every
   // one of those must be accompanied by the record.
   const src = fs.readFileSync(path.join(ROOT, 'lib', 'delegation', 'engine.js'), 'utf8');

--- a/test/unit/delegation-relaunch.test.js
+++ b/test/unit/delegation-relaunch.test.js
@@ -115,7 +115,7 @@ describe('a delegation in flight survives the app quitting', () => {
 });
 
 describe('the handback signal is written where the handback is seen', () => {
-  const { markDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+  const { setDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
 
   test('an observed handback is recorded on disk, so it outlives the process that saw it', () => {
     // AND THIS IS THE HALF THAT MAKES THE RESET REAL. The loader now resets only
@@ -125,7 +125,7 @@ describe('the handback signal is written where the handback is seen', () => {
     const original = config.getWorkspace();
     config.setWorkspace(dir);
     try {
-      markDelegationReturned('c1');
+      setDelegationReturned('c1', true);
       const stored = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8'));
       assert.strictEqual(stored[0].delegationReturned, true,
         'the handback is on disk, readable by a server that did not observe it');
@@ -140,9 +140,9 @@ describe('the handback signal is written where the handback is seen', () => {
     const original = config.getWorkspace();
     config.setWorkspace(dir);
     try {
-      markDelegationReturned('c1');
+      setDelegationReturned('c1', true);
       const after = fs.readFileSync(file, 'utf8');
-      markDelegationReturned('c1');
+      setDelegationReturned('c1', true);
       assert.strictEqual(fs.readFileSync(file, 'utf8'), after, 'the second mark wrote nothing');
     } finally {
       config.setWorkspace(original);
@@ -154,7 +154,7 @@ describe('the handback signal is written where the handback is seen', () => {
     const original = config.getWorkspace();
     config.setWorkspace(dir);
     try {
-      assert.doesNotThrow(() => markDelegationReturned('no-such-conversation'));
+      assert.doesNotThrow(() => setDelegationReturned('no-such-conversation', true));
     } finally {
       config.setWorkspace(original);
     }
@@ -162,7 +162,7 @@ describe('the handback signal is written where the handback is seen', () => {
 });
 
 describe('a handback that cannot be recorded does not take the handback down with it', () => {
-  const { markDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+  const { setDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
 
   test('an unwritable store is warned about, not thrown out of', () => {
     // The caller is mid-handback: the specialist has returned and the
@@ -179,7 +179,7 @@ describe('a handback that cannot be recorded does not take the handback down wit
     config.setWorkspace(dir);
     try {
       fs.chmodSync(file, 0o444);
-      assert.doesNotThrow(() => markDelegationReturned('c1'),
+      assert.doesNotThrow(() => setDelegationReturned('c1', true),
         'the handback survives a store it cannot write');
       assert.ok(warnings.some((w) => /could not record the handback/.test(w)),
         `and says so rather than failing silently (got ${JSON.stringify(warnings)})`);
@@ -301,12 +301,73 @@ describe('every path that returns control to a parent records the handback', () 
       // Within the enclosing region rather than a fixed few lines: one of these
       // marks at the top of its function and announces sixty lines later.
       const before = lines.slice(Math.max(0, at - 70), at).join('\n');
-      assert.match(before, /markDelegationReturned\(convoId\)/,
+      assert.match(before, /setDelegationReturned\(convoId, true\)/,
         `the handback announced at line ${at + 1} is recorded nowhere:\n`
         + `${lines[at].trim()}\n`
         + 'Every path returning control to a parent must record it, or a finished '
         + 'delegation is never reconciled and the conversation stays pointed at a '
         + 'specialist that has already handed back.');
+    }
+  });
+});
+
+describe('the record describes the delegation running now, not the conversation history', () => {
+  const { setDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+
+  test('a second delegation after a handback is not reconciled away', () => {
+    // THE FLAG IS ABOUT THIS DELEGATION, NOT ABOUT EVER. Written true on a
+    // handback and never cleared, it answers "has this conversation ever had
+    // one", which is true forever after the first. Every later delegation would
+    // then be reset on a relaunch: the reported bug, back again, for every
+    // delegation after the first in a conversation's life.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      // First delegation hands back.
+      setDelegationReturned('c1', true);
+      // A second delegation starts. The engine clears the record as it spawns.
+      setDelegationReturned('c1', false);
+    } finally {
+      config.setWorkspace(original);
+    }
+    // The app quits mid-second-delegation, and the conversation is loaded again.
+    const { stored } = load(dir);
+    assert.strictEqual(stored[0].activeAgentId, 'lead-developer',
+      'the second delegation keeps its specialist, because it never handed back');
+  });
+
+  test('clearing a record that is already clear writes nothing', () => {
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const file = path.join(dir, '.rundock', 'conversations.json');
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      const before = fs.readFileSync(file, 'utf8');
+      setDelegationReturned('c1', false);
+      assert.strictEqual(fs.readFileSync(file, 'utf8'), before, 'no write for no change');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+
+  test('every delegation start clears the record, so the engine cannot forget', () => {
+    // The clear belongs beside the spawn, the same way the mark belongs beside
+    // the handback. Bound here because driving a real spawn needs a live child
+    // process, and what must hold is narrower than that.
+    const src = fs.readFileSync(path.join(ROOT, 'lib', 'delegation', 'engine.js'), 'utf8');
+    const lines = src.split('\n');
+    const starts = [];
+    lines.forEach((line, i) => {
+      if (line.includes("subtype: 'agent_switch'")
+        && lines.slice(i, i + 4).join('\n').includes('toAgent: targetAgent.id')) starts.push(i);
+    });
+    assert.ok(starts.length >= 1, 'the engine still announces a delegation starting');
+    for (const at of starts) {
+      const before = lines.slice(Math.max(0, at - 25), at).join('\n');
+      assert.match(before, /setDelegationReturned\(convoId, false\)/,
+        `the delegation starting at line ${at + 1} does not clear the handback record, so a `
+        + 'previous handback would be read as this one\'s');
     }
   });
 });

--- a/test/unit/delegation-relaunch.test.js
+++ b/test/unit/delegation-relaunch.test.js
@@ -190,3 +190,123 @@ describe('a handback that cannot be recorded does not take the handback down wit
     }
   });
 });
+
+describe('the rule both sides apply, and the routing that depends on it', () => {
+  const { restoredActiveAgentId } = require(path.join(ROOT, 'public', 'delegation-restore.js'));
+  const { handleSaveConversation } = require(path.join(ROOT, 'lib', 'protocol', 'handlers', 'conversations.js'));
+
+  test('a restored delegation routes the next message to the specialist', () => {
+    // THE REPORTED BUG, AT THE POINT IT ACTUALLY BITES. dispatchMessage resolves
+    // its target as `state.activeAgentId || convo.agentId`, and the runtime
+    // state is seeded from this rule. An earlier version narrowed the reset and
+    // seeded nothing, so the server preserved the specialist on disk while the
+    // client still sent the next message to the orchestrator: the symptom
+    // survived a fix that looked right.
+    assert.strictEqual(
+      restoredActiveAgentId({ agentId: 'chief-of-staff', activeAgentId: 'lead-developer' }),
+      'lead-developer',
+      'no observed handback: the next message goes to the specialist');
+  });
+
+  test('a delegation that handed back routes to the orchestrator', () => {
+    assert.strictEqual(
+      restoredActiveAgentId({ agentId: 'chief-of-staff', activeAgentId: 'lead-developer', delegationReturned: true }),
+      'chief-of-staff',
+      'an observed handback returns the conversation to its owner');
+  });
+
+  test('an undelegated conversation routes to its own agent', () => {
+    assert.strictEqual(restoredActiveAgentId({ agentId: 'chief-of-staff' }), 'chief-of-staff');
+    assert.strictEqual(restoredActiveAgentId({ agentId: 'chief-of-staff', activeAgentId: null }), 'chief-of-staff');
+  });
+
+  test('an ordinary save does not wipe the handback record', () => {
+    // save_conversation rebuilds the record from a whitelist and replaces the
+    // whole entry, and the client sends it after essentially every turn. Left
+    // out of that whitelist, a rename or a finished turn would erase the one
+    // signal saying a delegation ended, and the conversation would stay pointed
+    // at a specialist that had already handed back.
+    const dir = workspaceWith({ ...IN_FLIGHT, delegationReturned: true });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      handleSaveConversation({}, captureWs(), {
+        type: 'save_conversation',
+        conversation: { id: 'c1', agentId: 'chief-of-staff', activeAgentId: 'lead-developer', title: 'Renamed' },
+      });
+      const stored = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8'));
+      assert.strictEqual(stored[0].delegationReturned, true, 'the handback record survived an ordinary save');
+      assert.strictEqual(stored[0].title, 'Renamed', 'and the save still did its job');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+
+  test('a client cannot assert a handback that never happened', () => {
+    // The flag is server-owned. Only the engine observes a handback, so a
+    // message claiming one is ignored rather than believed.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      handleSaveConversation({}, captureWs(), {
+        type: 'save_conversation',
+        conversation: { id: 'c1', agentId: 'chief-of-staff', activeAgentId: 'lead-developer', title: 'T', delegationReturned: true },
+      });
+      const stored = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8'));
+      assert.strictEqual(stored[0].delegationReturned, false,
+        'a handback the engine never saw is not created by a client saying so');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+});
+
+describe('every path that returns control to a parent records the handback', () => {
+  // A SOURCE BINDING, AND DELIBERATELY SO. Driving the engine to a real handback
+  // needs a live child process, a session, and an intercepted Agent tool call;
+  // what has to be guaranteed is narrower than that and does not survive being
+  // tested through all of it: wherever control goes back to a parent, the
+  // handback is recorded.
+  //
+  // The first version of this fix marked in ONE place, handleScopeReturn, which
+  // fires only for a second-level event. Ordinary single-level delegations
+  // return through finishDelegateClose and never touched it, so the flag stayed
+  // false for the common case and a finished delegation was never reconciled.
+  // Nothing failed: the unit test passed, because the unit worked.
+  //
+  // The invariant below is what that test could not see. `agent_switch` carrying
+  // a `toAgent` is the engine saying control moved back to a parent, and every
+  // one of those must be accompanied by the record.
+  const src = fs.readFileSync(path.join(ROOT, 'lib', 'delegation', 'engine.js'), 'utf8');
+
+  test('each restoration path marks the handback before announcing the switch', () => {
+    // A switch back to a PARENT, not every switch. The engine announces the
+    // same way when a delegation STARTS (toAgent: targetAgent.id), and marking
+    // there would record a handback that has not happened. The parent-bound
+    // ones name the parent they are returning to.
+    const PARENT_BOUND = /toAgent: (orchestrator\.id|orchestratorAgentId|parentAgentId|delegateEntry\.delegation\.originalAgentId)/;
+    const lines = src.split('\n');
+    const handbacks = [];
+    lines.forEach((line, i) => {
+      if (!line.includes("subtype: 'agent_switch'")) return;
+      // The toAgent sits on this line or the next few, depending on how the
+      // object literal was wrapped.
+      if (PARENT_BOUND.test(lines.slice(i, i + 4).join('\n'))) handbacks.push(i);
+    });
+    assert.ok(handbacks.length >= 3,
+      `the engine still has its parent-bound switches (found ${handbacks.length})`);
+
+    for (const at of handbacks) {
+      // Within the enclosing region rather than a fixed few lines: one of these
+      // marks at the top of its function and announces sixty lines later.
+      const before = lines.slice(Math.max(0, at - 70), at).join('\n');
+      assert.match(before, /markDelegationReturned\(convoId\)/,
+        `the handback announced at line ${at + 1} is recorded nowhere:\n`
+        + `${lines[at].trim()}\n`
+        + 'Every path returning control to a parent must record it, or a finished '
+        + 'delegation is never reconciled and the conversation stays pointed at a '
+        + 'specialist that has already handed back.');
+    }
+  });
+});

--- a/test/unit/delegation-relaunch.test.js
+++ b/test/unit/delegation-relaunch.test.js
@@ -1,0 +1,192 @@
+'use strict';
+// A delegation in flight survives the app quitting.
+//
+// REPORTED BY A DAILY USER. Leave Rundock while an agent is working, relaunch,
+// open the active thread, and it has gone back to the orchestrator, which then
+// asks the specialist for work it already delivered.
+//
+// THE UNSOUND INFERENCE. On every conversation load, a delegated conversation's
+// activeAgentId is reset to the orchestrator whenever no live process is found,
+// and the reset is written to disk. That is correct after a page RELOAD, where
+// the delegate process is parked and reported idle. It is wrong after a
+// RELAUNCH: the process map lives in memory and dies with the server, so
+// absence carries no information at all, and every in-flight delegation is
+// recorded as finished.
+//
+// The distinction the code cannot currently draw is between "no process because
+// the delegate handed back" and "no process because the app quit". Only the
+// first is a finished delegation, and only an OBSERVED handback says so.
+//
+// These drive the handler rather than reading its source. An earlier test in
+// regression.test.js pins the source text of the reset instead, which is why it
+// could not notice that the rule it pins is wrong after a restart.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const config = require(path.join(ROOT, 'lib', 'config.js'));
+const { handleGetConversations } = require(path.join(ROOT, 'lib', 'protocol', 'handlers', 'conversations.js'));
+
+function captureWs() {
+  const sent = [];
+  return { sent, send: (m) => sent.push(JSON.parse(m)), readyState: 1 };
+}
+
+/** A workspace holding one conversation, written the way the product writes it. */
+function workspaceWith(convo) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relaunch-'));
+  fs.mkdirSync(path.join(dir, '.rundock'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.rundock', 'conversations.json'),
+    JSON.stringify([convo], null, 2));
+  return dir;
+}
+
+function load(dir, processes = new Map()) {
+  const original = config.getWorkspace();
+  config.setWorkspace(dir);
+  try {
+    const ws = captureWs();
+    handleGetConversations({ processes }, ws, { type: 'get_conversations' });
+    const stored = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8'));
+    return { sent: ws.sent, stored };
+  } finally {
+    config.setWorkspace(original);
+  }
+}
+
+const IN_FLIGHT = {
+  id: 'c1',
+  agentId: 'chief-of-staff',
+  activeAgentId: 'lead-developer',
+  sessionId: 's1',
+  createdAt: new Date().toISOString(),
+  lastActiveAt: new Date().toISOString(),
+};
+
+describe('a delegation in flight survives the app quitting', () => {
+  test('after a restart, a delegated conversation still points at the specialist', () => {
+    // No live process, because the process map died with the server. That is
+    // the whole shape of the bug: absence of a process after a relaunch says
+    // nothing about whether the delegate finished.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const { stored } = load(dir);
+    assert.strictEqual(stored[0].activeAgentId, 'lead-developer',
+      'the pointer to the specialist survives a restart, because no handback was ever observed');
+  });
+
+  test('and that load writes no change to the stored conversation', () => {
+    // The reset is not merely displayed, it is PERSISTED, which is what makes
+    // the damage outlive the load that caused it.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const before = fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8');
+    load(dir);
+    const after = fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8');
+    assert.strictEqual(after, before, 'a load that changes nothing must write nothing');
+  });
+
+  test('a delegation whose handback was observed does reset to the orchestrator', () => {
+    // The other direction, and the reason this cannot simply delete the reset.
+    // A delegate that handed back really is finished, and the conversation
+    // really should return to the orchestrator.
+    const dir = workspaceWith({ ...IN_FLIGHT, delegationReturned: true });
+    const { stored } = load(dir);
+    assert.strictEqual(stored[0].activeAgentId, 'chief-of-staff',
+      'an observed handback still returns the conversation to the orchestrator');
+  });
+
+  test('a live process still holds its pointer, which is the reload case', () => {
+    // Unchanged behaviour, kept honest: with the delegate parked and reported
+    // idle, the pointer was already left alone and must stay that way.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const { stored } = load(dir, new Map([['c1', { pid: 1 }]]));
+    assert.strictEqual(stored[0].activeAgentId, 'lead-developer',
+      'a live process keeps its delegate pointer');
+  });
+
+  test('a conversation that was never delegated is untouched', () => {
+    const dir = workspaceWith({ ...IN_FLIGHT, activeAgentId: 'chief-of-staff' });
+    const { stored } = load(dir);
+    assert.strictEqual(stored[0].activeAgentId, 'chief-of-staff');
+  });
+});
+
+describe('the handback signal is written where the handback is seen', () => {
+  const { markDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+
+  test('an observed handback is recorded on disk, so it outlives the process that saw it', () => {
+    // AND THIS IS THE HALF THAT MAKES THE RESET REAL. The loader now resets only
+    // on this flag, so a flag nothing writes would disable the reset entirely
+    // and leave every finished delegation pointing at its specialist forever.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      markDelegationReturned('c1');
+      const stored = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8'));
+      assert.strictEqual(stored[0].delegationReturned, true,
+        'the handback is on disk, readable by a server that did not observe it');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+
+  test('marking twice writes once, so an idle load rewrites nothing', () => {
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const file = path.join(dir, '.rundock', 'conversations.json');
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      markDelegationReturned('c1');
+      const after = fs.readFileSync(file, 'utf8');
+      markDelegationReturned('c1');
+      assert.strictEqual(fs.readFileSync(file, 'utf8'), after, 'the second mark wrote nothing');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+
+  test('a conversation that is not there is not an error the handback dies on', () => {
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      assert.doesNotThrow(() => markDelegationReturned('no-such-conversation'));
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+});
+
+describe('a handback that cannot be recorded does not take the handback down with it', () => {
+  const { markDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+
+  test('an unwritable store is warned about, not thrown out of', () => {
+    // The caller is mid-handback: the specialist has returned and the
+    // orchestrator is being resumed. Failing to record that is worth saying out
+    // loud, and worth nothing else. Throwing here would abandon the return
+    // itself, which is a worse outcome than the stale-pointer bug this flag
+    // exists to fix.
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const file = path.join(dir, '.rundock', 'conversations.json');
+    const original = config.getWorkspace();
+    const warnings = [];
+    const realWarn = console.warn;
+    console.warn = (m) => warnings.push(String(m));
+    config.setWorkspace(dir);
+    try {
+      fs.chmodSync(file, 0o444);
+      assert.doesNotThrow(() => markDelegationReturned('c1'),
+        'the handback survives a store it cannot write');
+      assert.ok(warnings.some((w) => /could not record the handback/.test(w)),
+        `and says so rather than failing silently (got ${JSON.stringify(warnings)})`);
+    } finally {
+      console.warn = realWarn;
+      config.setWorkspace(original);
+      try { fs.chmodSync(file, 0o644); } catch { /* going anyway */ }
+    }
+  });
+});

--- a/test/unit/delegation-relaunch.test.js
+++ b/test/unit/delegation-relaunch.test.js
@@ -115,7 +115,7 @@ describe('a delegation in flight survives the app quitting', () => {
 });
 
 describe('the handback signal is written where the handback is seen', () => {
-  const { setDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+  const { recordControlReturnedTo } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
 
   test('an observed handback is recorded on disk, so it outlives the process that saw it', () => {
     // AND THIS IS THE HALF THAT MAKES THE RESET REAL. The loader now resets only
@@ -125,7 +125,7 @@ describe('the handback signal is written where the handback is seen', () => {
     const original = config.getWorkspace();
     config.setWorkspace(dir);
     try {
-      setDelegationReturned('c1', true);
+      recordControlReturnedTo('c1', 'chief-of-staff');
       const stored = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'conversations.json'), 'utf8'));
       assert.strictEqual(stored[0].delegationReturned, true,
         'the handback is on disk, readable by a server that did not observe it');
@@ -140,9 +140,9 @@ describe('the handback signal is written where the handback is seen', () => {
     const original = config.getWorkspace();
     config.setWorkspace(dir);
     try {
-      setDelegationReturned('c1', true);
+      recordControlReturnedTo('c1', 'chief-of-staff');
       const after = fs.readFileSync(file, 'utf8');
-      setDelegationReturned('c1', true);
+      recordControlReturnedTo('c1', 'chief-of-staff');
       assert.strictEqual(fs.readFileSync(file, 'utf8'), after, 'the second mark wrote nothing');
     } finally {
       config.setWorkspace(original);
@@ -154,7 +154,7 @@ describe('the handback signal is written where the handback is seen', () => {
     const original = config.getWorkspace();
     config.setWorkspace(dir);
     try {
-      assert.doesNotThrow(() => setDelegationReturned('no-such-conversation', true));
+      assert.doesNotThrow(() => recordControlReturnedTo('no-such-conversation', 'chief-of-staff'));
     } finally {
       config.setWorkspace(original);
     }
@@ -162,7 +162,7 @@ describe('the handback signal is written where the handback is seen', () => {
 });
 
 describe('a handback that cannot be recorded does not take the handback down with it', () => {
-  const { setDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+  const { recordControlReturnedTo } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
 
   test('an unwritable store is warned about, not thrown out of', () => {
     // The caller is mid-handback: the specialist has returned and the
@@ -179,7 +179,7 @@ describe('a handback that cannot be recorded does not take the handback down wit
     config.setWorkspace(dir);
     try {
       fs.chmodSync(file, 0o444);
-      assert.doesNotThrow(() => setDelegationReturned('c1', true),
+      assert.doesNotThrow(() => recordControlReturnedTo('c1', 'chief-of-staff'),
         'the handback survives a store it cannot write');
       assert.ok(warnings.some((w) => /could not record the handback/.test(w)),
         `and says so rather than failing silently (got ${JSON.stringify(warnings)})`);
@@ -301,8 +301,8 @@ describe('every path that returns control to a parent records the handback', () 
       // Within the enclosing region rather than a fixed few lines: one of these
       // marks at the top of its function and announces sixty lines later.
       const before = lines.slice(Math.max(0, at - 70), at).join('\n');
-      assert.match(before, /setDelegationReturned\(convoId, true\)/,
-        `the handback announced at line ${at + 1} is recorded nowhere:\n`
+      assert.match(before, /recordControlReturnedTo\(convoId/,
+        `the handback announced at line ${at + 1} records nothing about where control went:\n`
         + `${lines[at].trim()}\n`
         + 'Every path returning control to a parent must record it, or a finished '
         + 'delegation is never reconciled and the conversation stays pointed at a '
@@ -312,7 +312,7 @@ describe('every path that returns control to a parent records the handback', () 
 });
 
 describe('the record describes the delegation running now, not the conversation history', () => {
-  const { setDelegationReturned } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+  const { recordControlReturnedTo } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
 
   test('a second delegation after a handback is not reconciled away', () => {
     // THE FLAG IS ABOUT THIS DELEGATION, NOT ABOUT EVER. Written true on a
@@ -325,9 +325,9 @@ describe('the record describes the delegation running now, not the conversation 
     config.setWorkspace(dir);
     try {
       // First delegation hands back.
-      setDelegationReturned('c1', true);
+      recordControlReturnedTo('c1', 'chief-of-staff');
       // A second delegation starts. The engine clears the record as it spawns.
-      setDelegationReturned('c1', false);
+      recordControlReturnedTo('c1', 'lead-developer');
     } finally {
       config.setWorkspace(original);
     }
@@ -344,7 +344,7 @@ describe('the record describes the delegation running now, not the conversation 
     config.setWorkspace(dir);
     try {
       const before = fs.readFileSync(file, 'utf8');
-      setDelegationReturned('c1', false);
+      recordControlReturnedTo('c1', 'lead-developer');
       assert.strictEqual(fs.readFileSync(file, 'utf8'), before, 'no write for no change');
     } finally {
       config.setWorkspace(original);
@@ -371,3 +371,53 @@ describe('the record describes the delegation running now, not the conversation 
     }
   });
 });
+
+describe('nested delegation: coming back to a parent is not coming home', () => {
+  const { recordControlReturnedTo } = require(path.join(ROOT, 'lib', 'delegation', 'engine.js'));
+  const { restoredActiveAgentId } = require(path.join(ROOT, 'public', 'delegation-restore.js'));
+
+  test('returning to a mid-level parent leaves the conversation delegated', () => {
+    // Orchestrator delegates to a specialist that has its own reports, and that
+    // specialist delegates again. When the sub-delegate returns, control goes
+    // back to the MID-LEVEL parent and the orchestrator's own delegation is
+    // still in flight. A bare "returned" boolean could not say that, and set
+    // there it told the loader the conversation had come home when it had not.
+    const dir = workspaceWith({ ...IN_FLIGHT, activeAgentId: 'content-lead' });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      recordControlReturnedTo('c1', 'content-lead');  // a delegate, not the base agent
+    } finally {
+      config.setWorkspace(original);
+    }
+    const { stored } = load(dir);
+    // Absent, not written false: unreturned is the default and a writer that
+    // rewrote the file to say so would churn the store on every nested return.
+    assert.notStrictEqual(stored[0].delegationReturned, true,
+      'control reached a delegate, so the conversation is still delegated');
+    assert.strictEqual(stored[0].activeAgentId, 'content-lead',
+      'and the pointer stays on the parent that now holds it');
+  });
+
+  test('returning to the base agent does bring the conversation home', () => {
+    const dir = workspaceWith({ ...IN_FLIGHT });
+    const original = config.getWorkspace();
+    config.setWorkspace(dir);
+    try {
+      recordControlReturnedTo('c1', 'chief-of-staff');  // the conversation's own agent
+    } finally {
+      config.setWorkspace(original);
+    }
+    const { stored } = load(dir);
+    assert.strictEqual(stored[0].delegationReturned, true);
+    assert.strictEqual(stored[0].activeAgentId, 'chief-of-staff',
+      'control reached the base agent, so the conversation is reconciled');
+  });
+
+  test('the rule reads that record the same way', () => {
+    assert.strictEqual(
+      restoredActiveAgentId({ agentId: 'chief-of-staff', activeAgentId: 'content-lead', delegationReturned: false }),
+      'content-lead', 'still delegated: the next message goes to whoever holds it');
+  });
+});
+

--- a/test/unit/regression.test.js
+++ b/test/unit/regression.test.js
@@ -291,8 +291,16 @@ describe('P2/P3 regressions', () => {
       'get_conversations must persist at most once per load');
     assert.match(block, /if \(convosChanged\) writeConversations\(cleaned\)/,
       'the single write must be conditional on a change');
-    assert.match(block, /!ctx\.processes\.has\(c\.id\)/,
-      'reconciliation must skip conversations with a live process');
+    // The property, not one spelling of it. This pinned `!ctx.processes.has(...)`
+    // as an inline condition, which broke when the loop was rewritten to skip
+    // early and delegate the decision to the shared restore rule, even though
+    // the guarantee never changed. Behaviour for both directions is covered by
+    // test/unit/delegation-relaunch.test.js; what stays pinned here is that the
+    // live-process check is still present at all.
+    assert.match(block, /ctx\.processes\.has\(c\.id\)/,
+      'reconciliation must still consult the live process map');
+    assert.match(block, /restoredActiveAgentId\(c\)/,
+      'and must decide through the one shared restore rule, not a second copy of it');
   });
 
   test('the exited guard is per-line so post-kill chunk lines are dropped', () => {


### PR DESCRIPTION
Reported by a daily user: leave Rundock while an agent is working, relaunch, open the active thread, and it has gone back to the orchestrator. The orchestrator then asks the specialist for work it already delivered.

**Absence of a process is not evidence of a handback.** On every conversation load, a delegated conversation's `activeAgentId` was reset to the orchestrator whenever no live process was found, and the reset was written to disk. That is sound after a page reload, where the delegate is parked and reported idle. It is unsound after a RELAUNCH: the process map lives in memory and dies with the server, so absence carries no information at all, and every in-flight delegation was recorded as finished.

A handback is an event, and the only party that observes one is the engine resuming the orchestrator. It is recorded there now, and the loader reads that record instead of inferring it. The two cases the old rule could not tell apart, a delegate that handed back and an app that quit, are finally distinct. A live process is still skipped, because a running delegate's pointer is legitimate whatever the record says.

Both reset sites are fixed, because either alone reproduces the symptom.

**Recording the handback cannot break the handback.** The caller is mid-return, so a store that cannot be written is warned about and nothing else. Throwing there would abandon the return itself, which is a worse outcome than the stale pointer this fixes. That branch is covered, because the coverage floor for the area refused to ratchet down for it.

**On the existing integration test.** It asserted the old rule: no handback recorded, reset expected. I did not flip its assertion. It now asserts BOTH directions, a recorded handback resets and an in-flight delegation does not, checked in the response and on disk. It asserts more than it did before, not less. If that reads as a test weakened to accommodate a change, it should be challenged, and this note exists so it can be.

`markDelegationReturned` is exported so the one writer of this signal can be driven directly and proven to persist. A signal nothing writes is a dead condition that silently disables the reset it guards, and that is exactly what the first draft of this fix shipped: every test green, over a flag no code ever set. The engine's export surface is a pinned registry, so widening it required saying why in writing.

**Verified red-first.** Before the fix, the two tests describing the reported symptom fail and the three describing behaviour that must not change pass. Nine tests in total, plus the strengthened integration case.

**Known gap, flagged rather than hidden:** the client-side rule in `public/views/chat.js` is fixed but has no direct test, because the view module needs DOM globals. Covering it means extracting the decision as a pure function or introducing a jsdom test, and both are real work rather than an edit.

Local gate green at 638s.