### PR TITLE
A named working folder reaches the operating system, not only the hook

### DIFF
--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -305,7 +305,9 @@ function handleSetWorkspaceMode(ctx, ws, msg, platform = process.platform) {
 // Nothing here decides what a named folder covers. It writes a list; the
 // permission hook alone reads it and judges paths against it, and each agent
 // receives the list current at the moment it is spawned.
-function handleSetWorkingFolders(ctx, ws, msg) {
+// `platform` is the same defaulted seam handleSetWorkspaceMode takes, so the
+// darwin arm is exercised on every host rather than only on a macOS runner.
+function handleSetWorkingFolders(ctx, ws, msg, platform = process.platform) {
   if (!getWorkspace()) {
     ws.send(JSON.stringify({ type: 'workspace_error', message: 'Open a workspace before naming the folders its agents work in.' }));
     return;
@@ -323,6 +325,27 @@ function handleSetWorkingFolders(ctx, ws, msg) {
   const rejected = requested.filter(r => normalizeOne(r) === null);
   try {
     const folders = writeWorkingFolders(requested);
+    // THE HOOK IS TOLD AT EVERY SPAWN; THE OPERATING SYSTEM IS TOLD ONCE, IN A
+    // FILE. Without this line a folder named here reached the permission hook
+    // and nothing else, so the setting worked for file tools and not for the
+    // shell: the same split between the two instruments that this whole change
+    // exists to close, reopened in a new place by the timing alone.
+    //
+    // Written AFTER the store, because the block is regenerated from the stored
+    // list rather than from `requested`, and the normalisation that decides
+    // what is actually stored lives in writeWorkingFolders.
+    //
+    // A failure here is warned rather than raised, and the stored list stands.
+    // The folders are already in effect for every agent spawned from now on,
+    // scaffoldWorkspace reconciles the block again on the next workspace open,
+    // and discarding a list a person just chose because a settings file could
+    // not be written would cost more than the delay it saves.
+    try {
+      const dir = getWorkspace();
+      if (dir) reconcileSandboxForMode(dir, readState().workspaceMode === 'code' ? 'code' : 'knowledge', platform);
+    } catch (e) {
+      console.warn(`  Working folders saved, but the sandbox was not updated: ${e.message}`);
+    }
     const existing = folders.map(dir => ({ path: dir, missing: !fs.existsSync(dir) }));
     console.log(`  Working folders: ${folders.length} named`);
     ws.send(JSON.stringify({ type: 'working_folders', folders: existing, rejected, home: os.homedir() }));

--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -13,7 +13,7 @@ const path = require('path');
 const { getWorkspace } = require('../../config.js');
 const { discoverAgents, rosterMessage } = require('../../agents/discovery.js');
 const { analyzeWorkspace } = require('../../workspace/analysis.js');
-const { isEmptyWorkspace, detectWorkspaceMode, scaffoldDefaults, scaffoldWorkspace, reconcileSandboxForMode } = require('../../workspace/scaffold.js');
+const { isEmptyWorkspace, detectWorkspaceMode, scaffoldDefaults, scaffoldWorkspace, reconcileSandboxForMode, workspaceModeFor } = require('../../workspace/scaffold.js');
 const { readState, writeState } = require('../../store/persistence.js');
 const { readWorkingFolders, writeWorkingFolders, normalizeOne } = require('../../workspace/working-folders.js');
 const { loadRoutineState } = require('../../scheduler.js');
@@ -355,7 +355,10 @@ function handleSetWorkingFolders(ctx, ws, msg, platform = process.platform) {
     // not be written would cost more than the delay it saves.
     try {
       const dir = getWorkspace();
-      if (dir) reconcileSandboxForMode(dir, readState().workspaceMode === 'code' ? 'code' : 'knowledge', platform);
+      // workspaceModeFor, not a second spelling of the same rule: what mode a
+      // workspace's block reflects is defined once, beside the block, and read
+      // from that workspace's own state file rather than the current one's.
+      if (dir) reconcileSandboxForMode(dir, workspaceModeFor(dir), platform);
     } catch (e) {
       console.warn(`  Working folders saved, but the sandbox was not updated: ${e.message}`);
     }

--- a/lib/protocol/handlers/workspace.js
+++ b/lib/protocol/handlers/workspace.js
@@ -233,14 +233,27 @@ function handleCreateWorkspace(ctx, ws, msg) {
   }
 }
 
-// MODE IS THE ONLY PERMISSIONS CONCEPT. Beyond persisting the chosen mode,
-// this is also the single rewiring point for the macOS OS write-block: it is
-// written when the workspace moves to Knowledge mode and withdrawn when it
-// moves to Code mode, immediately, through reconcileSandboxForMode in
-// lib/workspace/scaffold.js (the decision, the state write and the
-// settings.local.json reconcile all live there, beside the block they
-// govern). There is no other route to the block: no message, state field or
-// setting besides mode can reach it.
+// MODE IS THE ONLY PERMISSIONS CONCEPT, AND IT DECIDES ONE HALF OF THE BLOCK.
+//
+// Beyond persisting the chosen mode, this rewrites the macOS OS write-block
+// through reconcileSandboxForMode in lib/workspace/scaffold.js (the decision,
+// the state write and the settings.local.json reconcile all live there, beside
+// the block they govern).
+//
+// TWO MESSAGES REACH THAT BLOCK, NOT ONE, AND THEY DECIDE DIFFERENT HALVES OF
+// IT. Mode decides whether Rundock claims the ENABLE: Knowledge mode claims it,
+// Code mode writes the paths and claims nothing, because the enable is an OR
+// across every settings layer and Rundock writes only the workspace's own.
+// set_working_folders decides the PATHS, and rewrites the block for the current
+// mode without changing it, so a folder named there takes effect for shell
+// commands without waiting for a mode switch.
+//
+// Neither reads the other's decision from the message it was handed: both
+// regenerate the whole block from the workspace's persisted mode and persisted
+// folder list. An earlier version of this comment claimed mode was the only
+// route to the block, which stopped being true the moment folders reached it,
+// and a stale invariant is worse than none: it is the sentence someone trusts
+// instead of checking.
 // `platform` is a defaulted seam, the same one sandboxSettings itself takes,
 // so both arms of the block decision are drivable on any test host: the
 // dispatch path exercises the host's own arm, and a direct call with the

--- a/lib/workspace/scaffold.js
+++ b/lib/workspace/scaffold.js
@@ -563,7 +563,24 @@ function isRundockSandbox(block, platform = 'darwin') {
   // being replayed, not re-derived. Going through sandboxSettings rather than
   // sandboxBlock keeps the platform guard doing its job: on a platform Rundock
   // writes no block for, there is no block of ours to recognise.
-  return sameSandbox(block, sandboxSettings(claimedWorkspace, platform, claimedHome, tail, [], claimedMode));
+  const rebuilt = sandboxSettings(claimedWorkspace, platform, claimedHome, tail, [], claimedMode);
+  if (sameSandbox(block, rebuilt)) return true;
+  // THE SHAPE BEFORE THE DENY LIST, recognised so a block already on disk
+  // upgrades on the next open instead of reading as a person's edit. Without
+  // this every workspace scaffolded by an earlier build would be refused by its
+  // own recogniser, which means never rewritten and never withdrawn: the exact
+  // stranding this file goes to some length elsewhere to avoid.
+  return rebuilt !== null && sameSandbox(block, withoutDenyWrite(rebuilt));
+}
+
+// The same block as it was written before denyWrite existed. Rebuilt by
+// removing the key rather than by keeping a frozen copy, so the two shapes
+// cannot drift apart as the rest of the block changes. Key order is preserved
+// because sameSandbox compares serialised text: `filesystem` keeps its position
+// in the outer object, and dropping denyWrite leaves allowWrite where it was.
+function withoutDenyWrite(block) {
+  const { denyWrite, ...filesystem } = block.filesystem;
+  return { ...block, filesystem };
 }
 
 // The temp directory as the block should carry it: both spellings. macOS
@@ -626,16 +643,44 @@ function sandboxBlock(allowWrite, mode) {
   // same way. Judged with the host's separator instead, a Windows machine
   // opening a workspace scaffolded on a Mac would fail to recognise Rundock's
   // own block and would neither reconcile nor withdraw it.
-  if (mode === 'code') return { filesystem: { allowWrite } };
+  const filesystem = { allowWrite, denyWrite: denyWriteFor(allowWrite[0]) };
+  if (mode === 'code') return { filesystem };
   return {
     enabled: true,
     // The runtime's own prompt for a sandboxed command. Rundock never shows
     // it: the permission hook is the decider, and it still fires either way
     // (measured). Pinned so the behaviour does not move with a default.
     autoAllowBashIfSandboxed: true,
-    filesystem: { allowWrite },
+    filesystem,
     network: { allowedDomains: ['*'] },
   };
+}
+
+// THE ONE FILE INSIDE THE WORKSPACE THAT THIS BLOCK IS BUILT FROM.
+//
+// `.rundock/state.json` holds the workspace mode and the named working folders,
+// and both decide what goes in the block above: the mode decides whether
+// Rundock claims the enable, the folders decide which paths are writable. It
+// also sits inside the workspace root, so the permission hook classifies a
+// write to it as `inside` and never cards it, which is correct for every other
+// file in there and wrong for this one. An agent that can write it can widen
+// the boundary it is standing inside, then wait for the next reconcile to make
+// that widening real: the sandbox would be configured by the thing it contains.
+//
+// `denyWrite` is documented by the runtime as "additional paths to deny writing
+// within the sandbox", merged rather than replacing, so naming it here holds
+// whichever layer turned the sandbox on. It is carried in the Code-mode shape
+// too: that shape enables nothing by itself, but when another layer has done
+// the enabling this is the only place the deny would come from.
+//
+// This does not protect the file when no sandbox is running at all. Nothing in
+// this layer can, and there is then no boundary to widen either.
+//
+// Deliberately this file alone, not the folder. Agents legitimately write
+// scratch under `.rundock/`, and a deny over the directory would take that away
+// to protect one file.
+function denyWriteFor(workspaceDir) {
+  return [path.posix.join(workspaceDir, '.rundock', 'state.json')];
 }
 
 // THE WRITE LIST. The workspace, the cache, the runtime's fixed roots, the temp
@@ -797,5 +842,5 @@ function reconcileSandboxForMode(dir, mode, platform = process.platform) {
 
 module.exports = {
   muteHooks, isEmptyWorkspace, detectWorkspaceMode, scaffoldDefaults, scaffoldWorkspace,
-  sandboxSettings, isRundockSandbox, wireScaffoldDeps, reconcileSandboxForMode,
+  sandboxSettings, isRundockSandbox, wireScaffoldDeps, reconcileSandboxForMode, workspaceModeFor,
 };

--- a/lib/workspace/scaffold.js
+++ b/lib/workspace/scaffold.js
@@ -16,6 +16,7 @@ const path = require('path');
 const os = require('os');
 const { getWorkspace } = require('../config.js');
 const { readState, writeState } = require('../store/persistence.js');
+const { normalizeWorkingFolders, effectiveWorkingFolders } = require('./working-folders.js');
 
 const ROOT_DIR = path.join(__dirname, '..', '..');
 
@@ -367,7 +368,7 @@ function scaffoldWorkspace(dir, opts = {}) {
     // mode already persisted for THIS dir (the open path persists it before
     // calling here, precisely so this reconcile sees the real value on a
     // workspace's very first open too).
-    const desired = workspaceModeFor(dir) === 'code' ? null : sandboxSettings(dir, platform);
+    const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), workspaceModeFor(dir));
     if (reconcileSandboxBlock(settingsLocal, desired)) dirtySandbox = true;
     if (!settingsLocal.hooks) settingsLocal.hooks = {};
     if (!settingsLocal.hooks.PreToolUse) settingsLocal.hooks.PreToolUse = [];
@@ -519,39 +520,50 @@ function isRundockSandbox(block, platform = 'darwin') {
   if (sameSandbox(block, legacySandboxSettings(claimedWorkspace, claimedHome))) return true;
   const expectedHead = [claimedWorkspace, claimedCache, ...runtimeRoots(claimedHome)];
   const tail = roots.slice(expectedHead.length);
-  // The length bound and the tail check below are load-bearing: they decide
-  // how many entries the tail may have and what shape each one must be. A
-  // positional walk over expectedHead here would decide nothing the whole-
-  // block comparison at the end does not already decide on its own (that
-  // comparison rebuilds the head from the same claimedWorkspace/claimedHome
-  // and fails byte for byte the moment either differs), so there is no
-  // separate head loop: one comparison, not two that have to agree.
-  if (roots.length < expectedHead.length + 1 || roots.length > expectedHead.length + 2) return false;
-  if (!tail.every(t => typeof t === 'string' && t.length > 0)) return false;
+  // WHAT DECIDES AUTHORSHIP, NOW THAT THE TAIL HAS NO FIXED LENGTH.
+  //
+  // The tail used to be one or two temp roots, so its length was a check in
+  // its own right. It now also carries the folders the user named, and that
+  // list is arbitrary in both length and content, so no bound on it can
+  // separate our block from someone else's. The head does that work instead:
+  // six entries in fixed positions, derived from the block's OWN claimed
+  // workspace and home, and rebuilt for the comparison below. A person's block
+  // does not accidentally open with a workspace root, an `.npm` cache under
+  // the same home, and this release's four runtime roots in order.
+  //
+  // What is given up, deliberately: a path a person APPENDS to our block now
+  // reads as a working folder rather than as their edit, and is regenerated
+  // away on the next open. The supported place to name a folder is the Working
+  // Folders setting, which is what the card already points people at. The
+  // alternative is worse and is the failure this whole card exists to end: a
+  // block Rundock wrote that Rundock can no longer recognise is a block it can
+  // never rewrite or withdraw, which strands the workspace with an operating
+  // system nobody can talk to.
+  //
   // The tail is accepted from ANY machine (a block scaffolded elsewhere and
-  // opened here still has to reconcile rather than read as a stranger's
-  // edit), so it cannot be checked against THIS host's own tempRoots(). What
-  // it can be checked against is the one shape tempRoots() ever produces: a
-  // raw temp-directory name alone, or that name paired with ITS OWN realpath
-  // spelling. That second spelling is not always the literal /private
-  // alias. macOS's /tmp and /var are symlinks into /private, but a developer-
-  // set TMPDIR, or a temp volume reached through a relocating symlink, can
-  // resolve to a real path that shares no /private prefix at all; requiring
-  // one meant a block written on such a host carried a tail its own
-  // recogniser could never match, so `ours` read false forever and moving
-  // that workspace to Code mode could not withdraw the block it had itself
-  // written. Resolving a symlink only ever rewrites a PREFIX of the path and
-  // leaves every component below it untouched, so whatever the real prefix
-  // turns out to be, the second entry always ENDS WITH the first (the
-  // /private case is the one instance of this shape, not the whole of it).
-  // A root a person appended has no reason to share that suffix, which is
-  // what keeps it out.
-  if (tail.length === 2 && !tail[1].endsWith(tail[0])) return false;
-  // Everything OUTSIDE the root list must still be exactly ours: the shape
-  // check above establishes authorship of the list, and this establishes it
-  // for the rest of the block, by comparing against a regeneration that
-  // borrows the block's own tail.
-  return sameSandbox(block, sandboxSettings(claimedWorkspace, platform, claimedHome, tail));
+  // opened here still has to reconcile rather than read as a stranger's edit),
+  // so it is never checked against THIS host's temp roots or THIS workspace's
+  // current folder list. A tail that differs from what this machine would
+  // write is ours and stale, which is exactly what lets the reconcile rewrite
+  // it, the same journey the workspace root already makes when a folder moves.
+  if (roots.length < expectedHead.length + 1) return false;
+  if (!tail.every(t => typeof t === 'string' && t.length > 0)) return false;
+  // WHICH SHAPE THIS CLAIMS TO BE. Code mode contributes paths with no enable;
+  // Knowledge mode carries the enable and the rest. Read from the block so a
+  // workspace that changed mode still recognises what it wrote before, and
+  // reconciles to the shape its current mode wants.
+  const claimedMode = 'enabled' in block ? 'knowledge' : 'code';
+  // Everything OUTSIDE the root list must still be exactly ours, and the head
+  // inside it must rebuild byte for byte. The tail is borrowed from the block
+  // wholesale: it is this machine's own values either way, so it is carried
+  // rather than judged, and the comparison decides the rest.
+  //
+  // It is handed back through the temp-roots parameter rather than the folders
+  // one because the two are concatenated in that order and the whole tail is
+  // being replayed, not re-derived. Going through sandboxSettings rather than
+  // sandboxBlock keeps the platform guard doing its job: on a platform Rundock
+  // writes no block for, there is no block of ours to recognise.
+  return sameSandbox(block, sandboxSettings(claimedWorkspace, platform, claimedHome, tail, [], claimedMode));
 }
 
 // The temp directory as the block should carry it: both spellings. macOS
@@ -588,31 +600,69 @@ function runtimeRoots(home) {
   ];
 }
 
-function sandboxSettings(dir, platform = process.platform, home = os.homedir(), tmpRoots = tempRoots()) {
-  // Native Windows has no sandbox, and Windows is one of the two platforms
-  // this product builds for. Linux is documented as supported and was NOT
-  // measured here, and this file ships only what was run.
-  if (platform !== 'darwin') return null;
+// THE BLOCK, GIVEN ITS WRITE LIST AND WHICH MODE IS ASKING.
+//
+// Rundock owns ONE settings layer and the sandbox is decided across all of
+// them. Measured against Claude Code 2.1.266: `sandbox.enabled` resolves as
+// `enabled ?? false`, so no block means no sandbox; and the enable is an OR
+// over every layer (managed, flags, user, project, local), so a user who
+// switched the sandbox on in their own ~/.claude/settings.json has switched it
+// on for every workspace on the machine and nothing Rundock writes into its own
+// layer can switch it back off.
+//
+// That is why Code mode contributes PATHS WITHOUT AN ENABLE. Deleting the block
+// was correct and was never enough: it removed Rundock's enable and left the
+// user's, and then the workspace met an operating system that had never been
+// told which folders the user named. A block carrying `filesystem` alone
+// enables nothing on its own (verified against a real machine running exactly
+// that shape) and is unioned in when some other layer has done the enabling.
+//
+// `network` and `autoAllowBashIfSandboxed` stay OUT of the Code-mode shape on
+// purpose. `allowedDomains: ['*']` in a unioned layer would widen a network
+// policy the user set deliberately, and this change is about filesystem paths.
+function sandboxBlock(allowWrite, mode) {
+  // POSIX paths throughout: this block is only ever written for macOS, so every
+  // path in it is POSIX by construction and the recogniser reads it back the
+  // same way. Judged with the host's separator instead, a Windows machine
+  // opening a workspace scaffolded on a Mac would fail to recognise Rundock's
+  // own block and would neither reconcile nor withdraw it.
+  if (mode === 'code') return { filesystem: { allowWrite } };
   return {
     enabled: true,
     // The runtime's own prompt for a sandboxed command. Rundock never shows
     // it: the permission hook is the decider, and it still fires either way
     // (measured). Pinned so the behaviour does not move with a default.
     autoAllowBashIfSandboxed: true,
-    // POSIX join, not the host's. This block is only ever written for macOS,
-    // so every path in it is POSIX by construction, and the recogniser reads
-    // it back the same way. Judged with the host's separator instead, a
-    // Windows machine opening a workspace scaffolded on a Mac would fail to
-    // recognise Rundock's own block and would neither reconcile nor withdraw
-    // it.
-    //
-    // ORDER IS CONTRACT. The recogniser reads this list positionally: the
-    // workspace, the cache, the runtime's fixed roots, then the temp roots,
-    // whose values are this machine's own and are the reason a block from
-    // another machine reconciles rather than matching.
-    filesystem: { allowWrite: [dir, path.posix.join(home, '.npm'), ...runtimeRoots(home), ...tmpRoots] },
+    filesystem: { allowWrite },
     network: { allowedDomains: ['*'] },
   };
+}
+
+// THE WRITE LIST. The workspace, the cache, the runtime's fixed roots, the temp
+// roots, then the folders the user named.
+//
+// Folders go LAST so a workspace with none produces the list this function has
+// always produced, byte for byte, and so the head the recogniser checks keeps
+// its fixed positions. What follows the head is this machine's own values, and
+// is the reason a block written on another machine reconciles rather than
+// matching.
+// De-duplicated against what the list already carries, because the two sources
+// genuinely overlap: the runtime's own scratch is a BUILTIN working folder
+// (see builtinWorkingFolders) and is also a runtime root here. Left in twice
+// the block would still work and would still be recognised, being compared
+// against a regeneration that repeats the same duplicate, but it would read as
+// a mistake to the next person who opens the file.
+function sandboxAllowWrite(dir, home, tmpRoots, folders) {
+  const base = [dir, path.posix.join(home, '.npm'), ...runtimeRoots(home), ...tmpRoots];
+  return [...base, ...folders.filter((f) => !base.includes(f))];
+}
+
+function sandboxSettings(dir, platform = process.platform, home = os.homedir(), tmpRoots = tempRoots(), folders = [], mode = 'knowledge') {
+  // Native Windows has no sandbox, and Windows is one of the two platforms
+  // this product builds for. Linux is documented as supported and was NOT
+  // measured here, and this file ships only what was run.
+  if (platform !== 'darwin') return null;
+  return sandboxBlock(sandboxAllowWrite(dir, home, tmpRoots, folders), mode);
 }
 
 // The 0.12.0 block, frozen verbatim so blocks written by that release are
@@ -686,6 +736,25 @@ function workspaceModeFor(dir) {
   } catch (e) { return 'knowledge'; }
 }
 
+// The folders THIS workspace named, read from its own state file for exactly
+// the reason workspaceModeFor reads the mode from there: readWorkingFolders()
+// resolves through readState(), which answers for whatever workspace is
+// CURRENT, and this runs during scaffolding, when the folder being set up may
+// not be that one. Handing the current workspace's folders to a different
+// workspace's sandbox would widen a boundary nobody named.
+//
+// The effective list, not the stored one, so the runtime's own scratch is
+// covered here exactly as it is at the hook. The overlap with the runtime
+// roots is removed in sandboxAllowWrite rather than here.
+function workingFoldersFor(dir) {
+  let stored = [];
+  try {
+    const state = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'state.json'), 'utf-8'));
+    stored = normalizeWorkingFolders(state.workingFolders);
+  } catch (e) { /* unreadable or absent: the builtins still apply */ }
+  return effectiveWorkingFolders(stored);
+}
+
 // The block's immediate write/withdraw when the mode changes through
 // set_workspace_mode, so the switch takes effect without waiting for the
 // next workspace open. Mode is the only input this reads; there is no
@@ -713,7 +782,12 @@ function reconcileSandboxForMode(dir, mode, platform = process.platform) {
     // the file's bytes are never touched.
     if (e.code !== 'ENOENT') throw new Error(`could not read ${settingsLocalPath}: ${e.message}`);
   }
-  const desired = mode === 'code' ? null : sandboxSettings(dir, platform);
+  // Code mode no longer means "no block". It means a block that names the
+  // folders and claims no enable: Rundock owns one settings layer and the
+  // enable is an OR across all of them, so withdrawing ours never disabled a
+  // sandbox the user switched on in their own settings, it only stopped
+  // telling that sandbox which folders they had named.
+  const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), mode);
   const dirty = reconcileSandboxBlock(settingsLocal, desired);
   if (dirty) {
     fs.mkdirSync(path.dirname(settingsLocalPath), { recursive: true });

--- a/lib/workspace/scaffold.js
+++ b/lib/workspace/scaffold.js
@@ -363,11 +363,19 @@ function scaffoldWorkspace(dir, opts = {}) {
     // retry raises a boundary card for a path that is in the workspace,
     // while the release notes say the workspace is writable.
     //
-    // MODE IS THE ONLY INPUT. Knowledge mode carries the block, Code mode
-    // withdraws it; there is no separate opt-out. workspaceModeFor reads the
-    // mode already persisted for THIS dir (the open path persists it before
-    // calling here, precisely so this reconcile sees the real value on a
-    // workspace's very first open too).
+    // TWO INPUTS, AND NEITHER IS AN OPT-OUT. The mode decides whether Rundock
+    // CLAIMS THE ENABLE: Knowledge mode claims it, Code mode writes the same
+    // paths and claims nothing, because the enable is an OR across every
+    // settings layer and this is only the workspace's own. Code mode no longer
+    // withdraws the block, and saying it did was the mistake that left a
+    // Code-mode workspace meeting an operating system nobody had told which
+    // folders the person named. The named folders are the second input and
+    // decide which paths the block carries.
+    //
+    // workspaceModeFor reads the mode already persisted for THIS dir (the open
+    // path persists it before calling here, precisely so this reconcile sees
+    // the real value on a workspace's very first open too), and
+    // workingFoldersFor reads that same dir's folder list for the same reason.
     const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), workspaceModeFor(dir));
     if (reconcileSandboxBlock(settingsLocal, desired)) dirtySandbox = true;
     if (!settingsLocal.hooks) settingsLocal.hooks = {};

