### PR TITLE
Say what changed for the reader, and stop the suite fighting itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,29 +10,25 @@ All notable changes to Rundock are documented here. Format follows [Keep a Chang
 
 ### Fixed
 
-- **An agent coming back knows what happened while it was away:** a specialist brought into a conversation after other agents had worked could not see any of it. It carried its own history and the brief it was handed, and nothing else, so it came back to its own draft as though the intervening work had never happened and rebuilt it from scratch. The orchestrator had it worse: it was started fresh on every handback, so it knew what the last specialist had just said and nothing about what you originally asked for, and briefed the next specialist from that empty picture. A request for a short blog post could come back, two handoffs later, as a request for a LinkedIn post. Every agent resumed into a conversation is now given the turns it missed since its own last turn, attributed by name so it reads as a record of a conversation rather than a list of identifiers. Its own earlier turns are left out, because its session already holds them, and so is the message it is being handed back, because that arrives separately. What you asked for is never dropped to make room: the request is the thing every later turn exists to serve, and it is the oldest, so it would otherwise be the first to go. Four separate paths return an agent to a conversation, and all four carry it.
+- **Agents remember what happened while they were away:** a specialist brought back into a conversation after other agents had worked could not see any of it, so it repeated work that was already done and briefed the next agent from an out-of-date picture. Every agent returning to a conversation is now given what it missed, attributed by name, so it reads like a record of the conversation rather than a fresh start.
 
-- **A specialist can say its part is done without ending the work:** an agent that finished its own piece and asked for the rest to be picked up was treated as having finished everything, and the conversation stopped there in silence, with no error and nothing on screen to say the request had been dropped. Finishing your part and finishing the request are now different things, and the second one carries on.
+- **A specialist can finish its part without ending the work:** an agent that completed its own piece and asked for the rest to be picked up was treated as having finished everything, and the conversation stopped there with nothing on screen to say the request had been dropped.
 
-- **A confirmation appears in the conversation that earned it:** creating or deleting an agent or a skill in one conversation announced itself in whichever conversation happened to be on screen, and a failure did the same. Every confirmation now travels with the conversation that asked for it.
+- **Confirmations appear in the conversation that earned them:** creating or deleting an agent or a skill announced itself in whichever conversation happened to be on screen.
 
-- **An agent's activity shows in its own bubble:** while one specialist handed over to another, the incoming agent's file reads and web searches appeared inside the previous agent's bubble, and one agent working alone could show two bubbles, one with its activity and one empty.
+- **Each agent's activity shows in its own bubble:** during a handover the incoming agent's work appeared inside the previous agent's bubble, and an agent working alone could show two.
 
-- **An approval appears beside the work it interrupted:** approvals raised while an agent was writing landed below the finished response, so a conclusion appeared above the permissions that had been granted before it could have been reached.
+- **Approvals appear beside the work they interrupted**, rather than below a response that had not been written yet.
 
-- **An agent's own working files no longer ask permission over and over:** an agent that saved a working file outside the workspace was asked to confirm every time it read the file back, with no way to answer once, because an approval for a folder and an approval for a command are different questions. Working files now stay inside the workspace where they belong, and the folder the runtime uses for its own is recognised.
+- **An agent's own working files stop asking permission over and over:** a file an agent saved and read back could raise an approval every single time, with no way to answer once.
 
-- **An approval for a command says when it reaches outside your workspace:** the question was whether a command could run, which is easy to agree to while reading past the file it opens.
+- **An approval for a command says when it reaches outside your workspace**, rather than only asking whether the command may run.
 
-- **A delegation in flight survives the app quitting:** the conversation came back pointing at an agent that was no longer running, so the next message went nowhere useful.
+- **A delegation in flight survives the app quitting:** the conversation came back pointing at an agent that was no longer running, so the next message went nowhere.
 
 ### Added
 
-- **Run a routine now:** a routine can be run on demand rather than only on its schedule, and it asks for your approval only when the plan has changed since you last agreed to it.
-
-### Changed
-
-- **Checks that cannot make their measurement say so:** a check that could not run reported the same result as one that ran and found nothing wrong, so a green result sometimes described a measurement that never happened.
+- **Run a routine now:** a routine can be run on demand rather than only on its schedule, and asks for your approval only when the plan has changed since you last agreed to it.
 
 ## 0.13.2: Callouts That Read (2026-09-09)
 

--- a/scripts/preflight.js
+++ b/scripts/preflight.js
@@ -235,7 +235,21 @@ function main() {
   for (const c of CHECKS) results.push(run(c.name, 'npm', c.args));
   // One process for all the registry suites: they are small, and the node test
   // runner reports each file's failures without stopping at the first.
-  results.push(run('registries', process.execPath, ['--test', '--test-reporter=spec', ...REGISTRY_SUITES]));
+  // ONE AT A TIME, BECAUSE THIS RUNS INSIDE A TEST RUN TOO.
+  //
+  // preflight.test.js spawns this whole script to prove the phase really
+  // executes the suites it names, and it does so while the outer suite is
+  // running those same suites. Both copies then read the same source tree and
+  // temp roots at once, and the registry suites are the ones that walk files.
+  // Measured: three separate gate runs failed here on a change that touched
+  // only CHANGELOG.md, and every one of those suites passed alone immediately
+  // afterwards.
+  //
+  // Serialising the nested run removes the contention rather than waiting it
+  // out. The suites are small: the step costs a few seconds more and stops
+  // failing for reasons that have nothing to do with the change under test.
+  results.push(run('registries', process.execPath,
+    ['--test', '--test-concurrency=1', '--test-reporter=spec', ...REGISTRY_SUITES]));
 
   // The captures, checked together and reported with the rest.
   const captures = staleCaptures();

--- a/test/unit/precommit-gate-orphans.test.js
+++ b/test/unit/precommit-gate-orphans.test.js
@@ -83,7 +83,20 @@ const LONG = 600000 + (process.pid % 991);
 
 const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
-async function until(predicate, ms = 20000) {
+// A CEILING ON PATIENCE, NOT A HOPE. What this waits for is a real process
+// tree starting: node spawns the gate, the gate reaches its mutation step, the
+// step spawns a harness, and the harness writes its pid. Under the parallel
+// load of the full suite that took 19.1 seconds against a 20 second budget and
+// failed a release twice in a row, on a change that touched only CHANGELOG.md.
+//
+// Raised rather than removed, and deliberately not the same call as the
+// end-to-end flake fixed earlier in this release: there a poll had already
+// established the condition and a second assertion re-checked it, so more time
+// would have hidden a redundancy. Here the wait is the right mechanism and the
+// number was simply smaller than a loaded machine. A gate that genuinely never
+// starts still fails, one minute later instead of twenty seconds later, and
+// that difference costs nothing because it is the failing case.
+async function until(predicate, ms = 60000) {
   const deadline = Date.now() + ms;
   while (Date.now() < deadline) {
     if (predicate()) return true;


### PR DESCRIPTION
The release notes described mechanism. They ran to seven hundred words, explained deltas and caps and how many code paths were involved, and invited the reader to picture a failure they may never have hit. They also carried an entry for a change to the pre-commit gate, which is a change to how the product is built rather than to the product: the test for a release note is whether anyone will notice, not whether something was merged.

Rewritten to nine entries and three hundred words, each one thing a person will see. The mechanism lives in the commits.

Landing that took three gate runs, all failing on tests that pass alone, on a change touching one markdown file. The last of those made the cause undeniable, so it is fixed here rather than waited out: preflight.test.js spawns the whole preflight script while the outer suite is running the same registry suites, and both copies then walk the same tree at once. The nested run is now serialised. Nine seconds slower, and it stops failing for reasons that have nothing to do with the change under test.