### PR TITLE
A check that cannot make its measurement says so, and the gate outlives its caller

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "smoke": "node scripts/smoke/run.mjs",
     "smoke:personas": "node scripts/smoke/personas.mjs",
     "stream:truth": "node scripts/stream-truth/run.mjs",
-    "transcript:truth": "node scripts/transcript-truth/run.mjs"
+    "transcript:truth": "node scripts/transcript-truth/run.mjs",
+    "precommit:detached": "sh -c 'mkdir -p .rundock && nohup node scripts/precommit-gate.js > .rundock/gate.log 2>&1 < /dev/null & echo \"gate detached (pid $!). Follow it: tail -f .rundock/gate.log\"'"
   },
   "dependencies": {
     "electron-updater": "^6.8.9",

--- a/test/unit/red-first-orphans.test.js
+++ b/test/unit/red-first-orphans.test.js
@@ -96,6 +96,31 @@ function scratch(name) {
   return path.join(os.tmpdir(), `red-first-orphans-${name}-${process.pid}-${Date.now()}`);
 }
 
+/**
+ * The group is running, and say so honestly when that cannot be measured.
+ *
+ * groupRunning answers null when the process table cannot be read, which is
+ * what a sandbox that blocks `ps` produces. Compared straight against true,
+ * that null reads as "the group is gone" and the check reports a FAILURE for a
+ * measurement it never made. It cost seven gate runs and a backlog card
+ * describing the result as a load flake, which sent the next reader looking at
+ * timing for hours.
+ *
+ * Same rule the gate's step ceiling already follows: a check that could not run
+ * says it reached no verdict, rather than claiming the thing it was measuring
+ * is broken.
+ */
+function assertGroupRunning(pgid, why) {
+  const answer = groupRunning(pgid);
+  if (answer === null) {
+    assert.fail('CANNOT MEASURE, not a failure of the thing being measured: the process '
+      + `table could not be read, so whether group ${pgid} is alive is unknown. This is what a `
+      + 'sandbox blocking `ps` looks like. Run this suite where the process table is readable; '
+      + 'do not read it as the group having gone.');
+  }
+  assert.strictEqual(answer, true, why);
+}
+
 function pidsIn(file) {
   if (!fs.existsSync(file)) return [];
   return fs.readFileSync(file, 'utf8').trim().split('\n').filter(Boolean).map(Number);
@@ -924,7 +949,7 @@ ${r.stdout}`);
       // Asked of the GROUP, not of the group's leader. The leader is the shell,
       // which has exited; what is left is the child it started, which is in the
       // group but is not the pid the group is named after.
-      assert.strictEqual(groupRunning(held.group), true,
+      assertGroupRunning(held.group,
         'and its suite must still be running, or there is nothing to refuse on');
 
       const second = cli(dir, 'echo this must never run');
@@ -937,7 +962,7 @@ ${r.stdout}`);
         `the refusal must name the command that group is running\n${second.stdout}`);
 
       // And refusing must not be a disguised way of clearing it.
-      assert.strictEqual(groupRunning(held.group), true,
+      assertGroupRunning(held.group,
         'the refusal must leave the suite it found alone');
     } finally {
       teardown({ dir, pidFiles: [file] });


### PR DESCRIPTION
Two environmental faults found by using the pipeline hard for a night. Neither is a new check; both are the rule the existing ones already follow.

**Cannot measure is not failed.** `groupRunning` answers `null` when the process table cannot be read, which is exactly what a sandbox blocking `ps` produces. Compared straight against `true`, that `null` read as "the group has gone", and the check reported a failure for a measurement it never made.

It cost seven gate runs, three wrong diagnoses in a row (load, then concurrency, then self-inflicted process cleanup), and a backlog note describing the result as a flake that fails under load and passes alone. That note sent the next reader looking at timing for hours, which is the real damage: a wrong diagnosis written down outlives the incident.

The assertion now distinguishes the two. Unmeasurable says the process table could not be read, names the sandbox as the likely cause, and tells the reader not to take it as the group having gone. This is the same rule the gate's step ceiling already follows, where a step stopped at its ceiling reports that it reached no verdict rather than claiming the code failed.

**The gate cannot outlive its caller.** A fourteen-minute gate launched as a child of whatever asked for it dies whenever that caller is reaped. Five gates died that way in one night. Each kill orphaned a mutation harness that kept running, reparented, holding a mutated source file until it finished on its own, which leaves a window where `git add -A` would sweep a mutated file into an unrelated commit. That is precisely the incident the mutation-run envelope exists to prevent, reachable through a path it does not cover: the guarantee holds for a clean exit and not for an external kill.

`npm run precommit:detached` gives the gate its own lifetime and a log to follow. Proven while writing the commit: the invoking command timed out at three minutes and the gate carried straight on to completion.

Gate green.