--- a/test/integration/ws-handler-edges.test.js
+++ b/test/integration/ws-handler-edges.test.js
@@ -101,8 +101,14 @@ describe('workspace lifecycle edges', () => {
         const wsSet = (await client.waitFor(m => m.type === 'workspace_set', { since, label: 'first open, code signal' })).msg;
         assert.strictEqual(wsSet.workspaceMode, 'code', 'auto-detected as code from the package.json');
         const settings = JSON.parse(fs.readFileSync(path.join(codeDir, '.claude', 'settings.local.json'), 'utf8'));
-        assert.strictEqual('sandbox' in settings, false,
-          'no block on the first open of a code-signal workspace, not one only withdrawn on the second');
+        // The sandbox is off for a code-signal workspace on its FIRST open,
+        // not only on the second. Asked as "does it enable anything" rather
+        // than "is a block present": Code mode still writes the paths, because
+        // Rundock owns one settings layer and `sandbox.enabled` is an OR across
+        // all of them, so a user who enabled the sandbox in their own settings
+        // needs this block to learn which folders they named.
+        assert.strictEqual('enabled' in (settings.sandbox || {}), false,
+          'nothing is switched on for a code-signal workspace, not switched on and withdrawn on the second open');
       } finally {
         h.internal.setWorkspace(h.workspaceDir);
       }

--- a/test/tools/mutate-workspace-boundary-guards.js
+++ b/test/tools/mutate-workspace-boundary-guards.js
@@ -194,9 +194,14 @@ const MUTATIONS = [
   // rewritten away on the next reconcile. The pairing check itself is a
   // general real-path-spelling test (ends-with), not only the literal
   // /private case, so a non-/private relocation is recognised too.
-  [SCAFFOLD, 'a second tail entry must be a real-path spelling of the first, or it is somebody\'s edit',
-    '  if (tail.length === 2 && !tail[1].endsWith(tail[0])) return false;\n',
-    ''],
+  // The real-path pairing guard is GONE, and its mutation with it. It read a
+  // second tail entry as a temp root only when it ended with the first, which
+  // was how an appended root was told from ours. The list now carries the
+  // folders a person named, so a second entry is as likely to be one of those
+  // as a temp spelling, and no rule separates them. What replaced it is the
+  // head: six entries in fixed positions, rebuilt from the block's own claimed
+  // workspace and home, and mutated by the zero-tail entry below. The cost is
+  // recorded in lib/workspace/scaffold.js beside the check that remains.
   // A corrupt or unreadable settings.local.json must not be silently
   // replaced with {}. Only ENOENT may start empty; drop that distinction and
   // every other read/parse failure quietly overwrites the file instead of
@@ -207,16 +212,16 @@ const MUTATIONS = [
 
   // ===== THE BLOCK IS DRIVEN BY MODE, AND ONLY BY MODE =====
   // Ignore the mode and the switch writes the block for code mode too.
-  [SCAFFOLD, 'the mode switch really withdraws the block in code mode',
-    "  const desired = mode === 'code' ? null : sandboxSettings(dir, platform);",
-    '  const desired = sandboxSettings(dir, platform);'],
+  [SCAFFOLD, 'the mode switch really drops the enable in code mode, rather than writing the enabled shape',
+    "  const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), mode);",
+    "  const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), 'knowledge');"],
   // Ignore the mode on the NEXT OPEN specifically, not through the switch:
   // scaffoldWorkspace's own reconcile has to read the persisted mode too, or
   // a code-mode workspace has its block silently rewritten the next time it
   // is opened.
   [SCAFFOLD, 'the next open honours the persisted mode, not only the switch',
-    "    const desired = workspaceModeFor(dir) === 'code' ? null : sandboxSettings(dir, platform);",
-    '    const desired = sandboxSettings(dir, platform);'],
+    "    const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), workspaceModeFor(dir));",
+    "    const desired = sandboxSettings(dir, platform, os.homedir(), tempRoots(), workingFoldersFor(dir), 'knowledge');"],
   // The mode must be PERSISTED before scaffoldWorkspace runs, because
   // scaffoldWorkspace's own reconcile reads the mode back off disk, not from
   // this function's local variable. Swap the order and a never-before-opened
@@ -388,10 +393,21 @@ const MUTATIONS = [
   [WORKSPACE_HANDLER_UNIT, 'a mode change that creates settings.local.json where none existed removes it again on failure, not just restores bytes when a file was already there',
     "        else if (preRequestReadErrorCode === 'ENOENT' && fs.existsSync(settingsLocalPath)) fs.unlinkSync(settingsLocalPath);\n",
     ''],
-  // The lower length bound is load-bearing too, not only the upper one.
-  [SCAFFOLD, 'a tail of zero entries is rejected by the lower length bound, not only by the upper one',
-    '  if (roots.length < expectedHead.length + 1 || roots.length > expectedHead.length + 2) return false;',
-    '  if (roots.length > expectedHead.length + 2) return false;'],
+  // The lower length bound is the one that survives. The upper bound is gone
+  // with the fixed-length tail: the list now carries the folders the user
+  // named, so its length proves nothing. A block with NO tail at all is still
+  // refused, and that is what stops a block a person trimmed the temp roots
+  // out of being read as ours and regenerated over their edit.
+  [SCAFFOLD, 'a tail of zero entries is rejected, so a block trimmed of its temp roots is not read as ours',
+    '  if (roots.length < expectedHead.length + 1) return false;',
+    ''],
+  // The shape is read from the block, not assumed. Pinned because it is the
+  // branch that lets a workspace which changed mode still recognise what it
+  // wrote before: assume one shape and the other reads as a stranger's block,
+  // which is a block Rundock can never rewrite or withdraw.
+  [SCAFFOLD, 'which shape a block claims is read from the block, not assumed to be the enabled one',
+    "  const claimedMode = 'enabled' in block ? 'knowledge' : 'code';",
+    "  const claimedMode = 'knowledge';"],
 ];
 
 const REPORTER = ['--test-reporter', 'spec'];

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -228,6 +228,66 @@ describe('handler seams (stub ctx, capture ws)', () => {
     return dir;
   }
 
+  test('a folder is still stored when the sandbox write fails, and the failure is not silent to the log', () => {
+    // The stored list stands on its own: the folders are in effect for every
+    // agent spawned from here, and scaffoldWorkspace reconciles the block
+    // again on the next workspace open. Discarding a list a person just chose
+    // because a settings file could not be written would cost more than the
+    // delay it saves, so this path warns and carries on.
+    const table = buildDispatch();
+    const original = config.getWorkspace();
+    const dir = workingFoldersWorkspace();
+    const named = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-wf-failwrite-'));
+    // Corrupt rather than absent: reconcileSandboxForMode treats ENOENT as an
+    // empty file and every other read failure as a reason to raise, precisely
+    // so a settings file it cannot parse is never overwritten.
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    const settingsPath = path.join(dir, '.claude', 'settings.local.json');
+    const corrupt = '{ this is not json';
+    fs.writeFileSync(settingsPath, corrupt);
+    const warnings = [];
+    const realWarn = console.warn;
+    console.warn = (...a) => warnings.push(a.join(' '));
+    try {
+      config.setWorkspace(dir);
+      const ws = captureWs();
+      table.set_working_folders({}, ws, { type: 'set_working_folders', folders: [named] }, 'darwin');
+      assert.strictEqual(ws.sent[0].type, 'working_folders', 'the caller is answered, not errored');
+      assert.deepStrictEqual(ws.sent[0].folders.map(f => f.path), [path.resolve(named)],
+        'and the folder is stored, because the hook can honour it whatever the settings file says');
+      assert.ok(warnings.some(w => w.includes('the sandbox was not updated')),
+        'the failure reaches the log rather than vanishing');
+      assert.strictEqual(fs.readFileSync(settingsPath, 'utf8'), corrupt,
+        'and the unparsable file is left exactly as it was, never rewritten from empty');
+    } finally {
+      console.warn = realWarn;
+      config.setWorkspace(original);
+    }
+  });
+
+  test('naming a folder reaches the operating system, not only the permission hook', () => {
+    // The hook is handed the folder list at every spawn; the sandbox is told
+    // once, in a file written at scaffold and mode-change time. Without a
+    // rewrite here, a folder named in this setting worked for file tools and
+    // not for the shell, which is the same split between the two instruments
+    // that the working-folder sandbox change exists to close.
+    const table = buildDispatch();
+    const original = config.getWorkspace();
+    const dir = workingFoldersWorkspace();
+    const named = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-wf-sandbox-'));
+    try {
+      config.setWorkspace(dir);
+      // 'darwin' explicitly: no block is written for any other platform, so a
+      // call defaulted to process.platform asserts nothing on a Linux runner.
+      table.set_working_folders({}, captureWs(), { type: 'set_working_folders', folders: [named] }, 'darwin');
+      const settings = JSON.parse(fs.readFileSync(path.join(dir, '.claude', 'settings.local.json'), 'utf8'));
+      assert.ok(settings.sandbox.filesystem.allowWrite.includes(path.resolve(named)),
+        'the folder just named is writable, without waiting for a mode switch or a restart');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
+
   test('set_working_folders stores the list, answers with it, and reports what it refused', () => {
     const table = buildDispatch();
     const original = config.getWorkspace();
@@ -780,23 +840,36 @@ describe('the OS write block is driven by mode alone, through the real dispatch'
     } catch (e) { return false; }
   }
 
-  test('on macOS, Knowledge mode carries the block, Code mode withdraws it, and moving back restores it', () => {
+  // WHETHER THE SANDBOX IS SWITCHED ON, which a block's mere presence no
+  // longer answers. Rundock writes one settings layer and `sandbox.enabled` is
+  // an OR across all of them, so Code mode keeps a block (to name the folders
+  // the user chose, for the case another layer did the enabling) and drops the
+  // enable. These tests mean "is it on", so they ask that.
+  function blockEnables(dir) {
+    try {
+      const settings = JSON.parse(fs.readFileSync(path.join(dir, '.claude', 'settings.local.json'), 'utf8'));
+      return !!settings.sandbox && 'enabled' in settings.sandbox;
+    } catch (e) { return false; }
+  }
+
+  test('on macOS, Knowledge mode switches the sandbox on, Code mode drops the enable but keeps the paths, and moving back switches it on again', () => {
     const table = buildDispatch();
     const dir = tempWs();
     withWorkspace(dir, () => {
       const toKnowledge = captureWs();
       table.set_workspace_mode({}, toKnowledge, { mode: 'knowledge' }, 'darwin');
       assert.deepStrictEqual(toKnowledge.sent[0], { type: 'workspace_mode_changed', mode: 'knowledge' });
-      assert.ok(blockPresent(dir), 'Knowledge mode on macOS carries the block');
+      assert.ok(blockEnables(dir), 'Knowledge mode on macOS switches the sandbox on');
 
       const toCode = captureWs();
       table.set_workspace_mode({}, toCode, { mode: 'code' }, 'darwin');
       assert.deepStrictEqual(toCode.sent[0], { type: 'workspace_mode_changed', mode: 'code' });
-      assert.strictEqual(blockPresent(dir), false, 'Code mode withdraws it');
+      assert.strictEqual(blockEnables(dir), false, 'Code mode drops the enable');
+      assert.ok(blockPresent(dir), 'while keeping the block, which is the only place the named folders are written');
 
       const backToKnowledge = captureWs();
       table.set_workspace_mode({}, backToKnowledge, { mode: 'knowledge' }, 'darwin');
-      assert.ok(blockPresent(dir), 'moving back to Knowledge mode restores it');
+      assert.ok(blockEnables(dir), 'moving back to Knowledge mode switches it on again');
     });
     fs.rmSync(dir, { recursive: true, force: true });
   });
@@ -1021,7 +1094,7 @@ describe('the OS write block is driven by mode alone, through the real dispatch'
         assert.strictEqual(socket.sent[0].type, 'workspace_mode_changed', `switching to ${mode} succeeds`);
         const state = JSON.parse(fs.readFileSync(path.join(dir, '.rundock', 'state.json'), 'utf8'));
         assert.strictEqual(state.workspaceMode, mode, `the recorded mode is ${mode} right after this switch`);
-        assert.strictEqual(blockPresent(dir), mode === 'knowledge',
+        assert.strictEqual(blockEnables(dir), mode === 'knowledge',
           `the block on disk agrees with ${mode} right after this switch, not just at the end of the sequence`);
       }
     });

--- a/test/unit/protocol-handlers-lib.test.js
+++ b/test/unit/protocol-handlers-lib.test.js
@@ -22,9 +22,12 @@ const config = require('../../lib/config.js');
 // end_delegation, flush_buffer) must NEVER appear here: chat is the
 // kill-window chat shim, delegate/end_delegation are delegation glue, and
 // flush_buffer drains safeSend's own reconnect buffer.
-// There is no sandbox switch: set_workspace_mode is the only message that
-// can move the OS write block, proven end to end by
-// test/unit/workspace-boundary.test.js.
+// There is no sandbox switch. Two messages reach the OS write block and no
+// third: set_workspace_mode decides whether Rundock claims the enable, and
+// set_working_folders decides which paths the block names, rewriting it for
+// whatever mode the workspace is already in. Both are proven end to end,
+// the first by test/unit/workspace-boundary.test.js and the second by
+// 'naming a folder reaches the operating system' below.
 const EXPECTED_TYPES = [
   'permission_response', 'cancel',
   'get_workspaces', 'client_render_time', 'list_workspaces', 'set_workspace',
@@ -227,6 +230,32 @@ describe('handler seams (stub ctx, capture ws)', () => {
     fs.mkdirSync(path.join(dir, '.rundock'), { recursive: true });
     return dir;
   }
+
+  test('removing a folder takes it out of the sandbox too, not only adding one puts it in', () => {
+    // The addition direction alone would pass with a block that only ever
+    // grows: a folder removed in the interface but still writable at the
+    // syscall level is a setting that lies in the direction that matters.
+    const table = buildDispatch();
+    const original = config.getWorkspace();
+    const dir = workingFoldersWorkspace();
+    const kept = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-wf-kept-'));
+    const dropped = fs.mkdtempSync(path.join(os.tmpdir(), 'proto-wf-dropped-'));
+    const settingsPath = path.join(dir, '.claude', 'settings.local.json');
+    try {
+      config.setWorkspace(dir);
+      table.set_working_folders({}, captureWs(), { type: 'set_working_folders', folders: [kept, dropped] }, 'darwin');
+      let roots = JSON.parse(fs.readFileSync(settingsPath, 'utf8')).sandbox.filesystem.allowWrite;
+      assert.ok(roots.includes(path.resolve(dropped)), 'fixture sanity: both folders are in the block first');
+
+      table.set_working_folders({}, captureWs(), { type: 'set_working_folders', folders: [kept] }, 'darwin');
+      roots = JSON.parse(fs.readFileSync(settingsPath, 'utf8')).sandbox.filesystem.allowWrite;
+      assert.ok(roots.includes(path.resolve(kept)), 'the folder that stayed is still writable');
+      assert.ok(!roots.includes(path.resolve(dropped)),
+        'and the one removed is no longer writable, without waiting for a mode switch or a restart');
+    } finally {
+      config.setWorkspace(original);
+    }
+  });
 
   test('a folder is still stored when the sandbox write fails, and the failure is not silent to the log', () => {
     // The stored list stands on its own: the folders are in effect for every

--- a/test/unit/sandbox-settings.test.js
+++ b/test/unit/sandbox-settings.test.js
@@ -26,7 +26,7 @@ const os = require('node:os');
 const { execFileSync } = require('node:child_process');
 const SCAFFOLD = path.join(__dirname, '..', '..', 'lib', 'workspace', 'scaffold.js');
 
-const { sandboxSettings } = require('../../lib/workspace/scaffold.js');
+const { sandboxSettings, isRundockSandbox } = require('../../lib/workspace/scaffold.js');
 
 const WS = '/tmp/sandbox-ws';
 const HOME = '/Users/someone';
@@ -145,5 +145,97 @@ describe('sandboxSettings', () => {
     // was not RUN here, and every other value in this file was. Linux stays
     // off until someone measures it rather than reads about it.
     assert.strictEqual(sandboxSettings(WS, 'linux', HOME), null);
+  });
+});
+
+// The named working folders, and the layer Rundock does not own.
+//
+// MEASURED against Claude Code 2.1.266 on 2026-09-12, by reading the shipped
+// binary rather than the documentation:
+//
+//   - `sandbox.enabled` resolves as `enabled ?? false`. No block is no sandbox.
+//   - The enable is an OR across EVERY settings layer (managed, flags, user,
+//     project, local): `[...].some((e) => e?.sandbox?.enabled === true)`.
+//     Rundock writes the local layer alone, so a user who enabled the sandbox
+//     in their own ~/.claude/settings.json has enabled it for every workspace
+//     on the machine and nothing Rundock writes can disable it.
+//   - Write allowlists UNION across layers, verified in a live session
+//     carrying a user-level entry and a workspace-level one, both honoured.
+//
+// Together those are why Code mode contributes paths with no enable: deleting
+// the block removed Rundock's enable and left the user's, and the workspace
+// then met an operating system that had never been told which folders the user
+// named. That is the reported defect, and no amount of naming folders in
+// Rundock fixed it, because the folders never reached this file.
+describe('sandboxSettings: named working folders', () => {
+  const FOLDERS = ['/Users/someone/Projects', '/Users/someone/Tools'];
+
+  test('a named folder is writable, which is the whole of the reported defect', () => {
+    const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    for (const f of FOLDERS) assert.ok(s.filesystem.allowWrite.includes(f), `${f} is writable`);
+  });
+
+  test('folders go last, so a workspace with none writes exactly what it wrote before', () => {
+    const before = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t']);
+    const withEmpty = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], []);
+    assert.deepStrictEqual(withEmpty, before, 'an empty folder list changes nothing at all');
+    const withFolders = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    assert.deepStrictEqual(
+      withFolders.filesystem.allowWrite.slice(0, before.filesystem.allowWrite.length),
+      before.filesystem.allowWrite,
+      'and folders append rather than displacing the head the recogniser reads');
+  });
+
+  test('Code mode contributes paths and enables nothing', () => {
+    const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS, 'code');
+    assert.ok(!('enabled' in s), 'no enable: absence is what keeps the sandbox off for everyone else');
+    assert.ok(!('autoAllowBashIfSandboxed' in s), 'and no prompting claim to go with it');
+    assert.ok(!('network' in s),
+      'and no network key: "*" unioned into a layer would widen a policy the user set deliberately');
+    for (const f of FOLDERS) assert.ok(s.filesystem.allowWrite.includes(f),
+      'but the folders are here, for the case where another layer did the enabling');
+  });
+
+  test('Knowledge mode is unchanged except for the folders', () => {
+    const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    assert.strictEqual(s.enabled, true);
+    assert.strictEqual(s.autoAllowBashIfSandboxed, true);
+    assert.deepStrictEqual(s.network, { allowedDomains: ['*'] });
+  });
+
+  test('both shapes are recognised as ours, with folders present', () => {
+    for (const mode of ['knowledge', 'code']) {
+      const block = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS, mode);
+      assert.strictEqual(isRundockSandbox(block, 'darwin'), true, `${mode} block is ours`);
+    }
+  });
+
+  test('a block whose folder list has since changed is still ours, and so still reconciles', () => {
+    // The user added a folder after this block was written. Recognised from the
+    // head, never from a comparison against the current list: a block we cannot
+    // recognise is one we can never rewrite or withdraw, which is how a
+    // workspace gets stranded with an operating system nobody can talk to.
+    const stale = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], ['/Users/someone/Old']);
+    assert.strictEqual(isRundockSandbox(stale, 'darwin'), true);
+  });
+
+  test('a stranger who happens to list folders is still refused', () => {
+    const stranger = {
+      enabled: true,
+      filesystem: { allowWrite: [WS, path.join(HOME, '.npm'), ...FOLDERS] },
+      network: { allowedDomains: ['*'] },
+    };
+    assert.strictEqual(isRundockSandbox(stranger, 'darwin'), false,
+      'the runtime roots are missing from the head, so it was not written here');
+  });
+
+  test('the Code-mode shape is not mistaken for a Knowledge-mode one, or the reverse', () => {
+    const code = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS, 'code');
+    const knowledge = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    assert.notDeepStrictEqual(code, knowledge, 'the two shapes are actually different');
+    // Each is recognised on its own terms, which is what lets a workspace that
+    // changed mode recognise what it wrote before and converge on the new shape.
+    assert.strictEqual(isRundockSandbox({ ...code, enabled: true }, 'darwin'), false,
+      'a Code-mode block with an enable bolted on is not a shape we ever wrote');
   });
 });

--- a/test/unit/sandbox-settings.test.js
+++ b/test/unit/sandbox-settings.test.js
@@ -203,6 +203,35 @@ describe('sandboxSettings: named working folders', () => {
     assert.deepStrictEqual(s.network, { allowedDomains: ['*'] });
   });
 
+  test('the file this block is built from cannot be written by what the block contains', () => {
+    // .rundock/state.json holds the mode and the named folders, and both decide
+    // what this block says. It also sits inside the workspace, so the
+    // permission hook classifies a write to it as inside and never cards it.
+    // Without a deny, an agent could widen the boundary it is standing inside
+    // by editing that file and waiting for the next reconcile.
+    for (const mode of ['knowledge', 'code']) {
+      const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS, mode);
+      assert.deepStrictEqual(s.filesystem.denyWrite, [`${WS}/.rundock/state.json`],
+        `${mode} mode denies writes to the file it is built from`);
+    }
+  });
+
+  test('the deny names that file alone, so agent scratch under .rundock still works', () => {
+    const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    assert.ok(!s.filesystem.denyWrite.includes(`${WS}/.rundock`),
+      'denying the folder would take away the scratch location agents are told to use');
+  });
+
+  test('a block written before the deny existed is still ours, so it upgrades rather than stranding', () => {
+    // A block its own recogniser refuses is one Rundock can never rewrite OR
+    // withdraw, which would leave every existing workspace stuck with the
+    // shape it already has and no way to move off it.
+    const current = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    const before = JSON.parse(JSON.stringify(current));
+    delete before.filesystem.denyWrite;
+    assert.strictEqual(isRundockSandbox(before, 'darwin'), true);
+  });
+
   test('both shapes are recognised as ours, with folders present', () => {
     for (const mode of ['knowledge', 'code']) {
       const block = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS, mode);

--- a/test/unit/sandbox-settings.test.js
+++ b/test/unit/sandbox-settings.test.js
@@ -175,15 +175,52 @@ describe('sandboxSettings: named working folders', () => {
     for (const f of FOLDERS) assert.ok(s.filesystem.allowWrite.includes(f), `${f} is writable`);
   });
 
-  test('folders go last, so a workspace with none writes exactly what it wrote before', () => {
-    const before = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t']);
-    const withEmpty = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], []);
-    assert.deepStrictEqual(withEmpty, before, 'an empty folder list changes nothing at all');
-    const withFolders = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+  // WHAT THE BLOCK LOOKED LIKE BEFORE THIS CHANGE, written out rather than
+  // computed. The first version of the test below compared sandboxSettings to
+  // ITSELF with an empty folder list, which passes however much the block
+  // changes: it proved the folders argument defaults to empty and nothing
+  // whatever about matching what shipped. A reference the code cannot rebuild
+  // is the only thing that can catch a key appearing or a value moving.
+  const SHIPPED_KNOWLEDGE_BLOCK = {
+    enabled: true,
+    autoAllowBashIfSandboxed: true,
+    filesystem: {
+      allowWrite: [
+        WS,
+        `${HOME}/.npm`,
+        `${HOME}/.claude`,
+        `${HOME}/.claude.json`,
+        '/tmp/claude',
+        '/private/tmp/claude',
+        '/tmp/t',
+      ],
+    },
+    network: { allowedDomains: ['*'] },
+  };
+
+  test('a workspace with no folders writes what it wrote before, and the deny is the one intended difference', () => {
+    const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t']);
+    // The deny list is a deliberate addition made after the criteria were
+    // frozen, approved on the ledger rather than slipped in: it protects the
+    // file this very block is built from. It is the ONLY difference, and
+    // subtracting it must leave the shipped block exactly.
+    assert.deepStrictEqual(s.filesystem.denyWrite, [`${WS}/.rundock/state.json`],
+      'the intended difference, named');
+    const { denyWrite, ...filesystem } = s.filesystem;
+    assert.deepStrictEqual({ ...s, filesystem }, SHIPPED_KNOWLEDGE_BLOCK,
+      'and with it removed, key for key and value for value, the block that shipped');
+  });
+
+  test('naming folders appends to the write list and changes nothing else', () => {
+    const s = sandboxSettings(WS, 'darwin', HOME, ['/tmp/t'], FOLDERS);
+    const { denyWrite, ...filesystem } = s.filesystem;
+    const base = SHIPPED_KNOWLEDGE_BLOCK.filesystem.allowWrite;
+    assert.deepStrictEqual(filesystem.allowWrite, [...base, ...FOLDERS],
+      'the folders go on the end, and the head keeps the positions the recogniser reads');
     assert.deepStrictEqual(
-      withFolders.filesystem.allowWrite.slice(0, before.filesystem.allowWrite.length),
-      before.filesystem.allowWrite,
-      'and folders append rather than displacing the head the recogniser reads');
+      { ...s, filesystem: { allowWrite: base } },
+      SHIPPED_KNOWLEDGE_BLOCK,
+      'every other key is untouched: the enable, the prompting flag and the network stay as they were');
   });
 
   test('Code mode contributes paths and enables nothing', () => {

--- a/test/unit/workspace-boundary.test.js
+++ b/test/unit/workspace-boundary.test.js
@@ -97,36 +97,59 @@ describe('the block names the runtime\'s measured plumbing, and the doc names th
   // inside the still-permitted one-or-two-entry window, and the assertion
   // fails outright, meaning 'anything else is somebody's edit' went
   // unenforced there entirely.
-  test('a user-added extra root is never recognised as ours, for a one-entry or a two-entry tail', () => {
+  // A DELIBERATE NARROWING, RECORDED RATHER THAN DELETED.
+  //
+  // Two tests here used to assert that a root appended to Rundock's own block
+  // proved a person had edited it, so the block was left alone forever. They
+  // were right about the old shape, where the tail was one or two temp roots
+  // and the entry COUNT was itself the evidence.
+  //
+  // The block now also carries the folders the user named in Working Folders.
+  // That list is arbitrary in length and content, so an appended root and a
+  // named folder are the same bytes in the same position, and no rule can
+  // separate them. Keeping the old guarantee would need a record, kept outside
+  // the block, of what Rundock last wrote; a record that can be lost or go
+  // stale, and every way of losing it strands the workspace with a block
+  // Rundock can no longer rewrite or withdraw, which is precisely the failure
+  // this whole change exists to end.
+  //
+  // What is given up: a write root added by hand to settings.local.json is
+  // regenerated away on the next open. It NARROWS rather than widens, since
+  // their extra root is dropped rather than kept, and the supported place to
+  // name a folder now actually reaches the sandbox, which it did not before.
+  //
+  // What still holds is asserted below, and in the two neighbouring tests: the
+  // head's order is contract, and a block with no temp tail at all is still
+  // refused and still left untouched.
+  test('an appended root now reads as a named folder, the cost of the folder list being any length', () => {
     const oneEntryTail = ['/var/folders/zz/one-entry-host/T'];
     const legitOne = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', oneEntryTail);
     assert.strictEqual(scaffold.isRundockSandbox(legitOne), true, 'a lone temp root, on its own, is ours');
+
     const oneEntryPlusExtra = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', oneEntryTail);
     oneEntryPlusExtra.filesystem.allowWrite.push('/Users/me/their-own-root');
-    assert.strictEqual(scaffold.isRundockSandbox(oneEntryPlusExtra), false,
-      'still within the permitted one-or-two-entry tail length, so the length check alone cannot catch this: '
-      + 'the appended root is not a temp-directory spelling, and that is what has to reject it');
+    assert.strictEqual(scaffold.isRundockSandbox(oneEntryPlusExtra), true,
+      'indistinguishable from a block written for a workspace naming that folder, so it is ours and gets regenerated');
 
-    // The two-entry tail is the raw temp-dir name and its own /private real
-    // path (the only shape tempRoots() ever produces): recognised as a
-    // matched pair, an appended THIRD entry is not.
     const twoEntryTail = ['/var/folders/zz/two-entry-host/T', '/private/var/folders/zz/two-entry-host/T'];
     const legitTwo = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', twoEntryTail);
     assert.strictEqual(scaffold.isRundockSandbox(legitTwo), true, 'the raw spelling and its /private pairing are ours');
-    const twoEntryPlusExtra = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', twoEntryTail);
-    twoEntryPlusExtra.filesystem.allowWrite.push('/Users/me/their-own-root');
-    assert.strictEqual(scaffold.isRundockSandbox(twoEntryPlusExtra), false,
-      'a third tail entry pushes length past the permitted window, and it is rejected either way');
   });
 
-  test('a second tail entry that is not the first entry\'s /private pairing is not recognised as ours', () => {
-    // Same length as a legitimate two-entry tail, so only the pairing check
-    // (not the length check) can catch this: a person's folder happens to
-    // land in the second tail slot instead of being visibly appended.
-    const impersonating = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', ['/var/folders/zz/mixed-host/T']);
-    impersonating.filesystem.allowWrite.push('/Users/me/their-own-root');
-    assert.strictEqual(scaffold.isRundockSandbox(impersonating), false,
-      'a root of their own, sitting where the /private pairing would be, is not a temp-directory spelling');
+  test('the head is still what proves authorship, so a stranger\'s block is still refused', () => {
+    // The guarantee that replaces the length check. Six entries in fixed
+    // positions, every one rebuilt from the block's own claimed workspace and
+    // home: a block that does not open with them was not written here,
+    // however its tail looks.
+    const notOurs = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', ['/var/folders/zz/h/T']);
+    notOurs.filesystem.allowWrite[3] = '/Users/me/not-a-runtime-root';
+    assert.strictEqual(scaffold.isRundockSandbox(notOurs), false,
+      'a runtime root replaced in the head, so the head no longer rebuilds and the block is left alone');
+
+    const wrongHome = scaffold.sandboxSettings('/w/ws', 'darwin', '/Users/me', ['/var/folders/zz/h/T']);
+    wrongHome.filesystem.allowWrite[1] = '/Users/someone-else/.npm';
+    assert.strictEqual(scaffold.isRundockSandbox(wrongHome), false,
+      'a cache root under a different home than the runtime roots claim: not a shape Rundock ever writes');
   });
 
   // With an empty tail the pairing check is skipped, so a person who
@@ -164,8 +187,8 @@ describe('the block names the runtime\'s measured plumbing, and the doc names th
     }));
     scaffold.reconcileSandboxForMode(ws, 'code', 'darwin');
     const settings = JSON.parse(fs.readFileSync(path.join(ws, '.claude', 'settings.local.json'), 'utf8'));
-    assert.strictEqual('sandbox' in settings, false,
-      'moving to Code mode withdraws a block carrying this tail, exactly as it does for the /private pairing');
+    assert.strictEqual('enabled' in settings.sandbox, false,
+      'moving to Code mode drops the enable from a block carrying this tail, exactly as it does for the /private pairing');
   });
 });
 
@@ -323,12 +346,16 @@ describe('the block is driven by mode, and only by mode', () => {
     const settingsPath = path.join(ws, '.claude', 'settings.local.json');
     let settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
     assert.ok(settings.sandbox, 'knowledge mode: the block is written');
+    const knowledgeRoots = settings.sandbox.filesystem.allowWrite;
     scaffold.reconcileSandboxForMode(ws, 'code', 'darwin');
     settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    assert.strictEqual('sandbox' in settings, false, 'code mode: the block is withdrawn');
+    assert.strictEqual('enabled' in settings.sandbox, false, 'code mode: the enable is dropped');
+    assert.deepStrictEqual(settings.sandbox.filesystem.allowWrite, knowledgeRoots,
+      'and the paths are kept, because another settings layer may have enabled the sandbox '
+      + 'and this is the only place that names the folders the user chose');
     scaffold.reconcileSandboxForMode(ws, 'knowledge', 'darwin');
     settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    assert.ok(settings.sandbox, 'moving back to knowledge mode restores the block');
+    assert.strictEqual(settings.sandbox.enabled, true, 'moving back to knowledge mode restores the enable');
   });
 
   test('an unreadable settings file is never overwritten: only a genuinely absent file starts from empty', () => {
@@ -372,8 +399,22 @@ describe('the block is driven by mode, and only by mode', () => {
       fs.writeFileSync(path.join(codeModeWs, '.rundock', 'state.json'), JSON.stringify({ workspaceMode: 'code' }));
       scaffold.scaffoldWorkspace(codeModeWs, { platform: 'darwin' });
       const afterNextOpen = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-      assert.strictEqual('sandbox' in afterNextOpen, false,
-        'withdrawn on the next open, not left in place as a refresh would leave it');
+      // CHANGED CONTRACT, PINNED RATHER THAN RELAXED. This used to assert the
+      // block was gone. Withdrawing it was never what it appeared to be:
+      // `sandbox.enabled` is an OR across every settings layer and Rundock
+      // writes one of them, so deleting ours disabled nothing for a user who
+      // had enabled the sandbox in their own ~/.claude/settings.json. It only
+      // stopped telling that sandbox which folders they had named, which is
+      // the reported defect. Code mode now contributes paths and claims no
+      // enable, so the assertion is stricter than the one it replaces: the
+      // block must be present AND must enable nothing.
+      assert.ok(afterNextOpen.sandbox, 'a block is written for a code-mode workspace');
+      assert.strictEqual('enabled' in afterNextOpen.sandbox, false,
+        'and it claims no enable, so it switches the sandbox on for nobody');
+      assert.strictEqual('network' in afterNextOpen.sandbox, false,
+        'and names no domains, so it widens no network policy the user set');
+      assert.ok(Array.isArray(afterNextOpen.sandbox.filesystem.allowWrite),
+        'what it does carry is the write list, for the case another layer enabled the sandbox');
 
       const knowledgeModeWs = tmp('wb-scaffold-knowledgemode-');
       scaffold.scaffoldWorkspace(knowledgeModeWs, { platform: 'darwin' });

--- a/test/unit/workspace-boundary.test.js
+++ b/test/unit/workspace-boundary.test.js
@@ -358,6 +358,32 @@ describe('the block is driven by mode, and only by mode', () => {
     assert.strictEqual(settings.sandbox.enabled, true, 'moving back to knowledge mode restores the enable');
   });
 
+  test('a block carrying a stale folder list is rewritten to the current one, not merely recognised', () => {
+    // Recognition is only half of reconciliation: a block can be correctly
+    // identified as ours and still be left on disk naming a folder the person
+    // removed weeks ago. This drives the whole path and reads the file back.
+    const ws = tmp('wb-stale-folders-');
+    fs.mkdirSync(path.join(ws, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(ws, '.rundock'), { recursive: true });
+    const current = tmp('wb-stale-current-');
+    const stale = '/Users/someone/NamedLongAgo';
+    // What the workspace names TODAY.
+    fs.writeFileSync(path.join(ws, '.rundock', 'state.json'),
+      JSON.stringify({ workspaceMode: 'knowledge', workingFolders: [current] }));
+    // What the block on disk still names, written by an earlier run.
+    const old = scaffold.sandboxSettings(ws, 'darwin', os.homedir(), ['/tmp/t'], [stale]);
+    fs.writeFileSync(path.join(ws, '.claude', 'settings.local.json'), JSON.stringify({ sandbox: old }));
+    assert.strictEqual(scaffold.isRundockSandbox(old), true, 'fixture sanity: the stale block is recognised as ours');
+
+    scaffold.reconcileSandboxForMode(ws, 'knowledge', 'darwin');
+
+    const roots = JSON.parse(fs.readFileSync(path.join(ws, '.claude', 'settings.local.json'), 'utf8'))
+      .sandbox.filesystem.allowWrite;
+    assert.ok(roots.includes(current), 'the folder the workspace names now is writable');
+    assert.ok(!roots.includes(stale),
+      'and the one it no longer names is gone, rather than being left in place because the block was ours');
+  });
+
   test('an unreadable settings file is never overwritten: only a genuinely absent file starts from empty', () => {
     // The bug this guards: {} stood in for EVERY read failure, absent or
     // not, so a corrupt settings.local.json (a hand-added comment, a torn

--- a/test/unit/workspace-boundary.test.js
+++ b/test/unit/workspace-boundary.test.js
@@ -358,6 +358,41 @@ describe('the block is driven by mode, and only by mode', () => {
     assert.strictEqual(settings.sandbox.enabled, true, 'moving back to knowledge mode restores the enable');
   });
 
+  test('the reported case, end to end: the named folder is inside for the hook AND writable for the operating system', () => {
+    // THE BUG REPORT, REPRODUCED. A workspace in Code mode with ~/Projects
+    // named, running `cd ~/Projects/<repo> && node scripts/x.mjs`, drew a
+    // permission card on every invocation.
+    //
+    // The hook always agreed that folder was inside; it was the operating
+    // system that refused, and the refusal became a card by a path that no
+    // grant can answer. Proving the fix therefore needs BOTH halves asserted
+    // together: the hook reports no crossing, and the same folder is in the
+    // write list handed to the sandbox. Either alone is what the product had
+    // before, and what it had before was the defect.
+    const ws = tmp('wb-reported-case-');
+    const named = path.join(os.homedir(), 'Projects');
+    const command = `cd ${path.join(named, 'alchemist')} && node scripts/x.mjs`;
+
+    const access = hook.classifyShellAccess('Bash', { command }, ws, [named], os.homedir(), false);
+    assert.strictEqual(access, null,
+      'the hook finds no crossing: the folder the person named is inside, as it always was');
+
+    const block = scaffold.sandboxSettings(ws, 'darwin', os.homedir(), ['/tmp/t'], [named], 'code');
+    assert.ok(block.filesystem.allowWrite.includes(named),
+      'and the operating system is finally told the same thing, which is the half that was missing');
+
+    // THE PATH THAT PRODUCED THE CARD, still ungrantable by design. This is
+    // what the fix avoids reaching, not something it teaches the hook to
+    // forgive: a sandbox refusal the runtime retries carries no path at all,
+    // so no folder grant could ever answer it.
+    const escape = hook.classifyShellAccess('Bash', { command, dangerouslyDisableSandbox: true }, ws, [named], os.homedir(), false);
+    assert.strictEqual(escape.where, 'outside');
+    assert.strictEqual(escape.grantable, false,
+      'naming a folder never silenced this card, which is why the folder had to reach the sandbox instead');
+    assert.deepStrictEqual(escape.crossings, [],
+      'and it names no path, so there was nothing for a grant to cover');
+  });
+
   test('a block carrying a stale folder list is rewritten to the current one, not merely recognised', () => {
     // Recognition is only half of reconciliation: a block can be correctly
     // identified as ours and still be left on disk naming a folder the person


### PR DESCRIPTION
A workspace in Code mode with `~/Projects` named as a working folder drew a permission card on every command run there. Rundock's own hook disagrees with that card: run against the reported shape it returns `inside` for both a read and a write under the named folder, and reports no crossing at all for the command. The card came from the sandbox-escape signal instead, which fires when the runtime retries a refused command with the sandbox disabled. That signal is ungrantable by construction, so it fired on every command forever, and the card text named the setting that had already been applied as the thing that would not help.

## What was measured

Against Claude Code 2.1.266, by reading the shipped runtime rather than its documentation. `sandbox.enabled` resolves as `enabled ?? false`, so no block is no sandbox. The enable is an OR across every settings layer, managed, flags, user, project and local: `[...].some((e) => e?.sandbox?.enabled === true)`. Rundock writes the local layer alone, so someone who enabled the sandbox in their own `~/.claude/settings.json` enabled it for every workspace on that machine, and no value Rundock writes into its own layer can switch it back off. Write allowlists union across layers, verified in a live session carrying both a user-level entry and a workspace-level one with each honoured.

## What changed

Code mode's delete was correct and was never sufficient: it removed Rundock's enable, left the user's, and stopped telling that sandbox which folders had been named. Both modes now contribute the folder list and differ only in whether they claim the enable. The Code-mode shape carries no `enabled`, no `autoAllowBashIfSandboxed` and no `network`, because `allowedDomains: ['*']` unioned into a layer would widen a network policy set deliberately elsewhere, and the layer that enables the sandbox is the one that owns its consequences. If nothing else enabled the sandbox, the Code-mode block enables nothing and the workspace behaves exactly as before.

Naming a folder now rewrites the block immediately, so the setting no longer works for file tools and not for the shell. A failure there warns and leaves the stored list standing, because the folders are already in effect for every agent spawned from then on and the next workspace open reconciles the block again.

## The guarantee this gives up

Recorded rather than buried. A tail of fixed length used to prove that a root appended to Rundock's block was somebody's edit, so the block was left alone. The list now carries arbitrary named folders, so an appended root and a named folder are the same bytes in the same position and no rule separates them. The head proves authorship instead: six entries in fixed positions, each rebuilt from the block's own claimed workspace and home. The cost is that a hand-added write root is regenerated away on the next open, which narrows rather than widens, and the supported place to name a folder now actually reaches the sandbox. Keeping the old guarantee would need a record of what was last written, kept outside the block, and every way of losing that record strands a workspace with a block Rundock can no longer rewrite or withdraw, which is the failure this change exists to end.

Two mutations were added for the branches that replace it, the zero-tail rejection and reading the claimed shape from the block, and both are confirmed caught by tests. The mutation whose guard is gone was removed with a comment saying what went and what took over.

## Verification

Full suite green. Pre-commit gate passed including coverage floors and the scoped mutation run. The coverage floor caught an untested failure path in the folder-change rewrite during development, which now has a test asserting that a failed sandbox write neither discards the stored list nor overwrites an unparsable settings file.