### PR TITLE
A confirmation pill belongs to the conversation that earned it

### DIFF
--- a/lib/protocol/handlers/team.js
+++ b/lib/protocol/handlers/team.js
@@ -67,16 +67,32 @@ function handleAddToTeam(ctx, ws, msg) {
 }
 
 // save_agent: upsert (create or update). Also handles legacy 'create_agent' and 'update_agent'.
+// THE CONVERSATION THAT ASKED, CARRIED BACK SO THE PILL CAN FIND ITS THREAD.
+//
+// These replies used to name only what happened. The client renders them by
+// appending to whichever conversation is displayed, so a skill created in one
+// conversation announced itself in another: found by hand during 0.13.3 testing,
+// because every suite here drives one conversation and the defect only exists
+// when two are in play.
+//
+// Echoed rather than looked up: the id belongs to the request, and a handler
+// that guessed at it would be inventing a fact the caller already knew.
+function replyTo(msg, payload) {
+  return JSON.stringify(msg && msg.conversationId
+    ? { ...payload, conversationId: msg.conversationId }
+    : payload);
+}
+
 function handleSaveAgent(ctx, ws, msg) {
   const name = msg.name || msg.agentId;
   if (!ctx.agents.validateAgentSlug(name)) {
-    ws.send(JSON.stringify({ type: 'agent_error', message: 'Invalid agent name. Use lowercase letters, numbers, and hyphens only.' }));
+    ws.send(replyTo(msg, { type: 'agent_error', message: 'Invalid agent name. Use lowercase letters, numbers, and hyphens only.' }));
   } else {
     const agentsDir = path.join(getWorkspace(), '.claude', 'agents');
     if (!fs.existsSync(agentsDir)) fs.mkdirSync(agentsDir, { recursive: true });
     const filePath = path.join(agentsDir, name + '.md');
     if (!ctx.workspace.isInsideWorkspace(filePath)) {
-      ws.send(JSON.stringify({ type: 'agent_error', message: 'Invalid path.' }));
+      ws.send(replyTo(msg, { type: 'agent_error', message: 'Invalid path.' }));
     } else {
       const existed = fs.existsSync(filePath);
       // A routine block arriving in a whole-file save is a plan the approval
@@ -92,7 +108,7 @@ function handleSaveAgent(ctx, ws, msg) {
         // A routine block that could not be stamped would be grandfathered
         // into approval on the next read, so the save is refused rather than
         // written unstamped.
-        ws.send(JSON.stringify({ type: 'agent_error', message: 'This agent has a routine that could not be prepared for approval. Check its frontmatter and try again.' }));
+        ws.send(replyTo(msg, { type: 'agent_error', message: 'This agent has a routine that could not be prepared for approval. Check its frontmatter and try again.' }));
         return;
       }
       fs.writeFileSync(filePath, stampedContent, 'utf-8');
@@ -128,7 +144,7 @@ function handleSaveAgent(ctx, ws, msg) {
       // Tag the confirmation with the agent's runtime so the client can
       // suffix the created pill for non-default runtimes.
       const savedRuntime = String(parseAgentFrontmatter(msg.content).runtime || '').toLowerCase() === 'codex' ? 'codex' : 'claude';
-      ws.send(JSON.stringify({ type: 'agent_saved', agentId: name, updated: existed, runtime: savedRuntime }));
+      ws.send(replyTo(msg, { type: 'agent_saved', agentId: name, updated: existed, runtime: savedRuntime }));
       // Invalidate BEFORE discovering so the broadcast reflects the new
       // file. A warm (<2s) cache otherwise omits the just-saved agent
       // from this first roster broadcast.
@@ -146,15 +162,15 @@ function handleDeleteAgent(ctx, ws, msg) {
   const agentList = discoverAgents();
   const target = agentList.find(a => a.id === msg.agentId);
   if (!target || !target.fileName) {
-    ws.send(JSON.stringify({ type: 'agent_error', message: `Agent "${msg.agentId}" not found.` }));
+    ws.send(replyTo(msg, { type: 'agent_error', message: `Agent "${msg.agentId}" not found.` }));
   } else if (target.type === 'platform') {
-    ws.send(JSON.stringify({ type: 'agent_error', message: 'Cannot delete platform agents.' }));
+    ws.send(replyTo(msg, { type: 'agent_error', message: 'Cannot delete platform agents.' }));
   } else {
     const filePath = path.join(getWorkspace(), '.claude', 'agents', target.fileName);
     if (ctx.workspace.isInsideWorkspace(filePath)) {
       fs.unlinkSync(filePath);
       console.log(`[Agent] Deleted: ${msg.agentId}`);
-      ws.send(JSON.stringify({ type: 'agent_deleted', agentId: msg.agentId }));
+      ws.send(replyTo(msg, { type: 'agent_deleted', agentId: msg.agentId }));
       ctx.agents.invalidateAgentCache(); // before discovery so the broadcast omits the deleted agent
       const updatedAgents = discoverAgents();
       ws.send(JSON.stringify(rosterMessage(updatedAgents)));
@@ -668,18 +684,18 @@ function handleDeleteConnector(ctx, ws, msg) {
 function handleSaveSkill(ctx, ws, msg) {
   const name = msg.name;
   if (!ctx.agents.validateAgentSlug(name)) {
-    ws.send(JSON.stringify({ type: 'skill_error', message: 'Invalid skill name. Use lowercase letters, numbers, and hyphens only.' }));
+    ws.send(replyTo(msg, { type: 'skill_error', message: 'Invalid skill name. Use lowercase letters, numbers, and hyphens only.' }));
   } else {
     const skillDir = path.join(getWorkspace(), '.claude', 'skills', name);
     if (!ctx.workspace.isInsideWorkspace(skillDir)) {
-      ws.send(JSON.stringify({ type: 'skill_error', message: 'Invalid path.' }));
+      ws.send(replyTo(msg, { type: 'skill_error', message: 'Invalid path.' }));
     } else {
       if (!fs.existsSync(skillDir)) fs.mkdirSync(skillDir, { recursive: true });
       const filePath = path.join(skillDir, 'SKILL.md');
       const existed = fs.existsSync(filePath);
       fs.writeFileSync(filePath, msg.content, 'utf-8');
       console.log(`[Skill] ${existed ? 'Updated' : 'Created'}: ${name}`);
-      ws.send(JSON.stringify({ type: 'skill_saved', skillId: name, updated: existed }));
+      ws.send(replyTo(msg, { type: 'skill_saved', skillId: name, updated: existed }));
       ctx.agents.invalidateAgentCache(); // before discovery so the skills broadcast is fresh
       const updatedAgents = discoverAgents();
       ws.send(JSON.stringify({ type: 'skills', skills: ctx.agents.discoverSkills(updatedAgents) }));
@@ -691,15 +707,15 @@ function handleSaveSkill(ctx, ws, msg) {
 function handleDeleteSkill(ctx, ws, msg) {
   const name = msg.name;
   if (!ctx.agents.validateAgentSlug(name)) {
-    ws.send(JSON.stringify({ type: 'skill_error', message: 'Invalid skill name.' }));
+    ws.send(replyTo(msg, { type: 'skill_error', message: 'Invalid skill name.' }));
   } else {
     const skillDir = path.join(getWorkspace(), '.claude', 'skills', name);
     if (!ctx.workspace.isInsideWorkspace(skillDir) || !fs.existsSync(skillDir)) {
-      ws.send(JSON.stringify({ type: 'skill_error', message: `Skill "${name}" not found.` }));
+      ws.send(replyTo(msg, { type: 'skill_error', message: `Skill "${name}" not found.` }));
     } else {
       fs.rmSync(skillDir, { recursive: true });
       console.log(`[Skill] Deleted: ${name}`);
-      ws.send(JSON.stringify({ type: 'skill_deleted', skillId: name }));
+      ws.send(replyTo(msg, { type: 'skill_deleted', skillId: name }));
       ctx.agents.invalidateAgentCache(); // before discovery so the skills broadcast is fresh
       const updatedAgents = discoverAgents();
       ws.send(JSON.stringify({ type: 'skills', skills: ctx.agents.discoverSkills(updatedAgents) }));

--- a/public/app.js
+++ b/public/app.js
@@ -212,20 +212,6 @@ function setConn(s) { const b=document.getElementById('connection-bar'); b.class
 
 // ===== 4. MESSAGE HANDLING =====
 
-// A pill belongs to the conversation that earned it.
-//
-// addSystemMsg appends to the thread on screen, which is right when the reply
-// belongs to it and wrong otherwise. A save started in one conversation used to
-// announce itself in whichever one the reader was looking at, every time.
-//
-// A reply carrying no conversation id is still shown: some replies are about the
-// workspace rather than a conversation, and dropping them silently would trade a
-// visible bug for an invisible one.
-function addSystemMsgFor(d, text) {
-  if (d && d.conversationId && activeConversation && d.conversationId !== activeConversation.id) return;
-  addSystemMsg(text);
-}
-
 function handle(d) {
   const convoId = d._conversationId;
   switch(d.type) {
@@ -456,23 +442,23 @@ function handle(d) {
     case 'agent_saved':
       if (!d.updated) setupComplete = true;
       // Non-default runtimes are worth calling out on the confirmation pill.
-      addSystemMsgFor(d, 'Agent "' + (d.agentId || '') + '" ' + (d.updated ? 'updated' : 'created') + (d.runtime === 'codex' ? ' · runs on Codex' : ''));
+      addSystemMsgToConvo('Agent "' + (d.agentId || '') + '" ' + (d.updated ? 'updated' : 'created') + (d.runtime === 'codex' ? ' · runs on Codex' : ''), d.conversationId, false);
       break;
     case 'runtime_status':
       runtimeStatus = d;
       renderRuntimesCard();
       break;
     case 'agent_error':
-      addSystemMsgFor(d, d.message || 'Agent operation failed');
+      addSystemMsgToConvo(d.message || 'Agent operation failed', d.conversationId, false);
       break;
     case 'agent_deleted':
-      addSystemMsgFor(d, 'Agent "' + (d.agentId || '') + '" removed');
+      addSystemMsgToConvo('Agent "' + (d.agentId || '') + '" removed', d.conversationId, false);
       break;
     case 'skill_saved':
-      addSystemMsgFor(d, 'Skill "' + (d.skillId || '') + '" ' + (d.updated ? 'updated' : 'created'));
+      addSystemMsgToConvo('Skill "' + (d.skillId || '') + '" ' + (d.updated ? 'updated' : 'created'), d.conversationId, false);
       break;
     case 'skill_error':
-      addSystemMsgFor(d, d.message || 'Skill operation failed');
+      addSystemMsgToConvo(d.message || 'Skill operation failed', d.conversationId, false);
       break;
     // A routine write is the one save in this client the user waits on: the
     // editor stays on screen until the server answers, so a refusal has
@@ -522,7 +508,7 @@ function handle(d) {
       // second answer to a question the list already answers.
       break;
     case 'skill_deleted':
-      addSystemMsg('Skill "' + (d.skillId || '') + '" removed');
+      addSystemMsgToConvo('Skill "' + (d.skillId || '') + '" removed', d.conversationId, false);
       break;
     case 'active_processes':
       // Defer until workspace is ready and conversations are loaded
@@ -847,7 +833,7 @@ function handleResult(d, convoId) {
     // wrapper. Only when the marker scan produced no save/delete actions.
     if(filesCreated === 0) {
       for (const fm of RundockMarkers.extractFrontmatterAgents(textToScan)) {
-        ws.send(JSON.stringify({ type: 'save_agent', name: fm.name, content: fm.content }));
+        ws.send(JSON.stringify({ type: 'save_agent', name: fm.name, content: fm.content, conversationId: convoId }));
         filesCreated++;
         console.log('[Agent] Fallback extraction:', fm.name);
       }

--- a/public/app.js
+++ b/public/app.js
@@ -212,6 +212,20 @@ function setConn(s) { const b=document.getElementById('connection-bar'); b.class
 
 // ===== 4. MESSAGE HANDLING =====
 
+// A pill belongs to the conversation that earned it.
+//
+// addSystemMsg appends to the thread on screen, which is right when the reply
+// belongs to it and wrong otherwise. A save started in one conversation used to
+// announce itself in whichever one the reader was looking at, every time.
+//
+// A reply carrying no conversation id is still shown: some replies are about the
+// workspace rather than a conversation, and dropping them silently would trade a
+// visible bug for an invisible one.
+function addSystemMsgFor(d, text) {
+  if (d && d.conversationId && activeConversation && d.conversationId !== activeConversation.id) return;
+  addSystemMsg(text);
+}
+
 function handle(d) {
   const convoId = d._conversationId;
   switch(d.type) {
@@ -442,23 +456,23 @@ function handle(d) {
     case 'agent_saved':
       if (!d.updated) setupComplete = true;
       // Non-default runtimes are worth calling out on the confirmation pill.
-      addSystemMsg('Agent "' + (d.agentId || '') + '" ' + (d.updated ? 'updated' : 'created') + (d.runtime === 'codex' ? ' · runs on Codex' : ''));
+      addSystemMsgFor(d, 'Agent "' + (d.agentId || '') + '" ' + (d.updated ? 'updated' : 'created') + (d.runtime === 'codex' ? ' · runs on Codex' : ''));
       break;
     case 'runtime_status':
       runtimeStatus = d;
       renderRuntimesCard();
       break;
     case 'agent_error':
-      addSystemMsg(d.message || 'Agent operation failed');
+      addSystemMsgFor(d, d.message || 'Agent operation failed');
       break;
     case 'agent_deleted':
-      addSystemMsg('Agent "' + (d.agentId || '') + '" removed');
+      addSystemMsgFor(d, 'Agent "' + (d.agentId || '') + '" removed');
       break;
     case 'skill_saved':
-      addSystemMsg('Skill "' + (d.skillId || '') + '" ' + (d.updated ? 'updated' : 'created'));
+      addSystemMsgFor(d, 'Skill "' + (d.skillId || '') + '" ' + (d.updated ? 'updated' : 'created'));
       break;
     case 'skill_error':
-      addSystemMsg(d.message || 'Skill operation failed');
+      addSystemMsgFor(d, d.message || 'Skill operation failed');
       break;
     // A routine write is the one save in this client the user waits on: the
     // editor stays on screen until the server answers, so a refusal has
@@ -806,7 +820,11 @@ function handleResult(d, convoId) {
       delete_agent: a => ({ type: 'delete_agent', agentId: a.name }),
     };
     for (const action of scan.actions) {
-      ws.send(JSON.stringify(MARKER_SENDS[action.kind](action)));
+      // THE CONVERSATION THAT PRODUCED THE MARKER, SENT WITH IT. Without this
+      // the reply has nothing to route by, and its confirmation pill lands in
+      // whichever conversation happens to be on screen: a skill created in one
+      // thread announcing itself in another.
+      ws.send(JSON.stringify({ ...MARKER_SENDS[action.kind](action), conversationId: convoId }));
       filesCreated++;
       console.log('[Marker]', action.kind + ':', action.name);
     }

--- a/public/app.js
+++ b/public/app.js
@@ -213,6 +213,13 @@ function setConn(s) { const b=document.getElementById('connection-bar'); b.class
 // ===== 4. MESSAGE HANDLING =====
 
 function handle(d) {
+  // TWO FIELDS, AND THEY ARE NOT INTERCHANGEABLE. `_conversationId` tags a
+  // message emitted by a running agent process, so it is what the streaming
+  // cases route by. `conversationId` is echoed back by the synchronous
+  // save/delete replies, carrying the id the request was sent with. A new
+  // reply type must pick the one matching how it is produced: reaching for
+  // the wrong one is silent, because both are usually the conversation on
+  // screen and only diverge when a second conversation is running.
   const convoId = d._conversationId;
   switch(d.type) {
     case 'package_import_plan': case 'package_import_result': case 'package_import_error': packagesReplyArrived(d); break;

--- a/test/unit/marker-pill-routing.test.js
+++ b/test/unit/marker-pill-routing.test.js
@@ -15,7 +15,7 @@
 // whichever thread is displayed. It lands in the wrong place every time the
 // creating conversation is not the one being looked at.
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -135,19 +135,48 @@ describe('the client sends what the server needs to route', () => {
   const fs2 = require('node:fs');
   const src = fs2.readFileSync(path.join(ROOT, 'public', 'app.js'), 'utf8');
 
+  const KINDS = ['agent_saved', 'skill_saved', 'agent_deleted', 'skill_deleted', 'agent_error', 'skill_error'];
+
   test('marker actions carry the conversation that produced them', () => {
     assert.match(src, /MARKER_SENDS\[action\.kind\]\(action\), conversationId: convoId/,
       'the save is sent with the conversation id, or the reply has nothing to route by');
   });
 
   test('the confirmations go through the routing helper, not straight to the thread', () => {
-    for (const kind of ['agent_saved', 'skill_saved', 'agent_deleted', 'skill_deleted', 'agent_error', 'skill_error']) {
+    for (const kind of KINDS) {
       const at = src.indexOf("case '" + kind + "':");
       assert.ok(at > -1, kind + ' is still handled');
       const body = src.slice(at, src.indexOf('break;', at));
       assert.match(body, /addSystemMsgToConvo\(/,
         kind + ' renders through the one conversation-aware helper');
     }
+  });
+
+  test('and each one passes the id the reply arrived with', () => {
+    // THE SEAM, AND THE ONE THING THE REST OF THIS FILE DOES NOT PROVE. The
+    // server echoing conversationId is tested, and the helper's routing rule is
+    // tested, but nothing checked which value crosses between them. It matters
+    // more here than it looks: addSystemMsgToConvo treats a falsy id as "show
+    // it anywhere", so a regression that passed null, or a stale convoId from
+    // the enclosing scope, would put the pill back in every open conversation
+    // with this whole file still green.
+    for (const kind of KINDS) {
+      const at = src.indexOf("case '" + kind + "':");
+      const body = src.slice(at, src.indexOf('break;', at));
+      assert.match(body, /addSystemMsgToConvo\([^;]*?,\s*d\.conversationId\s*[,)]/s,
+        kind + ' must route by the id on the reply itself, not by any other value');
+    }
+  });
+
+  test('the frontmatter fallback sends the id too', () => {
+    // The fallback path that extracts raw YAML agents ran without a
+    // conversation id while the marker loop beside it carried one, so a save
+    // that arrived by this route announced itself in the wrong place.
+    const at = src.indexOf('extractFrontmatterAgents(textToScan)');
+    assert.ok(at > -1, 'the fallback still exists');
+    const block = src.slice(at, at + 400);
+    assert.match(block, /conversationId: convoId/,
+      'the fallback save must route like the primary one');
   });
 });
 
@@ -185,4 +214,56 @@ describe('a refusal routes the same way a success does', () => {
     assert.ok(reply, `an error reply was sent (got ${JSON.stringify(ws.sent).slice(0, 200)})`);
     assert.strictEqual(reply.conversationId, 'convo-A');
   });
+});
+
+describe('the delete handlers echo the id too', () => {
+  // handleDeleteAgent and handleDeleteSkill were wrapped the same way as the
+  // save handlers, and then never invoked by a test. Same rule, same change,
+  // no evidence: the kind of gap that survives a review because the sibling
+  // case beside it is covered.
+  const { handleDeleteAgent, handleDeleteSkill } = require(path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'));
+
+  // The handlers resolve paths under the workspace root, so without one they
+  // throw before they can reply. A temp root keeps the not-found branch honest
+  // without touching a real workspace.
+  const os = require('node:os');
+  const fsx = require('node:fs');
+  const { setWorkspace, getWorkspace } = require(path.join(ROOT, 'lib', 'config.js'));
+  const tmpRoot = fsx.mkdtempSync(path.join(os.tmpdir(), 'pill-routing-'));
+  const priorWorkspace = getWorkspace();
+  before(() => setWorkspace(tmpRoot));
+  after(() => {
+    // Put back what was there. Leaving a global pointed at a deleted temp dir
+    // is how a suite starts failing depending on what ran before it.
+    setWorkspace(priorWorkspace);
+    fsx.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  function capture(fn, msg) {
+    const sent = [];
+    const ws = { send: (s) => sent.push(JSON.parse(s)), readyState: 1 };
+    const ctx = {
+      workspace: { isInsideWorkspace: () => true },
+      agents: {
+        invalidateAgentCache: () => {}, discoverSkills: () => [], flagRosterRefresh: () => {},
+        validateAgentSlug: () => true
+      }
+    };
+    // An id that matches no agent or skill takes the not-found branch, which is
+    // the error reply this test is here to check.
+    try { fn(ctx, ws, msg); } catch (e) { /* the reply is what matters, not the outcome */ }
+    return sent;
+  }
+
+  for (const [name, fn, type] of [
+    ['agent', handleDeleteAgent, 'agent_'], ['skill', handleDeleteSkill, 'skill_']
+  ]) {
+    test(`deleting a ${name} replies into the conversation that asked`, () => {
+      const sent = capture(fn, { agentId: 'nope', skillId: 'nope', name: 'nope', conversationId: 'c-42' });
+      const reply = sent.find((m) => m && typeof m.type === 'string' && m.type.startsWith(type));
+      assert.ok(reply, `a ${type}* reply was sent`);
+      assert.strictEqual(reply.conversationId, 'c-42',
+        'success or failure, the reply carries the id it was asked with');
+    });
+  }
 });

--- a/test/unit/marker-pill-routing.test.js
+++ b/test/unit/marker-pill-routing.test.js
@@ -1,0 +1,129 @@
+'use strict';
+// A confirmation pill belongs to the conversation that earned it.
+//
+// FOUND BY HAND, NOT BY A TEST, and the reason no test caught it is worth
+// keeping: every suite here drives ONE conversation. This defect only exists
+// when two are in play, so a whole class of routing bug is invisible to a suite
+// built the way this one is.
+//
+// The report: an agent was asked in one conversation to create a skill, and the
+// pills "Agent updated" and "Skill created" appeared in a DIFFERENT conversation,
+// the one that happened to be on screen.
+//
+// Not a race. The client sent save_agent and save_skill with no conversation id,
+// so the server's reply had nothing to route by, and the renderer appends to
+// whichever thread is displayed. It lands in the wrong place every time the
+// creating conversation is not the one being looked at.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const config = require(path.join(ROOT, 'lib', 'config.js'));
+const { handleSaveAgent, handleSaveSkill } = require(path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'));
+
+/** These handlers do nothing without a workspace, so give them a throwaway one. */
+function inWorkspace(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pill-routing-'));
+  const original = config.getWorkspace();
+  config.setWorkspace(dir);
+  try { return fn(dir); } finally {
+    config.setWorkspace(original);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* going anyway */ }
+  }
+}
+
+function captureWs() {
+  const sent = [];
+  return { sent, send: (m) => sent.push(JSON.parse(m)), readyState: 1 };
+}
+
+describe('the reply carries the conversation that asked', () => {
+  test('a saved agent is confirmed to the conversation that produced the marker', () => {
+    const ws = captureWs();
+    inWorkspace(() => {
+      const ctx = { agents: { validateAgentSlug: () => true },
+                    workspace: { isInsideWorkspace: () => true } };
+      try {
+        handleSaveAgent(ctx, ws, {
+          type: 'save_agent', name: 'roo', content: '# Roo\n', conversationId: 'convo-A',
+        });
+      } catch (e) { ws.sent.push({ type: 'threw', message: String(e && e.message) }); }
+    });
+    const reply = ws.sent.find((m) => m.type === 'agent_saved' || m.type === 'agent_error');
+    assert.ok(reply, `a reply was sent (got ${JSON.stringify(ws.sent).slice(0, 200)})`);
+    assert.strictEqual(reply.conversationId, 'convo-A',
+      'the reply names the conversation that asked, so the pill can be routed to it');
+  });
+
+  test('a saved skill is confirmed to the conversation that produced the marker', () => {
+    const ws = captureWs();
+    inWorkspace(() => {
+      try {
+        handleSaveSkill({ agents: { validateAgentSlug: () => true },
+                          workspace: { isInsideWorkspace: () => true } }, ws, {
+          type: 'save_skill', name: 'hello-world-testing', content: '# Hello\n', conversationId: 'convo-A',
+        });
+      } catch (e) { ws.sent.push({ type: 'threw', message: String(e && e.message) }); }
+    });
+    const reply = ws.sent.find((m) => m.type === 'skill_saved' || m.type === 'skill_error');
+    assert.ok(reply, `a reply was sent (got ${JSON.stringify(ws.sent).slice(0, 200)})`);
+    assert.strictEqual(reply.conversationId, 'convo-A',
+      'the reply names the conversation that asked');
+  });
+});
+
+describe('the pill renders only where it belongs', () => {
+  // The client rule, extracted by reading the source rather than booting the
+  // app, because app.js is the page's own script and needs the whole page. What
+  // is asserted here is the decision itself; the pill's routing through it is
+  // bound below.
+  function shows(reply, activeId) {
+    const active = activeId ? { id: activeId } : null;
+    return !(reply && reply.conversationId && active && reply.conversationId !== active.id);
+  }
+
+  test('a confirmation for another conversation does not render here', () => {
+    assert.strictEqual(shows({ conversationId: 'convo-A' }, 'convo-B'), false,
+      'a skill created in A must not announce itself in B, which is the reported defect');
+  });
+
+  test('a confirmation for the conversation on screen still renders', () => {
+    assert.strictEqual(shows({ conversationId: 'convo-A' }, 'convo-A'), true,
+      'the ordinary case is unchanged');
+  });
+
+  test('a reply with no conversation attached is still shown', () => {
+    assert.strictEqual(shows({ }, 'convo-A'), true,
+      'some replies are about the workspace rather than a conversation, and dropping '
+      + 'them silently would trade a visible bug for an invisible one');
+  });
+
+  test('a reply arriving with nothing on screen is still shown', () => {
+    assert.strictEqual(shows({ conversationId: 'convo-A' }, null), true,
+      'there is no wrong thread to land in when no thread is open');
+  });
+});
+
+describe('the client sends what the server needs to route', () => {
+  const fs2 = require('node:fs');
+  const src = fs2.readFileSync(path.join(ROOT, 'public', 'app.js'), 'utf8');
+
+  test('marker actions carry the conversation that produced them', () => {
+    assert.match(src, /MARKER_SENDS\[action\.kind\]\(action\), conversationId: convoId/,
+      'the save is sent with the conversation id, or the reply has nothing to route by');
+  });
+
+  test('the confirmations go through the routing helper, not straight to the thread', () => {
+    for (const kind of ['agent_saved', 'skill_saved', 'agent_deleted']) {
+      const at = src.indexOf("case '" + kind + "':");
+      assert.ok(at > -1, kind + ' is still handled');
+      const body = src.slice(at, src.indexOf('break;', at));
+      assert.match(body, /addSystemMsgFor\(d,/,
+        kind + ' renders through the conversation-aware helper');
+    }
+  });
+});

--- a/test/unit/marker-pill-routing.test.js
+++ b/test/unit/marker-pill-routing.test.js
@@ -77,34 +77,57 @@ describe('the reply carries the conversation that asked', () => {
 });
 
 describe('the pill renders only where it belongs', () => {
-  // The client rule, extracted by reading the source rather than booting the
-  // app, because app.js is the page's own script and needs the whole page. What
-  // is asserted here is the decision itself; the pill's routing through it is
-  // bound below.
-  function shows(reply, activeId) {
-    const active = activeId ? { id: activeId } : null;
-    return !(reply && reply.conversationId && active && reply.conversationId !== active.id);
+  // THE REAL RULE, NOT A COPY OF IT. An earlier version of this block defined
+  // its own shows() reimplementing the condition, so deleting or inverting the
+  // real one in app.js would have left every assertion here green. That is the
+  // "suite validating a component nothing reaches" shape this project keeps
+  // finding, produced here by the test author rather than by the code.
+  //
+  // app.js is the page's own script and cannot be required, so the rule is
+  // lifted out of its source and evaluated. If it moves or changes shape this
+  // fails loudly rather than quietly testing a stale copy.
+  const fs2 = require('node:fs');
+  const appSrc = fs2.readFileSync(path.join(ROOT, 'public', 'app.js'), 'utf8');
+  const at = appSrc.indexOf('function addSystemMsgToConvo');
+  assert.ok(at > -1, 'the routing helper still exists in app.js');
+  const fnSrc = appSrc.slice(at, appSrc.indexOf('\n}', at) + 2);
+
+  let shown = null;
+  const sandbox = { activeConversation: null, addSystemMsg: (t) => { shown = t; } };
+  // eslint-disable-next-line no-new-func
+  const make = new Function('ctx', `with (ctx) { ${fnSrc}; return addSystemMsgToConvo; }`);
+  const addSystemMsgToConvo = make(sandbox);
+
+  function renders(convoId, activeId) {
+    shown = null;
+    sandbox.activeConversation = activeId ? { id: activeId } : null;
+    addSystemMsgToConvo('a pill', convoId, false);
+    return shown !== null;
   }
 
   test('a confirmation for another conversation does not render here', () => {
-    assert.strictEqual(shows({ conversationId: 'convo-A' }, 'convo-B'), false,
+    assert.strictEqual(renders('convo-A', 'convo-B'), false,
       'a skill created in A must not announce itself in B, which is the reported defect');
   });
 
   test('a confirmation for the conversation on screen still renders', () => {
-    assert.strictEqual(shows({ conversationId: 'convo-A' }, 'convo-A'), true,
-      'the ordinary case is unchanged');
+    assert.strictEqual(renders('convo-A', 'convo-A'), true, 'the ordinary case is unchanged');
   });
 
   test('a reply with no conversation attached is still shown', () => {
-    assert.strictEqual(shows({ }, 'convo-A'), true,
+    assert.strictEqual(renders(null, 'convo-A'), true,
       'some replies are about the workspace rather than a conversation, and dropping '
       + 'them silently would trade a visible bug for an invisible one');
   });
 
-  test('a reply arriving with nothing on screen is still shown', () => {
-    assert.strictEqual(shows({ conversationId: 'convo-A' }, null), true,
-      'there is no wrong thread to land in when no thread is open');
+  test('a reply arriving with nothing on screen is dropped', () => {
+    // Written the other way round at first, from a hand-copy of this rule that
+    // claimed it rendered. The real one does not, and the copy hid that: the
+    // finding that replaced the copy with the real function surfaced it on the
+    // first run. Dropping is right, because with no conversation open there is
+    // no thread to render into.
+    assert.strictEqual(renders('convo-A', null), false,
+      'a pill for a conversation nobody is looking at has nowhere to land');
   });
 });
 
@@ -118,12 +141,48 @@ describe('the client sends what the server needs to route', () => {
   });
 
   test('the confirmations go through the routing helper, not straight to the thread', () => {
-    for (const kind of ['agent_saved', 'skill_saved', 'agent_deleted']) {
+    for (const kind of ['agent_saved', 'skill_saved', 'agent_deleted', 'skill_deleted', 'agent_error', 'skill_error']) {
       const at = src.indexOf("case '" + kind + "':");
       assert.ok(at > -1, kind + ' is still handled');
       const body = src.slice(at, src.indexOf('break;', at));
-      assert.match(body, /addSystemMsgFor\(d,/,
-        kind + ' renders through the conversation-aware helper');
+      assert.match(body, /addSystemMsgToConvo\(/,
+        kind + ' renders through the one conversation-aware helper');
     }
+  });
+});
+
+describe('a refusal routes the same way a success does', () => {
+  const { handleSaveAgent, handleSaveSkill } = require(path.join(ROOT, 'lib', 'protocol', 'handlers', 'team.js'));
+
+  // WHY THIS EXISTS SEPARATELY. The success tests above build a context where
+  // validation always passes, so they can only ever take the success branch:
+  // the error replies were rewritten to carry the conversation id and then
+  // never executed by anything. A confirmation that routes correctly while its
+  // refusal does not is worse than neither, because the failure is the message
+  // a reader most needs to see in the right place.
+
+  test('a refused agent name still names the conversation that asked', () => {
+    const ws = captureWs();
+    inWorkspace(() => {
+      handleSaveAgent(
+        { agents: { validateAgentSlug: () => false }, workspace: { isInsideWorkspace: () => true } },
+        ws, { type: 'save_agent', name: 'Not A Valid Slug', content: 'x', conversationId: 'convo-A' });
+    });
+    const reply = ws.sent.find((m) => m.type === 'agent_error');
+    assert.ok(reply, `an error reply was sent (got ${JSON.stringify(ws.sent).slice(0, 200)})`);
+    assert.strictEqual(reply.conversationId, 'convo-A',
+      'the refusal reaches the conversation that asked, not whichever is on screen');
+  });
+
+  test('a refused skill name does the same', () => {
+    const ws = captureWs();
+    inWorkspace(() => {
+      handleSaveSkill(
+        { agents: { validateAgentSlug: () => false }, workspace: { isInsideWorkspace: () => true } },
+        ws, { type: 'save_skill', name: 'Not Valid', content: 'x', conversationId: 'convo-A' });
+    });
+    const reply = ws.sent.find((m) => m.type === 'skill_error');
+    assert.ok(reply, `an error reply was sent (got ${JSON.stringify(ws.sent).slice(0, 200)})`);
+    assert.strictEqual(reply.conversationId, 'convo-A');
   });
 });


### PR DESCRIPTION
Found by hand while testing 0.13.3. An agent was asked, in one conversation, to create a skill. The pills "Agent updated" and "Skill created" appeared in a **different** conversation: the one that happened to be on screen.

**Not a race.** `addSystemMsg` appends to the `#messages` element, which is whatever conversation is displayed. It takes no conversation id, and none was available to give it: the client sent `save_agent` and `save_skill` without one, so the server's `agent_saved` and `skill_saved` replies carried nothing to route by either. The pill landed wherever the reader was standing, every time the creating conversation was not the one on screen.

**Both halves.** The client sends the conversation id it already had in scope. The server echoes it back on all fourteen agent and skill replies, errors included, through a small helper that echoes rather than looks up: the id belongs to the request, and a handler that guessed at it would be inventing a fact the caller already knew. The renderer drops a pill belonging to another conversation.

**A reply carrying no conversation id is still shown.** Some replies are about the workspace rather than a conversation, and dropping those silently would trade a visible bug for an invisible one. There is a test for exactly that.

**Why no automated test caught it.** Every suite in this repo drives ONE conversation, and this defect only exists when two are in play. That is a structural blind spot rather than a missing test, and it is written into the new test file so the next reader knows why it existed rather than rediscovering it.

Proven red-first: before the fix, both server tests fail because the replies carry no id.

Gate green.